### PR TITLE
fix analysis of entry to be a weakref (typo introduced in d96dfd)

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -802,7 +802,7 @@ class Scope(object):
 
         for entry in self.var_entries:
             if entry.type.is_pyobject:
-                if include_weakref or entry.name != "weakref":
+                if include_weakref or entry.name != "__weakref__":
                     py_attrs.append(entry)
             elif entry.type == PyrexTypes.c_py_buffer_type:
                 py_buffers.append(entry)


### PR DESCRIPTION
Originally reported in Debian http://bugs.debian.org/cgi-bin/bugreport.cgi\?bug\=692313
Lead to crash with python-dbg:

  python-dbg: ../Modules/gcmodule.c:366: visit_decref: Assertion 'gc->gc.gc_refs != 0' failed
