### PR TITLE
Add '/openmp' flag when compiling Cpp code with msvc compilers

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -124,7 +124,9 @@ def get_openmp_compiler_flags(language):
         cc = sysconfig.get_config_var('CC')
 
     if not cc:
-        return None # Windows?
+        if sys.platform == 'win32':
+            return '/openmp', ''
+        return None
 
     # For some reason, cc can be e.g. 'gcc -pthread'
     cc = cc.split()[0]


### PR DESCRIPTION
This fixes a test failure in Cython-0.17b3 and b4 on Windows as discussed on the mailing list http://mail.python.org/pipermail/cython-devel/2012-August/003068.html. The problem is that runtests.py does not add the '/openmp' flag when compiling Cpp files with Visual Studio compilers. The failing test is:

```
======================================================================
FAIL: test_num_threads (line 33) (parallel.__test__)
Doctest: parallel.__test__.test_num_threads (line 33)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27\lib\doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for parallel.__test__.test_num_threads (line 33)
  File "\Cython-0.17b3\BUILD\run\cpp\parallel\parallel.pyd", line unknown line number, in test_num_threads (line 33)

----------------------------------------------------------------------
File "\Cython-0.17b3\BUILD\run\cpp\parallel\parallel.pyd", line ?, in parallel.__test__.test_num_threads (line 33)
Failed example:
    test_num_threads()
Expected:
    1
    get_num_threads called
    3
    get_num_threads called
    3
Got:
    1
    get_num_threads called
    1
    get_num_threads called
    1
```
