### PR TITLE
Non-Wrapped Inline Declaration Breaking Compatibility with C89 Compilers

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -262,21 +262,6 @@
   #define __Pyx_DOCSTR(n)  (n)
 #endif
 
-#ifdef NAN
-#define __PYX_NAN() ((float) NAN)
-#else
-static inline float __PYX_NAN() {
-  /* Initialize NaN. The sign is irrelevant, an exponent with all bits 1 and
-   a nonzero mantissa means NaN. If the first bit in the mantissa is 1, it is
-   a quiet NaN. */
-  float value;
-  memset(&value, 0xFF, sizeof(value));
-  return value;
-}
-#endif
-
-/////////////// UtilityFunctionPredeclarations.proto ///////////////
-
 /* inline attribute */
 #ifndef CYTHON_INLINE
   #if defined(__GNUC__)
@@ -289,6 +274,21 @@ static inline float __PYX_NAN() {
     #define CYTHON_INLINE
   #endif
 #endif
+
+#ifdef NAN
+#define __PYX_NAN() ((float) NAN)
+#else
+static CYTHON_INLINE float __PYX_NAN() {
+  /* Initialize NaN. The sign is irrelevant, an exponent with all bits 1 and
+   a nonzero mantissa means NaN. If the first bit in the mantissa is 1, it is
+   a quiet NaN. */
+  float value;
+  memset(&value, 0xFF, sizeof(value));
+  return value;
+}
+#endif
+
+/////////////// UtilityFunctionPredeclarations.proto ///////////////
 
 /* unused attribute */
 #ifndef CYTHON_UNUSED


### PR DESCRIPTION
ef219fd6487ba2f93d1f4d02761f27e041af1ac9 added an inline declaration of `__PYX_NAN` without using the compatibility wrappers, which ended up breaking the build on MSVC and (I assume) any other compiler that only supports C89 standards. See below:

```
C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Development\bin.apps\cpython-2.7.3\release-x86\include /TcCython\Plex\Scanners.c /Fobuild\temp.win32-2.7\Release\Cython\Plex\Scanners.obj
Scanners.c
Cython\Plex\Scanners.c(256) : error C2054: expected '(' to follow 'inline'
Cython\Plex\Scanners.c(256) : error C2085: '__PYX_NAN' : not in formal parameter list
Cython\Plex\Scanners.c(256) : error C2143: syntax error : missing ';' before '{'
error: command '"c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\BIN\cl.exe"' failed with exit status 2
```

and

```
Charles@Charles-PC /c/Development/py.thirdparty/repositories/cython
$ /mingw/bin/gcc.exe -I/mingw/include/python2.7 -std=c89 -o build/tmp/Scanners.o Cython/Plex/Scanners.c
Cython/Plex/Scanners.c:256:15: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'float'
```

I figured rather than move the `__PYX_NAN` declaration to a later point in the compilation, it'd be more appropriate to make the inline wrappers part of the preamble. (though I honestly don't know the internals enough to understand the distinction, so I may be wrong)
