### PR TITLE
Directory with __init__.pyc file is a package dir

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -144,6 +144,7 @@ def check_package_dir(dir, package_names):
 @cached_function
 def is_package_dir(dir_path):
     for filename in ("__init__.py",
+                     "__init__.pyc",
                      "__init__.pyx",
                      "__init__.pxd"):
         path = os.path.join(dir_path, filename)


### PR DESCRIPTION
Consider a directory with **init**.pyc as a package directory.
