### PR TITLE
Fixed .srctree tests execution

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1188,8 +1188,8 @@ class EndToEndTest(unittest.TestCase):
         old_path = os.environ.get('PYTHONPATH')
         os.environ['PYTHONPATH'] = self.cython_syspath + os.pathsep + (old_path or '')
         try:
-            for command in commands.split('\n'):
-                p = subprocess.Popen(commands,
+            for command in filter(None, commands.splitlines()):
+                p = subprocess.Popen(command,
                                      stderr=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      shell=True)


### PR DESCRIPTION
The patch fixes the following problems:
- .srctree tests pass unexpectedly on Windows, because only the first test command is executed (typically `setup.py build_ext`).
- .srctree test commands are executed multiple times on Linux.

The origin of this bug is clearly a typo.
Linux version of `Popen` masked the problem by accepting newline-separated list of commands as a valid input.
