### PR TITLE
If cppclass is redefined, make sure the this pointer enters the correct scope

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -573,7 +573,7 @@ class Scope(object):
                     entry.type.scope.declare_inherited_cpp_attributes(base_class.scope)
         if entry.type.scope:
             declare_inherited_attributes(entry, base_classes)
-            entry.type.scope.declare_var(name="this", cname="this", type=PyrexTypes.CPtrType(entry.type), pos=entry.pos)
+            scope.declare_var(name="this", cname="this", type=PyrexTypes.CPtrType(entry.type), pos=entry.pos)
         if self.is_cpp_class_scope:
             entry.type.namespace = self.outer_scope.lookup(self.name).type
         return entry

--- a/tests/run/cpp_class_redef.pxd
+++ b/tests/run/cpp_class_redef.pxd
@@ -1,0 +1,6 @@
+# tag: cpp
+
+cdef extern cppclass Foo:
+    int _foo
+    void set_foo(int foo) nogil
+    int get_foo() nogil

--- a/tests/run/cpp_class_redef.pyx
+++ b/tests/run/cpp_class_redef.pyx
@@ -1,0 +1,22 @@
+# tag: cpp
+
+# This gives a warning, but should not give an error.
+cdef cppclass Foo:
+    int _foo
+    int get_foo():
+        return this._foo
+    void set_foo(int foo):
+        this._foo = foo
+
+def test_Foo(n):
+    """
+    >>> test_Foo(1)
+    1
+    """
+    cdef Foo* foo = NULL
+    try:
+        foo = new Foo()
+        foo.set_foo(n)
+        return foo.get_foo()
+    finally:
+        del foo


### PR DESCRIPTION
If the change is not made, in case of a redefined cppclass, the first CppClassScope gets both this pointers declared, while the second CppClassScope is left without a this pointer.  The consequence is very confusing error messages like "undeclared name not builtin: this" or "Accessing Python attribute not allowed without gil'" (depending on gil).

Even though it is currently not very useful to declare/define a cppclass twice, I think this should be fixed, because in fact the wrong scope is modified, the error message is confusing, and in the future declaring and defining a cppclass may actually be useful (I added a test case with a suggestive syntax).
