### PR TITLE
prevent compiler warning for missing virtual destructor

### DIFF
--- a/tests/run/cpp_template_subclasses_helper.h
+++ b/tests/run/cpp_template_subclasses_helper.h
@@ -3,6 +3,7 @@ using namespace std;
 class Base {
 public:
     virtual const char* name() { return "Base"; }
+    virtual ~Base() {}
 };
 
 template <class A1>


### PR DESCRIPTION
This adds a `virtual` destructor to a base class in a C++ test. It doesn't change the test result, but it prevents the compiler from emitting a warning.
