### PR TITLE
DOC: Updates EPD references to refer to Canopy

### DIFF
--- a/docs/src/quickstart/install.rst
+++ b/docs/src/quickstart/install.rst
@@ -1,13 +1,12 @@
 Installing Cython
 =================
 
-Many scientific Python distributions, such as the Enthought Python
-Distribution [EPD]_, Python(x,y) [Pythonxy]_, and Sage [Sage]_, bundle
-Cython and no setup is needed. Note however that if your distribution
-ships a version of Cython which is too old you can still use the
-instructions below to update Cython. Everything in this tutorial
-should work with Cython 0.11.2 and newer, unless a footnote says
-otherwise.
+Many scientific Python distributions, such as Enthought Canopy
+[Canopy]_, Python(x,y) [Pythonxy]_, and Sage [Sage]_, bundle Cython
+and no setup is needed. Note however that if your distribution ships a
+version of Cython which is too old you can still use the instructions
+below to update Cython. Everything in this tutorial should work with
+Cython 0.11.2 and newer, unless a footnote says otherwise.
 
 Unlike most Python software, Cython requires a C compiler to be
 present on the system. The details of getting a C compiler varies
@@ -24,11 +23,11 @@ according to the system used:
 
  - **Windows** A popular option is to use the open source MinGW (a
    Windows distribution of gcc). See the appendix for instructions for
-   setting up MinGW manually. EPD and Python(x,y) bundle MinGW, but
-   some of the configuration steps in the appendix might still be
-   necessary.  Another option is to use Microsoft's Visual C. One must
-   then use the same version which the installed Python was compiled
-   with.
+   setting up MinGW manually. Enthought Canopy and Python(x,y) bundle
+   MinGW, but some of the configuration steps in the appendix might
+   still be necessary.  Another option is to use Microsoft's Visual C.
+   One must then use the same version which the installed Python was
+   compiled with.
 
 .. dagss tried other forms of ReST lists and they didn't look nice
 .. with rst2latex.
@@ -47,6 +46,6 @@ able to fetch Cython from PyPI and install it using::
 For Windows there is also an executable installer available for
 download.
 
-.. [EPD] http://www.enthought.com/products/epd.php
+.. [Canopy] https://enthought.com/products/canopy/
 .. [Pythonxy] http://www.pythonxy.com/
 .. [Sage] W. Stein et al., Sage Mathematics Software, http://sagemath.org


### PR DESCRIPTION
Hello Cython devs, (it's been a while...)

My employer requested that I update the Cython documentation to refer to Canopy and update the broken link to EPD to point to our Canopy page.
