### PR TITLE
use -fPIC -shared when compiling "libraries" demo

### DIFF
--- a/Demos/libraries/setup.py
+++ b/Demos/libraries/setup.py
@@ -8,7 +8,7 @@ from Cython.Distutils import build_ext
 # For demo purposes, we build our own tiny library.
 try:
     print "building libmymath.a"
-    assert os.system("gcc -c mymath.c -o mymath.o") == 0
+    assert os.system("gcc -shared -fPIC -c mymath.c -o mymath.o") == 0
     assert os.system("ar rcs libmymath.a mymath.o") == 0
 except:
     if not os.path.exists("libmymath.a"):


### PR DESCRIPTION
This fixes the "libraries" demo's setup.py for building the call_mymath
extension.

Here's the problem that this fixes:

```
kanzure@raichu:~/local/cython/Demos/libraries$ python setup.py build_ext
building libmymath.a
running build_ext
cythoning call_mymath.pyx to call_mymath.c
building 'call_mymath' extension
creating build
creating build/temp.linux-x86_64-2.7
x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/home/kanzure/local/cython/Demos/libraries -I/usr/include/python2.7 -c call_mymath.c -o build/temp.linux-x86_64-2.7/call_mymath.o
creating build/lib.linux-x86_64-2.7
x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/call_mymath.o -L/home/kanzure/local/cython/Demos/libraries -lmymath -o build/lib.linux-x86_64-2.7/call_mymath.so
/usr/bin/ld: /home/kanzure/local/cython/Demos/libraries/libmymath.a(mymath.o): relocation R_X86_64_PC32 against undefined symbol `sin' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
