### PR TITLE
Fix compilation issues on windows (got this error from 0.16 already)

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -438,7 +438,10 @@ static PyObject * __Pyx_CyFunction_Call(PyObject *func, PyObject *arg, PyObject 
     return NULL;
 }
 #else
-#define __Pyx_CyFunction_Call PyCFunction_Call
+static PyObject * __PyCFunction_Call(PyObject *func, PyObject *arg, PyObject *kw) {
+	return PyCFunction_Call(func, arg, kw);
+}
+#define __Pyx_CyFunction_Call __PyCFunction_Call
 #endif
 
 static PyTypeObject __pyx_CyFunctionType_type = {


### PR DESCRIPTION
Hi,

The current Cython 0.16 and latest master doesn't compile on Windows Seven / Mingw32:

<pre>building 'Cython.Compiler.Scanning' extension

c:\Users\tito\Desktop\Kivy-dev\MinGW\bin\gcc.exe -mno-cygwin -mdll -O -Wall -Ic:
\Users\tito\Desktop\Kivy-dev\Python\include -Ic:\Users\tito\Desktop\Kivy-dev\Pyt
hon\PC -c c:\Users\tito\Desktop\processcraft\build\cython\Cython\Compiler\Scanni
ng.c -o c:\users\tito\desktop\processcraft\build\cython\cython\compiler\scanning
.o

c:\Users\tito\Desktop\processcraft\build\cython\Cython\Compiler\Scanning.c:14455
: error: initializer element is not constant

c:\Users\tito\Desktop\processcraft\build\cython\Cython\Compiler\Scanning.c:14455
: error: (near initialization for `__pyx_CyFunctionType_type.tp_call')

error: command 'gcc' failed with exit status 1

----------------------------------------
  Rolling back uninstall of Cython
Command c:\Users\tito\Desktop\Kivy-dev\Python\python.exe -c "import setuptools;_
_file__='c:\\Users\\tito\\Desktop\\processcraft\\build\\cython\\setup.py';exec(c
ompile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install
--single-version-externally-managed --record c:\users\tito\appdata\local\temp\pi
p-xe4cyu-record\install-record.txt failed with error code 1 in c:\Users\tito\Des
ktop\processcraft\build\cython
Storing complete log in C:\Users\tito\AppData\Roaming\pip\pip.log
</pre>


This pull request is a fix, as some peoples have discussed in http://permalink.gmane.org/gmane.comp.python.cython.devel/13606
