### PR TITLE
cython_inline: Stop passing unused `ctx` parameter to `cythonize`.

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -201,7 +201,7 @@ def __invoke(%(params)s):
                 extra_compile_args = cflags)
             if build_extension is None:
                 build_extension = _get_build_extension()
-            build_extension.extensions = cythonize([extension], ctx=ctx, quiet=quiet)
+            build_extension.extensions = cythonize([extension], include_path=cython_include_dirs, quiet=quiet)
             build_extension.build_temp = os.path.dirname(pyx_file)
             build_extension.build_lib  = lib_dir
             build_extension.run()


### PR DESCRIPTION
A cursory glance at [cythonize](https://github.com/cython/cython/blob/master/Cython/Build/Dependencies.py#L568) shows that it will never use the `ctx` parameter. Since `cython_inline` generates `ctx` only from `cython_include_dirs` (which I believe is the same as `include_path` in `cythonize`), the fix is pretty simple.

None of this is at all urgent, and it's hard to think of a case where the current behavior fails -- perhaps when it is necessary to pass an include directory to `cython.inline` (which is probably never in practice).

Closes trac ticket [#781](http://trac.cython.org/cython_trac/ticket/781).
