### PR TITLE
Consistently declare local error reporting variables (lineno, clineno, filename)

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1618,6 +1618,12 @@ class CCodeWriter(object):
             else:
                 self.putln("%s%s;" % (static and "static " or "", decl))
 
+        if func_context.should_declare_error_indicator:
+            # Initialize these variables to silence compiler warnings
+            self.putln("int %s = 0;" % Naming.lineno_cname)
+            self.putln("const char *%s = NULL;" % Naming.filename_cname)
+            self.putln("int %s = 0;" % Naming.clineno_cname)
+
     def put_h_guard(self, guard):
         self.putln("#ifndef %s" % guard)
         self.putln("#define %s" % guard)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1914,13 +1914,6 @@ class FuncDefNode(StatNode, BlockNode):
 
         # ----- Go back and insert temp variable declarations
         tempvardecl_code.put_temp_declarations(code.funcstate)
-        if code.funcstate.should_declare_error_indicator:
-            # Initialize these variables to silence compiler warnings
-            tempvardecl_code.putln("int %s = 0;" % Naming.lineno_cname)
-            tempvardecl_code.putln("const char *%s = NULL;" %
-                                                    Naming.filename_cname)
-            if code.c_line_in_traceback:
-                tempvardecl_code.putln("int %s = 0;" % Naming.clineno_cname)
 
         # ----- Python version
         code.exit_cfunc_scope()


### PR DESCRIPTION
Currently `lineno/clineno/filename` variables are not declared locally for cpdef wrappers and utility functions, leading to suboptimal code. Compiler has to generate 3 useless global stores (lineno, clineno and filename) for every exception check, that's 25 bytes of junk (on x86).

The patch simply moves lineno declarations so that any function using temporary variables gets them autoamtically (and only if they are actually needed).
Handcoded Cython utilities keep using the global lineno, but their overhead is negligible.

I had observed 4% code size reduction (on x86) as a result of this change, mostly coming from the module init function, which is always heavy on exception checking.
