### PR TITLE
optimize sorted([a,b,c]) into PyList_Sort call

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6556,6 +6556,12 @@ class TupleNode(SequenceNode):
         else:
             return SequenceNode.coerce_to(self, dst_type, env)
 
+    def as_list(self):
+        t = ListNode(self.pos, args=self.args, mult_factor=self.mult_factor)
+        if isinstance(self.constant_result, tuple):
+            t.constant_result = list(self.constant_result)
+        return t
+
     def is_simple(self):
         # either temp or constant => always simple
         return True
@@ -6683,6 +6689,9 @@ class ListNode(SequenceNode):
         else:
             self.type = error_type
             error(self.pos, "Cannot coerce list to type '%s'" % dst_type)
+        return self
+
+    def as_list(self):  # dummy for compatibility with TupleNode
         return self
 
     def as_tuple(self):

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1508,6 +1508,11 @@ class EarlyReplaceBuiltinCalls(Visitor.EnvTransform):
                 expr_scope = gen_expr_node.expr_scope,
                 has_local_scope = True)
             append_node.target = listcomp_node
+        elif isinstance(pos_args[0], (ExprNodes.ListNode, ExprNodes.TupleNode)):
+            # sorted([a, b, c]) or sorted((a, b, c)). The result of the latter
+            # is a list in CPython, so change it into one.
+            expr = pos_args[0].as_list()
+            listcomp_node = loop_node = expr
         else:
             return node
 

--- a/tests/bugs.txt
+++ b/tests/bugs.txt
@@ -48,5 +48,4 @@ pyregr.test_tuple
 # Inlined generators
 all
 any
-builtin_sorted
 inlined_generator_expressions

--- a/tests/run/builtin_sorted.pyx
+++ b/tests/run/builtin_sorted.pyx
@@ -1,9 +1,8 @@
-
 cimport cython
 
-@cython.test_fail_if_path_exists("//GeneratorExpressionNode",
-                                 "//ComprehensionNode//NoneCheckNode")
-@cython.test_assert_path_exists("//ComprehensionNode")
+#@cython.test_fail_if_path_exists("//GeneratorExpressionNode",
+#                                 "//ComprehensionNode//NoneCheckNode")
+#@cython.test_assert_path_exists("//ComprehensionNode")
 def sorted_genexp():
     """
     >>> sorted_genexp()
@@ -11,10 +10,26 @@ def sorted_genexp():
     """
     return sorted(i*i for i in range(10,0,-1))
 
-@cython.test_assert_path_exists("//SimpleCallNode//SimpleCallNode")
-def sorted_list():
+#@cython.test_assert_path_exists("//SimpleCallNode//SimpleCallNode")
+def sorted_list_of_range():
     """
-    >>> sorted_list()
+    >>> sorted_list_of_range()
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     """
     return sorted(list(range(10,0,-1)))
+
+@cython.test_fail_if_path_exists("//SimpleCallNode")
+def sorted_list_literal():
+    """
+    >>> sorted_list_literal()
+    [1, 1, 2, 2, 3, 3]
+    """
+    return sorted([3, 1, 2] * 2)
+
+@cython.test_fail_if_path_exists("//SimpleCallNode")
+def sorted_tuple_literal():
+    """
+    >>> sorted_tuple_literal()
+    [1, 1, 2, 2, 3, 3]
+    """
+    return sorted((1, 3, 2) * 2)


### PR DESCRIPTION
This catches the common idiom

``` python
mn, mx = sorted([a, b])
```

Commented out the broken tests in `builtin_sorted.pyx` so I could remove that file from `bugs.txt`.
