### PR TITLE
Use all distutils config files in pyximport

### DIFF
--- a/pyximport/pyxbuild.py
+++ b/pyximport/pyxbuild.py
@@ -80,9 +80,8 @@ def pyx_to_dll(filename, ext = None, force_rebuild = 0,
     build.build_base = pyxbuild_dir
 
     cfgfiles = dist.find_config_files()
-    try: cfgfiles.remove('setup.cfg')
-    except ValueError: pass
     dist.parse_config_files(cfgfiles)
+
     try:
         ok = dist.parse_command_line()
     except DistutilsArgError:


### PR DESCRIPTION
Pyximport uses distutils to compile cython code. In my project,
I needed special compiler options to compile the code, so I wrote
a setup.cfg file to cope for that. Weirdly, pyximport completely
ignored this. So I tried to find where pyximport is looking, and
found: nowhere! This patch removes this oddity.

The proponents of the current behavior argued that users might
be astonished to see that their settings were overridden by a random
config file. This argument is flawed: config files don't just appear by
themselves. And for those people out there who know how to write config
files and know where to put them, let them do it!
