### PR TITLE
Adding +/- operators for c++ vector iterators

### DIFF
--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -4,6 +4,8 @@ cdef extern from "<vector>" namespace "std":
             T& operator*() nogil
             iterator operator++() nogil
             iterator operator--() nogil
+            iterator operator+(size_t) nogil
+            iterator operator-(size_t) nogil
             bint operator==(iterator) nogil
             bint operator!=(iterator) nogil
             bint operator<(iterator) nogil
@@ -14,6 +16,8 @@ cdef extern from "<vector>" namespace "std":
             T& operator*() nogil
             iterator operator++() nogil
             iterator operator--() nogil
+            iterator operator+(size_t) nogil
+            iterator operator-(size_t) nogil
             bint operator==(reverse_iterator) nogil
             bint operator!=(reverse_iterator) nogil
             bint operator<(reverse_iterator) nogil


### PR DESCRIPTION
Adding +/- operators for vector iterator allows the use of stl algorithm like "partial_sort":

``` cython
from libcpp.vector import vector

ctypedef vector[float] farray
ctypedef vector[float].iterator fiter

cdef extern from "<algorithm>" namespace "std":
    void partial_sort(fiter, fiter, fiter)    

def my_partial_sort(np.ndarray[float, ndim=1] x, int k):
   cdef farray arr = x
   partial_sort(arr.begin(), arr.begin()+k, arr.end())
   x[:] = arr
```

The += operator works properly but it leads to some problems when using it in a prange loop since the variable becomes a reduce variable.
