### PR TITLE
FIX: prevent missing cimport warnings when using cythonize.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -346,9 +346,9 @@ class DependencyTree(object):
             self_pxd = [filename[:-4] + '.pxd']
         else:
             self_pxd = []
-        a = self.cimports(filename)
+        a = list(x for x in self.cimports(filename) if x.split('.')[0] != 'cython')
         b = filter(None, [self.find_pxd(m, filename) for m in self.cimports(filename)])
-        if len(a) - int('cython' in a) != len(b):
+        if len(a) != len(b):
             print("missing cimport", filename)
             print("\n\t".join(a))
             print("\n\t".join(b))


### PR DESCRIPTION
The `cython` package fakes several sub-modules, including
`cython.operator` and `cython.view`. Since the `cythonize` command
cannot find a corresponding pxd file for these modules, it prints
a warning. To fix this, we exclude all modules in the `cython`
namespace when checking for missing pxd files.

See #85 for a further discussion of this issue.
