### PR TITLE
Fix npy_bool signedness

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -293,7 +293,7 @@ cdef extern from "numpy/arrayobject.h":
                 # info.shape was stored after info.strides in the same block
 
 
-    ctypedef signed char      npy_bool
+    ctypedef unsigned char      npy_bool
 
     ctypedef signed char      npy_byte
     ctypedef signed short     npy_short


### PR DESCRIPTION
From numpy's definition in

https://github.com/numpy/numpy/blob/master/numpy/core/include/numpy/npy_common.h#L211

`typedef unsigned char npy_bool;`
