### PR TITLE
add fdopen to stdio.pxd

### DIFF
--- a/Cython/Includes/libc/stdio.pxd
+++ b/Cython/Includes/libc/stdio.pxd
@@ -16,6 +16,7 @@ cdef extern from "stdio.h" nogil:
     enum: FILENAME_MAX
     FILE *fopen   (const char *filename, const char  *opentype)
     FILE *freopen (const char *filename, const char *opentype, FILE *stream)
+    FILE *fdopen  (int fdescriptor, const char *opentype)
     int  fclose   (FILE *stream)
     int  remove   (const char *filename)
     int  rename   (const char *oldname, const char *newname)


### PR DESCRIPTION
Allow attaching a stream to an opened file via its file descriptor. This is very handy when one wants to manipulate a file, which is already opened in python, e.g.:

``` cython
from libc.stdio cimport *

pfile = open("file")
cdef FILE * cfile = fdopen(pfile.fileno(), "r")
# ...
```
