### PR TITLE
.travis.yml: Upgrade gdb and use python-dbg so cygdb tests can run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,14 @@ branches:
   only:
     - master
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install gdb python-dbg
+  - dpkg -l | grep gdb
+
 install: pip install .
 
-script: CFLAGS=-O0 python runtests.py -vv
+script: CFLAGS=-O0 python-dbg runtests.py -vv
 
 matrix:
   allow_failures:

--- a/Cython/Debugger/Tests/TestLibCython.py
+++ b/Cython/Debugger/Tests/TestLibCython.py
@@ -304,6 +304,8 @@ class TestAll(GdbDebuggerTestCase):
 
             sys.stderr.write(errmsg)
 
+        self.assertEqual(exit_status, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The Travis CI build was skipping the cygdb tests because the default gdb installed wasn't >= 7.4 and because we weren't using a debug build of python (i.e.: `python-dbg`).

This PR fixes both of those issues so that Travis CI can run the cygdb tests (which incidentally, are failing, even though they're not properly returning a failed exit status so that the Travis CI build is marked as a failure).

See this Travis CI job which shows that with this PR it's now running the cygdb tests (and failing):

https://travis-ci.org/msabramo/cython/builds/12493612#L326

or the following job which also includes 113f8fc so that `Cython.Debugger.Tests.TestLibCython.TestAll` fails (as it should):

https://travis-ci.org/msabramo/cython/builds/12500576#L556