### PR TITLE
Multiple fixes to array.extend()

### DIFF
--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -154,11 +154,10 @@ cdef inline int extend_buffer(array self, char* stuff, Py_ssize_t n):
         return -1
     memcpy(self.data.as_chars + orgsize * itemsize, stuff, n * itemsize)
 
-cdef inline int extend(array self, array other):
+cdef inline int extend(array self, array other) except -2:
     """ extend array with data from another array; types must match. """
-    if self.ob_descr.typecode != self.ob_descr.typecode:
+    if self.ob_descr.typecode != other.ob_descr.typecode:
         PyErr_BadArgument()
-        return -1
     return extend_buffer(self, other.data.as_chars, Py_SIZE(other))
 
 cdef inline void zero(array op):

--- a/tests/run/pyarray.pyx
+++ b/tests/run/pyarray.pyx
@@ -147,8 +147,15 @@ def test_extend():
     """
     cdef array.array ca = array.array('i', [1, 2, 3])
     cdef array.array cb = array.array('i', [4, 5])
+    cdef array.array cf = array.array('f', [1.0, 2.0, 3.0])
     array.extend(ca, cb)
     assert list(ca) == [1, 2, 3, 4, 5], list(ca)
+    try:
+        array.extend(ca, cf)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError('tried to extend with an incompatible array type')
 
 def test_likes(a):
     """


### PR DESCRIPTION
```
* Fix self / other typecode compatibility check and add test

* In CPython, PyErr_BadArgument() C-API function always raises an
  exception and returns zero

* It is needed to add the `except -2` clause, so that the exception
  raised by PyErr_BadArgument() is not ignored

* Additionaly, the `return -1` statement in array.extend() will have
  no effect, and hence is misleading, so it needs to be removed
```

Signed-off-by: Yury V. Zaytsev yury@shurup.com
