### PR TITLE
Cython/Debugger/Cygdb.py: Modify gdb command script to support virtualenv

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -33,9 +33,26 @@ def make_command_file(path_to_debug_info, prefix_code='', no_import=False):
     fd, tempfilename = tempfile.mkstemp()
     f = os.fdopen(fd, 'w')
     f.write(prefix_code)
-    f.write('set breakpoint pending on\n')
-    f.write("set print pretty on\n")
-    f.write('python from Cython.Debugger import libcython, libpython\n')
+    f.write(textwrap.dedent('''\
+        # This is a gdb command file
+        # See https://sourceware.org/gdb/onlinedocs/gdb/Command-Files.html
+
+        set breakpoint pending on
+        set print pretty on
+
+        python
+        # Activate virtualenv, if we were launched from one
+        import os
+        virtualenv = os.getenv('VIRTUAL_ENV')
+        if virtualenv:
+            path_to_activate_this_py = os.path.join(virtualenv, 'bin', 'activate_this.py')
+            print("gdb command file: Activating virtualenv: %s; path_to_activate_this_py: %s"
+                % (virtualenv, path_to_activate_this_py,))
+            execfile(path_to_activate_this_py, dict(__file__=path_to_activate_this_py))
+
+        from Cython.Debugger import libcython, libpython
+        end
+    '''))
 
     if no_import:
         # don't do this, this overrides file command in .gdbinit


### PR DESCRIPTION
This lets [cygdb](http://docs.cython.org/src/userguide/debugging.html) use the currently active virtualenv.

This is nice because I can install Cython in the virtualenv and use cygdb. Without this, I have to install Cython in the system Python for cygdb to work (otherwise I will get the error: `ImportError: No module named Cython.Debugger`).

Note: If you're trying to reproduce the problem or test the change here, you probably want to merge #259 first.

Example of use:

```
(py27_cython_dbg)marca@marca-ubuntu13:~/dev/cygdb_example2$ echo $VIRTUAL_ENV 
/home/marca/virtualenvs/py27_cython_dbg
(py27_cython_dbg)marca@marca-ubuntu13:~/dev/cygdb_example2$ cygdb . -- --args python-dbg -c 'import hello; hello.func_line_1()'
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/marca/virtualenvs/py27_cython_dbg/bin/python-dbg...done.
gdb command file: Activating virtualenv: /home/marca/virtualenvs/py27_cython_dbg; path_to_activate_this_py: /home/marca/virtualenvs/py27_cython_dbg/bin/activate_this.py
(gdb) cy break hello.func_line_1
Function "__pyx_pw_5hello_1func_line_1" not defined.
Breakpoint 1 (__pyx_pw_5hello_1func_line_1) pending.
(gdb) cy run
1    def func_line_1():
(gdb) cy bt
#7  0x000000000051ba17 in <module>() at <string>:1
#9  0x00007ffff65ea9b0 in func_line_1() at /home/marca/dev/cygdb_example2/hello.pyx:0
         1    def func_line_1():
```
