### PR TITLE
Optimize reversed(range(...)), with non-constant values.

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -680,13 +680,13 @@ class IterationTransform(Visitor.EnvTransform):
                     spanning_step_type = PyrexTypes.spanning_type(spanning_type, step.type)
 
                     if step_value < 0:
-                        begin_value = copy.copy(bound2)
-                        end_value = copy.copy(bound1)
+                        begin_value = copy.deepcopy(bound2)
+                        end_value = copy.deepcopy(bound1)
                         final_op = '-'
                         final_node = ExprNodes.SubNode
                     else:
-                        begin_value = copy.copy(bound1)
-                        end_value = copy.copy(bound2)
+                        begin_value = copy.deepcopy(bound1)
+                        end_value = copy.deepcopy(bound2)
                         final_op = '+'
                         final_node = ExprNodes.AddNode
 
@@ -694,7 +694,7 @@ class IterationTransform(Visitor.EnvTransform):
                         bound1.pos,
                         operand1=final_node(
                             bound1.pos,
-                            operand1=copy.copy(bound2),
+                            operand1=copy.deepcopy(bound2),
                             operator=final_op,
                             operand2=ExprNodes.MulNode(
                                 bound1.pos,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -661,54 +661,8 @@ class IterationTransform(Visitor.EnvTransform):
             bound1, bound2 = bound2, bound1
             abs_step = abs(step_value)
             if abs_step != 1:
-                if not (isinstance(bound1.constant_result, (int, long)) and
+                if (isinstance(bound1.constant_result, (int, long)) and
                         isinstance(bound2.constant_result, (int, long))):
-                    spanning_type = PyrexTypes.spanning_type(bound1.type, bound2.type)
-                    spanning_step_type = PyrexTypes.spanning_type(spanning_type, step.type)
-
-                    if step_value < 0:
-                        begin_value = bound2
-                        end_value = bound1
-                        final_op = '-'
-                        final_node = ExprNodes.SubNode
-                    else:
-                        begin_value = bound1
-                        end_value = bound2
-                        final_op = '+'
-                        final_node = ExprNodes.AddNode
-                    beg_sub_end = ExprNodes.SubNode(bound1.pos,
-                                                    operand1=begin_value,
-                                                    operator='-',
-                                                    operand2=end_value,
-                                                    type=spanning_type)
-                    one_node = ExprNodes.IntNode(bound1.pos, value='1', constant_result=1)
-                    beg_sub_end_sub_1 = ExprNodes.SubNode(bound1.pos,
-                                                          operand1=beg_sub_end,
-                                                          operator='-',
-                                                          operand2=one_node,
-                                                          type=spanning_step_type)
-                    abs_step_node = ExprNodes.IntNode(bound1.pos, value=str(abs_step), constant_value=abs_step)
-                    div_val_node = ExprNodes.DivNode(bound1.pos, 
-                                                     operand1=beg_sub_end_sub_1,
-                                                     operator='//',
-                                                     operand2=abs_step_node,
-                                                     type=spanning_step_type)
-                    delta_node = ExprNodes.MulNode(bound1.pos,
-                                                   operand1=abs_step_node,
-                                                   operator='*',
-                                                   operand2=div_val_node,
-                                                   type=spanning_step_type)
-                    beg_func_delta = final_node(bound1.pos,
-                                                operand1=bound2,
-                                                operator=final_op,
-                                                operand2=delta_node,
-                                                type=spanning_step_type)
-                    bound1 = final_node(bound1.pos,
-                                        operand1=beg_func_delta,
-                                        operator=final_op,
-                                        operand2=one_node,
-                                        type=spanning_type)
-                else:
                     if step_value < 0:
                         begin_value = bound2.constant_result
                         end_value = bound1.constant_result
@@ -721,6 +675,66 @@ class IterationTransform(Visitor.EnvTransform):
                     bound1 = ExprNodes.IntNode(
                         bound1.pos, value=str(bound1_value), constant_result=bound1_value,
                         type=PyrexTypes.spanning_type(bound1.type, bound2.type))
+                else:
+                    spanning_type = PyrexTypes.spanning_type(bound1.type, bound2.type)
+                    spanning_step_type = PyrexTypes.spanning_type(spanning_type, step.type)
+
+                    if step_value < 0:
+                        begin_value = copy.copy(bound2)
+                        end_value = copy.copy(bound1)
+                        final_op = '-'
+                        final_node = ExprNodes.SubNode
+                    else:
+                        begin_value = copy.copy(bound1)
+                        end_value = copy.copy(bound2)
+                        final_op = '+'
+                        final_node = ExprNodes.AddNode
+
+                    bound1 = final_node(
+                        bound1.pos,
+                        operand1=final_node(
+                            bound1.pos,
+                            operand1=copy.copy(bound2),
+                            operator=final_op,
+                            operand2=ExprNodes.MulNode(
+                                bound1.pos,
+                                operand1=ExprNodes.IntNode(
+                                    bound1.pos,
+                                    value=str(abs_step),
+                                    constant_value=abs_step,
+                                    type=spanning_step_type),
+                                operator='*',
+                                operand2=ExprNodes.DivNode(
+                                    bound1.pos, 
+                                    operand1=ExprNodes.SubNode(
+                                        bound1.pos,
+                                        operand1=ExprNodes.SubNode(
+                                            bound1.pos,
+                                            operand1=begin_value,
+                                            operator='-',
+                                            operand2=end_value,
+                                            type=spanning_type),
+                                        operator='-',
+                                        operand2=ExprNodes.IntNode(
+                                            bound1.pos,
+                                            value='1',
+                                            constant_result=1),
+                                        type=spanning_step_type),
+                                    operator='//',
+                                    operand2=ExprNodes.IntNode(
+                                        bound1.pos,
+                                        value=str(abs_step),
+                                        constant_value=abs_step,
+                                        type=spanning_step_type),
+                                    type=spanning_step_type),
+                                type=spanning_step_type),
+                            type=spanning_step_type),
+                        operator=final_op,
+                        operand2=ExprNodes.IntNode(
+                            bound1.pos,
+                            value='1',
+                            constant_result=1),
+                        type=spanning_type)
 
         if step_value < 0:
             step_value = -step_value

--- a/tests/errors/reversed_literal_pyobjs.pyx
+++ b/tests/errors/reversed_literal_pyobjs.pyx
@@ -1,0 +1,31 @@
+# mode: error
+# tag: reversed
+
+cdef int i, j
+for i in reversed(range([], j, 2)):
+    pass
+for i in reversed(range([], j, -2)):
+    pass
+for i in reversed(range(j, [], 2)):
+    pass
+for i in reversed(range(j, [], -2)):
+    pass
+for i in reversed(range({}, j, 2)):
+    pass
+for i in reversed(range({}, j, -2)):
+    pass
+for i in reversed(range(j, {}, 2)):
+    pass
+for i in reversed(range(j, {}, -2)):
+    pass
+
+_ERRORS = """
+5:24: Cannot coerce list to type 'long'
+7:24: Cannot coerce list to type 'long'
+9:27: Cannot coerce list to type 'long'
+11:27: Cannot coerce list to type 'long'
+13:24: Cannot interpret dict as type 'long'
+15:24: Cannot interpret dict as type 'long'
+17:27: Cannot interpret dict as type 'long'
+19:27: Cannot interpret dict as type 'long'
+"""

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -214,14 +214,6 @@ def reversed_range_step3_py_args(a, b):
     []
     >>> reversed_range_step3_py_args(1, 1)
     ([], 99)
-
-    >>> reversed_range_step3_py_args(set(), 1)
-    Traceback (most recent call last):
-    TypeError: range() integer start argument expected, got set.
-
-    >>> reversed_range_step3_py_args(1, set())
-    Traceback (most recent call last):
-    TypeError: range() integer end argument expected, got set.
     """
     i = 99
     result = []
@@ -250,14 +242,6 @@ def reversed_range_step3_neg_py_args(a, b):
     []
     >>> reversed_range_step3_neg_py_args(1, 1)
     ([], 99)
-
-    >>> reversed_range_step3_neg_py_args(set(), 1)
-    Traceback (most recent call last):
-    TypeError: range() integer start argument expected, got set.
-
-    >>> reversed_range_step3_neg_py_args(1, set())
-    Traceback (most recent call last):
-    TypeError: range() integer end argument expected, got set.
     """
     i = 99
     result = []

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -165,6 +165,21 @@ def reversed_range_step3(int a, int b):
 
 @cython.test_assert_path_exists('//ForFromStatNode')
 @cython.test_fail_if_path_exists('//ForInStatNode')
+def reversed_range_step3_expr(int a, int b):
+    """
+    >>> [ i for i in _reversed(range(0, 5, 3)) ]
+    [3, 0]
+    >>> reversed_range_step3_expr(0, 5)
+    ([3, 0], 0)
+    """
+    cdef int i = 99, c = 100
+    result = []
+    for i in reversed(range(c-c + a + c-c, c-c + b + c-c, 3)):
+        result.append(i)
+    return result, i
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
 def reversed_range_step3_neg(int a, int b):
     """
     >>> [ i for i in _reversed(range(0, -5, -3)) ]
@@ -193,6 +208,21 @@ def reversed_range_step3_neg(int a, int b):
         result.append(i)
     return result, i
 
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
+def reversed_range_step3_neg_expr(int a, int b):
+    """
+    >>> [ i for i in _reversed(range(5, 0, -3)) ]
+    [2, 5]
+    >>> reversed_range_step3_neg_expr(5, 0)
+    ([2, 5], 5)
+    """
+    cdef int i = 99, c = 100
+    result = []
+    for i in reversed(range(c-c + a + c-c, c-c + b + c-c, -3)):
+        result.append(i)
+    return result, i
+
 def reversed_range_step3_py_args(a, b):
     """
     >>> [ i for i in _reversed(range(-5, 0, 3)) ]
@@ -214,6 +244,14 @@ def reversed_range_step3_py_args(a, b):
     []
     >>> reversed_range_step3_py_args(1, 1)
     ([], 99)
+
+    >>> reversed_range_step3_py_args(set(), 1) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...integer...
+
+    >>> reversed_range_step3_py_args(1, set()) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...integer...
     """
     i = 99
     result = []
@@ -242,6 +280,14 @@ def reversed_range_step3_neg_py_args(a, b):
     []
     >>> reversed_range_step3_neg_py_args(1, 1)
     ([], 99)
+
+    >>> reversed_range_step3_neg_py_args(set(), 1) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...integer...
+
+    >>> reversed_range_step3_neg_py_args(1, set()) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...integer...
     """
     i = 99
     result = []

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -134,7 +134,8 @@ def reversed_range_step_neg(int a, int b):
     return result, i
 
 
-#cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
 def reversed_range_step3(int a, int b):
     """
     >>> [ i for i in _reversed(range(-5, 0, 3)) ]
@@ -155,6 +156,32 @@ def reversed_range_step3(int a, int b):
     cdef int i = 99
     result = []
     for i in reversed(range(a, b, 3)):
+        result.append(i)
+    return result, i
+
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
+def reversed_range_step3_neg(int a, int b):
+    """
+    >>> [ i for i in _reversed(range(0, -5, -3)) ]
+    [-3, 0]
+    >>> reversed_range_step3_neg(0, -5)
+    ([-3, 0], 0)
+
+    >>> [ i for i in _reversed(range(5, 0, -3)) ]
+    [2, 5]
+    >>> reversed_range_step3_neg(5, 0)
+    ([2, 5], 5)
+
+    >>> [ i for i in _reversed(range(0, 5, -3)) ]
+    []
+    >>> reversed_range_step3_neg(0, 5)
+    ([], 99)
+    """
+    cdef int i = 99
+    result = []
+    for i in reversed(range(a, b, -3)):
         result.append(i)
     return result, i
 

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -133,7 +133,6 @@ def reversed_range_step_neg(int a, int b):
         result.append(i)
     return result, i
 
-
 @cython.test_assert_path_exists('//ForFromStatNode')
 @cython.test_fail_if_path_exists('//ForInStatNode')
 def reversed_range_step3(int a, int b):
@@ -152,13 +151,17 @@ def reversed_range_step3(int a, int b):
     []
     >>> reversed_range_step3(5, 0)
     ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, 3)) ]
+    []
+    >>> reversed_range_step3(1, 1)
+    ([], 99)
     """
     cdef int i = 99
     result = []
     for i in reversed(range(a, b, 3)):
         result.append(i)
     return result, i
-
 
 @cython.test_assert_path_exists('//ForFromStatNode')
 @cython.test_fail_if_path_exists('//ForInStatNode')
@@ -178,6 +181,11 @@ def reversed_range_step3_neg(int a, int b):
     []
     >>> reversed_range_step3_neg(0, 5)
     ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, -3)) ]
