### PR TITLE
fix import of pyx modules when '' is in sys.path

### DIFF
--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -291,17 +291,21 @@ class PyxImporter(object):
             paths = sys.path
         join_path = os.path.join
         is_file = os.path.isfile
+        is_abs = os.path.isabs
+        abspath = os.path.abspath
         #is_dir = os.path.isdir
         sep = os.path.sep
         for path in paths:
             if not path:
                 path = os.getcwd()
+            elif not is_abs(path):
+                path = abspath(path)
             if is_file(path+sep+pyx_module_name):
                 return PyxLoader(fullname, join_path(path, pyx_module_name),
                                  pyxbuild_dir=self.pyxbuild_dir,
                                  inplace=self.inplace,
                                  language_level=self.language_level)
-                
+
         # not found, normal package, not a .pyx file, none of our business
         _debug("%s not found" % fullname)
         return None


### PR DESCRIPTION
If '' is in sys.path and a module is found the package_path
is relative and breaks the build process.
