### PR TITLE
Fix -Wreserved-user-defined-literal error in C++11.

### DIFF
--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -802,7 +802,7 @@ static CYTHON_INLINE int __Pyx_GetBufferAndValidate(
   }
   if ((unsigned)buf->itemsize != dtype->size) {
     PyErr_Format(PyExc_ValueError,
-      "Item size of buffer (%"PY_FORMAT_SIZE_T"d byte%s) does not match size of '%s' (%"PY_FORMAT_SIZE_T"d byte%s)",
+      "Item size of buffer (%" PY_FORMAT_SIZE_T "d byte%s) does not match size of '%s' (%" PY_FORMAT_SIZE_T "d byte%s)",
       buf->itemsize, (buf->itemsize > 1) ? "s" : "",
       dtype->name, (Py_ssize_t)dtype->size, (dtype->size > 1) ? "s" : "");
     goto fail;


### PR DESCRIPTION
Fixes the following error in `clang++ -std=c++11`:

```
error: invalid suffix on literal; C++11 requires a space between literal and identifier
          [-Wreserved-user-defined-literal]
          "Item size of buffer (%"PY_FORMAT_SIZE_T"d byte%s) does not match size of '%s' (%"PY_FORMAT_SIZE_T"d byte%s)",
                                  ^
```
