### PR TITLE
Allow conditional compilation environment in distutils

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -686,4 +686,5 @@ default_options = dict(
     c_line_in_traceback = True,
     language_level = 2,
     gdb_debug = False,
+    compile_time_env = None,
 )

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -67,6 +67,9 @@ class CompileTimeScope(object):
     def declare(self, name, value):
         self.entries[name] = value
 
+    def update(self, other):
+        self.entries.update(other)
+
     def lookup_here(self, name):
         return self.entries[name]
 
@@ -286,6 +289,9 @@ class PyrexScanner(Scanner):
             self.compile_time_env = initial_compile_time_env()
             self.compile_time_eval = 1
             self.compile_time_expr = 0
+            if hasattr(context.options, 'compile_time_env') and \
+               context.options.compile_time_env is not None:
+                self.compile_time_env.update(context.options.compile_time_env)
         self.parse_comments = parse_comments
         self.source_encoding = source_encoding
         if filename.is_python_file():

--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -83,6 +83,8 @@ class build_ext(_build_ext.build_ext):
             "compiler directive overrides"),
         ('pyrex-gdb', None,
          "generate debug information for cygdb"),
+        ('pyrex-compile-time-env', None,
+            "pyrex compile time environment"),
         ])
 
     boolean_options.extend([
@@ -101,6 +103,7 @@ class build_ext(_build_ext.build_ext):
         self.pyrex_gen_pxi = 0
         self.pyrex_gdb = False
         self.no_c_in_traceback = 0
+        self.pyrex_compile_time_env = None
 
     def finalize_options (self):
         _build_ext.build_ext.finalize_options(self)
@@ -182,6 +185,9 @@ class build_ext(_build_ext.build_ext):
                 (extension.language and extension.language.lower() == 'c++')
         pyrex_gen_pxi = self.pyrex_gen_pxi or getattr(extension, 'pyrex_gen_pxi', 0)
         pyrex_gdb = self.pyrex_gdb or getattr(extension, 'pyrex_gdb', False)
+        pyrex_compile_time_env = self.pyrex_compile_time_env or \
+            getattr(extension, 'pyrex_compile_time_env', None)
+
         # Set up the include_path for the Cython compiler:
         #    1.    Start with the command line option.
         #    2.    Add in any (unique) paths from the extension
@@ -270,7 +276,8 @@ class build_ext(_build_ext.build_ext):
                     c_line_in_traceback = not no_c_in_traceback,
                     generate_pxi = pyrex_gen_pxi,
                     output_dir = output_dir,
-                    gdb_debug = pyrex_gdb)
+                    gdb_debug = pyrex_gdb,
+                    compile_time_env = pyrex_compile_time_env)
                 result = cython_compile(source, options=options,
                                         full_module_name=module_name)
             else:

--- a/Cython/Distutils/extension.py
+++ b/Cython/Distutils/extension.py
@@ -63,6 +63,7 @@ class Extension(_Extension.Extension):
             pyrex_gen_pxi = 0,
             pyrex_gdb = False,
             no_c_in_traceback = False,
+            pyrex_compile_time_env = None,
             **kw):
 
         _Extension.Extension.__init__(self, name, sources,
@@ -90,6 +91,7 @@ class Extension(_Extension.Extension):
         self.pyrex_gen_pxi = pyrex_gen_pxi
         self.pyrex_gdb = pyrex_gdb
         self.no_c_in_traceback = no_c_in_traceback
+        self.pyrex_compile_time_env = pyrex_compile_time_env
 
 # class Extension
 

--- a/tests/build/compile_env_distutils.srctree
+++ b/tests/build/compile_env_distutils.srctree
@@ -1,0 +1,23 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import a; import sys; sys.exit(a.compile_env_test())"
+
+######## setup.py ########
+
+from distutils.core import setup
+from Cython.Distutils.extension import Extension
+from Cython.Distutils import build_ext
+
+setup(
+  cmdclass = {'build_ext': build_ext},
+  ext_modules = [Extension(
+    "a", ["a.pyx"],
+    pyrex_compile_time_env = {'TEST': True},
+  )],
+)
+
+######## a.pyx ########
+def compile_env_test():
+    IF TEST:
+        return 0
+    ELSE:
+        return 1


### PR DESCRIPTION
This commit allows you to pass in variables for the conditional compilation
feature from distutils. This allows you to do fairly complex autoconf-type
checks from setup.py and pass the results in to the compiler.

This is an update to the change in ticket #323 here:
http://trac.cython.org/cython_trac/ticket/323
