### PR TITLE
Add specific support for list/tuple slicing

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3580,9 +3580,29 @@ class SliceIndexNode(ExprNode):
                         code.error_goto_if_null(result, self.pos)))
         elif self.base.type is unicode_type:
             code.globalstate.use_utility_code( 
-                          UtilityCode.load_cached("PyUnicode_Substring", "StringTools.c")) 
+                    UtilityCode.load_cached("PyUnicode_Substring", "StringTools.c")) 
             code.putln(
                 "%s = __Pyx_PyUnicode_Substring(%s, %s, %s); %s" % (
+                    result,
+                    base_result,
+                    start_code,
+                    stop_code,
+                    code.error_goto_if_null(result, self.pos)))
+        elif self.base.type is list_type:
+            code.globalstate.use_utility_code( 
+                    UtilityCode.load_cached("PyList_GetSlice", "ObjectHandling.c")) 
+            code.putln(
+                "%s = __Pyx_PyList_GetSlice(%s, %s, %s); %s" % (
+                    result,
+                    base_result,
+                    start_code,
+                    stop_code,
+                    code.error_goto_if_null(result, self.pos)))
+        elif self.base.type is tuple_type:
+            code.globalstate.use_utility_code( 
+                    UtilityCode.load_cached("PyTuple_GetSlice", "ObjectHandling.c")) 
+            code.putln(
+                "%s = __Pyx_PyTuple_GetSlice(%s, %s, %s); %s" % (
                     result,
                     base_result,
                     start_code,

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -655,3 +655,93 @@ bad:
 static CYTHON_INLINE PyObject* __Pyx_tp_new_kwargs(PyObject* type_obj, PyObject* args, PyObject* kwargs) {
     return (PyObject*) (((PyTypeObject*)type_obj)->tp_new((PyTypeObject*)type_obj, args, kwargs));
 }
+
+/////////////// PyList_GetSlice.proto ///////////////
+
+static CYTHON_INLINE PyObject* __Pyx_PyList_GetSlice(
+                PyObject* lst, Py_ssize_t start, Py_ssize_t stop);
+
+/////////////// PyList_GetSlice ///////////////
+
+static CYTHON_INLINE PyObject* __Pyx_PyList_GetSlice(
+                PyObject* lst, Py_ssize_t start, Py_ssize_t stop) {
+    Py_ssize_t i, length;
+    PyListObject* np; 
+    PyObject **src, **dest;
+    PyObject *v;
+
+    length = PyList_GET_SIZE(lst);
+
+    if (start < 0) {
+        start += length;
+        if (start < 0)
+            start = 0;
+    }
+
+    if (stop < 0)
+        stop += length;    
+    else if (stop > length)
+        stop = length;
+
+    length = stop - start;
+    if (length <= 0)
+        return PyList_New(0);
+
+    np = (PyListObject*) PyList_New(length);
+    if (np == NULL)
+        return NULL;
+
+    src = ((PyListObject*)lst)->ob_item + start;
+    dest = np->ob_item;
+    for (i = 0; i < length; i++) {
+        v = src[i];
+        Py_INCREF(v);
+        dest[i] = v;
+    }
+    return (PyObject*)np;
+} 
+
+/////////////// PyTuple_GetSlice.proto ///////////////
+
+static CYTHON_INLINE PyObject* __Pyx_PyTuple_GetSlice(
+                PyObject* ob, Py_ssize_t start, Py_ssize_t stop);
+
+/////////////// PyTuple_GetSlice ///////////////
+
+static CYTHON_INLINE PyObject* __Pyx_PyTuple_GetSlice(
+                PyObject* ob, Py_ssize_t start, Py_ssize_t stop) {
+    Py_ssize_t i, length;
+    PyTupleObject* np; 
+    PyObject **src, **dest;
+    PyObject *v;
+
+    length = PyTuple_GET_SIZE(ob);
+
+    if (start < 0) {
+        start += length;
+        if (start < 0)
+            start = 0;
+    }
+
+    if (stop < 0)
+        stop += length;    
+    else if (stop > length)
+        stop = length;
+
+    length = stop - start;
+    if (length <= 0)
+        return PyTuple_New(0);
+
+    np = (PyTupleObject*) PyTuple_New(length);
+    if (np == NULL)
+        return NULL;
+
+    src = ((PyTupleObject*)ob)->ob_item + start;
+    dest = np->ob_item;
+    for (i = 0; i < length; i++) {
+        v = src[i];
+        Py_INCREF(v);
+        dest[i] = v;
+    }
+    return (PyObject*)np;
+} 

--- a/tests/run/typed_slice.pyx
+++ b/tests/run/typed_slice.pyx
@@ -1,21 +1,142 @@
-def slice_list(list l):
+def slice_list(list l, int start, int stop):
     """
-    >>> slice_list([1,2,3,4])
+    >>> slice_list([1,2,3,4], 1, 3)
     [2, 3]
+    >>> slice_list([1,2,3,4], 1, 7)
+    [2, 3, 4]
+    >>> slice_list([], 1, 3)
+    []
+    >>> slice_list([1], 1, 3)
+    []
+    >>> slice_list([1,2,3,4], -3, -1)
+    [2, 3]
+    >>> slice_list([1,2,3,4], -10, -1)
+    [1, 2, 3]
+    >>> slice_list([], -3, -1)
+    []
+    >>> slice_list([1], -3, -1)
+    []
     """
-    return l[1:3]
+    return l[start:stop]
+
+def slice_list2(list l, int start):
+    """
+    >>> slice_list2([1,2,3,4], 1)
+    [2, 3, 4]
+    >>> slice_list2([], 1)
+    []
+    >>> slice_list2([1], 1)
+    []
+    >>> slice_list2([1], 2)
+    []
+    >>> slice_list2([1,2,3,4], -3)
+    [2, 3, 4]
+    >>> slice_list2([1,2,3,4], -10)
+    [1, 2, 3, 4]
+    >>> slice_list2([], -3)
+    []
+    >>> slice_list2([1], -3)
+    [1]
+    """
+    return l[start:]
+
+def slice_list3(list l, int stop):
+    """
+    >>> slice_list3([1,2,3,4], 3)
+    [1, 2, 3]
+    >>> slice_list3([1,2,3,4], 7)
+    [1, 2, 3, 4]
+    >>> slice_list3([], 3)
+    []
+    >>> slice_list3([1], 3)
+    [1]
+    >>> slice_list3([1,2,3,4], -3)
+    [1]
+    >>> slice_list3([1,2,3,4], -10)
+    []
+    >>> slice_list3([], -1)
+    []
+    >>> slice_list3([1], -1)
+    []
+    >>> slice_list3([1, 2], -3)
+    []
+    """
+    return l[:stop]
 
 def slice_list_copy(list l):
-    cdef list retlist = l[1:3]
-    return retlist
+    """
+    >>> slice_list_copy([])
+    []
+    >>> slice_list_copy([1,2,3])
+    [1, 2, 3]
+    """
+    return l[:]
 
-def slice_tuple(tuple t):
+def slice_tuple_copy(tuple l):
     """
-    >>> l = [1,2,3,4]
-    >>> slice_tuple(tuple(l))
+    >>> slice_tuple_copy(())
+    ()
+    >>> slice_tuple_copy((1,2,3))
+    (1, 2, 3)
+    """
+    return l[:]
+
+def slice_tuple(tuple t, int start, int stop):
+    """
+    >>> slice_tuple((1,2,3,4), 1, 3)
     (2, 3)
+    >>> slice_tuple((1,2,3,4), 1, 7)
+    (2, 3, 4)
+    >>> slice_tuple((), 1, 3)
+    ()
+    >>> slice_tuple((1,), 1, 3)
+    ()
+    >>> slice_tuple((1,2,3,4), -3, -1)
+    (2, 3)
+    >>> slice_tuple((1,2,3,4), -10, -1)
+    (1, 2, 3)
+    >>> slice_tuple((), -3, -1)
+    ()
+    >>> slice_tuple((1,), -3, -1)
+    ()
     """
-    return t[1:3]
+    return t[start:stop]
+
+def slice_tuple2(tuple t, int start):
+    """
+    >>> slice_tuple2((1,2,3,4), 1)
+    (2, 3, 4)
+    >>> slice_tuple2((), 1)
+    ()
+    >>> slice_tuple2((1,), 1)
+    ()
+    >>> slice_tuple2((1,2,3,4), -3)
+    (2, 3, 4)
+    >>> slice_tuple2((1,2,3,4), -10)
+    (1, 2, 3, 4)
+    >>> slice_tuple2((), -3)
+    ()
+    >>> slice_tuple2((1,), -3)
+    (1,)
+    """
+    return t[start:]
+
+def slice_tuple3(tuple t, int stop):
+    """
+    >>> slice_tuple3((1,2,3,4), 3)
+    (1, 2, 3)
+    >>> slice_tuple3((1,2,3,4), 7)
+    (1, 2, 3, 4)
+    >>> slice_tuple3((), 3)
+    ()
+    >>> slice_tuple3((1,), 3)
+    (1,)
+    >>> slice_tuple3((1,2,3,4), -1)
+    (1, 2, 3)
+    >>> slice_tuple3((), -1)
+    ()
+    """
+    return t[:stop]
 
 def slice_list_assign_list(list l):
     """


### PR DESCRIPTION
Currently Cython generates generic PySequence_GetSlice for slicing of list/tuple. 
Adding specialization of code generation that reflects specifics of list/tuple slicing slightly impove performance of list/tuple slicing.
