### PR TITLE
Fix C/C++ compilation error when if/else expression has extension class type.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9234,6 +9234,8 @@ class CondExprNode(ExprNode):
         self.true_val = self.true_val.analyse_types(env)
         self.false_val = self.false_val.analyse_types(env)
         self.type = PyrexTypes.independent_spanning_type(self.true_val.type, self.false_val.type)
+        if self.type.is_pyobject:
+            self.result_ctype = py_object_type
         if self.true_val.type.is_pyobject or self.false_val.type.is_pyobject:
             self.true_val = self.true_val.coerce_to(self.type, env)
             self.false_val = self.false_val.coerce_to(self.type, env)

--- a/tests/run/if_else_expr.pyx
+++ b/tests/run/if_else_expr.pyx
@@ -1,7 +1,11 @@
 # mode: run
-# tag: if_else_expr
+# tag: condexpr
+
+cimport cython
 
 cdef class Foo:
+    cdef dict data
+
     def __repr__(self):
         return '<Foo>'
 
@@ -14,3 +18,16 @@ cpdef test_type_cast(Foo obj, cond):
     <Foo>
     """
     return [obj] if cond else obj
+
+
+cdef func(Foo foo, dict data):
+    return foo, data
+
+
+@cython.test_fail_if_path_exists('//PyTypeTestNode')
+def test_cpp_pyobject_cast(Foo obj1, Foo obj2, cond):
+    """
+    >>> test_cpp_pyobject_cast(Foo(), Foo(), True)
+    (<Foo>, None)
+    """
+    return func(obj1 if cond else obj2, obj1.data if cond else obj2.data)


### PR DESCRIPTION
This example fails to compile in C and C++ (I'm using MSVC):

```
cdef class ExtType:
    pass

cdef int cond = ...
cdef ExtType a = ExtType(), b = ExtType()
cdef ExtType c = a if cond else b  # generated code does not compile
```

Both assignment source (if/else expression) and target have the C type of `struct __pyx_xxx_ExtType *`, but assignment goes through a `PyObject *` temporary, which is not type compatible and requires and explicit cast.

Note: I've retagged the test as "condexpr" for consistency with other if/else expression tests.
