### PR TITLE
Optimize range(start, stop, step), when step is a variable, at compile time.

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6185,12 +6185,10 @@ class ForFromStatNode(LoopNode, StatNode):
     def generate_execution_code(self, code):
         old_loop_labels = code.new_loop_labels()
         from_range = self.from_range
-        constant_step = (self.step is not None and
-                            isinstance(self.step.constant_result, (int, long)))
         self.bound1.generate_evaluation_code(code)
         self.bound2.generate_evaluation_code(code)
         offset, incop = self.relation_table[self.relation1]
-        if (self.from_range and self.step is not None and
+        if (self.from_range and self.step and
                 not isinstance(self.step.constant_result, (int, long))):
             self.step.generate_evaluation_code(code)
             step = self.step.result()
@@ -6236,7 +6234,7 @@ class ForFromStatNode(LoopNode, StatNode):
             self.py_loopvar_node.generate_evaluation_code(code)
             self.target.generate_assignment_code(self.py_loopvar_node, code)
         elif from_range:
-            if constant_step or self.step is None:
+            if self.step is None or isinstance(self.step.constant_result, (int, long)):
                 code.putln("%s = %s;" % (
                                 self.target.result(), loopvar_name))
             else:

--- a/tests/errors/reversed_literal_pyobjs.pyx
+++ b/tests/errors/reversed_literal_pyobjs.pyx
@@ -1,7 +1,7 @@
 # mode: error
 # tag: reversed
 
-cdef int i, j
+cdef int i, j = 1
 for i in reversed(range([], j, 2)):
     pass
 for i in reversed(range([], j, -2)):
@@ -18,6 +18,10 @@ for i in reversed(range(j, {}, 2)):
     pass
 for i in reversed(range(j, {}, -2)):
     pass
+for i in reversed(range(j, 2, [])):
+    pass
+for i in reversed(range(j, 2, {})):
+    pass
 
 _ERRORS = """
 5:24: Cannot coerce list to type 'long'
@@ -28,4 +32,6 @@ _ERRORS = """
 15:24: Cannot interpret dict as type 'long'
 17:27: Cannot interpret dict as type 'long'
 19:27: Cannot interpret dict as type 'long'
+21:30: Cannot coerce list to type 'long'
+23:30: Cannot interpret dict as type 'long'
 """

--- a/tests/run/r_forloop.pyx
+++ b/tests/run/r_forloop.pyx
@@ -52,6 +52,16 @@ def go_c_int(int a, int b):
     for i in range(a,b,2):
         print u"Spam!"
 
+def go_3_int(int a, int b, int c):
+    """
+    >>> go_3_int(1,5,2)
+    Spam!
+    Spam!
+    """
+    cdef int i
+    for i in range(a,b,c):
+        print u"Spam!"
+
 def go_c_all():
     """
     >>> go_c_all()
@@ -75,6 +85,19 @@ def go_c_all_exprs(x):
     for i in range(4*x,2*x,-3):
         print u"Spam!"
 
+def go_c_3_exprs(x):
+    """
+    >>> go_c_3_exprs(1)
+    Spam!
+    Spam!
+    >>> go_c_3_exprs(3)
+    Spam!
+    Spam!
+    """
+    cdef int i
+    for i in range(4*x,2*x,-1*x):
+        print u"Spam!"
+
 def go_c_const_exprs():
     """
     >>> go_c_const_exprs()
@@ -87,6 +110,15 @@ def go_c_const_exprs():
 
 def f(x):
     return 2*x
+
+def go_3_calc(x):
+    """
+    >>> go_3_calc(2)
+    Spam!
+    """
+    cdef int i
+    for i in range(2*f(x),f(x), -1*f(x)):
+        print u"Spam!"
 
 def go_c_calc(x):
     """

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -247,11 +247,11 @@ def reversed_range_step3_py_args(a, b):
 
     >>> reversed_range_step3_py_args(set(), 1) # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...integer...
+    TypeError: ...set...
 
     >>> reversed_range_step3_py_args(1, set()) # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...integer...
+    TypeError: ...set...
     """
     i = 99
     result = []
@@ -283,11 +283,11 @@ def reversed_range_step3_neg_py_args(a, b):
 
     >>> reversed_range_step3_neg_py_args(set(), 1) # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...integer...
+    TypeError: ...set...
 
     >>> reversed_range_step3_neg_py_args(1, set()) # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...integer...
+    TypeError: ...set...
     """
     i = 99
     result = []
@@ -302,9 +302,8 @@ def reversed_range_step3_py_obj_left(a, int b):
     TypeError: an integer is required
     """
     cdef long i
-    result = []
     for i in reversed(range(a, b, 3)):
-        result.append(i)
+        pass
 
 def reversed_range_step3_py_obj_right(int a, b):
     """
@@ -313,9 +312,8 @@ def reversed_range_step3_py_obj_right(int a, b):
     TypeError: an integer is required
     """
     cdef long i
-    result = []
     for i in reversed(range(a, b, 3)):
-        result.append(i)
+        pass
 
 def reversed_range_step3_neg_py_obj_left(a, int b):
     """
@@ -324,9 +322,8 @@ def reversed_range_step3_neg_py_obj_left(a, int b):
     TypeError: an integer is required
     """
     cdef long i
-    result = []
     for i in reversed(range(a, b, -3)):
-        result.append(i)
+        pass
 
 def reversed_range_step3_neg_py_obj_right(int a, b):
     """
@@ -337,7 +334,7 @@ def reversed_range_step3_neg_py_obj_right(int a, b):
     cdef long i
     result = []
     for i in reversed(range(a, b, -3)):
-        result.append(i)
+        pass
 
 @cython.test_fail_if_path_exists('//ForInStatNode')
 def reversed_range_constant():
@@ -795,3 +792,219 @@ def range_unsigned_by_neg_3(int a, int b):
     """
     cdef unsigned int i
     return [i for i in range(b, a, -3)]
+
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+def reversed_pos_var_step(int c):
+    """
+    >>> reversed_pos_var_step(1)
+    ([4, 3, 2, 1, 0], 0)
+    >>> reversed_pos_var_step(2)
+    ([4, 2, 0], 0)
+    >>> reversed_pos_var_step(3)
+    ([3, 0], 0)
+    >>> reversed_pos_var_step(5)
+    ([0], 0)
+    >>> reversed_pos_var_step(0) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ValueError: range() ...arg...must not be zero
+    """
+    cdef int i = 99
+    result = []
+    for i in reversed(range(0, 5, c)):
+        result.append(i)
+    return result, i
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+def reversed_neg_var_step(int c):
+    """
+    >>> reversed_neg_var_step(-1)
+    ([1, 2, 3, 4, 5], 5)
+    >>> reversed_neg_var_step(-2)
+    ([1, 3, 5], 5)
+    >>> reversed_neg_var_step(-3)
+    ([2, 5], 5)
+    >>> reversed_neg_var_step(-5)
+    ([5], 5)
+    """
+    cdef int i = 99
+    result = []
+    for i in reversed(range(5, 0, c)):
+        result.append(i)
+    return result, i
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+def reversed_all_var_pos_step(int a, int b, int c):
+    """
+    >>> reversed_all_var_pos_step(-10, -7, 3)
+    ([-10], -10)
+    >>> reversed_all_var_pos_step(-10, -6, 3)
+    ([-7, -10], -10)
+    >>> reversed_all_var_pos_step(-10, -5, 3)
+    ([-7, -10], -10)
+    >>> reversed_all_var_pos_step(-10, -4, 3)
+    ([-7, -10], -10)
+    >>> reversed_all_var_pos_step(-10, -3, 3)
+    ([-4, -7, -10], -10)
+    >>> reversed_all_var_pos_step(-2, 5, 3)
+    ([4, 1, -2], -2)
+    >>> reversed_all_var_pos_step(-1, 5, 3)
+    ([2, -1], -1)
+    >>> reversed_all_var_pos_step(0, 5, 3)
+    ([3, 0], 0)
+    >>> reversed_all_var_pos_step(1, 5, 3)
+    ([4, 1], 1)
+    >>> reversed_all_var_pos_step(2, 5, 3)
+    ([2], 2)
+    >>> reversed_all_var_pos_step(-5, -5, 1)
+    ([], 99)
+    >>> reversed_all_var_pos_step(-5, -7, 1)
+    ([], 99)
+    >>> reversed_all_var_pos_step(5, 5, 1)
+    ([], 99)
+    >>> reversed_all_var_pos_step(7, 5, 1)
+    ([], 99)
+    """
+    cdef int i = 99
+    result = []
+    for i in reversed(range(a, b, c)):
+        result.append(i)
+    return result, i
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+def reversed_all_var_neg_step(int a, int b, int c):
+    """
+    >>> reversed_all_var_neg_step(-7, -10, -3)
+    ([-7], -7)
+    >>> reversed_all_var_neg_step(-6, -10, -3)
+    ([-9, -6], -6)
+    >>> reversed_all_var_neg_step(-5, -10, -3)
+    ([-8, -5], -5)
+    >>> reversed_all_var_neg_step(-4, -10, -3)
+    ([-7, -4], -4)
+    >>> reversed_all_var_neg_step(-3, -10, -3)
+    ([-9, -6, -3], -3)
+    >>> reversed_all_var_neg_step(5, -2, -3)
+    ([-1, 2, 5], 5)
+    >>> reversed_all_var_neg_step(5, -1, -3)
+    ([2, 5], 5)
+    >>> reversed_all_var_neg_step(5, 0, -3)
+    ([2, 5], 5)
+    >>> reversed_all_var_neg_step(5, 1, -3)
+    ([2, 5], 5)
+    >>> reversed_all_var_neg_step(5, 2, -3)
+    ([5], 5)
+    >>> reversed_all_var_neg_step(-5, -5, -1)
+    ([], 99)
+    >>> reversed_all_var_neg_step(-5, -3, -1)
+    ([], 99)
+    >>> reversed_all_var_neg_step(5, 5, -1)
+    ([], 99)
+    >>> reversed_all_var_neg_step(3, 5, -1)
+    ([], 99)
+    """
+    cdef int i = 99
+    result = []
+    for i in reversed(range(a, b, c)):
+        result.append(i)
+    return result, i
+
+def reversed_range_py_obj_var_step(int b, c):
+    """
+    >>> reversed_range_py_obj_var_step(0, set()) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...set...
+    """
+    cdef long i
+    for i in reversed(range(0, b, c)):
+        pass
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
+def reversed_range_neg_expr_step(int c):
+    """
+    >>> [ i for i in _reversed(range(5, 0, -3)) ]
+    [2, 5]
+    >>> reversed_range_neg_expr_step(-3)
+    ([2, 5], 5)
+    """
+    cdef int i = 99, d = 100
+    result = []
+    for i in reversed(range(5, 0, d-d + c + d-d)):
+        result.append(i)
+    return result, i
+
+@cython.test_assert_path_exists('//ForFromStatNode')
+@cython.test_fail_if_path_exists('//ForInStatNode')
+def reversed_range_pos_expr_step(int c):
+    """
+    >>> [ i for i in _reversed(range(0, 5, 3)) ]
+    [3, 0]
+    >>> reversed_range_pos_expr_step(3)
+    ([3, 0], 0)
+    """
+    cdef int i = 99, d = 100
+    result = []
+    for i in reversed(range(0, 5, d-d + c + d-d)):
+        result.append(i)
+    return result, i
+
+def reversed_all_py_var_neg_step(a, b, c):
+    """
+    >>> [ i for i in _reversed(range(0, -5, -3)) ]
+    [-3, 0]
+    >>> reversed_all_py_var_neg_step(0, -5, -3)
+    ([-3, 0], 0)
+
+    >>> [ i for i in _reversed(range(5, 0, -3)) ]
+    [2, 5]
+    >>> reversed_all_py_var_neg_step(5, 0, -3)
+    ([2, 5], 5)
+
+    >>> [ i for i in _reversed(range(0, 5, -3)) ]
+    []
+    >>> reversed_all_py_var_neg_step(0, 5, -3)
+    ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, -1)) ]
+    []
+    >>> reversed_all_py_var_neg_step(1, 1, -1)
+    ([], 99)
+
+    >>> reversed_all_py_var_neg_step(1000, 0, 0) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ValueError: range() ...arg...must not be zero
+    """
+    i = 99
+    result = []
+    for i in reversed(range(a, b, c)):
+        result.append(i)
+    return result, i
+
+def reversed_all_py_var_pos_step(a, b, c):
+    """
+    >>> [ i for i in _reversed(range(-5, 0, 3)) ]
+    [-2, -5]
+    >>> reversed_all_py_var_pos_step(-5, 0, 3)
+    ([-2, -5], -5)
+
+    >>> [ i for i in _reversed(range(0, 5, 3)) ]
+    [3, 0]
+    >>> reversed_all_py_var_pos_step(0, 5, 3)
+    ([3, 0], 0)
+
+    >>> [ i for i in _reversed(range(5, 0, 3)) ]
+    []
+    >>> reversed_all_py_var_pos_step(5, 0, 3)
+    ([], 99)
+
+    >>> [ i for i in _reversed(range(1, 1, 1)) ]
+    []
+    >>> reversed_all_py_var_pos_step(1, 1, 1)
+    ([], 99)
+    """
+    i = 99
+    result = []
+    for i in reversed(range(a, b, c)):
+        result.append(i)
+    return result, i

--- a/tests/run/reversed_iteration.pyx
+++ b/tests/run/reversed_iteration.pyx
@@ -911,9 +911,9 @@ def reversed_all_var_neg_step(int a, int b, int c):
 
 def reversed_range_py_obj_var_step(int b, c):
     """
