### PR TITLE
fix build_dir copying

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -671,8 +671,10 @@ def cythonize(module_list, exclude=[], nthreads=0, aliases=None, quiet=False, fo
         if build_dir:
             root = os.path.realpath(os.path.abspath(find_root_package_dir(m.sources[0])))
             def copy_to_build_dir(filepath, root=root):
-                filepath = os.path.realpath(os.path.abspath(filepath))
-                if filepath.startswith(root):
+                filepath_abs = os.path.realpath(os.path.abspath(filepath))
+                if os.path.isabs(filepath):
+                    filepath = filepath_abs
+                if filepath_abs.startswith(root):
                     mod_dir = os.path.join(build_dir,
                             os.path.dirname(_relpath(filepath, root)))
                     if not os.path.isdir(mod_dir):

--- a/tests/build/build_dir.srctree
+++ b/tests/build/build_dir.srctree
@@ -1,3 +1,4 @@
+PYTHON -c "import os; os.symlink('subdir', 'fake')"
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import a"
 PYTHON -c "import pkg.b"
@@ -43,12 +44,16 @@ int value2 = 200;
 
 ######## pkg/b.pyx ########
 
+cdef extern from "../fake/helper.h":
+    int value2
+
 cdef extern from "pkg_helper.h":
     int value3
 
 cdef extern from "subdir/pkg_helper.h":
     int value4
 
+assert value2 == 200
 assert value3 == 300
 assert value4 == 400
 
@@ -72,5 +77,6 @@ assert not os.path.exists("a.c")
 assert os.path.exists("scratchB/pkg/b.c")
 assert os.path.exists("scratchB/pkg/pkg_helper.h")
 assert os.path.exists("scratchB/pkg/subdir/pkg_helper.h")
+assert os.path.exists("scratchB/fake/helper.h")
 assert not os.path.exists("b.c")
 assert not os.path.exists("pkg/b.c")


### PR DESCRIPTION
Found that with the changes made over the past couple of days, using this feature with Sage was still broken. This resolves all edge cases Sage exposed.
