### PR TITLE
Fix compatibility with msvc < 1400

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -279,7 +279,7 @@
 #ifndef CYTHON_RESTRICT
   #if defined(__GNUC__)
     #define CYTHON_RESTRICT __restrict__
-  #elif defined(_MSC_VER)
+  #elif defined(_MSC_VER) && _MSC_VER >= 1400
     #define CYTHON_RESTRICT __restrict
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     #define CYTHON_RESTRICT restrict


### PR DESCRIPTION
Visual Studio .NET 2003, used by Python 2.5 32 bit, does not support the '__restrict' keyword.
This should be backported to the 0.19.x branch.
This fixes the following kind of compiler error:

```
building 'Cython.Compiler.Parsing' extension
C:\Program Files (x86)\Microsoft Visual Studio .NET 2003\Vc7\bin\cl.exe /c /nologo /Ox /MD /W3 /GX /DNDEBUG -IX:\Python25\include -IX:\Python25\PC /TcCython\Compiler\Parsing.c /Fobuild\temp.win32-2.5\Release\Cython\Compiler\Parsing.obj Parsing.c
Cython\Compiler\Parsing.c(55967) : error C4235: nonstandard extension used : '__restrict' keyword not supported in this product
Cython\Compiler\Parsing.c(55967) : error C4235: nonstandard extension used : '__restrict' keyword not supported in this product
error: command '"C:\Program Files (x86)\Microsoft Visual Studio .NET 2003\Vc7\bin\cl.exe"' failed with exit status 2
```
