### PR TITLE
Specifying a custom main function with --embed= causes a TypeError

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -89,7 +89,7 @@ def parse_command_line(args):
             elif option == "--embed":
                 Options.embed = "main"
             elif option.startswith("--embed="):
-                Options.embed = options[8:]
+                Options.embed = option[8:]
             elif option.startswith("-I"):
                 options.include_path.append(get_param(option))
             elif option == "--include-dir":


### PR DESCRIPTION
There's currently a typo in the Cython.Compiler.CmdLine module that causes the cython script to error out with a TypeError. I think you guys are actively working on a new command-line interface, but I figured I'd commit this this anyways.

To replicate:

```
cython.py --embed=my_main cython.py
Traceback (most recent call last):
  File "C:\Development\scripting.py\interop\cython\cython2\cython.py", line 17, in <module>
    main(command_line = 1)
  File "C:\Development\scripting.py\interop\cython\cython2\Cython\Compiler\Main.py", line 642, in main
    options, sources = parse_command_line(args)
  File "C:\Development\scripting.py\interop\cython\cython2\Cython\Compiler\CmdLine.py", line 92, in parse_command_line
    Options.embed = options[8:]
TypeError: 'CompilationOptions' object is not subscriptable
```
