### PR TITLE
Changed external function declarations to not use DL_IMPORT.

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2759,7 +2759,7 @@ def generate_cfunction_declaration(entry, env, code, definition):
             or entry.defined_in_pxd or entry.visibility == 'extern' or from_cy_utility)):
         if entry.visibility == 'extern':
             storage_class = Naming.extern_c_macro
-            dll_linkage = "DL_IMPORT"
+            dll_linkage = None
         elif entry.visibility == 'public':
             storage_class = Naming.extern_c_macro
             dll_linkage = "DL_EXPORT"


### PR DESCRIPTION
Prior to this change, the DL_IMPORT macro was being used for
external function declarations. On Windows, that made it so
that functions declared in this manner had to be loaded from
a dll and not linked from an object file.

External declarations attempting to use a function directly from an
object file would fail with an obscure linker error.