### PR TITLE
Fix docstring

### DIFF
--- a/Cython/Distutils/extension.py
+++ b/Cython/Distutils/extension.py
@@ -16,7 +16,6 @@ except ImportError:
     warnings = None
 
 class Extension(_Extension.Extension):
-    _Extension.Extension.__doc__ + \
     """cython_include_dirs : [string]
         list of directories to search for Pyrex header files (.pxd) (in
         Unix form for portability)
@@ -37,7 +36,8 @@ class Extension(_Extension.Extension):
     no_c_in_traceback : boolean
         emit the c file and line number from the traceback for exceptions
     """
-
+    __doc__ = _Extension.Extension.__doc__ + __doc__
+    
     # When adding arguments to this constructor, be sure to update
     # user_options.extend in build_ext.py.
     def __init__(self, name, sources,


### PR DESCRIPTION
The previous docstring was resulting in None

```
>>> class Foo:
...     """Parent class."""
...     
>>> class Bar(Foo):
...     Foo.__doc__ + \
...     """ Child class."""
...     
>>> Foo.__doc__
'Parent class.'
>>> Bar.__doc__
                    <---------- (None)
>>> class Bar2(Foo):
...     """ Child class."""
...     __doc__ = Foo.__doc__ + __doc__
...     
>>> Bar2.__doc__
'Parent class. Child class.'
```

This code still has some problem with -OO, resulting in:

```
TypeError: cannot concatenate 'str' and 'NoneType' objects
```
