### PR TITLE
Fix cygdb argument parsing

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -62,7 +62,7 @@ def make_command_file(path_to_debug_info, prefix_code='', no_import=False):
 
     return tempfilename
 
-usage = "Usage: cygdb [options] [PATH [GDB_ARGUMENTS]]"
+usage = "Usage: cygdb [options] [PATH [-- GDB_ARGUMENTS]]"
 
 def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
     """


### PR DESCRIPTION
cygdb argument parsing seems to be broken on master with the introduction of `optparse`?

Without this change:

```
marca@marca-ubuntu13:~/dev/cygdb_example2$ cygdb . -- --args python-dbg -c 'import hello; hello.func_line_1()'
Usage: cygdb [options] [PATH [GDB_ARGUMENTS]].
No debug files were found in /home/marca/dev/cygdb_example2/--args. Aborting.
```

With this change:

```
marca@marca-ubuntu13:~/dev/cygdb_example2$ cygdb . -- --args python-dbg -c 'import hello; hello.func_line_1()'
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /usr/bin/python2.7-dbg...done.
(gdb) cy break hello.func_line_1
Function "__pyx_pw_5hello_1func_line_1" not defined.
Breakpoint 1 (__pyx_pw_5hello_1func_line_1) pending.
(gdb) cy run
1    def func_line_1():
```
