### PR TITLE
fix isinf return type to int: returns -1 for negative infinity

### DIFF
--- a/Cython/Includes/libc/math.pxd
+++ b/Cython/Includes/libc/math.pxd
@@ -99,4 +99,4 @@ cdef extern from "math.h" nogil:
     bint isfinite(long double)
     bint isnormal(long double)
     bint isnan(long double)
-    bint isinf(long double)
+    int isinf(long double)

--- a/Cython/Includes/numpy/math.pxd
+++ b/Cython/Includes/numpy/math.pxd
@@ -26,7 +26,7 @@ cdef extern from "numpy/npy_math.h" nogil:
 
     # These four are actually macros and work on any floating-point type.
     bint isfinite "npy_isfinite"(long double)
-    bint isinf "npy_isinf"(long double)
+    int isinf "npy_isinf"(long double)
     bint isnan "npy_isnan"(long double)
     bint signbit "npy_signbit"(long double)
 

--- a/tests/run/numpy_math.pyx
+++ b/tests/run/numpy_math.pyx
@@ -37,7 +37,8 @@ def test_fp_classif():
     assert not npmath.isnan(d_zero)
     assert not npmath.isnan(f_zero)
 
-    assert npmath.isinf(npmath.INFINITY)
+    assert npmath.isinf(npmath.INFINITY) == 1
+    assert npmath.isinf(-npmath.INFINITY) == -1
     assert npmath.isnan(npmath.NAN)
 
     assert npmath.signbit(npmath.copysign(1., -1.))


### PR DESCRIPTION
This changes behavior in, e.g., `print(isinf(x))`, but not the more common `cdef int infinite = isinf(x)`.

Patch to 0.22.x in the hopes of getting this into the next release.