### PR TITLE
DOC initialize string with bytes

### DIFF
--- a/docs/src/tutorial/strings.rst
+++ b/docs/src/tutorial/strings.rst
@@ -456,7 +456,7 @@ and then copies its buffer into a new C++ string.
 For the other direction, efficient decoding support is available
 in Cython 0.17 and later::
 
-    cdef string s = string('abcdefg')
+    cdef string s = string(b'abcdefg')
 
     ustring1 = s.decode('UTF-8')
     ustring2 = s[2:-2].decode('UTF-8')


### PR DESCRIPTION
As-is the example doesn't compile:

```
Error compiling Cython file:
------------------------------------------------------------
...
        cdef string s = string('abcdefg')
                             ^
------------------------------------------------------------

my.pyx:125:30: no suitable method found
```

I'm using Python 3.4, Cython 0.21 and the following options: c_string_type=str, c_string_encoding=ascii
