### PR TITLE
complete struct stat in POSIX API

### DIFF
--- a/Cython/Includes/posix/stat.pxd
+++ b/Cython/Includes/posix/stat.pxd
@@ -4,8 +4,19 @@ from posix.types cimport (blkcnt_t, blksize_t, dev_t, gid_t, ino_t, mode_t,
 
 cdef extern from "sys/stat.h" nogil:
     cdef struct struct_stat "stat":
-        dev_t st_dev
-        ino_t st_ino
+        dev_t   st_dev
+        ino_t   st_ino
+        mode_t  st_mode
+        nlink_t st_nlink
+        uid_t   st_uid
+        gid_t   st_gid
+        dev_t   st_rdev
+        off_t   st_size
+        blksize_t st_blksize
+        blkcnt_t st_blocks
+        time_t  st_atime
+        time_t  st_mtime
+        time_t  st_ctime
 
 # POSIX prescribes including both <sys/stat.h> and <unistd.h> for these
 cdef extern from "unistd.h" nogil:


### PR DESCRIPTION
Didn't expose all members of this struct, making it not very useful.
