### PR TITLE
Destructor name again : compilation issue with gcc...

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1139,6 +1139,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # Make sure the namespace delimiter was not in a template arg.
             while destructor_name.count('<') != destructor_name.count('>'):
                 destructor_name = split_cname.pop() + '::' + destructor_name
+            destructor_name = destructor_name.split('<',1)[0]
             code.putln("p->%s.%s::~%s();" %
                 (entry.cname, entry.type.declaration_code(""), destructor_name))
 


### PR DESCRIPTION
There appears to be a pb in 9df8c9daf10ff30a8e6506b72406d032f268a17b.

For a template class, A::B::C<T1,T2>
the destructor name was C<T1,T2>
leading to code like
A::B::C<T1,T2>::~C<T1,T2>()

which does not compile on gcc (4.6, 4.7), also it seems to be correct code ...
clang and intel C++ compile it, but not gcc.

I changed the name to generate the code :

A::B::C<T1,T2>::~C()

which compiles on gcc, clang, intel

by further cutting the <...> in the destructor name.
