### PR TITLE
fix shrinking and overflow in cpython.array

### DIFF
--- a/tests/run/pyarray.pyx
+++ b/tests/run/pyarray.pyx
@@ -105,6 +105,16 @@ def test_resize(a):
     assert len(cb) == 10
     assert cb[9] == cb[-1] == cb.data.as_floats[9] == 9
 
+def test_resize_smart(a):
+    """
+    >>> a = array.array('d', [1, 2, 3])
+    >>> test_resize_smart(a)
+    2
+    """
+    cdef array.array cb = array.copy(a)
+    array.resize_smart(cb, 2)
+    return len(cb)
+
 def test_buffer():
     """
     >>> test_buffer()


### PR DESCRIPTION
I found two bugs in `cpython.array.resize_smart`:
- it's impossible to shrink the array, except to a size that is less then ¼ of the current size (in fact the array may grow when shrinking by a few elements is requested);
- the calculation of `newsize` could overflow.

This patch fixes both bugs. I took the easy way out: never actually shrink the allocation, just decrease the size.
