### PR TITLE
First stab at supporting fixed-size C array assignment

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -735,7 +735,16 @@ class ExprNode(Node):
             node = NameNode(self.pos, name='', type=self.coercion_type)
             node.coerce_to(dst_type, env)
 
-        if dst_type.is_memoryviewslice:
+        if dst_type.is_array and src.type.is_pyobject:
+            # if not dst_type.is_complete():
+                # error(self.pos, "XXX")
+            # XXX: TODO: other error cases here?
+            src = CoerceToCArrayNode(src, dst_type, env)
+            # elif not src_type.is_error:
+                # error(self.pos,
+                      # "Cannot convert '%s' to C array" % (src_type,))
+
+        elif dst_type.is_memoryviewslice:
             from . import MemoryView
             if not src.type.is_memoryviewslice:
                 if src.type.is_pyobject:
@@ -1856,6 +1865,11 @@ class NameNode(AtomicExprNode):
         return True
 
     def is_lvalue(self):
+        # XXX: need to make fixed-size arrays assignable (and therefore valid lvalues)
+        if self.entry.is_variable and \
+                self.entry.type.is_array and \
+                self.entry.type.is_complete():
+                    return True
         return self.entry.is_variable and \
             not self.entry.type.is_array and \
             not self.entry.is_readonly
@@ -2000,7 +2014,11 @@ class NameNode(AtomicExprNode):
                 code.putln("PyType_Modified(%s);" %
                            entry.scope.parent_type.typeptr_cname)
         else:
-            if self.type.is_memoryviewslice:
+
+            if self.type.is_array and self.type.is_complete():
+                self.generate_assign_to_c_array(rhs, code)
+
+            elif self.type.is_memoryviewslice:
                 self.generate_acquire_memoryviewslice(rhs, code)
 
             elif self.type.is_buffer:
@@ -2043,7 +2061,7 @@ class NameNode(AtomicExprNode):
                             assigned = False
                     if is_external_ref:
                         code.put_giveref(rhs.py_result())
-            if not self.type.is_memoryviewslice:
+            if not (self.type.is_memoryviewslice or self.type.is_array):
                 if not assigned:
                     code.putln('%s = %s;' % (
                         self.result(), rhs.result_as(self.ctype())))
@@ -2071,6 +2089,18 @@ class NameNode(AtomicExprNode):
             code=code,
             have_gil=not self.in_nogil_context,
             first_assignment=self.cf_is_null)
+
+    def generate_assign_to_c_array(self, rhs, code):
+
+        # XXX: this feels wrong...  Should probably be done inside CoerceToCArrayNode()
+        self.type.create_from_py_utility_code(rhs.env)
+
+        code.putln("%s(%s, %s, %s); %s" % (
+            self.type.from_py_function,
+            rhs.arg.py_result(),
+            self.result(),
+            self.type.size,
+            code.error_goto_if(self.type.error_condition(self.result()), self.pos)))
 
     def generate_acquire_buffer(self, rhs, code):
         # rhstmp is only used in case the rhs is a complicated expression leading to
@@ -10709,6 +10739,7 @@ class CoercionNode(ExprNode):
             code.annotate((file, line, col-1), AnnotationItem(
                 style='coerce', tag='coerce', text='[%s] to [%s]' % (self.arg.type, self.type)))
 
