### PR TITLE
Fix code-example syntax in documentation

### DIFF
--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -158,7 +158,7 @@ Sharing C Functions
 
 C functions defined at the top level of a module can be made available via
 :keyword:`cimport` by putting headers for them in the ``.pxd`` file, for
-example,::
+example:
 
 :file:`volume.pxd`::
 


### PR DESCRIPTION
The trailing `::` mean that the string `:file:`volume.pxd`::` was being treated as the code example and therefore `cdef float cube(float)` was simply indented as regular font.
