### PR TITLE
Stopgap solution for NumPy 1.7 API changes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4428,6 +4428,17 @@ class AttributeNode(ExprNode):
                     # method of an extension type, so we treat it like a Python
                     # attribute.
                     pass
+        # NumPy hack
+        if obj_type.is_extension_type and obj_type.objstruct_cname == 'PyArrayObject':
+            from NumpySupport import numpy_transform_attribute_node
+            replacement_node = numpy_transform_attribute_node(self)
+            # Since we can't actually replace our node yet, we only grasp its
+            # type, and then the replacement happens in
+            # AnalyseExpresssionsTransform...
+            self.type = replacement_node.type
+            if replacement_node is not self:
+                return
+        
         # If we get here, the base object is not a struct/union/extension
         # type, or it is an extension type and the attribute is either not
         # declared or is declared as a Python method. Treat it as a Python

--- a/Cython/Compiler/NumpySupport.py
+++ b/Cython/Compiler/NumpySupport.py
@@ -1,0 +1,56 @@
+# The hacks that are specific for NumPy. These were introduced because
+# the NumPy ABI changed so that the shape, ndim, strides, etc. fields were
+# no longer available, however the use of these were so entrenched in
+# Cython codes
+
+import PyrexTypes
+import ExprNodes
+from StringEncoding import EncodedString
+
+
+def numpy_transform_attribute_node(node):
+    assert isinstance(node, ExprNodes.AttributeNode)
+
+    if node.obj.type.objstruct_cname != 'PyArrayObject':
+        return node
+
+    pos = node.pos
+    numpy_pxd_scope = node.obj.entry.type.scope.parent_scope
+        
+    def macro_call_node(numpy_macro_name):
+        array_node = node.obj
+        func_entry = numpy_pxd_scope.entries[numpy_macro_name]
+        function_name_node = ExprNodes.NameNode(
+            name=EncodedString(numpy_macro_name),
+            pos=pos,
+            entry=func_entry,
+            is_called=1,
+            type=func_entry.type,
+            cf_maybe_null=False,
+            cf_is_null=False)
+        
+        call_node = ExprNodes.SimpleCallNode(
+            pos=pos,
+            function=function_name_node,
+            name=EncodedString(numpy_macro_name),
+            args=[array_node],
+            type=func_entry.type.return_type,
+            analysed=True)
+        return call_node
+        
+    
+    if node.attribute == u'ndim':
+        result = macro_call_node(u'PyArray_NDIM')
+    elif node.attribute == u'data':
+        call_node = macro_call_node(u'PyArray_DATA')
+        cast_node = ExprNodes.TypecastNode(pos,
+                                           type=PyrexTypes.c_char_ptr_type,
+                                           operand=call_node)
+        result = cast_node
+    elif node.attribute == u'shape':
+        result = macro_call_node(u'PyArray_DIMS')
+    elif node.attribute == u'strides':
+        result = macro_call_node(u'PyArray_STRIDES')
+    else:
+        result = node
+    return result

--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -188,6 +188,7 @@ def create_pipeline(context, mode, exclude_classes=()):
         _check_c_declarations,
         InlineDefNodeCalls(context),
         AnalyseExpressionsTransform(context),
+        # AnalyseExpressionsTransform also contains the NumPy-specific support
         FindInvalidUseOfFusedTypes(context),
         CreateClosureClasses(context),  ## After all lookups and type inference
         ExpandInplaceOperators(context),

--- a/tests/run/numpy_attributes.pyx
+++ b/tests/run/numpy_attributes.pyx
@@ -1,0 +1,45 @@
+# tag: numpy
+
+
+import numpy as np
+cimport numpy as np
+
+
+def f():
+    """
+    >>> f()
+    ndim 2
+    data 1
+    shape 3 2
+    shape[1] 2
+    strides 16 8
+    """
+    cdef np.ndarray x = np.ones((3, 2), dtype=np.int64)
+    cdef int i
+    cdef Py_ssize_t j, k
+    cdef char *p
+    # todo: int * p: 23:13: Cannot assign type 'char *' to 'int *'
+
+    with nogil:
+        i = x.ndim
+    print 'ndim', i
+    
+    with nogil:
+        p = x.data
+    print 'data', (<np.int64_t*>p)[0]
+
+    with nogil:
+        j = x.shape[0]
+        k = x.shape[1]
+    print 'shape', j, k
+    # Check that non-typical uses still work
+    cdef np.npy_intp *shape
+    with nogil:
+        shape = x.shape + 1
+    print 'shape[1]', shape[0]
+
+    with nogil:
+        j = x.strides[0]
+        k = x.strides[1]
+    print 'strides', j, k
+    


### PR DESCRIPTION
NumPy is starting to seriously deprecating access to the member fields
in an ndarray (it was always frowned upon, but now it is starting to
become enforced). To support the large body of Cython code out there
accessing these fields (arr.shape[0] and so on), we special-case
PyArrayObject in Cython, with special knowledge of the NumPy API.

Ideally, we may introduce features in Cython in the future that allows
specifying this kind of magic with syntax in pxd files, and then we can
move away from special-casing NumPy.

PS. This may not yet have been tested with enough versions of NumPy, though a beta is a good way to find out...
