### PR TITLE
Add testcase for cimport+alias+subclass bug

### DIFF
--- a/tests/run/cimport_alias_subclass.pyx
+++ b/tests/run/cimport_alias_subclass.pyx
@@ -1,0 +1,13 @@
+cimport cimport_alias_subclass_helper as cash
+
+cdef class Derived(cash.Base):
+    cdef bint foo(self):
+        print "Hello"
+
+def run():
+    """
+    >>> run()
+    Hello
+    """
+    d = Derived()
+    d.foo()

--- a/tests/run/cimport_alias_subclass_helper.pxd
+++ b/tests/run/cimport_alias_subclass_helper.pxd
@@ -1,0 +1,2 @@
+cdef class Base:
+    cdef bint foo(self)


### PR DESCRIPTION
it seems that when I do:

> cimport foo as f
> 
> cdef class DerivedClass(f.BaseClass):
>     pass

I get following compilation errors:

> 3:5: 'BaseClass' is not declared
> 3:5: 'f.pxd' not found

which looks like a bug to me.

When I use plain "cimport foo" + "foo.BaseClass" or "from foo cimport 
BaseClass" + "BaseClass", it works as expected. Cython version 
0.20dev add8091340e (git describe: 0.19-324-gadd8091)

The test may require moving into tests/compile after the bug is fixed.

Mailing list link: TODO
