### PR TITLE
Fixes for absolute_import and inop test failures on Windows.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -53,7 +53,7 @@ def extended_iglob(pattern):
                 if path not in seen:
                     seen.add(path)
                     yield path
-            for path in extended_iglob(join_path(root, '*', '**', rest)):
+            for path in extended_iglob(join_path(root, '*', '**/' + rest)):
                 if path not in seen:
                     seen.add(path)
                     yield path

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -203,7 +203,7 @@ wide_unicode_character_surrogate2 = 0xDEDC
 
 @cython.test_fail_if_path_exists("//SwitchStatNode")
 @cython.test_assert_path_exists("//PrimaryCmpNode")
-def m_wide_unicode_literal(Py_UNICODE a):
+def m_wide_unicode_literal(Py_UCS4 a):
     """
     >>> m_unicode_literal(ord('f'))
     1


### PR DESCRIPTION
1) absolute_import fails on Windows because it compiles nothing. The pattern passed to cythonize matches zero files.
cythonize's `extended_iglob` disregards Windows path separators yet it uses `os.path.join` that produces them.

2) one of inop tests fails on Windows Python 3.3, because it incorrectly uses `Py_UNICODE` type. (`Py_UNICODE` is not guaranteed to be 4-byte even on 3.3)
