### PR TITLE
Ignore byte compiled elisp modules in the repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ Cython/Compiler/*.c
 Cython/Plex/*.c
 Cython/Runtime/refnanny.c
 
+Tools/*.elc
+
 BUILD/
 build/
 !tests/build/


### PR DESCRIPTION
- When cython.git is included as a submodule in an
  Emacs configuration to load cython-mode.el and is
  byte-compiled, it generates an .elc file which causes
  the submodule to appear dirty unnecessarily in the parent
  git repository. Adding this rule will avoid dirty submodules.

Signed-off-by: Yesudeep Mangalapilly yesudeep@google.com
