### PR TITLE
add CYTHON_CACHE_DIR env

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -96,7 +96,7 @@ def safe_type(arg, context=None):
 
 def cython_inline(code,
                   get_type=unsafe_type,
-                  lib_dir=get_cython_cache_dir(),
+                  lib_dir=os.path.join(get_cython_cache_dir(), 'inline'),
                   cython_include_dirs=['.'],
                   force=False,
                   quiet=False,

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -374,7 +374,7 @@ def get_cython_cache_dir():
     1. CYTHON_CACHE_DIR
     2. (OS X): ~/Library/Caches/Cython
        (posix not OS X): XDG_CACHE_HOME/cython if XDG_CACHE_HOME defined
-    3. ~/.cython/inline
+    3. ~/.cython
 
     """
     if 'CYTHON_CACHE_DIR' in os.environ:
@@ -392,4 +392,4 @@ def get_cython_cache_dir():
         return os.path.join(parent, 'cython')
 
     # last fallback: ~/.cython/inline
-    return os.path.expanduser(os.path.join('~', '.cython', 'inline'))
+    return os.path.expanduser(os.path.join('~', '.cython'))


### PR DESCRIPTION
resolution for the Cython cache dir:
1. CYTHON_CACHE_DIR env if defined
2. platform cache dir
   - (OS X): ~/Library/Caches/Cython if ~/Library/Caches exists
   - (posix not OS X): XDG_CACHE_HOME/cython if XDG_CACHE_HOME defined
3. ~/.cython

Possible alterations:
- This only uses XDG_CACHE_HOME if it is defined, rather than using its default interpretation of '~/.cache', which is an easy change.
- I'd be happy to add a Windows-appropriate cache dir if anyone knows of one and/or cares.
- skip the platform cache dirs, and just do CYTHON_CACHE_DIR or ~/.cython

per [ML discussion](https://groups.google.com/forum/?fromgroups#!topic/cython-users/FonB2n_2l8c)
