### PR TITLE
Fix variable name in doc.

### DIFF
--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -226,7 +226,7 @@ and another module which uses it.::
 
     cdef Shrubbing.Shrubbery sh
     sh = Shrubbing.standard_shrubbery()
-    print "Shrubbery size is %d x %d" % (sh.width, sh.height)
+    print "Shrubbery size is %d x %d" % (sh.width, sh.length)
  
 Some things to note about this example:
 


### PR DESCRIPTION
Fix a mismatched variable name in the "Sharing Extention Types"
documentation.
