### PR TITLE
Cython/Debugger/Cygdb.py: Add debug logging with `logging` module

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -18,6 +18,9 @@ import tempfile
 import textwrap
 import subprocess
 import optparse
+import logging
+
+logger = logging.getLogger(__name__)
 
 def make_command_file(path_to_debug_info, prefix_code='', no_import=False):
     if not no_import:
@@ -78,6 +81,9 @@ def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
     parser.add_option("--gdb-executable",
         dest="gdb", default='gdb',
         help="gdb executable to use [default: gdb]")
+    parser.add_option("--verbose", "-v",
+        dest="verbosity", action="count", default=0,
+        help="Verbose mode. Multiple -v options increase the verbosity")
 
     (options, args) = parser.parse_args()
     if path_to_debug_info is None:
@@ -92,13 +98,34 @@ def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
     if path_to_debug_info == '--':
         no_import = True
 
+    logging_level = logging.WARN
+    if options.verbosity == 1:
+        logging_level = logging.INFO
+    if options.verbosity == 2:
+        logging_level = logging.DEBUG
+    logging.basicConfig(level=logging_level)
+
+    logger.info("verbosity = %r", options.verbosity)
+    logger.debug("options = %r; args = %r", options, args)
+    logger.debug("Done parsing command-line options. path_to_debug_info = %r, gdb_argv = %r",
+        path_to_debug_info, gdb_argv)
+
     tempfilename = make_command_file(path_to_debug_info, no_import=no_import)
+    logger.info("Launching %s with command file: %s and gdb_argv: %s",
+        options.gdb, tempfilename, gdb_argv)
+    logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, open(tempfilename).read())
+    logger.info("Spawning %s...", options.gdb)
     p = subprocess.Popen([options.gdb, '-command', tempfilename] + gdb_argv)
+    logger.info("Spawned %s (pid %d)", options.gdb, p.pid)
     while True:
         try:
-            p.wait()
+            logger.debug("Waiting for gdb (pid %d) to exit...", p.pid)
+            ret = p.wait()
+            logger.debug("Wait for gdb (pid %d) to exit is done. Returned: %r", p.pid, ret)
         except KeyboardInterrupt:
             pass
         else:
             break
+    logger.debug("Removing temp command file: %s", tempfilename)
     os.remove(tempfilename)
+    logger.debug("Removed temp command file: %s", tempfilename)


### PR DESCRIPTION
This adds configurable logging to show what's going on and to aid in debugging.

Note: If you're trying to test the change here, you probably want to merge #259 first.

Example usage:

```
(py27_cython_dbg)marca@marca-ubuntu13:~/dev/cygdb_example2$ cygdb -vv . -- --args python-dbg -c 'import hello; hello.func_line_1()'
INFO:Cython.Debugger.Cygdb:verbosity = 2
DEBUG:Cython.Debugger.Cygdb:options = <Values at 0x19349c0: {'gdb': 'gdb', 'verbosity': 2}>; args = ['.', '--args', 'python-dbg', '-c', 'import hello; hello.func_line_1()']
DEBUG:Cython.Debugger.Cygdb:Done parsing command-line options. path_to_debug_info = '.', gdb_argv = ['--args', 'python-dbg', '-c', 'import hello; hello.func_line_1()']
INFO:Cython.Debugger.Cygdb:Launching gdb with command file: /tmp/tmpHicium and gdb_argv: ['--args', 'python-dbg', '-c', 'import hello; hello.func_line_1()']
DEBUG:Cython.Debugger.Cygdb:Command file (/tmp/tmpHicium) contains: """
# This is a gdb command file
# See https://sourceware.org/gdb/onlinedocs/gdb/Command-Files.html

set breakpoint pending on
set print pretty on

python
# Activate virtualenv, if we were launched from one
import os
virtualenv = os.getenv('VIRTUAL_ENV')
if virtualenv:
    path_to_activate_this_py = os.path.join(virtualenv, 'bin', 'activate_this.py')
    print("gdb command file: Activating virtualenv: %s; path_to_activate_this_py: %s"
        % (virtualenv, path_to_activate_this_py,))
    execfile(path_to_activate_this_py, dict(__file__=path_to_activate_this_py))

from Cython.Debugger import libcython, libpython
end
file /usr/bin/python-dbg
cy import ./cython_debug/cython_debug_info_hello

cy import ./cython_debug/cython_debug_info_hello.xml
python
import sys
try:
    gdb.lookup_type('PyModuleObject')
except RuntimeError:
    sys.stderr.write(
        'Python was not compiled with debug symbols (or it was '
        'stripped). Some functionality may not work (properly).\n')
end
"""
INFO:Cython.Debugger.Cygdb:Spawning gdb...
INFO:Cython.Debugger.Cygdb:Spawned gdb (pid 9047)
DEBUG:Cython.Debugger.Cygdb:Waiting for gdb (pid 9047) to exit...
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/marca/virtualenvs/py27_cython_dbg/bin/python-dbg...done.
gdb command file: Activating virtualenv: /home/marca/virtualenvs/py27_cython_dbg; path_to_activate_this_py: /home/marca/virtualenvs/py27_cython_dbg/bin/activate_this.py
(gdb) quit
close failed in file object destructor:
IOError: [Errno 9] Bad file descriptor
DEBUG:Cython.Debugger.Cygdb:Wait for gdb (pid 9047) to exit is done. Returned: 0
DEBUG:Cython.Debugger.Cygdb:Removing temp command file: /tmp/tmpHicium
DEBUG:Cython.Debugger.Cygdb:Removed temp command file: /tmp/tmpHicium
[45622 refs]
```
