### PR TITLE
Document `initializedcheck` compiler directive.

### DIFF
--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -292,6 +292,12 @@ Cython code.  Here is the list of currently supported directives:
     data corruption.
     Default is True.
 
+``initializedcheck`` (True / False)
+    If set to True, Cython checks that a memoryview is initialized
+    whenever its elements are accessed or assigned to. Setting this
+    to False disables these checks.
+    Default is True.
+
 ``nonecheck``  (True / False)
     If set to False, Cython is free to assume that native field
     accesses on variables typed as an extension type, or buffer


### PR DESCRIPTION
Document the `initializedcheck` compiler directive. With the default value of `True` the following is inserted into the generated .c files whenever memoryviews are accessed:

```
if (unlikely(!__pyx_v_lightfm->model_biases.memview)) 
{PyErr_SetString(PyExc_AttributeError,"Memoryview is not initialized");
{__pyx_filename = __pyx_f[0]; __pyx_lineno = 91; __pyx_clineno = __LINE__; goto __pyx_L1_error;}}
```

As far as I can tell this is not documented anywhere at the moment. There is some discussion here: https://mail.python.org/pipermail//cython-devel/2012-April/002289.html

Can anybody comment on the performance impact of changing this?