### PR TITLE
Remove redundant commas again

### DIFF
--- a/docs/src/reference/language_basics.rst
+++ b/docs/src/reference/language_basics.rst
@@ -486,7 +486,9 @@ For-loops
     for i in range(n):
         ...
 
-* Iteration over C arrays is also permitted, e.g.::
+* Iteration over C arrays is also permitted, e.g.,
+
+::
 
     cdef double x
     cdef double* data

--- a/docs/src/tutorial/clibraries.rst
+++ b/docs/src/tutorial/clibraries.rst
@@ -509,7 +509,9 @@ Callbacks
 Let's say you want to provide a way for users to pop values from the
 queue up to a certain user defined event occurs.  To this end, you
 want to allow them to pass a predicate function that determines when
-to stop, e.g.::
+to stop, e.g.,
+
+::
 
     def pop_until(self, predicate):
         while not predicate(self.peek()):

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -39,12 +39,12 @@ The currently supported attributes of the ``cython`` module are:
     x_ptr = cython.address(x)
 
 * ``sizeof`` emulates the `sizeof` operator. It can take both types and
-  expressions.::
+  expressions::
 
     cython.declare(n=cython.longlong)
     print cython.sizeof(cython.longlong), cython.sizeof(n)
 
-* ``struct`` can be used to create struct types.::
+* ``struct`` can be used to create struct types::
 
     MyStruct = cython.struct(x=cython.int, y=cython.int, data=cython.double)
     a = cython.declare(MyStruct)

--- a/docs/src/tutorial/pxd_files.rst
+++ b/docs/src/tutorial/pxd_files.rst
@@ -11,7 +11,8 @@ using the ``cimport`` keyword.
 
  1. They can be used for sharing external C declarations.
  2. They can contain functions which are well suited for inlining by
-    the C compiler. Such functions should be marked ``inline``, example:
+    the C compiler. Such functions should be marked ``inline``, for example,
+
     ::
 
        cdef inline int int_min(int a, int b):

--- a/docs/src/tutorial/queue_example/queue.pyx
+++ b/docs/src/tutorial/queue_example/queue.pyx
@@ -1,5 +1,4 @@
 cimport cqueue
-cimport python_exc
 
 cdef class Queue:
 

--- a/docs/src/tutorial/strings.rst
+++ b/docs/src/tutorial/strings.rst
@@ -150,7 +150,9 @@ However, in most other situations, such as for return values and
 variables that use specifically typedef-ed API types, it does matter
 and the C compiler will emit at least a warning if used incorrectly.
 To help with this, you can use the type definitions in the
-``libc.string`` module, e.g.::
+``libc.string`` module, e.g.,
+
+::
 
     from libc.string cimport const_char, const_uchar
 
