### PR TITLE
--dbg-outdir option: specify gdb output location (default os.curdir())

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -28,6 +28,7 @@ Options:
   -w, --working <directory>      Sets the working directory for Cython (the directory modules
                                  are searched from)
   --gdb                          Output debug information for cygdb
+  --gdb-outdir <directory>       Specify gdb debug information output directory. Implies --gdb.
 
   -D, --no-docstrings            Strip docstrings from the compiled module.
   -a, --annotate                 Produce a colorized HTML version of the source.
@@ -119,6 +120,9 @@ def parse_command_line(args):
             elif option == "--gdb":
                 options.gdb_debug = True
                 options.output_dir = os.curdir
+            elif option == "--gdb-outdir":
+                options.gdb_debug = True
+                options.output_dir = pop_arg()
             elif option == '-2':
                 options.language_level = 2
             elif option == '-3':


### PR DESCRIPTION
this patch implements a custom output directory for cygdb information. this is required in case os.curdir() is not writable, and simplifies issues if os.curdir() is the wrong place.
