### PR TITLE
generate less code for exceptions (in common cases)

### DIFF
--- a/tests/run/builtin_exceptions.py
+++ b/tests/run/builtin_exceptions.py
@@ -1,0 +1,25 @@
+def raise_classname():
+    """
+    >>> raise_classname()
+    Traceback (most recent call last):
+    IndexError
+    """
+    raise IndexError
+
+
+def raise_zeroargs():
+    """
+    >>> raise_zeroargs()
+    Traceback (most recent call last):
+    ValueError
+    """
+    raise ValueError()
+
+
+def raise_onearg():
+    """
+    >>> raise_onearg()
+    Traceback (most recent call last):
+    KeyError: 'foo!'
+    """
+    raise KeyError('foo' + '!')


### PR DESCRIPTION
Using `PyErr_Set{None,Object}` for built-in exceptions can save a few hundred lines of C code per module because we typically don't need the whole `__Pyx_Raise` machinery. The new code is not pretty, but it even seems to improve performance; a simple function such as

``` python
def foo():
    try: raise ValueError('foo!')
    except: pass
```

now runs in 36ns, vs. >70ns previously.
