### PR TITLE
make fpos_t an opaque type

### DIFF
--- a/Cython/Includes/libc/stdio.pxd
+++ b/Cython/Includes/libc/stdio.pxd
@@ -48,7 +48,7 @@ cdef extern from "stdio.h" nogil:
     void     rewind (FILE *stream)
     long int ftell  (FILE *stream)
 
-    ctypedef long long int fpos_t
+    ctypedef struct fpos_t
     ctypedef const fpos_t const_fpos_t "const fpos_t"
     int fgetpos (FILE *stream, fpos_t *position)
     int fsetpos (FILE *stream, const fpos_t *position)


### PR DESCRIPTION
According to the C11 standard, §7.21.1, `fpos_t`

> is a complete object type other than an array type

but there's no guarantee that its an integer type.
