### PR TITLE
Fixed a vcvarsall.bat error on win32/Py2.7 when trying to compile with mingw.

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -178,9 +178,9 @@ def __invoke(%(params)s):
             include_dirs = c_include_dirs,
             extra_compile_args = cflags)
         dist = Distribution()
+        # Ensure the build respects distutils configuration by parsing
+        # the configuration files
         config_files = dist.find_config_files()
-        try: config_files.remove('setup.cfg')
-        except ValueError: pass
         dist.parse_config_files(config_files)
         build_extension = build_ext(dist)
         build_extension.finalize_options()


### PR DESCRIPTION
Original traceback:

``` python
In [1]: %load_ext cythonmagic

In [2]: a=10; b=20

In [3]: %%cython_inline
   ...: return a+b
   ...:
Compiling C:\Users\dhirschfeld/.cython/inline\_cython_inline_53c3e6f9abc0482989da8d2631657346.pyx because it changed.
Cythonizing C:\Users\dhirschfeld/.cython/inline\_cython_inline_53c3e6f9abc0482989da8d2631657346.pyx
---------------------------------------------------------------------------
DistutilsPlatformError                    Traceback (most recent call last)
<ipython-input-3-bc9080ac2f2f> in <module>()
----> 1 get_ipython()._run_cached_cell_magic(u'cython_inline', u'')

c:\dev\code\ipython\IPython\core\interactiveshell.pyc in _run_cached_cell_magic(self, magic_name, line)
   2507         cell = self._current_cell_magic_body
   2508         self._current_cell_magic_body = None
-> 2509         return self.run_cell_magic(magic_name, line, cell)
   2510
   2511     def run_cell(self, raw_cell, store_history=False, silent=False):

c:\dev\code\ipython\IPython\core\interactiveshell.pyc in run_cell_magic(self, magic_name, line, cell)
   2089             magic_arg_s = self.var_expand(line, stack_depth)
   2090             with self.builtin_trap:
-> 2091                 result = fn(line, cell)
   2092             return result
   2093

c:\dev\code\ipython\IPython\extensions\cythonmagic.pyc in cython_inline(self, line, cell)

c:\dev\code\ipython\IPython\core\magic.pyc in <lambda>(f, *a, **k)
    188     # but it's overkill for just that one bit of state.
    189     def magic_deco(arg):
--> 190         call = lambda f, *a, **k: f(*a, **k)
    191
    192         if callable(arg):

c:\dev\code\ipython\IPython\extensions\cythonmagic.pyc in cython_inline(self, line, cell)
     71         locs = self.shell.user_global_ns
     72         globs = self.shell.user_ns
---> 73         return Cython.inline(cell, locals=locs, globals=globs)
     74
     75     @cell_magic

C:\dev\bin\Python27\lib\site-packages\Cython\Shadow.pyc in inline(f, *args, **kwds)
     36   if isinstance(f, basestring):
     37     from Cython.Build.Inline import cython_inline
---> 38     return cython_inline(f, *args, **kwds)
     39   else:
     40     assert len(args) == len(kwds) == 0

C:\dev\bin\Python27\lib\site-packages\Cython\Build\Inline.pyc in cython_inline(code, get_type, lib_dir, cython_include_dirs, force, quiet, locals, globals, **kwds)
    190         build_extension.build_temp = os.path.dirname(pyx_file)
    191         build_extension.build_lib  = lib_dir
--> 192         build_extension.run()
    193         _code_cache[key] = module_name
    194

C:\dev\bin\Python27\lib\distutils\command\build_ext.pyc in run(self)
    338
    339         # Now actually compile and link everything.
--> 340         self.build_extensions()
    341
    342     def check_extensions_list(self, extensions):

C:\dev\bin\Python27\lib\distutils\command\build_ext.pyc in build_extensions(self)
    447
    448         for ext in self.extensions:
--> 449             self.build_extension(ext)
    450
    451     def build_extension(self, ext):

C:\dev\bin\Python27\lib\distutils\command\build_ext.pyc in build_extension(self, ext)
    497                                          debug=self.debug,
    498                                          extra_postargs=extra_args,
--> 499                                          depends=ext.depends)
    500
    501         # XXX -- this is a Vile HACK!

C:\dev\bin\Python27\lib\distutils\msvc9compiler.pyc in compile(self, sources, output_dir, macros, include_dirs, debug, extra_preargs, extra_postargs, depends)
    471
    472         if not self.initialized:
--> 473             self.initialize()
    474         compile_info = self._setup_compile(output_dir, macros, include_dirs,
    475                                            sources, depends, extra_postargs)

C:\dev\bin\Python27\lib\distutils\msvc9compiler.pyc in initialize(self, plat_name)
    381                             PLAT_TO_VCVARS[plat_name]
    382
--> 383             vc_env = query_vcvarsall(VERSION, plat_spec)
    384
    385             # take care to only use strings in the environment.

C:\dev\bin\Python27\lib\distutils\msvc9compiler.pyc in query_vcvarsall(version, arch)
    269
    270     if vcvarsall is None:
--> 271         raise DistutilsPlatformError("Unable to find vcvarsall.bat")
    272     log.debug("Calling 'vcvarsall.bat %s' (version=%s)", arch, version)
    273     popen = subprocess.Popen('"%s" %s & set' % (vcvarsall, arch),

DistutilsPlatformError: Unable to find vcvarsall.bat

In [4]:
```

After the change:

``` python

In [1]: %load_ext cythonmagic

In [2]: a = 10; b= 20

In [3]: %%cython_inline
   ...: return a+b
   ...:
Compiling C:\Users\dhirschfeld/.cython/inline\_cython_inline_53c3e6f9abc0482989da8d2631657346.pyx because it changed.
Cythonizing C:\Users\dhirschfeld/.cython/inline\_cython_inline_53c3e6f9abc0482989da8d2631657346.pyx
Out[3]: 30

In [4]:
```

NOTE: I have two machines, a desktop and a server. Both have the distutils.cfg file shown below in their distutils directory. `cython_inline` worked out of the box on my desktop, but I had to copy the section described in http://wiki.cython.org/FAQ#HowdoIworkaroundthe.22unabletofindvcvarsall.bat.22errorwhenusingMinGWasthecompiler.28onWindows.29.3F to the inline.py file to get it to work on the server.

<pre>
[config]
compiler=mingw32

[build]
compiler=mingw32

[build_ext]
compiler=mingw32
</pre>