-    >>> reversed_range_py_obj_var_step(0, set()) # doctest: +ELLIPSIS
+    >>> reversed_range_py_obj_var_step(0, set())
     Traceback (most recent call last):
-    TypeError: ...set...
+    TypeError: an integer is required
     """
     cdef long i
     for i in reversed(range(0, b, c)):
@@ -1008,3 +1008,36 @@ def reversed_all_py_var_pos_step(a, b, c):
     for i in reversed(range(a, b, c)):
         result.append(i)
     return result, i
+
+#@cython.test_assert_path_exists('//ForFromStatNode')
+def reversed_unsigned_by_pos_var_step(int a, int b, int c):
+    """
+    >>> reversed_unsigned_by_pos_var_step(0, 5, 3)
+    [3, 0]
+    >>> reversed_unsigned_by_pos_var_step(0, 7, 3)
+    [6, 3, 0]
+    """
+    cdef unsigned int i
+    return [i for i in reversed(range(a, b, c))]
+
+#@cython.test_assert_path_exists('//ForFromStatNode')
+def range_unsigned_by_neg_var_step(int a, int b, int c):
+    """
+    >>> range_unsigned_by_neg_var_step(-1, 6, -3)
+    [6, 3, 0]
+    >>> range_unsigned_by_neg_var_step(0, 7, -3)
+    [7, 4, 1]
+    """
+    cdef unsigned int i
+    return [i for i in range(b, a, c)]
+
+#@cython.test_assert_path_exists('//ForFromStatNode')
+def range_unsigned_by_neg_var_step(int a, int b, int c):
+    """
+    >>> range_unsigned_by_neg_var_step(-1, 6, -3)
+    [6, 3, 0]
+    >>> range_unsigned_by_neg_var_step(0, 7, -3)
+    [7, 4, 1]
+    """
+    cdef unsigned int i
+    return [i for i in range(b, a, c)]

--- a/tests/run/tryfinally.pyx
+++ b/tests/run/tryfinally.pyx
@@ -480,3 +480,21 @@ def finally_yield(x):
                 return
         finally:
             yield 1
+
+def try_bad_range_step():
+    """
+    >>> try_bad_range_step()  # doctest: +ELLIPSIS
+    Caught "an integer is required" exception!
+    Caught "range() ...arg...must not be zero" exception!
+    """
+    cdef int i, zero = 0
+    try:
+        for i in range(0, 0, set([0])):
+            pass
+    except TypeError as e:
+        print('Caught "%s" exception!' % e)
+    try:
+        for i in range(0, 0, zero):
+            pass
+    except ValueError as e:
+        print('Caught "%s" exception!' % e)


### PR DESCRIPTION
The code:
``` python
for i in range(start, stop, step):
    ...
```
would ideally translate into:
``` c
if (pyx_step == 0) {
    PyErr..... or Pyx_object_call(pyx_builtin_range.....
}
if (pyx_step > 0) {
    pyx_t_1 = -1;
} else {
    pyx_t_1 = 1;
}
pyx_t_2 = Pyx_div(((pyx_stop+pyx_t_1)  - pyx_start), pyx_step);
for (pyx_t_1 = 0; pyx_t_1 <= pyx_t_2, pyx_t_1++) {
    pyx_i = pyx_start + pyx_step*pyx_t_1;
    ......
 }
```
however, my lack of proficiency with the nodes translates it into:
``` c
if (pyx_step > 0) {
    pyx_t_1 = -1;
} else {
    pyx_t_1 = 1;
}

if (!pyx_step) {           // step || 1
} else {
    pyx_t_2 = pyx_step;
    goto pyx_L38_bool_binop_done;
}
pyx_t_2 = 1;
pyx_L38_bool_binop_done:;

pyx_t_3 = Pyx_div(((pyx_stop+pyx_t_1)  - pyx_start), pyx_t_2);

if (pyx_step == 0) {
    PyErr.....
}
for (pyx_t_2 = 0; pyx_t_2 <= pyx_t_3, pyx_t_2++) {
    pyx_i = pyx_start + pyx_step*pyx_t_2;
    ......
 }
```
This is because I had a hard time getting an `IfStatNode` inside of `ExprNodes`, and the `LetNode` generates code before the `ForFromStatNode`, thus the zero check must happen after the divide in certain cases.
I had trouble getting PyTypes to have their nodes run code generation (printed None), so I have omitted them. Also had trouble getting the LetRefNodes to save to temps, so I have also omit function calls.

If you have any tips to make this cleaner, or tips to resolve the issues, or even a structure that you would prefer, feel free to tell them to me.