### PR TITLE
Added support for cpdef enum (take 2)

### DIFF
--- a/Cython/Compiler/CodeGeneration.py
+++ b/Cython/Compiler/CodeGeneration.py
@@ -17,16 +17,21 @@ class ExtractPxdCode(VisitorTransform):
     """
 
     def __call__(self, root):
-        self.funcs = []
+        self.code_statements = []
         self.visitchildren(root)
-        return (StatListNode(root.pos, stats=self.funcs), root.scope)
+        return (StatListNode(root.pos, stats=self.code_statements), root.scope)
 
     def visit_FuncDefNode(self, node):
-        self.funcs.append(node)
+        self.code_statements.append(node)
         # Do not visit children, nested funcdefnodes will
         # also be moved by this action...
         return node
 
     def visit_Node(self, node):
         self.visitchildren(node)
+        return node
+
+    def visit_CEnumDefNode(self, node):
+        if node.visibility == 'public' or node.is_overridable:
+            self.code_statements.append(node)
         return node

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -442,7 +442,7 @@ class CDefExternNode(StatNode):
         return self
 
     def generate_execution_code(self, code):
-        pass
+        self.body.generate_execution_code(code)  # for cpdef enums
 
     def annotate(self, code):
         self.body.annotate(code)
@@ -1354,7 +1354,7 @@ class CEnumDefNode(StatNode):
         return self
 
     def generate_execution_code(self, code):
-        if self.visibility == 'public' or self.api:
+        if self.visibility == 'public' or self.api or self.is_overridable:
             temp = code.funcstate.allocate_temp(PyrexTypes.py_object_type, manage_ref=True)
             for item in self.entry.enum_values:
                 code.putln("%s = PyInt_FromLong(%s); %s" % (

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1757,7 +1757,7 @@ if VALUE is not None:
         return None
 
     def visit_CEnumDefNode(self, node):
-        if node.visibility == 'public':
+        if node.visibility == 'public' or node.is_overridable:
             return node
         else:
             return None

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2591,8 +2591,8 @@ def p_cdef_statement(s, ctx):
     elif s.sy == 'IDENT' and s.systring in struct_enum_union:
         if ctx.level not in ('module', 'module_pxd'):
             error(pos, "C struct/union/enum definition not allowed here")
-        if ctx.overridable:
-            error(pos, "C struct/union/enum cannot be declared cpdef")
+        if ctx.overridable and s.systring != "enum":
+            error(pos, "C struct/union cannot be declared cpdef")
         return p_struct_enum(s, pos, ctx)
     elif s.sy == 'IDENT' and s.systring == 'fused':
         return p_fused_definition(s, pos, ctx)
@@ -2649,7 +2649,8 @@ def p_c_enum_definition(s, pos, ctx):
     return Nodes.CEnumDefNode(
         pos, name = name, cname = cname, items = items,
         typedef_flag = ctx.typedef_flag, visibility = ctx.visibility,
-        api = ctx.api, in_pxd = ctx.level == 'module_pxd')
+        api = ctx.api, in_pxd = ctx.level == 'module_pxd',
+        is_overridable = ctx.overridable)
 
 def p_c_enum_line(s, ctx, items):
     if s.sy != 'pass':

--- a/tests/run/cpdef_enum.srctree
+++ b/tests/run/cpdef_enum.srctree
@@ -1,0 +1,85 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -m doctest test.py
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(ext_modules=cythonize("*.pyx"))
+
+######## enum.h ########
+
+enum {
+    ANONYMOUS = 1
+};
+
+enum Enum {
+    NAMED = 1
+};
+
+typedef enum {
+    TYPEDEF = 1
+} TypedefEnum;
+
+#define DEFINED 1
+
+######## enum.pxd ########
+
+cpdef enum:
+    PY_ANONYMOUS = 1
+
+cpdef enum PyEnum:
+    PY_NAMED = 1
+
+cdef extern from "enum.h":
+    cpdef enum:
+        ANONYMOUS
+
+    cpdef enum Enum:
+        NAMED
+
+    cpdef enum:
+        DEFINED
+
+    cpdef enum _TypedefEnum:
+        TYPEDEF
+    ctypedef _TypedefEnum TypedefEnum
+
+cdef inline void func(PyEnum a, Enum b, TypedefEnum c):
+    pass
+
+######## enum.pyx ########
+
+# enums are defined in .pxd
+
+######## enum_pyx.pyx ########
+
+# enums are defined in .pyx
+include "enum.pxd"
+
+######## test.py ########
+"""
+>>> enum.ANONYMOUS, enum.NAMED, enum.TYPEDEF, enum.PY_ANONYMOUS, enum.PY_NAMED
+(1, 1, 1, 1, 1)
+>>> enum.Enum
+Traceback (most recent call last):
+  ...
+AttributeError: 'module' object has no attribute 'Enum'
+>>> enum.PyEnum
+Traceback (most recent call last):
+  ...
+AttributeError: 'module' object has no attribute 'PyEnum'
+
+>>> enum_pyx.ANONYMOUS, enum_pyx.NAMED, enum_pyx.TYPEDEF, enum_pyx.PY_ANONYMOUS, enum_pyx.PY_NAMED
+(1, 1, 1, 1, 1)
+>>> enum_pyx.Enum
+Traceback (most recent call last):
+  ...
+AttributeError: 'module' object has no attribute 'Enum'
+>>> enum_pyx.PyEnum
+Traceback (most recent call last):
+  ...
+AttributeError: 'module' object has no attribute 'PyEnum'
+"""
+import enum, enum_pyx


### PR DESCRIPTION
This is a resurrection of [PR45](https://github.com/cython/cython/pull/45).

I've started with @vitek's patch, fixed .pxd enum processing and added more tests.

To answer comments in the original thread:
- Enums as Python classes is a completely different feature. `cpdef enum` simply exposes C enumeration values, which are always module scoped.
  Therefore, `modname.VALUE_NAME` has the same meaning in Cython (C level) and Python.
- Cython type system and its handling of enum types is not affected in any way.

My use case: I have two modules full of numeric constants (~500 in total) that are used throughout the project. Currently it is impossible to expose them to Python without duplicating every definition. Also, it is impossible to declare Python values in the same module as C enum values, due to name conflict. (I have considered using `globals().extend(VALUE=..., etc)` but opted for this patch instead.)

Docs will be written if/when the change is approved.
