### PR TITLE
Add __eq__ to enum type

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3329,6 +3329,15 @@ class CEnumType(CType):
         return "<CEnumType %s %s%s>" % (self.name, self.cname,
             ("", " typedef")[self.typedef_flag])
 
+    def __eq__(self, other):
+        if isinstance(other, CEnumType):
+            return self.name == other.name
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self.name)
+
     def declaration_code(self, entity_code,
             for_display = 0, dll_linkage = None, pyrex = 0):
         if pyrex or for_display:

--- a/tests/run/funcwarn.srctree
+++ b/tests/run/funcwarn.srctree
@@ -1,0 +1,30 @@
+PYTHON cythonizepxd.py
+
+######## cythonizepxd.py ########
+
+import sys
+
+from Cython.Compiler.Main import (CompilationOptions, compile_single,
+                                  default_options)
+
+class AssertWarning:
+    warning = ('warning: a.pxd:6:12: Function signature does not match '
+               'previous declaration')
+    def write(self, stderr):
+        assert stderr.strip() != warning
+
+# redirect stderr
+old_stderr = sys.stderr
+sys.stderr = mystderr = AssertWarning()
+
+result = compile_single('a.pxd', CompilationOptions(default_options))
+
+sys.stderr = old_stderr
+
+######## a.pxd ########
+
+cdef extern from *:
+    ctypedef enum MyEnum:
+        Value1
+
+    MyEnum f()


### PR DESCRIPTION
If a function declaration contained an enum, there were
false warnings regarding the function signature when the
pxd file was compiled with Cython (the warnings don't
appear if the pxd file gets cimported in a pyx file).

The warning is:
Function signature does not match previous declaration

It can be tested manually with a pxd file with the following
contents:

```
cdef extern from *:
    ctypedef enum MyEnum:
        Value1

    MyEnum f()
```

I haven't found a way to write a test case. I don't know how to compile pxd files (without a pyx file) within the current test suite.
