### PR TITLE
use absolute filenames when reporting errors

### DIFF
--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -32,7 +32,7 @@ def context(position):
 
 def format_position(position):
     if position:
-        return u"%s:%d:%d: " % (position[0].get_description(),
+        return u"%s:%d:%d: " % (position[0].filename,
                                 position[1], position[2])
     return u''
 


### PR DESCRIPTION
this makes cython compatible with emacs compilation mode. I've written to the mailing list once about this issuee, but didn't see a response. cython shows only the basename of it's input files for compilation errors or warnings. this makes emacs compilation mode fail. the attached patch makes it show absolute filenames.
