### PR TITLE
.gitignore: Ignore *.egg and *.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__
 *.so
 *.o
 
+*.egg
+*.egg-info
+
 Cython/Compiler/*.c
 Cython/Plex/*.c
 Cython/Runtime/refnanny.c


### PR DESCRIPTION
Just to make `git status` output a little cleaner.
