### PR TITLE
fix bug in nested C++ template syntax

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3153,10 +3153,8 @@ class CppClassType(CType):
             if for_display:
                 brackets = "[%s]"
             else:
-                brackets = "<%s>"
+                brackets = "<%s> "
             templates = brackets % ",".join(template_strings)
-            if templates[-2:] == ">>":
-                templates = templates[:-2] + "> >"
         else:
             templates = ""
         if pyrex or for_display:

--- a/tests/compile/cpp_templates.pyx
+++ b/tests/compile/cpp_templates.pyx
@@ -16,6 +16,8 @@ cdef extern from "templates.h":
         T getValue1()
         U getValue2()
 
+    void template_function[T](TemplateTest1[T] &)
+
 cdef TemplateTest1[int] a
 cdef TemplateTest1[int]* b = new TemplateTest1[int]()
 
@@ -39,3 +41,11 @@ cdef TemplateTest1_int aa
 # Verify that T767 is fixed.
 cdef public int func(int arg):
     return arg
+
+# Regression test: the function call used to produce
+#   template_function<TemplateTest1<int>>(__pyx_v_t);
+# which is valid C++11, but not valid C++98 because the ">>" would be
+# parsed as a single token.
+cdef public void use_nested_templates():
+    cdef TemplateTest1[TemplateTest1[int]] t
+    template_function(t)

--- a/tests/compile/templates.h
+++ b/tests/compile/templates.h
@@ -22,4 +22,9 @@ public:
     U getValue2() { return value2; }
 };
 
+template <typename T>
+void template_function(TemplateTest1<T> &)
+{
+}
+
 #endif


### PR DESCRIPTION
This fixes a bug where Cython would generate expressions like

``` c++
f<vector<set<int>>()
```

which are invalid in C++98: the `>>` gets parsed as a single token, so there should be a space in between the closing angle brackets. (C++11 allows this, but GCC compiles in C++98 mode by default.)

Includes a regression test, which fails without the patch to `PyrexTypes.py`.

I ran into this while trying to wrap a [heavily templated C++ library](http://pointclouds.org/).
