### PR TITLE
Fix extern variable cimport code in cimport_from_pyx mode

### DIFF
--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -275,7 +275,8 @@ def create_pyx_as_pxd_pipeline(context, result):
             break
     def fake_pxd(root):
         for entry in root.scope.entries.values():
-            entry.defined_in_pxd = 1
+            if not entry.in_cinclude:
+                entry.defined_in_pxd = 1
         return StatListNode(root.pos, stats=[]), root.scope
     pipeline.append(fake_pxd)
     return pipeline

--- a/tests/run/cimport_from_pyx.srctree
+++ b/tests/run/cimport_from_pyx.srctree
@@ -15,18 +15,21 @@ setup(
 
 ######## a.pyx ########
 
-from b cimport Bclass, Bfunc, Bstruct, Benum, Benum_value, Btypedef
+from b cimport Bclass, Bfunc, Bstruct, Benum, Benum_value, Btypedef, Py_EQ, Py_NE
 cdef Bclass b = Bclass(5)
 assert Bfunc(&b.value) == b.value
 assert b.asStruct().value == b.value
 cdef Btypedef b_type = &b.value
 cdef Benum b_enum = Benum_value
+cdef int tmp = Py_EQ
 
 #from c cimport ClassC
 #cdef ClassC c = ClassC()
 #print c.value
 
 ######## b.pyx ########
+
+from cpython.object cimport Py_EQ, Py_NE
 
 cdef enum Benum:
     Benum_value


### PR DESCRIPTION
In `cimport_from_pyx` mode every top level .pyx construct is treated as being _defined_ in a virtual .pxd. This is incorrect for `cdef extern from` declarations, which are never _defined_, only _declared_.
As a result, incorrect code is being generated for cimporting `cdef extern from` variable values, which fails at compile time or runtime.
(In fact `cdef extern from` variables do not need any cimport code at all)

The modified test case demonstrates the problem nicely.
