### PR TITLE
construct 'lnotab' byte string for code objects

### DIFF
--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -149,7 +149,7 @@ def create_pipeline(context, mode, exclude_classes=()):
     from .ParseTreeTransforms import CalculateQualifiedNamesTransform, ReplacePropertyNode
     from .TypeInference import MarkParallelAssignments, MarkOverflowingArithmetic
     from .ParseTreeTransforms import AdjustDefByDirectives, AlignFunctionDefinitions
-    from .ParseTreeTransforms import RemoveUnreachableCode, GilCheck
+    from .ParseTreeTransforms import RemoveUnreachableCode, CreateLineNumberMaps, GilCheck
     from .FlowControl import ControlFlowAnalysis
     from .AnalysedTreeTransforms import AutoTestDictTransform
     from .AutoDocTransforms import EmbedSignature
@@ -221,6 +221,7 @@ def create_pipeline(context, mode, exclude_classes=()):
         DropRefcountingTransform(),
         FinalOptimizePhase(context),
         GilCheck(),
+        CreateLineNumberMaps(context),
         ]
     filtered_stages = []
     for s in stages:


### PR DESCRIPTION
The intention of this change is to eventually be able to support runtime mapping of line numbers for code objects. What CPython does is to pack a byte code offset to line number offset map into a byte string and store it in the code object. This is what this patch does as well, so that the line number could be computed by CPython by simply using `current source line  -  first source line of function` as a fake byte code offset for Cython functions when tracing or raising an exception. This will allow reuse of the code object over the whole body of a function.

A current problem is the syntax tree layout for Cython functions that have a code object. Here, the code object lives outside of the function, specifically in the fused functions object. It would be better to move it inside of the function itself, where the function code could use it. This is not entirely trivial because the fused function code currently reuses one code object for all specialisations, which doesn't work well with the idea of letting each separate function own it.

By itself, this patch isn't very interesting because Cython does not currently use byte code offsets in frame objects. But it's the first non-trivial step in that direction and should be applied at some point before refactoring the syntax tree.
