### PR TITLE
Add test for memoryview of extension type

### DIFF
--- a/tests/memoryview/extension_type_memoryview.pyx
+++ b/tests/memoryview/extension_type_memoryview.pyx
@@ -1,0 +1,35 @@
+# mode: run
+# tag: numpy
+
+import numpy as np
+
+
+cdef class ExtensionType(object):
+    cdef public int dummy
+
+    def __init__(self, n):
+        self.dummy = n
+
+items = [ExtensionType(1), ExtensionType(2)]
+cdef ExtensionType[:] view = np.array(items, dtype=ExtensionType)
+
+def test_getitem():
+    """
+    >>> test_getitem()
+    1
+    2
+    """
+    for i in range(view.shape[0]):
+        item = view[i]
+        print item.dummy
+
+def test_getitem_typed():
+    """
+    >>> test_getitem_typed()
+    1
+    2
+    """
+    cdef ExtensionType item
+    for i in range(view.shape[0]):
+        item = view[i]
+        print item.dummy


### PR DESCRIPTION
To be merged as a test-case for http://thread.gmane.org/gmane.comp.python.cython.devel/14489 when it is fixed. Note: I haven't actually tried the test within Cython testing infrastructure, just by hand.

There was a bug that produced C code where gcc emitted warnings:
extension_type_memoryview.c: In function ‘__pyx_pf_25extension_type_memoryview_test_getitem’:
extension_type_memoryview.c:1468:15: warning: assignment from incompatible pointer type
extension_type_memoryview.c: In function ‘__pyx_pf_25extension_type_memoryview_2test_getitem_typed’:
extension_type_memoryview.c:1565:15: warning: assignment from incompatible pointer type
extension_type_memoryview.c:1568:18: warning: assignment from incompatible pointer type

And g++ failed with errors:
extension_type_memoryview.c: In function ‘PyObject\* __pyx_pf_25extension_type_memoryview_test_getitem(PyObject_)’:
extension_type_memoryview.c:1468:213: error: cannot convert ‘__pyx_obj_25extension_type_memoryview_ExtensionType_’ to ‘PyObject_’ in assignment
extension_type_memoryview.c: In function ‘PyObject_ __pyx_pf_25extension_type_memoryview_2test_getitem_typed(PyObject_)’:
extension_type_memoryview.c:1565:213: error: cannot convert ‘__pyx_obj_25extension_type_memoryview_ExtensionType_’ to ‘PyObject_’ in assignment
extension_type_memoryview.c:1568:20: error: cannot convert ‘PyObject_’ to ‘__pyx_obj_25extension_type_memoryview_ExtensionType*’ in assignment
