### PR TITLE
setup.py: [0.19.x] Use setuptools when invoked with bdist_{egg,wheel}.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
-from distutils.core import setup, Extension
+import sys
+if 'bdist_egg' in sys.argv or 'bdist_wheel' in sys.argv:
+    from setuptools import setup, Extension
+else:
+    from distutils.core import setup, Extension
 from distutils.sysconfig import get_python_lib
 import os, os.path
-import sys
 
 try:
     import platform


### PR DESCRIPTION
This makes it easier to build eggs and wheels of 0.19.x releases; the master branch already uses `setuptools`.

I tried to make this as minimal as possible and to only use `setuptools` for the `bdist` commands, to reduce the likelihood of something breaking unexpectedly because of `setuptools`.
