### PR TITLE
Fix parallel/prange test failures on Windows

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7627,7 +7627,6 @@ class ParallelRangeNode(ParallelStatNode):
         # target index uninitialized
         code.putln("if (%(nsteps)s > 0)" % fmt_dict)
         code.begin_block() # if block
-        code.putln("%(target)s = 0;" % fmt_dict)
         self.generate_loop(code, fmt_dict)
         code.end_block() # end if block
 


### PR DESCRIPTION
Using Cython-0.17b3 on Windows with msvc9 and msvc10 compilers, several parralel prange tests fail sometimes, but not always. E.g.:

```
File "Cython-0.17b3\BUILD\run\c\parallel\parallel.pyd", line ?, in parallel.__test__.test_prange (line 20)
Failed example:
    test_prange()
Expected:
    (9, 9, 45, 45)
Got:
    (0, 9, 45, 45)
```

This issue was reported and discussed on the cython-devel mailing list http://mail.python.org/pipermail/cython-devel/2012-August/003068.html

A simple example is:

```
def test_parallel():
    cdef int i = 0, s = 0
    with nogil, cython.parallel.parallel():
        for i in prange(10):
            s += i
    return i
```

Repeated runs of  test_parallel() return 0 or 9.
Cython translates the function body to something like this (hope I got it right):

```
int i = 0;
int s = 0;
long t1;
long t2;
#pragma omp parallel reduction(+:s) private(t1, t2)
{
    t2 = 10;
    i = 0;  /* ! */
    #pragma omp for firstprivate(i) lastprivate(i)
    {
        for (t1 = 0; t1 < t2; t1++)
        {
            i = t1;
            s = s + i;
        }
    }
}
```

The variable `i` is initialized to zero a second time within the `#pragma omp parallel` block. While this looks OK, it turns out that when the `i = 0;` statement is deleted from the Cython generated C code, the example runs correctly.

On my system, this PR fixes all the lastprivate related test errors and does not have any side effects on other tests.

I wonder why the private loop variables `t1` and `t2` are of C `long`, not `ssize_t` types.
