### PR TITLE
Fix memoryview crashes when using msvc9 64 bit compiler 

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -836,7 +836,7 @@ cdef int slice_memviewslice(
         with cython.cdivision(True):
             new_shape = (stop - start) // step
 
-            if (stop - start) % step:
+            if (stop - start) - step * new_shape:
                 new_shape += 1
 
         if new_shape < 0:


### PR DESCRIPTION
This issue was first reported on [cython-devel](http://mail.python.org/pipermail/cython-devel/2012-August/003068.html) but could not be resolved at that time. It leads to crashes in the Cython test suite.

The following extension, a reduced example, is expected to print `1`. When compiled with msvc9 compiler for 64 bit using default compiler options, it prints `2`:

```
from cython.view cimport array as cvarray
import numpy as np

cdef int[:] a = np.zeros((1, ), 'int32')
cdef int[:] b = a[:1]
print(b.shape[0])
```

I tracked it down to [Utility/MemoryView.pyx#L839](https://github.com/cython/cython/blob/master/Cython/Utility/MemoryView.pyx#L839). In that context `(1 - 0) % 1` is computed to `1`.

This PR replaces the modulo operator by multiplication and subtraction. This fixes the issue and all unit tests pass, without crash, on win-amd64-py2.7.

There's another potential 64 bit Windows specific issue at [Utility/MemoryView_C.c#L516](https://github.com/cython/cython/blob/master/Cython/Utility/MemoryView_C.c#L516):
A `ssize_t` value is converted to a Python Integer (32 bit on win-amd64 platform), possibly losing data. It would be better to use the `PyLong_FromSsize_t` function instead of `PyInt_FromLong`, however `PyLong_FromSsize_t` is only available for Python >= 2.6.
