### PR TITLE
Fix computation of destructor name with namespaces

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1134,7 +1134,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln("if (p->__weakref__) PyObject_ClearWeakRefs(o);")
 
         for entry in cpp_class_attrs:
-            destructor_name = entry.type.cname.split("::")[-1]
+            l= entry.type.cname.split('<',1)
+            l[0] = l[0].split('::')[-1]
+            destructor_name = '<'.join(l)
             code.putln("p->%s.%s::~%s();" %
                 (entry.cname, entry.type.declaration_code(""), destructor_name))
 


### PR DESCRIPTION
In the computation of the destructor name,
currently the class name is computed by taking
everything at the right of the last ::
to remove the namespaces.
This is incorrect with template arguments containing :: ,
e.g. if the class is
Namespace1::Namespace2::myclass < A::B::C, D< F::G> >
(it gives G>>).
Correction is to take first the part before the <.