+    []
+    >>> reversed_range_step3_neg(1, 1)
+    ([], 99)
     """
     cdef int i = 99
     result = []
@@ -185,8 +193,122 @@ def reversed_range_step3_neg(int a, int b):
         result.append(i)
     return result, i
 
+def reversed_range_step3_py_args(a, b):
+    """
+    >>> [ i for i in _reversed(range(-5, 0, 3)) ]
+    [-2, -5]
+    >>> reversed_range_step3_py_args(-5, 0)
+    ([-2, -5], -5)
 
-@cython.test_assert_path_exists('//ForFromStatNode')
+    >>> [ i for i in _reversed(range(0, 5, 3)) ]
+    [3, 0]
+    >>> reversed_range_step3_py_args(0, 5)
+    ([3, 0], 0)
+
+    >>> [ i for i in _reversed(range(5, 0, 3)) ]
+    []
+    >>> reversed_range_step3_py_args(5, 0)
+    ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, 3)) ]
+    []
+    >>> reversed_range_step3_py_args(1, 1)
+    ([], 99)
+
+    >>> reversed_range_step3_py_args(set(), 1)
+    Traceback (most recent call last):
+    TypeError: range() integer start argument expected, got set.
+
+    >>> reversed_range_step3_py_args(1, set())
+    Traceback (most recent call last):
+    TypeError: range() integer end argument expected, got set.
+    """
+    i = 99
+    result = []
+    for i in reversed(range(a, b, 3)):
+        result.append(i)
+    return result, i
+
+def reversed_range_step3_neg_py_args(a, b):
+    """
+    >>> [ i for i in _reversed(range(0, -5, -3)) ]
+    [-3, 0]
+    >>> reversed_range_step3_neg_py_args(0, -5)
+    ([-3, 0], 0)
+
+    >>> [ i for i in _reversed(range(5, 0, -3)) ]
+    [2, 5]
+    >>> reversed_range_step3_neg_py_args(5, 0)
+    ([2, 5], 5)
+
+    >>> [ i for i in _reversed(range(0, 5, -3)) ]
+    []
+    >>> reversed_range_step3_neg_py_args(0, 5)
+    ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, -3)) ]
+    []
+    >>> reversed_range_step3_neg_py_args(1, 1)
+    ([], 99)
+
+    >>> reversed_range_step3_neg_py_args(set(), 1)
+    Traceback (most recent call last):
+    TypeError: range() integer start argument expected, got set.
+
+    >>> reversed_range_step3_neg_py_args(1, set())
+    Traceback (most recent call last):
+    TypeError: range() integer end argument expected, got set.
+    """
+    i = 99
+    result = []
+    for i in reversed(range(a, b, -3)):
+        result.append(i)
+    return result, i
+
+def reversed_range_step3_py_obj_left(a, int b):
+    """
+    >>> reversed_range_step3_py_obj_left(set(), 0)
+    Traceback (most recent call last):
+    TypeError: an integer is required
+    """
+    cdef int i
+    result = []
+    for i in reversed(range(a, b, 3)):
+        result.append(i)
+
+def reversed_range_step3_py_obj_right(int a, b):
+    """
+    >>> reversed_range_step3_py_obj_right(0, set())
+    Traceback (most recent call last):
+    TypeError: an integer is required
+    """
+    cdef int i
+    result = []
+    for i in reversed(range(a, b, 3)):
+        result.append(i)
+
+def reversed_range_step3_neg_py_obj_left(a, int b):
+    """
+    >>> reversed_range_step3_neg_py_obj_left(set(), 0)
+    Traceback (most recent call last):
+    TypeError: an integer is required
+    """
+    cdef int i
+    result = []
+    for i in reversed(range(a, b, -3)):
+        result.append(i)
+
+def reversed_range_step3_neg_py_obj_right(int a, b):
+    """
+    >>> reversed_range_step3_py_obj_right(0, set())
+    Traceback (most recent call last):
+    TypeError: an integer is required
+    """
+    cdef int i
+    result = []
+    for i in reversed(range(a, b, -3)):
+        result.append(i)
+
 @cython.test_fail_if_path_exists('//ForInStatNode')
 def reversed_range_constant():
     """
