### PR TITLE
Do not prepend source_root to build_dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ def compile_cython_modules(profile=False, compile_more=False, cython_with_refnan
                 for module in already_imported:
                     keep_alive(sys.modules[module])
                     del sys.modules[module]
-                sys.path.insert(0, os.path.join(source_root, self.build_lib))
+                sys.path.insert(0, self.build_lib)
 
                 if profile:
                     from Cython.Compiler.Options import directive_defaults


### PR DESCRIPTION
Prepending source_root seems a bit incorrect here.

If `build_lib` specifies an absolute path, the path should be used as-is. When it is relative, it should be treated as relative to the current directory and not `source_root`. In this case, using the path as-is works as well.
