### PR TITLE
report filenames relative to the current directory or as absolute paths i

### DIFF
--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -32,7 +32,7 @@ def context(position):
 
 def format_position(position):
     if position:
-        return u"%s:%d:%d: " % (position[0].get_description(),
+        return u"%s:%d:%d: " % (position[0].get_error_description(),
                                 position[1], position[2])
     return u''
 

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -204,6 +204,13 @@ class FileSourceDescriptor(SourceDescriptor):
     def get_description(self):
         return self.path_description
 
+    def get_error_description(self):
+        path = self.filename
+        cwd = os.getcwd() + os.path.sep
+        if path.startswith(cwd):
+            return path[len(cwd):]
+        return path
+
     def get_filenametable_entry(self):
         return self.filename
 
@@ -238,6 +245,8 @@ class StringSourceDescriptor(SourceDescriptor):
 
     def get_description(self):
         return self.name
+
+    get_error_description = get_description
 
     def get_filenametable_entry(self):
         return "stringsource"


### PR DESCRIPTION
report filenames relative to the current directory or as absolute paths in warnings/errors.

we use relative filenames for files in the directory itself or
subdirectories, absolute paths otherwise.

this makes cython compatible with emacs compilation mode.
