### PR TITLE
remove global dependency of _dep_tree

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -573,13 +573,13 @@ class DependencyTree(object):
         finally:
             del stack[node]
 
-_dep_tree = None
+#_dep_tree = None
 def create_dependency_tree(ctx=None, quiet=False):
-    global _dep_tree
-    if _dep_tree is None:
-        if ctx is None:
-            ctx = Context(["."], CompilationOptions(default_options))
-        _dep_tree = DependencyTree(ctx, quiet=quiet)
+    #global _dep_tree
+    #if _dep_tree is None:
+    if ctx is None:
+        ctx = Context(["."], CompilationOptions(default_options))
+    _dep_tree = DependencyTree(ctx, quiet=quiet)
     return _dep_tree
 
 


### PR DESCRIPTION
if the cythonrize function is called mutiple times with different ctx, since the _dep_tree is global value, it will    only record the first _dep_tree.
