### PR TITLE
Fix warning: unused function '__pyx_pw_5numpy_7ndarray_1__getbuffer__'

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2976,8 +2976,15 @@ class DefNodeWrapper(FuncDefNode):
                 "PyObject *%s, PyObject *%s"
                     % (Naming.args_cname, Naming.kwds_cname))
         arg_code = ", ".join(arg_code_list)
+
+        # Prevent warning: unused function '__pyx_pw_5numpy_7ndarray_1__getbuffer__'
+        mf = ""
+        if (entry.name in ("__getbuffer__", "__releasebuffer__")
+            and entry.scope.is_c_class_scope):
+            mf = "CYTHON_UNUSED "
+
         dc = self.return_type.declaration_code(entry.func_cname)
-        header = "static %s(%s)" % (dc, arg_code)
+        header = "static %s%s(%s)" % (mf, dc, arg_code)
         code.putln("%s; /*proto*/" % header)
 
         if proto_only:


### PR DESCRIPTION
I've been noticing some unused function warnings of the following variety:

```
test.cpp:1189:12: warning: unused function '__pyx_pw_5numpy_7ndarray_1__getbuffer__' [-Wunused-function]
static int __pyx_pw_5numpy_7ndarray_1__getbuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags) {
           ^
test.cpp:2008:13: warning: unused function '__pyx_pw_5numpy_7ndarray_3__releasebuffer__' [-Wunused-function]
static void __pyx_pw_5numpy_7ndarray_3__releasebuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info) {
            ^
2 warnings generated.
```

These can be easily generated from a small test script:

``` cython
from numpy cimport import_array, import_ufunc
import_array(); import_ufunc()
```

These warnings were once silenced by some code introduced in a previous commit:

> commit 6cc61605a91c8ebf16318a07439a206118d81614
> Author: Lisandro Dalcin dalcinl@gmail.com
> Date:   Wed Apr 28 16:18:43 2010 -0300
>     introduce CYTHON_UNUSED macro to annotate functions and parametes
>     - Silent compiler warnings about unused function/parametes
>     - Defined to **attribute**((**unused**)) for GCC(>3.4) and ICC
>     - Applied to a **{get|release}buffer** special methods
>     - Applied to a couple of (self,unused) parameter pairs

But later reappeared in:

> commit 519a19a9006494c6165ea481553a298d9bf9a008
> Author: Vitja Makarov vitja.makarov@gmail.com
> Date:   Sun Jan 8 19:22:38 2012 +0400
>     DefNode: split into function and python wrapper

This pull request re-silences the warnings by adding `CYTHON_UNUSED` to the function prototype.

```
OLD:
static int __pyx_pw_5numpy_7ndarray_1__getbuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /*proto*/

NEW:
static CYTHON_UNUSED int __pyx_pw_5numpy_7ndarray_1__getbuffer__(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /*proto*/
```
