### PR TITLE
Ignore any unused entry that starts with '_'.

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -634,7 +634,7 @@ def check_definitions(flow, compiler_directives):
     for entry in flow.entries:
         if (not entry.cf_references
                 and not entry.is_pyclass_attr):
-            if not entry.name.startswith('_'):
+            if entry.name != '_' and not entry.name.startswith('unused'):
                 # '_' is often used for unused variables, e.g. in loops
                 if entry.is_arg:
                     if warn_unused_arg:


### PR DESCRIPTION
This is a trivial change but it would allow me to get rid of warnings without having to remove descriptive variable names.

This commit makes it possible to follow PEP8 which recommends '__',
and to name unused entries, e.g.:

```
foo, _bar, _zed = func()
```
