### PR TITLE
Fix runtime crash as described on cython-devel.

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -554,7 +554,7 @@ static CYTHON_INLINE void *__Pyx_CyFunction_InitDefaults(PyObject *func, size_t 
     m->defaults = PyMem_Malloc(size);
     if (!m->defaults)
         return PyErr_NoMemory();
-    memset(m->defaults, 0, sizeof(size));
+    memset(m->defaults, 0, size);
     m->defaults_pyobjects = pyobjects;
     return m->defaults;
 }


### PR DESCRIPTION
__pyx_CyFunctionObject.defaults must be fully zeroed or a segfault or
memory corruption may occur if the object is visited by the garbage
collector before defaults is later populated. Uninitialized memory is
cast to PyObject\* with undefined results:

```
static int __Pyx_CyFunction_traverse(__pyx_CyFunctionObject *m, visitproc visit, void *arg)
{
    ...
    if (m->defaults) {
        PyObject **pydefaults = __Pyx_CyFunction_Defaults(PyObject *, m);
        int i;
        for (i = 0; i < m->defaults_pyobjects; i++)
            Py_VISIT(pydefaults[i]);
                     ^^^^^^^^^^^^^
```
