### PR TITLE
Change __Pyx_zeros and __Pyx_minusones scope to static.

### DIFF
--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -484,8 +484,8 @@ def use_bufstruct_declare_code(env):
 
 def get_empty_bufstruct_code(max_ndim):
     code = dedent("""
-        Py_ssize_t __Pyx_zeros[] = {%s};
-        Py_ssize_t __Pyx_minusones[] = {%s};
+        static Py_ssize_t __Pyx_zeros[] = {%s};
+        static Py_ssize_t __Pyx_minusones[] = {%s};
     """) % (", ".join(["0"] * max_ndim), ", ".join(["-1"] * max_ndim))
     return UtilityCode(proto=code)
 


### PR DESCRIPTION
Compiling two Cython modules (which use the Cython buffer interface) into a static Python binary results in a link error since the symbols `__Pyx_zeros` and `__Pyx_minusones` are exported multiple times.  Changing their scope to the current translation unit fixes the issue.
