### PR TITLE
Order cdef classes by inheritance before generating the code.

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -106,6 +106,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         self.find_referenced_modules(env, self.referenced_modules, {})
         if options.recursive:
             self.generate_dep_file(env, result)
+        self.sort_cdef_classes(env)
         self.generate_c_code(env, options, result)
         self.generate_h_code(env, options, result)
         self.generate_api_code(env, result)
@@ -454,6 +455,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             vtabslot_dict, objstruct_cname)
 
         return (vtab_list, vtabslot_list)
+
+    def sort_cdef_classes(self, env):
+        entry_dict = {}
+        for entry in env.c_class_entries:
+            entry_dict[entry.name] = entry
+        def entry_name(entry):
+            return entry.name
+        env.c_class_entries[:] = self.sort_types_by_inheritance(entry_dict, entry_name)
 
     def generate_type_definitions(self, env, modules, vtab_list, vtabslot_list, code):
         # TODO: Why are these separated out?

--- a/tests/run/cdef_class_order.pyx
+++ b/tests/run/cdef_class_order.pyx
@@ -1,0 +1,15 @@
+cimport cython
+
+cdef class B
+
+cdef class A(object):
+    cdef list dealloc1
+
+cdef class B(A):
+    cdef list dealloc2
+
+def test():
+    """
+    >>> test()
+    """
+    A(), B()


### PR DESCRIPTION
cdef classes must be (topologically) ordered by inheritance to satisfy the following dependencies:
1) dealloc function definition: derived classes call base class dealloc;
2) vtable pointer initialization in module init function.
Wrong order causes C/C++ compilation failure for 1) and segfault on import for 2).

Normally, source order is the correct order, but forward declarations can change this. See included test case for example.
I hit this problem because I forward declare all my classes in alphabetic order (and then include class definitions from .pxi files, one class per file).

The simple (although not obvious) workaround is to reorder forward delarations, but I believe it's worth fixing permanently.
