### PR TITLE
Fix indentation of __Pyx_GetBuffer

### DIFF
--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -617,20 +617,21 @@ class GetAndReleaseBufferUtilityCode(object):
               #endif
             """))
         
+        code.level = 1
+        code.bol = 1
         if len(types) > 0:
             clause = "if"
             for t, get, release in types:
-                code.putln("  %s (PyObject_TypeCheck(obj, %s)) return %s(obj, view, flags);" % (clause, t, get))
+                code.putln("%s (PyObject_TypeCheck(obj, %s)) return %s(obj, view, flags);" % (clause, t, get))
                 clause = "else if"
-            code.putln("  else {")
-        code.put(dedent("""\
-            PyErr_Format(PyExc_TypeError, "'%100s' does not have the buffer interface", Py_TYPE(obj)->tp_name);
-            return -1;
-            """, 2))
+            code.putln("else {")
+        code.putln("""PyErr_Format(PyExc_TypeError, "'%100s' does not have the buffer interface", Py_TYPE(obj)->tp_name);""")
+        code.putln("return -1;")
         if len(types) > 0:
-            code.putln("  }")
+            code.putln("}")
+        code.level = 0
         code.put(dedent("""\
-             }
+            }
 
             static void __Pyx_ReleaseBuffer(Py_buffer *view) {
               PyObject* obj = view->obj;


### PR DESCRIPTION
The indentation in the generated C code for __Pyx_GetBuffer was all messed up.  The result is now properly indented C code, but I am not sure my fix is the correct way to use the code object.  It seems like a hack to set code.bol and code.indent manually.
