### PR TITLE
pyximport: fix a bug crashing other processes

### DIFF
--- a/pyximport/pyxbuild.py
+++ b/pyximport/pyxbuild.py
@@ -124,6 +124,17 @@ def pyx_to_dll(filename, ext = None, force_rebuild = 0,
                                           basename + '.reload%s'%count)
                     try:
                         import shutil # late import / reload_support is: debugging
+                        try:
+                            # Try to unlink first --- if the .so file
+                            # is mmapped by another process,
+                            # overwriting its contents corrupts the
+                            # loaded image (on Linux) and crashes the
+                            # other process. On Windows, unlinking an
+                            # open file just fails.
+                            if os.path.isfile(r_path):
+                                os.unlink(r_path)
+                        except OSError:
+                            continue
                         shutil.copy2(org_path, r_path)
                         so_path = r_path
                     except IOError:


### PR DESCRIPTION
pyxbuild overwrites .so file contents, corrupting any mmapped code image
loaded. If pyximporting the same module from two different processes, on
Linux this leads to crashes with bus error.

This commit fixes the issue by unlinking the file first. On Linux et
al., this does not change the file contents of any open FDs.  On
Windows, unlinking fails, and we just switch to using a different file
name.
