### PR TITLE
Add "nogil" to the stdc++ pxd files

### DIFF
--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -3,17 +3,17 @@ from pair cimport pair
 cdef extern from "<deque>" namespace "std":
     cdef cppclass deque[T]:
         cppclass iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(iterator)
-            bint operator!=(iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
         cppclass reverse_iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(reverse_iterator)
-            bint operator!=(reverse_iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(reverse_iterator) nogil
+            bint operator!=(reverse_iterator) nogil
         #cppclass const_iterator(iterator):
         #    pass
         #cppclass const_reverse_iterator(reverse_iterator):
@@ -23,40 +23,40 @@ cdef extern from "<deque>" namespace "std":
         deque(size_t)
         deque(size_t, T&)
         #deque[input_iterator](input_iterator, input_iterator)
-        T& operator[](size_t)
+        T& operator[](size_t) nogil
         #deque& operator=(deque&)
-        bint operator==(deque&, deque&)
-        bint operator!=(deque&, deque&)
-        bint operator<(deque&, deque&)
-        bint operator>(deque&, deque&)
-        bint operator<=(deque&, deque&)
-        bint operator>=(deque&, deque&)
-        void assign(size_t, T&)
-        void assign(input_iterator, input_iterator)
-        T& at(size_t)
-        T& back()
-        iterator begin()
+        bint operator==(deque&, deque&) nogil
+        bint operator!=(deque&, deque&) nogil
+        bint operator<(deque&, deque&) nogil
+        bint operator>(deque&, deque&) nogil
+        bint operator<=(deque&, deque&) nogil
+        bint operator>=(deque&, deque&) nogil
+        void assign(size_t, T&) nogil
+        void assign(input_iterator, input_iterator) nogil
+        T& at(size_t) nogil
+        T& back() nogil
+        iterator begin() nogil
         #const_iterator begin()
-        void clear()
-        bint empty()
-        iterator end()
+        void clear() nogil
+        bint empty() nogil
+        iterator end() nogil
         #const_iterator end()
-        iterator erase(iterator)
-        iterator erase(iterator, iterator)
-        T& front()
-        iterator insert(iterator, T&)
-        void insert(iterator, size_t, T&)
-        void insert(iterator, input_iterator, input_iterator)
-        size_t max_size()
-        void pop_back()
-        void pop_front()
-        void push_back(T&)
-        void push_front(T&)
-        reverse_iterator rbegin()
+        iterator erase(iterator) nogil
+        iterator erase(iterator, iterator) nogil
+        T& front() nogil
+        iterator insert(iterator, T&) nogil
+        void insert(iterator, size_t, T&) nogil
+        void insert(iterator, input_iterator, input_iterator) nogil
+        size_t max_size() nogil
+        void pop_back() nogil
+        void pop_front() nogil
+        void push_back(T&) nogil
+        void push_front(T&) nogil
+        reverse_iterator rbegin() nogil
         #const_reverse_iterator rbegin()
-        reverse_iterator rend()
+        reverse_iterator rend() nogil
         #const_reverse_iterator rend()
-        void resize(size_t)
-        void resize(size_t, T&)
-        size_t size()
-        void swap(deque&)
+        void resize(size_t) nogil
+        void resize(size_t, T&) nogil
+        size_t size() nogil
+        void swap(deque&) nogil

--- a/Cython/Includes/libcpp/list.pxd
+++ b/Cython/Includes/libcpp/list.pxd
@@ -1,17 +1,17 @@
 cdef extern from "<list>" namespace "std":
     cdef cppclass list[T]:
         cppclass iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(iterator)
-            bint operator!=(iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
         cppclass reverse_iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(reverse_iterator)
-            bint operator!=(reverse_iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(reverse_iterator) nogil
+            bint operator!=(reverse_iterator) nogil
         #cppclass const_iterator(iterator):
         #    pass
         #cppclass const_reverse_iterator(reverse_iterator):
@@ -20,46 +20,46 @@ cdef extern from "<list>" namespace "std":
         list(list&)
         list(size_t, T&)
         #list operator=(list&)
-        bint operator==(list&, list&)
-        bint operator!=(list&, list&)
-        bint operator<(list&, list&)
-        bint operator>(list&, list&)
-        bint operator<=(list&, list&)
-        bint operator>=(list&, list&)
-        void assign(size_t, T&)
-        T& back()
-        iterator begin()
+        bint operator==(list&, list&) nogil
+        bint operator!=(list&, list&) nogil
+        bint operator<(list&, list&) nogil
+        bint operator>(list&, list&) nogil
+        bint operator<=(list&, list&) nogil
+        bint operator>=(list&, list&) nogil
+        void assign(size_t, T&) nogil
+        T& back() nogil
+        iterator begin() nogil
         #const_iterator begin()
-        void clear()
-        bint empty()
-        iterator end()
+        void clear() nogil
+        bint empty() nogil
+        iterator end() nogil
         #const_iterator end()
-        iterator erase(iterator)
-        iterator erase(iterator, iterator)
-        T& front()
-        iterator insert(iterator, T&)
-        void insert(iterator, size_t, T&)
-        size_t max_size()
-        void merge(list&)
+        iterator erase(iterator) nogil
+        iterator erase(iterator, iterator) nogil
+        T& front() nogil
+        iterator insert(iterator, T&) nogil
+        void insert(iterator, size_t, T&) nogil
+        size_t max_size() nogil
+        void merge(list&) nogil
         #void merge(list&, BinPred)
-        void pop_back()
-        void pop_front()
-        void push_back(T&)
-        void push_front(T&)
-        reverse_iterator rbegin()
+        void pop_back() nogil
+        void pop_front() nogil
+        void push_back(T&) nogil
+        void push_front(T&) nogil
+        reverse_iterator rbegin() nogil
         #const_reverse_iterator rbegin()
-        void remove(T&)
+        void remove(T&) nogil
         #void remove_if(UnPred)
-        reverse_iterator rend()
+        reverse_iterator rend() nogil
         #const_reverse_iterator rend()
-        void resize(size_t, T&)
-        void reverse()
-        size_t size()
-        void sort()
+        void resize(size_t, T&) nogil
+        void reverse() nogil
+        size_t size() nogil
+        void sort() nogil
         #void sort(BinPred)
-        void splice(iterator, list&)
-        void splice(iterator, list&, iterator)
-        void splice(iterator, list&, iterator, iterator)
-        void swap(list&)
-        void unique()
+        void splice(iterator, list&) nogil
+        void splice(iterator, list&, iterator) nogil
+        void splice(iterator, list&, iterator, iterator) nogil
+        void swap(list&) nogil
+        void unique() nogil
         #void unique(BinPred)

--- a/Cython/Includes/libcpp/map.pxd
+++ b/Cython/Includes/libcpp/map.pxd
@@ -3,17 +3,17 @@ from utility cimport pair
 cdef extern from "<map>" namespace "std":
     cdef cppclass map[T, U]:
         cppclass iterator:
-            pair[T,U]& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(iterator)
-            bint operator!=(iterator)
+            pair[T, U]& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
         cppclass reverse_iterator:
-            pair[T,U]& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(reverse_iterator)
-            bint operator!=(reverse_iterator)
+            pair[T, U]& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(reverse_iterator) nogil
+            bint operator!=(reverse_iterator) nogil
         #cppclass const_iterator(iterator):
         #    pass
         #cppclass const_reverse_iterator(reverse_iterator):
@@ -21,42 +21,42 @@ cdef extern from "<map>" namespace "std":
         map()
         map(map&)
         #map(key_compare&)
-        U& operator[](T&)
+        U& operator[](T&) nogil
         #map& operator=(map&)
-        bint operator==(map&, map&)
-        bint operator!=(map&, map&)
-        bint operator<(map&, map&)
-        bint operator>(map&, map&)
-        bint operator<=(map&, map&)
-        bint operator>=(map&, map&)
-        U& at(T&)
-        iterator begin()
+        bint operator==(map&, map&) nogil
+        bint operator!=(map&, map&) nogil
+        bint operator<(map&, map&) nogil
+        bint operator>(map&, map&) nogil
+        bint operator<=(map&, map&) nogil
+        bint operator>=(map&, map&) nogil
+        U& at(T&) nogil
+        iterator begin() nogil
         #const_iterator begin()
-        void clear()
-        size_t count(T&)
-        bint empty()
-        iterator end()
+        void clear() nogil
+        size_t count(T&) nogil
+        bint empty() nogil
+        iterator end() nogil
         #const_iterator end()
-        pair[iterator, iterator] equal_range(T&)
+        pair[iterator, iterator] equal_range(T&) nogil
         #pair[const_iterator, const_iterator] equal_range(key_type&)
-        void erase(iterator)
-        void erase(iterator, iterator)
-        size_t erase(T&)
-        iterator find(T&)
+        void erase(iterator) nogil
+        void erase(iterator, iterator) nogil
+        size_t erase(T&) nogil
+        iterator find(T&) nogil
         #const_iterator find(key_type&)
-        pair[iterator, bint] insert(pair[T,U]) # XXX pair[T,U]&
-        iterator insert(iterator, pair[T,U]) # XXX pair[T,U]&
+        pair[iterator, bint] insert(pair[T, U]) nogil # XXX pair[T,U]&
+        iterator insert(iterator, pair[T, U]) nogil # XXX pair[T,U]&
         #void insert(input_iterator, input_iterator)
         #key_compare key_comp()
-        iterator lower_bound(T&)
+        iterator lower_bound(T&) nogil
         #const_iterator lower_bound(key_type&)
-        size_t max_size()
-        reverse_iterator rbegin()
+        size_t max_size() nogil
+        reverse_iterator rbegin() nogil
         #const_reverse_iterator rbegin()
-        reverse_iterator rend()
+        reverse_iterator rend() nogil
         #const_reverse_iterator rend()
-        size_t size()
-        void swap(map&)
-        iterator upper_bound(T&)
+        size_t size() nogil
+        void swap(map&) nogil
+        iterator upper_bound(T&) nogil
         #const_iterator upper_bound(key_type&)
         #value_compare value_comp()

--- a/Cython/Includes/libcpp/queue.pxd
+++ b/Cython/Includes/libcpp/queue.pxd
@@ -3,18 +3,18 @@ cdef extern from "<queue>" namespace "std":
         queue()
         queue(queue&)
         #queue(Container&)
-        T& back()
-        bint empty()
-        T& front()
-        void pop()
-        void push(T&)
-        size_t size()
+        T& back() nogil
+        bint empty() nogil
+        T& front() nogil
+        void pop() nogil
+        void push(T&) nogil
+        size_t size() nogil
     cdef cppclass priority_queue[T]:
         priority_queue()
         priority_queue(priority_queue&)
         #priority_queue(Container&)
-        bint empty()
-        void pop()
-        void push(T&)
-        size_t size()
-        T& top()
+        bint empty() nogil
+        void pop() nogil
+        void push(T&) nogil
+        size_t size() nogil
+        T& top() nogil

--- a/Cython/Includes/libcpp/set.pxd
+++ b/Cython/Includes/libcpp/set.pxd
@@ -4,57 +4,57 @@ cdef extern from "<set>" namespace "std":
     cdef cppclass set[T]:
         cppclass iterator:
             T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(iterator)
-            bint operator!=(iterator)
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
         cppclass reverse_iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(reverse_iterator)
-            bint operator!=(reverse_iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(reverse_iterator) nogil
+            bint operator!=(reverse_iterator) nogil
         #cppclass const_iterator(iterator):
         #    pass
         #cppclass const_reverse_iterator(reverse_iterator):
         #    pass
-        set()
-        set(set&)
+        set() nogil
+        set(set&) nogil
         #set(key_compare&)
         #set& operator=(set&)
-        bint operator==(set&, set&)
-        bint operator!=(set&, set&)
-        bint operator<(set&, set&)
-        bint operator>(set&, set&)
-        bint operator<=(set&, set&)
-        bint operator>=(set&, set&)
-        iterator begin()
+        bint operator==(set&, set&) nogil
+        bint operator!=(set&, set&) nogil
+        bint operator<(set&, set&) nogil
+        bint operator>(set&, set&) nogil
+        bint operator<=(set&, set&) nogil
+        bint operator>=(set&, set&) nogil
+        iterator begin() nogil
         #const_iterator begin()
-        void clear()
-        size_t count(T&)
-        bint empty()
-        iterator end()
+        void clear() nogil
+        size_t count(T&) nogil
+        bint empty() nogil
+        iterator end() nogil
         #const_iterator end()
-        pair[iterator, iterator] equal_range(T&)
+        pair[iterator, iterator] equal_range(T&) nogil
         #pair[const_iterator, const_iterator] equal_range(T&)
-        void erase(iterator)
-        void erase(iterator, iterator)
-        size_t erase(T&)
-        iterator find(T&)
+        void erase(iterator) nogil
+        void erase(iterator, iterator) nogil
+        size_t erase(T&) nogil
+        iterator find(T&) nogil
         #const_iterator find(T&)
-        pair[iterator, bint] insert(T&)
-        iterator insert(iterator, T&)
+        pair[iterator, bint] insert(T&) nogil
+        iterator insert(iterator, T&) nogil
         #void insert(input_iterator, input_iterator)
         #key_compare key_comp()
-        iterator lower_bound(T&)
+        iterator lower_bound(T&) nogil
         #const_iterator lower_bound(T&)
-        size_t max_size()
-        reverse_iterator rbegin()
+        size_t max_size() nogil
+        reverse_iterator rbegin() nogil
         #const_reverse_iterator rbegin()
-        reverse_iterator rend()
+        reverse_iterator rend() nogil
         #const_reverse_iterator rend()
-        size_t size()
-        void swap(set&)
-        iterator upper_bound(T&)
+        size_t size() nogil
+        void swap(set&) nogil
+        iterator upper_bound(T&) nogil
         #const_iterator upper_bound(T&)
         #value_compare value_comp()

--- a/Cython/Includes/libcpp/stack.pxd
+++ b/Cython/Includes/libcpp/stack.pxd
@@ -3,8 +3,8 @@ cdef extern from "<stack>" namespace "std":
         stack()
         stack(stack&)
         #stack(Container&)
-        bint empty()
-        void pop()
-        void push(T&)
-        size_t size()
-        T& top()
+        bint empty() nogil
+        void pop() nogil
+        void push(T&) nogil
+        size_t size() nogil
+        T& top() nogil

--- a/Cython/Includes/libcpp/string.pxd
+++ b/Cython/Includes/libcpp/string.pxd
@@ -1,4 +1,3 @@
-
 cdef extern from "<string>" namespace "std":
 
     size_t npos = -1
@@ -11,104 +10,104 @@ cdef extern from "<string>" namespace "std":
         # as a string formed by a repetition of character c, n times.
         string(size_t, char)
 
-        char* c_str()
-        size_t size()
-        size_t max_size()
-        size_t length()
-        void resize(size_t)
-        void resize(size_t, char c)
-        size_t capacity()
-        void reserve(size_t)
-        void clear()
-        bint empty()
+        char* c_str() nogil
+        size_t size() nogil
+        size_t max_size() nogil
+        size_t length() nogil
+        void resize(size_t) nogil
+        void resize(size_t, char c) nogil
+        size_t capacity() nogil
+        void reserve(size_t) nogil
+        void clear() nogil
+        bint empty() nogil
 
-        char& at(size_t)
-        char& operator[](size_t)
-        int compare(string&)
+        char& at(size_t) nogil
+        char& operator[](size_t) nogil
+        int compare(string&) nogil
 
-        string& append(string&)
-        string& append(string&, size_t, size_t)
-        string& append(char *)
-        string& append(char *, size_t)
-        string& append(size_t, char)
+        string& append(string&) nogil
+        string& append(string&, size_t, size_t) nogil
+        string& append(char *) nogil
+        string& append(char *, size_t) nogil
+        string& append(size_t, char) nogil
 
-        void push_back(char c)
+        void push_back(char c) nogil
 
-        string& assign (string&)
-        string& assign (string&, size_t, size_t)
-        string& assign (char *, size_t)
-        string& assign (char *)
-        string& assign (size_t n, char c)
+        string& assign (string&) nogil
+        string& assign (string&, size_t, size_t) nogil
+        string& assign (char *, size_t) nogil
+        string& assign (char *) nogil
+        string& assign (size_t n, char c) nogil
 
-        string& insert(size_t, string&)
-        string& insert(size_t, string&, size_t, size_t)
-        string& insert(size_t, char* s, size_t)
+        string& insert(size_t, string&) nogil
+        string& insert(size_t, string&, size_t, size_t) nogil
+        string& insert(size_t, char* s, size_t) nogil
 
 
-        string& insert(size_t, char* s)
-        string& insert(size_t, size_t, char c)
+        string& insert(size_t, char* s) nogil
+        string& insert(size_t, size_t, char c) nogil
 
-        size_t copy(char *, size_t, size_t)
+        size_t copy(char *, size_t, size_t) nogil
 
-        size_t find(string&)
-        size_t find(string&, size_t)
-        size_t find(char*, size_t pos, size_t)
-        size_t find(char*, size_t pos)
-        size_t find(char, size_t pos)
+        size_t find(string&) nogil
+        size_t find(string&, size_t) nogil
+        size_t find(char*, size_t pos, size_t) nogil
+        size_t find(char*, size_t pos) nogil
+        size_t find(char, size_t pos) nogil
 
-        size_t rfind(string&, size_t)
-        size_t rfind(char* s, size_t, size_t)
-        size_t rfind(char*, size_t pos)
-        size_t rfind(char c, size_t)
-        size_t rfind(char c)
+        size_t rfind(string&, size_t) nogil
+        size_t rfind(char* s, size_t, size_t) nogil
+        size_t rfind(char*, size_t pos) nogil
+        size_t rfind(char c, size_t) nogil
+        size_t rfind(char c) nogil
 
-        size_t find_first_of(string&, size_t)
-        size_t find_first_of(char* s, size_t, size_t)
-        size_t find_first_of(char*, size_t pos)
-        size_t find_first_of(char c, size_t)
-        size_t find_first_of(char c)
+        size_t find_first_of(string&, size_t) nogil
+        size_t find_first_of(char* s, size_t, size_t) nogil
+        size_t find_first_of(char*, size_t pos) nogil
+        size_t find_first_of(char c, size_t) nogil
+        size_t find_first_of(char c) nogil
 
-        size_t find_first_not_of(string&, size_t)
-        size_t find_first_not_of(char* s, size_t, size_t)
-        size_t find_first_not_of(char*, size_t pos)
-        size_t find_first_not_of(char c, size_t)
-        size_t find_first_not_of(char c)
+        size_t find_first_not_of(string&, size_t) nogil
+        size_t find_first_not_of(char* s, size_t, size_t) nogil
+        size_t find_first_not_of(char*, size_t pos) nogil
+        size_t find_first_not_of(char c, size_t) nogil
+        size_t find_first_not_of(char c) nogil
 
-        size_t find_last_of(string&, size_t)
-        size_t find_last_of(char* s, size_t, size_t)
-        size_t find_last_of(char*, size_t pos)
-        size_t find_last_of(char c, size_t)
-        size_t find_last_of(char c)
+        size_t find_last_of(string&, size_t) nogil
+        size_t find_last_of(char* s, size_t, size_t) nogil
+        size_t find_last_of(char*, size_t pos) nogil
+        size_t find_last_of(char c, size_t) nogil
+        size_t find_last_of(char c) nogil
 
-        size_t find_last_not_of(string&, size_t)
-        size_t find_last_not_of(char* s, size_t, size_t)
-        size_t find_last_not_of(char*, size_t pos)
+        size_t find_last_not_of(string&, size_t) nogil
+        size_t find_last_not_of(char* s, size_t, size_t) nogil
+        size_t find_last_not_of(char*, size_t pos) nogil
 
-        string substr(size_t, size_t)
-        string substr()
-        string substr(size_t)
+        string substr(size_t, size_t) nogil
+        string substr() nogil
+        string substr(size_t) nogil
 
-        size_t find_last_not_of(char c, size_t)
-        size_t find_last_not_of(char c)
+        size_t find_last_not_of(char c, size_t) nogil
+        size_t find_last_not_of(char c) nogil
 
         #string& operator= (string&)
         #string& operator= (char*)
         #string& operator= (char)
 
-        bint operator==(string&)
-        bint operator==(char*)
+        bint operator==(string&) nogil
+        bint operator==(char*) nogil
 
-        bint operator!= (string& rhs )
-        bint operator!= (char* )
+        bint operator!= (string& rhs ) nogil
+        bint operator!= (char* ) nogil
 
-        bint operator< (string&)
-        bint operator< (char*)
+        bint operator< (string&) nogil
+        bint operator< (char*) nogil
 
-        bint operator> (string&)
-        bint operator> (char*)
+        bint operator> (string&) nogil
+        bint operator> (char*) nogil
 
-        bint operator<= (string&)
-        bint operator<= (char*)
+        bint operator<= (string&) nogil
+        bint operator<= (char*) nogil
 
-        bint operator>= (string&)
-        bint operator>= (char*)
+        bint operator>= (string&) nogil
+        bint operator>= (char*) nogil

--- a/Cython/Includes/libcpp/utility.pxd
+++ b/Cython/Includes/libcpp/utility.pxd
@@ -5,9 +5,9 @@ cdef extern from "<utility>" namespace "std":
         pair()
         pair(pair&)
         pair(T&, U&)
-        bint operator==(pair&, pair&)
-        bint operator!=(pair&, pair&)
-        bint operator<(pair&, pair&)
-        bint operator>(pair&, pair&)
-        bint operator<=(pair&, pair&)
-        bint operator>=(pair&, pair&)
+        bint operator==(pair&, pair&) nogil
+        bint operator!=(pair&, pair&) nogil
+        bint operator<(pair&, pair&) nogil
+        bint operator>(pair&, pair&) nogil
+        bint operator<=(pair&, pair&) nogil
+        bint operator>=(pair&, pair&) nogil

--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -1,68 +1,68 @@
 cdef extern from "<vector>" namespace "std":
     cdef cppclass vector[T]:
         cppclass iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(iterator)
-            bint operator!=(iterator)
-            bint operator<(iterator)
-            bint operator>(iterator)
-            bint operator<=(iterator)
-            bint operator>=(iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
+            bint operator<(iterator) nogil
+            bint operator>(iterator) nogil
+            bint operator<=(iterator) nogil
+            bint operator>=(iterator) nogil
         cppclass reverse_iterator:
-            T& operator*()
-            iterator operator++()
-            iterator operator--()
-            bint operator==(reverse_iterator)
-            bint operator!=(reverse_iterator)
-            bint operator<(reverse_iterator)
-            bint operator>(reverse_iterator)
-            bint operator<=(reverse_iterator)
-            bint operator>=(reverse_iterator)
+            T& operator*() nogil
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(reverse_iterator) nogil
+            bint operator!=(reverse_iterator) nogil
+            bint operator<(reverse_iterator) nogil
+            bint operator>(reverse_iterator) nogil
+            bint operator<=(reverse_iterator) nogil
+            bint operator>=(reverse_iterator) nogil
         #cppclass const_iterator(iterator):
         #    pass
         #cppclass const_reverse_iterator(reverse_iterator):
         #    pass
         vector()
-        vector(vector&)
-        vector(size_t)
-        vector(size_t, T&)
+        vector(vector&) nogil
+        vector(size_t) nogil
+        vector(size_t, T&) nogil
         #vector[input_iterator](input_iterator, input_iterator)
-        T& operator[](size_t)
+        T& operator[](size_t) nogil
         #vector& operator=(vector&)
-        bint operator==(vector&, vector&)
-        bint operator!=(vector&, vector&)
-        bint operator<(vector&, vector&)
-        bint operator>(vector&, vector&)
-        bint operator<=(vector&, vector&)
-        bint operator>=(vector&, vector&)
-        void assign(size_t, T&)
+        bint operator==(vector&, vector&) nogil
+        bint operator!=(vector&, vector&) nogil
+        bint operator<(vector&, vector&) nogil
+        bint operator>(vector&, vector&) nogil
+        bint operator<=(vector&, vector&) nogil
+        bint operator>=(vector&, vector&) nogil
+        void assign(size_t, T&) nogil
         #void assign[input_iterator](input_iterator, input_iterator)
-        T& at(size_t)
-        T& back()
-        iterator begin()
+        T& at(size_t) nogil
+        T& back() nogil
+        iterator begin() nogil
         #const_iterator begin()
-        size_t capacity()
-        void clear()
-        bint empty()
-        iterator end()
+        size_t capacity() nogil
+        void clear() nogil
+        bint empty() nogil
+        iterator end() nogil
         #const_iterator end()
-        iterator erase(iterator)
-        iterator erase(iterator, iterator)
-        T& front()
-        iterator insert(iterator, T&)
-        void insert(iterator, size_t, T&)
-        void insert(iterator, iterator, iterator)
-        size_t max_size()
-        void pop_back()
-        void push_back(T&)
-        reverse_iterator rbegin()
+        iterator erase(iterator) nogil
+        iterator erase(iterator, iterator) nogil
+        T& front() nogil
+        iterator insert(iterator, T&) nogil
+        void insert(iterator, size_t, T&) nogil
+        void insert(iterator, iterator, iterator) nogil
+        size_t max_size() nogil
+        void pop_back() nogil
+        void push_back(T&) nogil
+        reverse_iterator rbegin() nogil
         #const_reverse_iterator rbegin()
-        reverse_iterator rend()
+        reverse_iterator rend() nogil
         #const_reverse_iterator rend()
-        void reserve(size_t)
-        void resize(size_t)
-        void resize(size_t, T&)
-        size_t size()
-        void swap(vector&)
+        void reserve(size_t) nogil
+        void resize(size_t) nogil
+        void resize(size_t, T&) nogil
+        size_t size() nogil
+        void swap(vector&) nogil


### PR DESCRIPTION
A global "nogil" did not work in the include ...
I had to specify it for each method.
