### PR TITLE
Add a div with cython class for embedding

### DIFF
--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -135,7 +135,7 @@ class AnnotationCCodeWriter(CCodeWriter):
         return ''.join(outlist)
 
     def _save_annotation_body(self, lines, code_source_file):
-        outlist = []
+        outlist = [u'<div class="cython">']
         pos_comment_marker = u'/* \N{HORIZONTAL ELLIPSIS} */\n'
         new_calls_map = dict(
             (name, 0) for name in
@@ -170,6 +170,7 @@ class AnnotationCCodeWriter(CCodeWriter):
             outlist.append(u"<pre class='cython line score-%s' onclick='toggleDiv(this)'> %d: %s</pre>\n" % (
                 score, k, line.rstrip()))
             outlist.append(u"<pre class='cython code score-%s'>%s</pre>" % (score, code))
+        outlist.append(u"</div>")
         return outlist
 
 


### PR DESCRIPTION
This allow to reuse directly the body and embed it without having to
wrap it in the correct div and have the CSS apply to it.

@scoder thanks for your extra cleanup of annotation. 

This just wrap the code in a extra div with a `cython` class to help embedding the cython annotate when directly using `_save_annotation_body()` and have the css apply.