+
 class CoerceToMemViewSliceNode(CoercionNode):
     """
     Coerce an object to a memoryview slice. This holds a new reference in
@@ -11068,6 +11099,21 @@ class CoerceFromPyTypeNode(CoercionNode):
 
     def nogil_check(self, env):
         error(self.pos, "Coercion from Python not allowed without the GIL")
+
+
+class CoerceToCArrayNode(CoercionNode):
+
+    def __init__(self, arg, dst_type, env):
+        assert dst_type.is_array and dst_type.is_complete()
+        assert arg.type.is_pyobject
+        super(CoerceToCArrayNode, self).__init__(arg)
+        self.type = dst_type
+        # self.is_temp = 1
+        self.env = env
+        self.arg = arg
+
+    def generate_evaluation_code(self, code):
+        code.putln("/* CoerceToCArrayNode.generate_evaluation_code() */")
 
 
 class CoerceToBooleanNode(CoercionNode):

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2370,7 +2370,12 @@ def p_c_array_declarator(s, base):
     else:
         dim = None
     s.expect(']')
-    return Nodes.CArrayDeclaratorNode(pos, base = base, dimension = dim)
+    # XXX: Here is where we allow "=" and a rhs.
+    rhs = None
+    if s.sy == '=':
+        s.next()
+        rhs = p_test(s)
+    return Nodes.CArrayDeclaratorNode(pos, base = base, dimension = dim, default = rhs)
 
 def p_c_func_declarator(s, pos, ctx, base, cmethod_flag):
     #  Opening paren has already been skipped

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -612,3 +612,152 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
     }
 }
 
+/////////////// CArrayFromPy.proto ///////////////
+
+static int {{FROM_PY_FUNCTION}}(PyObject *, {{TYPE}}, const unsigned int);
+
+/////////////// CArrayFromPy ///////////////
+
+
+static int {{FROM_PY_FUNCTION}}(PyObject *__pyx_v_o, {{TYPE}} __pyx_v_a, unsigned int const __pyx_v_N) {
+  unsigned int __pyx_v_i;
+  PyObject *__pyx_v_elt = NULL;
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  Py_ssize_t __pyx_t_2;
+  PyObject *(*__pyx_t_3)(PyObject *);
+  PyObject *__pyx_t_4 = NULL;
+  int __pyx_t_5;
+  {{BASE_TYPE.declaration_code("")}} __pyx_t_6;
+  int __pyx_lineno = 0;
+  const char *__pyx_filename = NULL;
+  int __pyx_clineno = 0;
+  __Pyx_RefNannySetupContext("foo", 0);
+
+  /* "bootstrap_assign.pyx":3
+ * cdef int foo(object o, int *a, const unsigned int N) except -1:
+ *     cdef:
+ *         unsigned int i = 0             # <<<<<<<<<<<<<<
+ * 
+ *     for elt in o:
+ */
+  __pyx_v_i = 0;
+
+  /* "bootstrap_assign.pyx":5
+ *         unsigned int i = 0
+ * 
+ *     for elt in o:             # <<<<<<<<<<<<<<
+ *         if i == N:
+ *             break
+ */
+  if (PyList_CheckExact(__pyx_v_o) || PyTuple_CheckExact(__pyx_v_o)) {
+    __pyx_t_1 = __pyx_v_o; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
+    __pyx_t_3 = NULL;
+  } else {
+    __pyx_t_2 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_v_o); if (unlikely(!__pyx_t_1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_GOTREF(__pyx_t_1);
+    __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext;
+  }
+  for (;;) {
+    if (!__pyx_t_3 && PyList_CheckExact(__pyx_t_1)) {
+      if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
+      #if CYTHON_COMPILING_IN_CPYTHON
+      __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      #else
+      __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      #endif
+    } else if (!__pyx_t_3 && PyTuple_CheckExact(__pyx_t_1)) {
+      if (__pyx_t_2 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
+      #if CYTHON_COMPILING_IN_CPYTHON
+      __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      #else
+      __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      #endif
+    } else {
+      __pyx_t_4 = __pyx_t_3(__pyx_t_1);
+      if (unlikely(!__pyx_t_4)) {
+        PyObject* exc_type = PyErr_Occurred();
+        if (exc_type) {
+          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 5; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+        }
+        break;
+      }
+      __Pyx_GOTREF(__pyx_t_4);
+    }
+    __Pyx_XDECREF_SET(__pyx_v_elt, __pyx_t_4);
+    __pyx_t_4 = 0;
+
+    /* "bootstrap_assign.pyx":6
+ * 
+ *     for elt in o:
+ *         if i == N:             # <<<<<<<<<<<<<<
+ *             break
+ *         a[i] = elt
+ */
+    __pyx_t_5 = ((__pyx_v_i == __pyx_v_N) != 0);
+    if (__pyx_t_5) {
+
+      /* "bootstrap_assign.pyx":7
+ *     for elt in o:
+ *         if i == N:
+ *             break             # <<<<<<<<<<<<<<
+ *         a[i] = elt
+ *         i += 1
+ */
+      goto __pyx_L4_break;
+    }
+
+    /* "bootstrap_assign.pyx":8
+ *         if i == N:
+ *             break
+ *         a[i] = elt             # <<<<<<<<<<<<<<
+ *         i += 1
+ * 
+ */
+    __pyx_t_6 = {{BASE_TYPE.from_py_function}}(__pyx_v_elt);
+    if ({{BASE_TYPE.error_condition("__pyx_t_6")}})
+        goto __pyx_L1_error;
+    /* if (unlikely((__pyx_t_6 == (int)-1) && PyErr_Occurred())) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 8; __pyx_clineno = __LINE__; goto __pyx_L1_error;} */
+    (__pyx_v_a[__pyx_v_i]) = __pyx_t_6;
+
+    /* "bootstrap_assign.pyx":9
+ *             break
+ *         a[i] = elt
+ *         i += 1             # <<<<<<<<<<<<<<
+ * 
+ *     return 0
+ */
+    __pyx_v_i = (__pyx_v_i + 1);
+  }
+  __pyx_L4_break:;
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+
+  /* "bootstrap_assign.pyx":11
+ *         i += 1
+ * 
+ *     return 0             # <<<<<<<<<<<<<<
+ * 
+ * def caller(o):
+ */
+  __pyx_r = 0;
+  goto __pyx_L0;
+
+  /* "bootstrap_assign.pyx":1
+ * cdef int foo(object o, int *a, const unsigned int N) except -1:             # <<<<<<<<<<<<<<
+ *     cdef:
+ *         unsigned int i = 0
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("bootstrap_assign.foo", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_XDECREF(__pyx_v_elt);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}


### PR DESCRIPTION
_This PR is currently a work-in-progress._

Allows code like:

```
cdef int a[10]
cdef object o = range(10)
a = o
```

The list's contents are copied into the fixed array.

Currently supports:

``` python
def convert_int(o):
    cdef int a[10]
    a = o
    print a[0], a[9]

def convert_float(o):
    cdef float a[10]
    a = o
    print a[0], a[9]
```

Currently unsupported, working on implementing:
- assignment at declaration: `cdef int a[10] = obj`
- extensive error testing and handling edge cases
- automatic conversion from array back to Python object
  - what type?  `array.array`?
- cleaning up and improving tempita templates
