### PR TITLE
FIX: prevent missing cimport warning from cython.operator.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -348,7 +348,7 @@ class DependencyTree(object):
             self_pxd = []
         a = self.cimports(filename)
         b = filter(None, [self.find_pxd(m, filename) for m in self.cimports(filename)])
-        if len(a) - int('cython' in a) != len(b):
+        if len(a) - int('cython' in a) - int('cython.operator' in a) != len(b):
             print("missing cimport", filename)
             print("\n\t".join(a))
             print("\n\t".join(b))


### PR DESCRIPTION
`cython.operator` is not a real package, so `cythonize` cannot find
a corresponding `cython/operator.pxd` file.  We exclude this from the
count of cimports to avoid an irrelevant warning.
