### PR TITLE
add platform specific include directory to compile line

### DIFF
--- a/Demos/embed/Makefile
+++ b/Demos/embed/Makefile
@@ -3,6 +3,7 @@ PYTHON=python
 PYVERSION=$(shell $(PYTHON) -c "import sys; print(sys.version[:3])")
 
 INCDIR=$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc())")
+PLATINCDIR=$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True))")
 LIBDIR1=$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
 LIBDIR2=$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBPL'))")
 PYLIB=$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBRARY')[3:-2])")
@@ -17,7 +18,7 @@ embedded: embedded.o
 	$(LINKCC) -o $@ $^ -L$(LIBDIR1) -L$(LIBDIR2) -l$(PYLIB) $(LIBS) $(SYSLIBS) $(LINKFORSHARED)
 
 embedded.o: embedded.c
-	$(CC) -c $^ -I$(INCDIR)
+	$(CC) -c $^ -I$(INCDIR) -I$(PLATINCDIR)
 
 CYTHON=../../cython.py
 embedded.c: embedded.pyx


### PR DESCRIPTION
beginning with python3.3 it is different than the general include directory on debian based systems

without this change an embed test fails, see:
https://launchpadlibrarian.net/123283466/buildlog_ubuntu-raring-amd64.cython_0.17.1-1_FAILEDTOBUILD.txt.gz

ubuntu 13.04:

```
>>> from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True))
/usr/include/x86_64-linux-gnu/python3.3m
>>> from distutils import sysconfig; print(sysconfig.get_python_inc())
/usr/include/python3.3m
```

alternatively one could use $(PYTHON)-config --includes to get the full line
