### PR TITLE
docs: small wording fix in memory_allocation.rst

### DIFF
--- a/docs/src/tutorial/memory_allocation.rst
+++ b/docs/src/tutorial/memory_allocation.rst
@@ -86,7 +86,7 @@ e.g.::
       cdef double* data
 
       def __cinit__(self, number):
-          # allocate some memory (filled with random data)
+          # allocate some memory (uninitialized, )
           self.data = <double*> PyMem_Malloc(number * sizeof(double))
           if not self.data:
               raise MemoryError()


### PR DESCRIPTION
"uninitialized value" in C/C++ is not the same as "filled with random data":

In practice, on most implementation the content is not actually random.
Some implementations _may_ zero-initialize malloc()-allocated memory, but AFAIK it's not something common, nor it's portable.
In most other cases, the value will be "whatever was in memory on that address previously", which in general is also far from random/pseudorandom.

Speaking in terms of standards, if I understand correctly, accessing uninitialized value may, or may not, cause Undefined Behaviour. It goes like this:
- 'uninitialized' variable has 'indeterminate' value.
- 'indeterminate value' may be (depending on implementation) either:
  - an 'unspecified value' - no UB, just value can be anything.
  - a 'trap representation' (only if type of variable is other than [signed or unsigned] char). Merely accessing such value results in 'undefined behaviour'.

See also:
https://stackoverflow.com/questions/9219971/read-before-write-is-undefined-with-malloced-memory
https://stackoverflow.com/questions/11962457/why-is-using-an-uninitialized-variable-undefined-behavior-in-c
