### PR TITLE
Stop on the first error

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -35,6 +35,7 @@ Options:
   --embed                        Embed the Python interpreter in a main() method.
   -2                             Compile based on Python-2 syntax and code semantics.
   -3                             Compile based on Python-3 syntax and code semantics.
+  --fatal-errors                 Abort the compilation on the first error
   -X, --directive <name>=<value>[,<name=value,...] Overrides a compiler directive
 """
 
@@ -117,6 +118,8 @@ def parse_command_line(args):
                 options.language_level = 2
             elif option == '-3':
                 options.language_level = 3
+            elif option == "--fatal-errors":
+                Options.fatal_errors = True
             elif option in ("-X", "--directive"):
                 try:
                     options.compiler_directives = Options.parse_directive_list(

--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -5,6 +5,7 @@
 import sys
 from Cython.Utils import open_new_file
 from DebugFlags import debug_exception_on_error
+import Options
 
 
 class PyrexError(Exception):
@@ -138,6 +139,8 @@ def report_error(err):
             except UnicodeEncodeError:
                 echo_file.write(line.encode('ASCII', 'replace'))
         num_errors = num_errors + 1
+        if Options.fatal_errors:
+            sys.exit(1)
 
 def error(position, message):
     #print "Errors.error:", repr(position), repr(message) ###

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -18,6 +18,10 @@ generate_cleanup_code = 0
 
 annotate = 0
 
+# This will abort the compilation on the first error occured rather than trying
+# to keep going and printing further error messages.
+fatal_errors = False
+
 # This will convert statements of the form "for i in range(...)" 
 # to "for i from ..." when i is a cdef'd integer type, and the direction
 # (i.e. sign of step) can be determined. 


### PR DESCRIPTION
Option --fatal-errors implemented, which works just like -Wfatal-errors in gcc.

I am not sure if I implemented this correctly, but it does the job for me.
