### PR TITLE
Fix overflow_check CompileError with msvc

### DIFF
--- a/tests/run/overflow_check.pxi
+++ b/tests/run/overflow_check.pxi
@@ -34,7 +34,7 @@ cpdef check(func, op, a, b):
     if not func_overflow:
         assert res == op_res, "Inconsistant values: %s(%s, %s) == %s != %s" % (func, a, b, res, op_res)
 
-medium_values = (max_value_ / 2, max_value_ / 3, min_value_ / 2, <INT>sqrt(max_value_) - <INT>1, <INT>sqrt(max_value_) + 1)
+medium_values = (max_value_ / 2, max_value_ / 3, min_value_ / 2, <INT>sqrt(<long double>max_value_) - <INT>1, <INT>sqrt(<long double>max_value_) + 1)
 def run_test(func, op):
     cdef INT offset, b
     check(func, op, 300, 200)


### PR DESCRIPTION
This fixes 4 test errors with Cython 0.18 rc1 when using msvc compilers. Verified on win-amd64-py2.7 with msvc9 compiler.

The compiler error is:

```
overflow_check_int.cpp(4242) : error C2668: 'sqrt' : ambiguous call to overloaded function
        C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\math.h(581): could be 'long double sqrt(long double)'
        C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\math.h(533): or       'float sqrt(float)'
        C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\INCLUDE\math.h(128): or       'double sqrt(double)'
        while trying to match the argument list '(__pyx_t_18overflow_check_int_INT)'
```

The test errors are:

```
======================================================================
ERROR: runTest (__main__.CythonRunTestCase)
compiling (cpp) and running overflow_check_int
----------------------------------------------------------------------
Traceback (most recent call last):
  File "runtests.py", line 727, in run
    self.runCompileTest()
  File "runtests.py", line 531, in runCompileTest
    self.test_directory, self.expect_errors, self.annotate)
  File "runtests.py", line 710, in compile
    self.run_distutils(test_directory, module, workdir, incdir)
  File "runtests.py", line 670, in run_distutils
    build_extension.run()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 339, in run
    self.build_extensions()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 448, in build_extensions
    self.build_extension(ext)
  File "runtests.py", line 285, in build_extension
    _build_ext.build_extension(self, ext)
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 498, in build_extension
    depends=ext.depends)
  File "X:\Python27-x64\lib\distutils\msvc9compiler.py", line 552, in compile
    raise CompileError(msg)
CompileError: command '"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe"' failed with exit status 2

======================================================================
ERROR: runTest (__main__.CythonRunTestCase)
compiling (cpp) and running overflow_check_longlong
----------------------------------------------------------------------
Traceback (most recent call last):
  File "runtests.py", line 727, in run
    self.runCompileTest()
  File "runtests.py", line 531, in runCompileTest
    self.test_directory, self.expect_errors, self.annotate)
  File "runtests.py", line 710, in compile
    self.run_distutils(test_directory, module, workdir, incdir)
  File "runtests.py", line 670, in run_distutils
    build_extension.run()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 339, in run
    self.build_extensions()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 448, in build_extensions
    self.build_extension(ext)
  File "runtests.py", line 285, in build_extension
    _build_ext.build_extension(self, ext)
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 498, in build_extension
    depends=ext.depends)
  File "X:\Python27-x64\lib\distutils\msvc9compiler.py", line 552, in compile
    raise CompileError(msg)
CompileError: command '"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe"' failed with exit status 2

======================================================================
ERROR: runTest (__main__.CythonRunTestCase)
compiling (cpp) and running overflow_check_uint
----------------------------------------------------------------------
Traceback (most recent call last):
  File "runtests.py", line 727, in run
    self.runCompileTest()
  File "runtests.py", line 531, in runCompileTest
    self.test_directory, self.expect_errors, self.annotate)
  File "runtests.py", line 710, in compile
    self.run_distutils(test_directory, module, workdir, incdir)
  File "runtests.py", line 670, in run_distutils
    build_extension.run()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 339, in run
    self.build_extensions()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 448, in build_extensions
    self.build_extension(ext)
  File "runtests.py", line 285, in build_extension
    _build_ext.build_extension(self, ext)
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 498, in build_extension
    depends=ext.depends)
  File "X:\Python27-x64\lib\distutils\msvc9compiler.py", line 552, in compile
    raise CompileError(msg)
CompileError: command '"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe"' failed with exit status 2

======================================================================
ERROR: runTest (__main__.CythonRunTestCase)
compiling (cpp) and running overflow_check_ulonglong
---------------------------------------------------ALL DONE
-------------------
Traceback (most recent call last):
  File "runtests.py", line 727, in run
    self.runCompileTest()
  File "runtests.py", line 531, in runCompileTest
    self.test_directory, self.expect_errors, self.annotate)
  File "runtests.py", line 710, in compile
    self.run_distutils(test_directory, module, workdir, incdir)
  File "runtests.py", line 670, in run_distutils
    build_extension.run()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 339, in run
    self.build_extensions()
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 448, in build_extensions
    self.build_extension(ext)
  File "runtests.py", line 285, in build_extension
    _build_ext.build_extension(self, ext)
  File "X:\Python27-x64\lib\distutils\command\build_ext.py", line 498, in build_extension
    depends=ext.depends)
  File "X:\Python27-x64\lib\distutils\msvc9compiler.py", line 552, in compile
    raise CompileError(msg)
CompileError: command '"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe"' failed with exit status 2
```
