### PR TITLE
Add max_load_factor getter and setter for std::unordered_map.

### DIFF
--- a/Cython/Includes/libcpp/unordered_map.pxd
+++ b/Cython/Includes/libcpp/unordered_map.pxd
@@ -60,3 +60,5 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         iterator upper_bound(T&)
         #const_iterator upper_bound(key_type&)
         #value_compare value_comp()
+        void max_load_factor(float)
+        float max_load_factor()


### PR DESCRIPTION
This might be useful for controlling memory usage at the expense of collision probability.
