### PR TITLE
Enhance cython defintion of the Numpy dtype

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -154,8 +154,7 @@ cdef extern from "numpy/arrayobject.h":
 
     ctypedef class numpy.dtype [object PyArray_Descr]:
         # Use PyDataType_* macros when possible, however there are no macros
-        # for accessing some of the fields, so some are defined. Please
-        # ask on cython-dev if you need more.
+        # for accessing some of the fields, so some are defined.
         cdef char kind
         cdef char type
         cdef char byteorder

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -157,10 +157,13 @@ cdef extern from "numpy/arrayobject.h":
         # for accessing some of the fields, so some are defined. Please
         # ask on cython-dev if you need more.
         cdef char kind
+        cdef char type
+        cdef char byteorder
+        cdef char flags
         cdef int type_num
         cdef int itemsize "elsize"
-        cdef char byteorder
-        cdef object fields
+        cdef int alignment
+        cdef dict fields
         cdef tuple names
 
     ctypedef extern class numpy.flatiter [object PyArrayIterObject]:

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -156,6 +156,7 @@ cdef extern from "numpy/arrayobject.h":
         # Use PyDataType_* macros when possible, however there are no macros
         # for accessing some of the fields, so some are defined. Please
         # ask on cython-dev if you need more.
+        cdef char kind
         cdef int type_num
         cdef int itemsize "elsize"
         cdef char byteorder


### PR DESCRIPTION
There were several fields missing from the defintion of the Numpy dtype.

Contribution based on suggestions on the Numpy-Mailinglist:

http://mail.scipy.org/pipermail/numpy-discussion/2014-December/071952.html