### PR TITLE
 openmp lion fix

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1903,6 +1903,26 @@ class CCodeWriter(object):
         self.putln(string)
         self.putln("#endif /* _OPENMP */")
 
+    def undef_builtin_expect(self, cond):
+        """
+        Redefine the macros likely() and unlikely to no-ops, depending on
+        condition 'cond'
+        """
+        self.putln("#if %s" % cond)
+        self.putln("    #undef likely")
+        self.putln("    #undef unlikely")
+        self.putln("    #define likely(x)   (x)")
+        self.putln("    #define unlikely(x) (x)")
+        self.putln("#endif")
+
+    def redef_builtin_expect(self, cond):
+        self.putln("#if %s" % cond)
+        self.putln("    #undef likely")
+        self.putln("    #undef unlikely")
+        self.putln("    #define likely(x)   __builtin_expect(!!(x), 1)")
+        self.putln("    #define unlikely(x) __builtin_expect(!!(x), 0)")
+        self.putln("#endif")
+
 class PyrexCodeWriter(object):
     # f                file      output file
     # level            int       indentation level

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7737,21 +7737,11 @@ class ParallelStatNode(StatNode, ParallelNode):
         A bug on OS X Lion disallows __builtin_expect macros. This code avoids them
         """
         if not self.parent:
-            code.putln("#if %s" % self.redef_condition)
-            code.putln("    #undef likely")
-            code.putln("    #undef unlikely")
-            code.putln("    #define likely(x)   (x)")
-            code.putln("    #define unlikely(x) (x)")
-            code.putln("#endif")
+            code.undef_builtin_expect(self.redef_condition)
 
     def redef_builtin_expect_apple_gcc_bug(self, code):
         if not self.parent:
-            code.putln("#if %s" % self.redef_condition)
-            code.putln("    #undef likely")
-            code.putln("    #undef unlikely")
-            code.putln("    #define likely(x)   __builtin_expect(!!(x), 1)")
-            code.putln("    #define unlikely(x) __builtin_expect(!!(x), 0)")
-            code.putln("#endif")
+            code.redef_builtin_expect(self.redef_condition)
 
 
 class ParallelWithBlockNode(ParallelStatNode):


### PR DESCRIPTION
The workaround for __builtin_expect on OS X Lion in parallel code sections.
