### PR TITLE
Optimize reversed(range(...))

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1599,7 +1599,6 @@ class NameNode(AtomicExprNode):
     allow_null = False
     nogil = False
     inferred_type = None
-    for_value = None
 
     def as_cython_attribute(self):
         return self.cython_attribute

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6199,14 +6199,10 @@ class ForFromStatNode(LoopNode, StatNode):
             loopvar_name = code.funcstate.allocate_temp(self.target.type, False)
         else:
             loopvar_name = self.loopvar_node.result()
-        if isinstance(self.bound1, ExprNodes.NameNode) and self.bound1.for_value:
-            bound1_result = self.bound1.for_value
-        else:
-            bound1_result = self.bound1.result()
         code.putln(
             "for (%s = %s%s; %s %s %s; %s%s) {" % (
                 loopvar_name,
-                bound1_result, offset,
+                self.bound1.result(), offset,
                 loopvar_name, self.relation2, self.bound2.result(),
                 loopvar_name, incop))
         if self.py_loopvar_node:

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -666,8 +666,8 @@ class IterationTransform(Visitor.EnvTransform):
                 if isinstance(bound1, ExprNodes.NameNode) or isinstance(bound2, ExprNodes.NameNode):
                     end_value = bound2.get_constant_c_result_code()
                     begin_value = bound1.get_constant_c_result_code()
-                    bound1.for_value = ("%d*((%s-%s-1) / %d) + %s+1" %
-                                           (step_value, begin_value, end_value, step_value, end_value))
+                    bound1 = ExprNodes.ConstNode(range_function.pos, value="%d*((%s-%s-1) / %d) + %s+1" %
+                                 (step_value, begin_value, end_value, step_value, end_value), type=bound1.type)
                 else:
                     end_value = int(bound2.value)
                     begin_value = int(bound1.value)


### PR DESCRIPTION
I thought this would be the best place to ask, is there an easy way to get a value out of a NameNode? Right now it only optimizes it, if it has a number literals within the range (e.g. `reversed(0, 5, 3)`) because I don't know how to do this.

I realized I should use floor div (`\\`) because Python 3+ returns a float on normal division.

Ticket #765.
