### PR TITLE
Change __Pyx_TraceDeclarations to be C89 compliant

### DIFF
--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -43,10 +43,9 @@
   #endif
 
   #define __Pyx_TraceDeclarations(codeobj, nogil)                     \
-  static PyCodeObject *$frame_code_cname = NULL;                      \
+  PyCodeObject *$frame_code_cname = (PyCodeObject*) codeobj;          \
   CYTHON_FRAME_MODIFIER PyFrameObject *$frame_cname = NULL;           \
-  int __Pyx_use_tracing = 0;                                          \
-  if (codeobj) $frame_code_cname = (PyCodeObject*) codeobj;
+  int __Pyx_use_tracing = 0;
 
   #ifdef WITH_THREAD
   #define __Pyx_TraceCall(funcname, srcfile, firstlineno, nogil, goto_error)             \


### PR DESCRIPTION
[I added a line note elsewhere](https://github.com/cython/cython/commit/b42e181f0c3bd9e714245de11c692f6bbe48571b#commitcomment-11119128) about compiling a memoryview-heavy file with profiling enabled and getting an error from MSVC about how C89 doesn't let you declare more variables after an if statement.

I had to change $frame_code_cname to a non-static local as a static local does not allow initializing with a non-constant. I can't tell why it needed to be static, as the assignment runs during every function call.

Just having the if statement in a `Declarations` macro kind of makes it a misnomer. Also, that if statement was fairly iffy in and of itself - why would you need to check if `codeobj` is NULL if you're just going to assign NULL anyway if it is?