@@ -202,7 +324,6 @@ def reversed_range_constant():
     assert result == list(reversed(range(1, 1, 4))), result
     assert i == 99
 
-    result = []
     for i in reversed(range(1, 1, 1)):
         result.append(i)
     assert result == list(reversed(range(1, 1, 1))), result
@@ -272,12 +393,12 @@ def reversed_range_constant():
         result.append(i)
     assert result == list(reversed(range(0, 12, 4))), result
 
+    i = 99
     result = []
     for i in reversed(range(-12, -2, 4)):
         result.append(i)
     assert result == list(reversed(range(-12, -2, 4))), result
     return result, i
-
 
 @cython.test_assert_path_exists('//ForFromStatNode')
 @cython.test_fail_if_path_exists('//ForInStatNode')
@@ -413,7 +534,6 @@ def reversed_range_constant_neg():
     for i in reversed(range(-2, -12, -1)):
         result.append(i)
     assert result == list(reversed(range(-2, -12, -1))), result
-
 
 unicode_string = u"abcDEF"
 


### PR DESCRIPTION
One potential problem is that is does not generate warnings on the division, however we know that `step_value != 0`. I have a much larger test file on my computer, if there are doubts of the basic functionality. Hopefully it fits into the structure properly this time, if not comments are welcome.

Completing ticket #765.