### PR TITLE
allow inspection of the data used by PyArray_EquivTypes

### DIFF
--- a/Cython/Includes/numpy.pxd
+++ b/Cython/Includes/numpy.pxd
@@ -176,7 +176,8 @@ cdef extern from "numpy/arrayobject.h":
         cdef object fields
         cdef tuple names
         # Use PyDataType_HASSUBARRAY to test whether this field is
-        # valid (the pointer can be NULL).
+        # valid (the pointer can be NULL). Most users should access
+        # this field via the inline helper method PyDataType_SHAPE.
         cdef PyArray_ArrayDescr* subarray
 
     ctypedef extern class numpy.flatiter [object PyArrayIterObject]:
@@ -797,6 +798,12 @@ cdef inline object PyArray_MultiIterNew4(a, b, c, d):
 
 cdef inline object PyArray_MultiIterNew5(a, b, c, d, e):
     return PyArray_MultiIterNew(5, <void*>a, <void*>b, <void*>c, <void*> d, <void*> e)
+
+cdef inline tuple PyDataType_SHAPE(dtype d):
+    if PyDataType_HASSUBARRAY(d):
+        return <tuple>d.subarray.shape
+    else:
+        return None
 
 cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:
     # Recursive utility function used in __getbuffer__ to get format

--- a/Cython/Includes/numpy.pxd
+++ b/Cython/Includes/numpy.pxd
@@ -803,7 +803,7 @@ cdef inline tuple PyDataType_SHAPE(dtype d):
     if PyDataType_HASSUBARRAY(d):
         return <tuple>d.subarray.shape
     else:
-        return None
+        return ()
 
 cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset) except NULL:
     # Recursive utility function used in __getbuffer__ to get format

--- a/Cython/Includes/numpy.pxd
+++ b/Cython/Includes/numpy.pxd
@@ -154,7 +154,7 @@ cdef extern from "numpy/arrayobject.h":
 
     ctypedef void (*PyArray_VectorUnaryFunc)(void *, void *, npy_intp, void *,  void *)
 
-    ctypedef struct PyArray_SubArrayDescr "_arr_descr":
+    ctypedef struct PyArray_ArrayDescr:
         # shape is a tuple, but Cython doesn't support "tuple shape"
         # inside a non-PyObject declaration, so we have to declare it
         # as just a PyObject*.
@@ -177,7 +177,7 @@ cdef extern from "numpy/arrayobject.h":
         cdef tuple names
         # Use PyDataType_HASSUBARRAY to test whether this field is
         # valid (the pointer can be NULL).
-        cdef PyArray_SubArrayDescr* subarray
+        cdef PyArray_ArrayDescr* subarray
 
     ctypedef extern class numpy.flatiter [object PyArrayIterObject]:
         # Use through macros

--- a/tests/run/numpy_subarray.pyx
+++ b/tests/run/numpy_subarray.pyx
@@ -32,6 +32,6 @@ def test_record_subarray():
     assert <tuple>b_descr.subarray.shape == (3, 3)
 
     # Make sure the safe high-level helper function works
-    assert np.PyDataType_SHAPE(descr) is None
-    assert np.PyDataType_SHAPE(a_descr) is None
+    assert np.PyDataType_SHAPE(descr) == ()
+    assert np.PyDataType_SHAPE(a_descr) == ()
     assert np.PyDataType_SHAPE(b_descr) == (3, 3)

--- a/tests/run/numpy_subarray.pyx
+++ b/tests/run/numpy_subarray.pyx
@@ -19,10 +19,19 @@ def test_record_subarray():
     cdef np.dtype a_descr = descr.fields['a'][0]
     cdef np.dtype b_descr = descr.fields['b'][0]
 
+    # Make sure the dtype looks like we expect
     assert descr.fields == {'a': (py_numpy.dtype('int32'), 0),
                             'b': (py_numpy.dtype(('<f8', (3, 3))), 4)}
+
+    # Make sure that HASSUBARRAY is working
     assert not np.PyDataType_HASSUBARRAY(descr)
     assert not np.PyDataType_HASSUBARRAY(a_descr)
     assert np.PyDataType_HASSUBARRAY(b_descr)
 
+    # Make sure the direct field access works
     assert <tuple>b_descr.subarray.shape == (3, 3)
+
+    # Make sure the safe high-level helper function works
+    assert np.PyDataType_SHAPE(descr) is None
+    assert np.PyDataType_SHAPE(a_descr) is None
+    assert np.PyDataType_SHAPE(b_descr) == (3, 3)

--- a/tests/run/numpy_subarray.pyx
+++ b/tests/run/numpy_subarray.pyx
@@ -1,0 +1,28 @@
+# tag: numpy
+
+cimport numpy as np
+cimport cython
+
+import numpy as py_numpy
+
+__doc__ = u"""
+
+    >>> test_record_subarray()
+    
+"""
+
+def test_record_subarray():
+    cdef np.ndarray x = py_numpy.zeros((2,2),
+                                       dtype=[('a', py_numpy.int32),
+                                              ('b', py_numpy.float64, (3, 3))])
+    cdef np.dtype descr   = x.dtype
+    cdef np.dtype a_descr = descr.fields['a'][0]
+    cdef np.dtype b_descr = descr.fields['b'][0]
+
+    assert descr.fields == {'a': (py_numpy.dtype('int32'), 0),
+                            'b': (py_numpy.dtype(('<f8', (3, 3))), 4)}
+    assert not np.PyDataType_HASSUBARRAY(descr)
+    assert not np.PyDataType_HASSUBARRAY(a_descr)
+    assert np.PyDataType_HASSUBARRAY(b_descr)
+
+    assert <tuple>b_descr.subarray.shape == (3, 3)


### PR DESCRIPTION
Changes include:
- Added the PyDataType_HASSUBARRAY macro
- Added the new NPY_DATETIME and NPY_TIMEDELTA entries to NPY_TYPES
- Added the "kind" and "subarray" fields to the dtype class

Additional work could be done to expose the datatime metadata, but
non-performance users can already get at that data using the pure
python numpy.datetime_data function.

Author: Gerald Dalley
