### PR TITLE
Clean up the declaration of constants in numpy.pxd.

### DIFF
--- a/Cython/Includes/numpy.pxd
+++ b/Cython/Includes/numpy.pxd
@@ -81,17 +81,17 @@ cdef extern from "numpy/arrayobject.h":
         NPY_COMPLEX256
         NPY_COMPLEX512
 
-    enum NPY_ORDER:
+    ctypedef enum NPY_ORDER:
         NPY_ANYORDER
         NPY_CORDER
         NPY_FORTRANORDER
 
-    enum NPY_CLIPMODE:
+    ctypedef enum NPY_CLIPMODE:
         NPY_CLIP
         NPY_WRAP
         NPY_RAISE
 
-    enum NPY_SCALARKIND:
+    ctypedef enum NPY_SCALARKIND:
         NPY_NOSCALAR,
         NPY_BOOL_SCALAR,
         NPY_INTPOS_SCALAR,
@@ -101,12 +101,12 @@ cdef extern from "numpy/arrayobject.h":
         NPY_OBJECT_SCALAR
 
 
-    enum NPY_SORTKIND:
+    ctypedef enum NPY_SORTKIND:
         NPY_QUICKSORT
         NPY_HEAPSORT
         NPY_MERGESORT
 
-    cdef enum requirements:
+    enum:
         NPY_C_CONTIGUOUS
         NPY_F_CONTIGUOUS
         NPY_CONTIGUOUS


### PR DESCRIPTION
There are a large number of constants declared with 'cdef enum' in
numpy.pxd. Most of them did not correctly match the definitions in the
numpy headers -- either because of a missing 'ctypedef', or because
numpy.pxd claimed that they were of a named enum type ('enum
requirements') which did not actually exist.

Somewhere between Cython 0.12.1 and 0.14.1, the latter issue broke my
compile whenever I referred to np.NPY_F_CONTIGUOUS. Cython started
generating code like:
  enum requirements __pyx_t_10 = NPY_F_CONTIGUOUS;
  PyArray_NewFromDescr(..., __pyx_t_10, ....);
Since there is, in fact, no such thing as 'enum requirements', the C
compiler objected. (In earlier version, no temporary variable was
generated, so we got away with the incorrect declaration.)

And since I had to fix the declaration of this particular enum, I
figured I might as well double-check the rest as well, in case of
similar problems arising in the future.

With this patch, Cython can once again compile scikits.sparse v0.1.
