### PR TITLE
Add strerror to string.pxd

### DIFF
--- a/Cython/Includes/libc/string.pxd
+++ b/Cython/Includes/libc/string.pxd
@@ -31,6 +31,7 @@ cdef extern from "string.h" nogil:
     int    strcoll (const_char *S1, const_char *S2)
     size_t strxfrm (char *TO, const_char *FROM, size_t SIZE)
 
+    char *strerror (int ERRNUM)
 
     char *strchr  (const_char *STRING, int C)
     char *strrchr (const_char *STRING, int C)


### PR DESCRIPTION
It seems you omitted `strerror` from the C string library. I imagine this might be because it's also in Python's standard `os` module, but it might be useful to have the native C `strerror` available as well.