@@ -394,7 +396,9 @@ explicitly, and the following will print ``A`` (or ``b'A'`` in Python
 The explicit coercion works for any C integer type.  Values outside of
 the range of a :c:type:`char` or :c:type:`unsigned char` will raise an
 ``OverflowError`` at runtime.  Coercion will also happen automatically
-when assigning to a typed variable, e.g.::
+when assigning to a typed variable, e.g.,
+
+::
 
     cdef bytes py_byte_string
     py_byte_string = char_val

--- a/docs/src/userguide/debugging.rst
+++ b/docs/src/userguide/debugging.rst
@@ -66,7 +66,9 @@ You can also pass additional arguments to gdb::
 
     $ cygdb /path/to/build/directory/ GDBARGS
 
-i.e.::
+i.e.,
+
+::
 
     $ cygdb . --args python-dbg mainscript.py
 

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -253,7 +253,7 @@ corresponding operation is attempted.
 
 Here's a complete example. It defines a property which adds to a list each
 time it is written to, returns the list when it is read, and empties the list
-when it is deleted.::
+when it is deleted::
  
     # cheesy.pyx
     cdef class CheeseShop:
@@ -346,7 +346,7 @@ C methods
 Extension types can have C methods as well as Python methods. Like C
 functions, C methods are declared using :keyword:`cdef` or :keyword:`cpdef` instead of
 :keyword:`def`. C methods are "virtual", and may be overridden in derived
-extension types.::
+extension types::
 
     # pets.pyx
     cdef class Parrot:
@@ -450,7 +450,7 @@ objects defined in the Python core or in a non-Cython extension module.
     :ref:`sharing-declarations`.
 
 Here is an example which will let you get at the C-level members of the
-built-in complex object.::
+built-in complex object::
 
     cdef extern from "complexobject.h":
 

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -390,7 +390,9 @@ Forward-declaring extension types
 
 Extension types can be forward-declared, like :keyword:`struct` and
 :keyword:`union` types. This will be necessary if you have two extension types
-that need to refer to each other, e.g.::
+that need to refer to each other, e.g.,
+
+::
 
     cdef class Shrubbery # forward declaration
 

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -56,7 +56,9 @@ first method, but Cython code can use either method.
 By default, extension type attributes are only accessible by direct access,
 not Python access, which means that they are not accessible from Python code.
 To make them accessible from Python code, you need to declare them as
-:keyword:`public` or :keyword:`readonly`. For example::
+:keyword:`public` or :keyword:`readonly`. For example,
+
+::
 
     cdef class Shrubbery:
         cdef public int width, height
@@ -104,7 +106,9 @@ follows::
 
 Now the Cython compiler knows that ``sh`` has a C attribute called
 :attr:`width` and will generate code to access it directly and efficiently.
-The same consideration applies to local variables, for example,::
+The same consideration applies to local variables, for example,
+
+::
 
     cdef Shrubbery another_shrubbery(Shrubbery sh1):
         cdef Shrubbery sh2
@@ -375,7 +379,9 @@ extension types.::
     Lovely plumage!
 
 The above example also illustrates that a C method can call an inherited C
-method using the usual Python technique, i.e.::
+method using the usual Python technique, i.e.
+
+::
 
     Parrot.describe(self)
 
@@ -396,7 +402,9 @@ that need to refer to each other, e.g.::
 
 If you are forward-declaring an extension type that has a base class, you must
 specify the base class in both the forward declaration and its subsequent
-definition, for example,::
+definition, for example,
+
+::
 
     cdef class A(B)
 
@@ -410,7 +418,9 @@ Making extension types weak-referenceable
 
 By default, extension types do not support having weak references made to
 them. You can enable weak referencing by declaring a C attribute of type
-object called :attr:`__weakref__`. For example,::
+object called :attr:`__weakref__`. For example,
+
+::
 
     cdef class ExplodingAnimal:
         """This animal will self-destruct when it is
@@ -507,7 +517,9 @@ Implicit importing
 ------------------
 
 Cython requires you to include a module name in an extern extension class
-declaration, for example,::
+declaration, for example,
+
+::
 
     cdef extern class MyModule.Spam:
         ...
@@ -521,13 +533,17 @@ example an implicit::
 statement will be executed at module load time.
 
 The module name can be a dotted name to refer to a module inside a package
-hierarchy, for example,::
+hierarchy, for example,
+
+::
 
     cdef extern class My.Nested.Package.Spam:
         ...
 
 You can also specify an alternative name under which to import the type using
-an as clause, for example,::
+an as clause, for example,
+
+::
 
       cdef extern class My.Nested.Package.Spam as Yummy:
          ... 

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -336,7 +336,7 @@ header and call the :func:`import_modulename` function. The other functions
 can then be called and the extension types used as usual.
 
 Any public C type or extension type declarations in the Cython module are also
-made available when you include :file:`modulename_api.h`.::
+made available when you include :file:`modulename_api.h`::
 
     # delorean.pyx
     cdef public struct Vehicle:
@@ -460,7 +460,7 @@ Declaring a function as callable without the GIL
 --------------------------------------------------
 
 You can specify :keyword:`nogil` in a C function header or function type to
-declare that it is safe to call without the GIL.::
+declare that it is safe to call without the GIL::
 
     cdef void my_gil_free_func(int spam) nogil:
         ...

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -24,7 +24,9 @@ External declarations
 
 By default, C functions and variables declared at the module level are local
 to the module (i.e. they have the C static storage class). They can also be
-declared extern to specify that they are defined elsewhere, for example,::
+declared extern to specify that they are defined elsewhere, for example,
+
+::
 
     cdef extern int spam_counter
 
@@ -87,7 +89,9 @@ match the C ones, and in some cases they shouldn't or can't. In particular:
    to platform-dependent flavours of numeric types, you will need a
    corresponding :keyword:`ctypedef` statement, but you don't need to match
    the type exactly, just use something of the right general kind (int, float,
-   etc). For example,::
+   etc). For example,
+
+   ::
 
        ctypedef int word
 
@@ -185,7 +189,9 @@ Accessing Python/C API routines
 ---------------------------------
 
 One particular use of the ``cdef extern from`` statement is for gaining access to
-routines in the Python/C API. For example,::
+routines in the Python/C API. For example,
+
+::
 
     cdef extern from "Python.h":
 
@@ -204,7 +210,9 @@ Windows Calling Conventions
 ----------------------------
 
 The ``__stdcall`` and ``__cdecl`` calling convention specifiers can be used in
-Cython, with the same syntax as used by C compilers on Windows, for example,::
+Cython, with the same syntax as used by C compilers on Windows, for example,
+
+::
 
     cdef extern int __stdcall FrobnicateWindow(long handle)
 
@@ -245,7 +253,9 @@ Cython keywords. For example, if you want to call an external function called
 print, you can rename it to something else in your Cython module.
 
 As well as functions, C names can be specified for variables, structs, unions,
-enums, struct and union members, and enum values. For example,::
+enums, struct and union members, and enum values. For example,
+
+::
 
     cdef extern int one "ein", two "zwei"
     cdef extern float three "drei"
@@ -388,7 +398,9 @@ Multiple public and API declarations
 
 You can declare a whole group of items as :keyword:`public` and/or
 :keyword:`api` all at once by enclosing them in a :keyword:`cdef` block, for
-example,::
+example,
+
+::
 
     cdef public api:
         void order_spam(int tons)

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -74,7 +74,9 @@ match the C ones, and in some cases they shouldn't or can't. In particular:
    definition from the header file.
 
    In some cases, you might not need any of the struct's members, in which
-   case you can just put pass in the body of the struct declaration, e.g.::
+   case you can just put pass in the body of the struct declaration, e.g.,
+
+   ::
 
         cdef extern from "foo.h":
             struct spam:
@@ -374,7 +376,9 @@ import machinery is used to make the connection dynamically. However, only
 functions can be accessed this way, not variables.
 
 You can use both :keyword:`public` and :keyword:`api` on the same function to
-make it available by both methods, e.g.::
+make it available by both methods, e.g.,
+
+::
 
     cdef public api void belt_and_braces():
         ...

--- a/docs/src/userguide/fusedtypes.rst
+++ b/docs/src/userguide/fusedtypes.rst
@@ -121,7 +121,9 @@ by calling.
 Indexing
 --------
 
-You can index functions with types to get certain specializations, i.e.::
+You can index functions with types to get certain specializations, i.e.,
+
+::
 
     cfunc[cython.p_double](p1, p2)
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -556,7 +556,7 @@ A name defined using ``DEF`` can be used anywhere an identifier can appear,
 and it is replaced with its compile-time value as though it were written into
 the source at that point as a literal. For this to work, the compile-time
 expression must evaluate to a Python value of type ``int``, ``long``,
-``float`` or ``str``.::
+``float`` or ``str``::
 
     cdef int a1[ArraySize]
     cdef int a2[OtherArraySize]
@@ -567,7 +567,7 @@ Conditional Statements
 
 The ``IF`` statement can be used to conditionally include or exclude sections
 of code at compile time. It works in a similar way to the ``#if`` preprocessor
-directive in C.::
+directive in C::
 
     IF UNAME_SYSNAME == "Windows":
         include "icky_definitions.pxi"

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -42,7 +42,9 @@ and C :keyword:`struct`, :keyword:`union` or :keyword:`enum` types::
 See also :ref:`struct-union-enum-styles`
 
 There is currently no special syntax for defining a constant, but you can use
-an anonymous :keyword:`enum` declaration for this purpose, for example,::
+an anonymous :keyword:`enum` declaration for this purpose, for example,
+
+::
 
     cdef enum:
         tons_of_spam = 3
@@ -103,7 +105,9 @@ can be called from anywhere, but uses the faster C calling conventions
 when being called from other Cython code. 
 
 Parameters of either type of function can be declared to have C data types,
-using normal C declaration syntax. For example,::
+using normal C declaration syntax. For example,
+
+::
 
     def spam(int i, char *s):
         ...
@@ -144,7 +148,9 @@ parameters and a new reference is returned).
 
 The name object can also be used to explicitly declare something as a Python
 object. This can be useful if the name being declared would otherwise be taken
-as the name of a type, for example,::
+as the name of a type, for example,
+
+::
 
     cdef ftang(object int):
         ...
@@ -241,7 +247,9 @@ returns ``NULL``. The except clause doesn't work that way; its only purpose is
 for propagating Python exceptions that have already been raised, either by a Cython
 function or a C function that calls Python/C API routines. To get an exception
 from a non-Python-aware function such as :func:`fopen`, you will have to check the
-return value and raise it yourself, for example,::
+return value and raise it yourself, for example,
+
+::
 
     cdef FILE* p
     p = fopen("spam.txt", "r")
@@ -347,7 +355,9 @@ direct equivalent in Python.
 * There is no unary ``*`` operator in Cython. Instead of ``*p``, use ``p[0]``
 * There is an ``&`` operator, with the same semantics as in C.
 * The null C pointer is called ``NULL``, not ``0`` (and ``NULL`` is a reserved word).
-* Type casts are written ``<type>value`` , for example,::
+* Type casts are written ``<type>value`` , for example,
+
+::
 
         cdef char* p, float* q
         p = <char*>q
@@ -489,7 +499,9 @@ The include statement
     Use :ref:`sharing-declarations` instead.
 
 A Cython source file can include material from other files using the include
-statement, for example,::
+statement, for example,
+
+::
 
     include "spamstuff.pxi"
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -60,7 +60,9 @@ an anonymous :keyword:`enum` declaration for this purpose, for example,
 
         cdef struct Grail *gp # WRONG
 
-    There is also a ``ctypedef`` statement for giving names to types, e.g.::
+    There is also a ``ctypedef`` statement for giving names to types, e.g.,
+
+    ::
 
         ctypedef unsigned long ULong
 
@@ -156,7 +158,9 @@ as the name of a type, for example,
         ...
 
 declares a parameter called int which is a Python object. You can also use
-object as the explicit return type of a function, e.g.::
+object as the explicit return type of a function, e.g.,
+
+::
 
     cdef object ftang(object int):
         ...
@@ -310,7 +314,9 @@ leaving ``s`` dangling. Since this code could not possibly work, Cython refuses 
 compile it.
 
 The solution is to assign the result of the concatenation to a Python
-variable, and then obtain the ``char*`` from that, i.e.::
+variable, and then obtain the ``char*`` from that, i.e.,
+
+::
 
     cdef char *s
     p = pystring1 + pystring2

--- a/docs/src/userguide/pxd_package.rst
+++ b/docs/src/userguide/pxd_package.rst
@@ -40,7 +40,9 @@ are two alternatives:
       cd ..; cython foo/shrubbing.pyx
 
 2. arrange for the directory containing foo to be
-   passed as a -I option, e.g.::
+   passed as a -I option, e.g.,
+
+   ::
 
       cython -I .. shrubbing.pyx
 

--- a/docs/src/userguide/pyrex_differences.rst
+++ b/docs/src/userguide/pyrex_differences.rst
@@ -49,7 +49,9 @@ Keyword-only arguments
 ----------------------
 
 Python functions can have keyword-only arguments listed after the ``*``
-parameter and before the ``**`` parameter if any, e.g.::
+parameter and before the ``**`` parameter if any, e.g.,
+
+::
 
     def f(a, b, *args, c, d = 42, e, **kwds):
         ...
@@ -59,7 +61,9 @@ passed as keyword arguments. Furthermore, ``c`` and ``e`` are required keyword
 arguments, since they do not have a default value.
 
 If the parameter name after the ``*`` is omitted, the function will not accept any
-extra positional arguments, e.g.::
+extra positional arguments, e.g.,
+
+::
 
     def g(a, b, *, c, d):
         ...
@@ -108,7 +112,9 @@ Now, with cython, one can write::
 
     cdef int i = 2, j = 5, k = 7
     
-The expression on the right hand side can be arbitrarily complicated, e.g.::
+The expression on the right hand side can be arbitrarily complicated, e.g.,
+
+::
 
     cdef int n = python_call(foo(x,y), a + b + c) - 32
        
@@ -197,7 +203,9 @@ attribute lookup and can tell (by comparing pointers) whether or not the
 returned result is actually a new function. If, and only if, it is a new
 function, then the arguments packed into a tuple and the method called. This
 is all very fast. A flag is set so this lookup does not occur if one calls the
-method on the class directly, e.g.::
+method on the class directly, e.g.,
+
+::
 
     cdef class A:
         cpdef foo(self):

--- a/docs/src/userguide/pyrex_differences.rst
+++ b/docs/src/userguide/pyrex_differences.rst
@@ -85,7 +85,7 @@ cdef inline
 =============
 
 Module level functions can now be declared inline, with the :keyword:`inline`
-keyword passed on to the C compiler. These can be as fast as macros.::
+keyword passed on to the C compiler. These can be as fast as macros::
 
     cdef inline int something_fast(int a, int b):
         return a*a + b

--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -160,7 +160,7 @@ Sharing C Functions
 
 C functions defined at the top level of a module can be made available via
 :keyword:`cimport` by putting headers for them in the ``.pxd`` file, for
-example,::
+example,
 
 :file:`volume.pxd`::
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -14,7 +14,7 @@ file named :file:`primes.pyx`.
 
 Once you have written your ``.pyx`` file, there are a couple of ways of turning it
 into an extension module. One way is to compile it manually with the Cython
-compiler, e.g.:
+compiler, e.g.,
 
 .. sourcecode:: text
 

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -414,7 +414,9 @@ how to declare C++ classes.
 Since Cython 0.17, the STL containers coerce from and to the
 corresponding Python builtin types.  The conversion is triggered
 either by an assignment to a typed variable (including typed function
-arguments) or by an explicit cast, e.g.::
+arguments) or by an explicit cast, e.g.,
+
+::
 
     from libcpp.string cimport string
     from libcpp.vector cimport vector
@@ -521,7 +523,9 @@ If the Rectangle class has a static member:
         };
     }
 
-you can declare it as a function living in the class namespace, i.e.::
+you can declare it as a function living in the class namespace, i.e.,
+
+::
 
     cdef extern from "Rectangle.h" namespace "shapes::Rectangle":
         void do_something()


### PR DESCRIPTION
Sorry, I missed an import that now should be removed and fixed again the commas that got restored along with pointers.
