### PR TITLE
Fix several MS compiler warnings.

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -117,7 +117,7 @@ cdef class array:
         cdef Py_ssize_t i
         cdef PyObject **p
 
-        self.ndim = len(shape)
+        self.ndim = <int> len(shape)
         self.itemsize = itemsize
 
         if not self.ndim:
@@ -870,7 +870,7 @@ cdef int slice_memviewslice(
 #
 @cname('__pyx_pybuffer_index')
 cdef char *pybuffer_index(Py_buffer *view, char *bufp, Py_ssize_t index,
-                          int dim) except NULL:
+                          Py_ssize_t dim) except NULL:
     cdef Py_ssize_t shape, stride, suboffset = -1
     cdef Py_ssize_t itemsize = view.itemsize
     cdef char *resultp

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -25,7 +25,7 @@ typedef struct {
 //       libatomic + autotools-like distutils support? Such a pain...
 #if CYTHON_ATOMICS && __GNUC__ >= 4 && (__GNUC_MINOR__ > 1 ||           \
                     (__GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL >= 2)) && \
-                    !defined(__i386__)                   
+                    !defined(__i386__)
     /* gcc >= 4.1.2 */
     #define __pyx_atomic_incr_aligned(value, lock) __sync_fetch_and_add(value, 1)
     #define __pyx_atomic_decr_aligned(value, lock) __sync_fetch_and_sub(value, 1)
@@ -580,7 +580,7 @@ __pyx_memoryview_copy_new_contig(const __Pyx_memviewslice *from_mvs,
 
 
     for(i = 0; i < ndim; i++) {
-        temp_int = PyInt_FromLong(from_mvs->shape[i]);
+        temp_int = PyInt_FromSsize_t(from_mvs->shape[i]);
         if(unlikely(!temp_int)) {
             goto fail;
         } else {


### PR DESCRIPTION
This fixes several compiler warnings under Windows using Visual Studio.  Two of three are due to long being only 32 bits under Windows.  Here's the reasoning for each change.

MemoryView.pyx line 113: Cython converts the len(shape) call into PyTuple_GET_SIZE, which returns Py_ssize_t, while ndim is declared as an int.  Alternatively, the type of ndim could be changed, but that seems like it would be overkill.

MemoryView.pyx line 873: This function is called from line 357.  The dim variable is the index from the Python enumerate iterator, which Cython types as a Py_ssize_t.

MemoryView_C.c line 583: The shape field of __Pyx_memviewslice is declared as Py_ssize_t.
