### PR TITLE
Cython/Debugger/Cygdb.py: Source .cygdbinit file

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -56,6 +56,8 @@ def make_command_file(path_to_debug_info, prefix_code='', no_import=False):
                     'Python was not compiled with debug symbols (or it was '
                     'stripped). Some functionality may not work (properly).\\n')
             end
+
+            source .cygdbinit
         '''))
 
     f.close()


### PR DESCRIPTION
This allows the user to have a `.cygdbinit` file which is like a `.gdbinit` file but can have Cython stuff.

Note: If you're trying to test the change here, you probably want to merge #259 first.

Example use:

```
(py27_cython_dbg)marca@marca-ubuntu13:~/dev/cygdb_example2$ cat .cygdbinit 
cy break hello.func_line_1

(py27_cython_dbg)marca@marca-ubuntu13:~/dev/cygdb_example2$ cygdb . -- --args python-dbg -c 'import hello; hello.func_line_1()'
GNU gdb (GDB) 7.5.91.20130417-cvs-ubuntu
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/marca/virtualenvs/py27_cython_dbg/bin/python-dbg...done.
gdb command file: Activating virtualenv: /home/marca/virtualenvs/py27_cython_dbg; path_to_activate_this_py: /home/marca/virtualenvs/py27_cython_dbg/bin/activate_this.py
Function "__pyx_pw_5hello_1func_line_1" not defined.
Breakpoint 1 (__pyx_pw_5hello_1func_line_1) pending.
```
