### PR TITLE
Wrong Example in "Sharing Declarations Between Cython Modules"

### DIFF
--- a/Doc/sharing.html
+++ b/Doc/sharing.html
@@ -85,7 +85,7 @@ exactly parallels that of the normal Python import statement:
        <tt>&nbsp;&nbsp;&nbsp; print "%d oz spam, filler no. %d" % \</tt>
       <br>
        <tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; (d-&gt;oz_of_spam,
- d-&gt;otherstuff)</tt></p>
+ d-&gt;filler)</tt></p>
        </td>
   </tr>
       </tbody> </table>

--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -96,7 +96,7 @@ uses it.
     def serve():
         cdef spamdish d
         prepare(&d)
-        print "%d oz spam, filler no. %d" % (d.oz_of_spam, d.otherstuff)
+        print "%d oz spam, filler no. %d" % (d.oz_of_spam, d.filler)
                                
 It is important to understand that the :keyword:`cimport` statement can only
 be used to import C data types, C functions and variables, and extension


### PR DESCRIPTION
The example in "The cimport statement" references the type of a member where it should reference the member.
