### PR TITLE
Makefile: rework repo creation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TMPDIR = .repo_tmp
 	cd $(TMPDIR) && git reset -q "$(shell cat .gitrev)"
 	mv $(TMPDIR)/.git .
 	rm -rf $(TMPDIR)
-	git checkout -- .hgtags .hgignore Doc/s5
+	git ls-files -d | xargs git checkout --
 
 repo: .git
 


### PR DESCRIPTION
The current repo target may produce some error messages and creates a tmprepo.XX... directory each time make is called.  This series reworks the repo creation target so that it doesn't produce those errors, and also installs the git repository a little more efficiently.

-Brandon
