### PR TITLE
Fix "missing cimport: ... cython" warning.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -378,7 +378,7 @@ class DependencyTree(object):
         else:
             pxd_list = []
         for module in self.cimports(filename):
-            if module[:7] == 'cython.':
+            if module[:7] == 'cython.' or module == 'cython':
                 continue
             pxd_file = self.find_pxd(module, filename)
             if pxd_file is None:


### PR DESCRIPTION
To reproduce:

```
$ echo "cimport cython" > a.pyx
$ python -c "from Cython.Build import cythonize; cythonize(['a.pyx'])"
missing cimport: a.pyx
cython
Compiling a.pyx because it changed.
Cythonizing a.pyx
```
