### PR TITLE
work around memoryview.tobytes() off-by-one bug with suboffsets

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -987,7 +987,11 @@ cdef memoryview_fromslice({{memviewslice_name}} memviewslice,
 
     result.view.shape = <Py_ssize_t *> result.from_slice.shape
     result.view.strides = <Py_ssize_t *> result.from_slice.strides
-    result.view.suboffsets = <Py_ssize_t *> result.from_slice.suboffsets
+    result.view.suboffsets = NULL
+    for i in range(ndim):
+        if result.from_slice.suboffsets[i] >= 0:
+            result.view.suboffsets = <Py_ssize_t *> result.from_slice.suboffsets
+            break
 
     result.view.len = result.view.itemsize
     for i in range(ndim):


### PR DESCRIPTION
In CPython 2.7, the memoryview.tobytes() method (implemented in
function memoryview_tobytes() in cpython/Objects/memoryobject.c) calls
PyBuffer_ToContiguous() to copy the bytes in the buffer object to the
newly allocated string memory.  PyBuffer_ToContiguous() in turn calls
PyBuffer_IsContiguous(), which always returns false when the
suboffsets member of the Py_buffer struct is non-NULL (even if all
entries in that array are negative!).  When PyBuffer_IsContiguous()
returns false, PyBuffer_ToContiguous() runs an alternative memory copy
scheme which apparently has an off-by-one bug that the normal memory
copy scheme doesn't have.

This change sets the Py_buffer suboffsets member to NULL if all
entries are negative, avoiding the off-by-one bug.

To reproduce the bug:

    cpdef foo():
        cdef unsigned char[:] v = bytearray("testing")
        # the following prints 'estingt' without this workaround
        print repr(memoryview(v).tobytes())

Signed-off-by: Richard Hansen <rhansen@bbn.com>