### PR TITLE
Memoryviews: Improved fix for the problem when GNU intrinsics fail on MinGW

### DIFF
--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -71,13 +71,13 @@ typedef volatile __pyx_atomic_int_type __pyx_atomic_int;
     __pyx_atomic_int_type __sync_fetch_and_add_4(__pyx_atomic_int *x, __pyx_atomic_int_type v)
     
     {
-        return (__pyx_atomic_int_type) InterlockedAdd((LONG volatile*)x, (LONG)v) - 1;
+        return (__pyx_atomic_int_type) InterlockedAdd((LONG volatile*)x, (LONG)v) - v;
     }
 
     __inline__ __attribute__((always_inline))
     __pyx_atomic_int_type __sync_fetch_and_sub_4(__pyx_atomic_int *x, __pyx_atomic_int_type v)    
     {
-        return (__pyx_atomic_int_type) InterlockedAdd((LONG volatile*)x, (LONG)-v) + 1;
+        return (__pyx_atomic_int_type) InterlockedAdd((LONG volatile*)x, (LONG)-v) + v;
     }
 
 #endif            


### PR DESCRIPTION
*\* Allows GNU atomic intrinsics to be used if they do work (the common case).

*\* Uses Windows API atomic methods if they are unavailable.

*\* Python thread locking (implemented with slow kernel semaphore) is not used for refcounting memoryview buffers.
