### PR TITLE
BF: replace show-ref with rev-parse --verify for determining current treeish location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class sdist(sdist_orig):
         self.force_manifest = 1
         if (sys.platform != "win32" and 
             os.path.isdir('.git')):
-            assert os.system("git show-ref -s HEAD > .gitrev") == 0
+            assert os.system("git rev-parse --verify HEAD > .gitrev") == 0
         sdist_orig.run(self)
 add_command_class('sdist', sdist)
 


### PR DESCRIPTION
git show-ref -s HEAD  has shown to not work in all scenarios
and git rev-parse --help provides this as an ultimate example:

```
     ·   Print the object name of the current commit:

           $ git rev-parse --verify HEAD
```

Please verify that it works for you before merging ;)
