### PR TITLE
Fix document error "*.pyx" -> ["*.pyx"]

### DIFF
--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -68,7 +68,7 @@ explicitly, you can use glob patterns::
 You can also use glob patterns in :class:`Extension` objects if you pass
 them through :func:`cythonize`::
 
-    extensions = [Extension("*", "*.pyx")]
+    extensions = [Extension("*", ["*.pyx"])]
 
     setup(
         ext_modules = cythonize(extensions)


### PR DESCRIPTION
All 4 user guides are quite old. I have seen a lot of minor mistakes here and there.