### PR TITLE
Add casting to const

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1125,9 +1125,11 @@ class FusedTypeNode(CBaseTypeNode):
 
 
 class CConstTypeNode(CBaseTypeNode):
+    # name          string
     # base_type     CBaseTypeNode
 
     child_attrs = ["base_type"]
+    name = 'const'
 
     def analyse(self, env, could_be_name = False):
         base = self.base_type.analyse(env, could_be_name)

--- a/tests/compile/constcast.pyx
+++ b/tests/compile/constcast.pyx
@@ -1,0 +1,8 @@
+# mode: compile
+from libc.stdlib cimport malloc, free
+
+cdef void f():
+    cdef const int **allocated = <const int **>malloc(sizeof(int *))
+    free(allocated)
+
+f()


### PR DESCRIPTION
The included test is derived from a real world case
which would lead to warnings in GCC if the pointer
wouldn't be explicitly casted to const.
