### PR TITLE
Correctly handle compile-time strings appearing in Python context.

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -708,9 +708,9 @@ def wrap_compile_time_constant(pos, value):
     elif isinstance(value, float):
         return ExprNodes.FloatNode(pos, value=rep)
     elif isinstance(value, _unicode):
-        return ExprNodes.UnicodeNode(pos, value=value)
+        return ExprNodes.UnicodeNode(pos, value=EncodedString(value))
     elif isinstance(value, _bytes):
-        return ExprNodes.BytesNode(pos, value=value)
+        return ExprNodes.BytesNode(pos, value=BytesLiteral(value))
     elif isinstance(value, tuple):
         args = [wrap_compile_time_constant(pos, arg)
                 for arg in value]


### PR DESCRIPTION
Compile-time `unicode` and `bytes` values should be wrapped with `EncodedString` and `BytesLiteral` respectively.
Otherwise attempts to use them in Python context (for example, returning them from a function) result in errors like `AttributeError: 'unicode' object has no attribute 'is_unicode'`

Details: I had a compile-time constant PLATFORM = u'win32' (just an example) and Cython failed on a function like:

```
def get_platform():
    return PLATFORM
```
