### PR TITLE
Allow __new__ as an ordinary method

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1155,7 +1155,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         cpp_class_attrs = [entry for entry in scope.var_entries
                            if entry.type.is_cpp_class]
 
-        new_func_entry = scope.lookup_here("__new__")
+        new_func_entry = scope.lookup_here("__cinit__")
         if base_type or (new_func_entry and new_func_entry.is_special
                          and not new_func_entry.trivial_signature):
             unused_marker = ''

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1962,9 +1962,6 @@ class CClassScope(ClassScope):
         # Add an entry for a method.
         if name in ('__eq__', '__ne__', '__lt__', '__gt__', '__le__', '__ge__'):
             error(pos, "Special method %s must be implemented via __richcmp__" % name)
-        if name == "__new__":
-            error(pos, "__new__ method of extension type will change semantics "
-                "in a future version of Pyrex and Cython. Use __cinit__ instead.")
         entry = self.declare_var(name, py_object_type, pos,
                                  visibility='extern')
         special_sig = get_special_method_signature(name)
@@ -1981,8 +1978,6 @@ class CClassScope(ClassScope):
         return entry
 
     def lookup_here(self, name):
-        if name == "__new__":
-            name = EncodedString("__cinit__")
         entry = ClassScope.lookup_here(self, name)
         if entry and entry.is_builtin_cmethod:
             if not self.parent_type.is_builtin_type:


### PR DESCRIPTION
Using `__new__` instead of `__cinit__` in Cython extension types has been a warning since 2007 and an error since 2010. That is plenty of time such that we can now remove the restriction that methods cannot be called `__new__`.

This patch does not make `__new__` special (but that shouldn't a problem, since `__del__` also isn't special in Cython), but at least it allows experimenting with methods called `__new__`.