### PR TITLE
Allow C++ operator declarations outside of classes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10124,9 +10124,8 @@ class CBinopNode(BinopNode):
         cpp_type = None
         if type1.is_cpp_class or type1.is_ptr:
             cpp_type = type1.find_cpp_operation_type(self.operator, type2)
-        # FIXME: handle the reversed case?
-        #if cpp_type is None and (type2.is_cpp_class or type2.is_ptr):
-        #    cpp_type = type2.find_cpp_operation_type(self.operator, type1)
+        if cpp_type is None and (type2.is_cpp_class or type2.is_ptr):
+            cpp_type = type2.find_cpp_operation_type(self.operator, type1)
         # FIXME: do we need to handle other cases here?
         return cpp_type
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -838,19 +838,23 @@ class Scope(object):
         
         # look-up nonmember methods listed within a class
         method_alternatives = []
-        if (len(operands)==2 # binary operators only
-            and operands[1].type.is_cpp_class):
-            obj_type = operands[1].type
-            method = obj_type.scope.lookup("operator%s" % operator)
-            if method is not None:
-                # also allow lookup with things defined in the global scope
-                method_alternatives = method.all_alternatives()
+        if len(operands)==2: # binary operators only
+            for n in range(2):
+                if operands[n].type.is_cpp_class:
+                    obj_type = operands[n].type
+                    method = obj_type.scope.lookup("operator%s" % operator)
+                    if method is not None:
+                        method_alternatives += method.all_alternatives()       
         
         if (not method_alternatives) and (not function_alternatives):
             return None
         
+        
+        # select the unique alternatives
+        all_alternatives = list(set(method_alternatives+function_alternatives))
+               
         return PyrexTypes.best_match(operands,
-                                     method_alternatives+function_alternatives)
+                                     all_alternatives)
 
     def lookup_operator_for_types(self, pos, operator, types):
         from .Nodes import Node

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -312,6 +312,10 @@ Cython uses C++ for overloading operators::
             Foo* operator-(Foo)
             int operator*(Foo*)
             int operator/(int)
+            int operator*(int, Foo) # allows 1*Foo()
+        # nonmember operators can also be specified outside the class
+        double operator/(double, Foo)
+        
 
     cdef Foo* foo = new Foo()
     cdef int x
@@ -321,6 +325,10 @@ Cython uses C++ for overloading operators::
 
     x = foo[0] * foo2
     x = foo[0] / 1
+    x = 1*foo[0]
+    
+    cdef double y
+    y = 2.0/foo[0]    
 
     cdef Foo f
     foo = f + &f

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -27,18 +27,29 @@ cdef extern from "cpp_operators_helper.h":
         const_char* operator--(int)
 
         const_char* operator+(int)
+        const_char* operator+(int,const TestOps&)
         const_char* operator-(int)
+        const_char* operator-(int,const TestOps&)
         const_char* operator*(int)
+        # deliberately omitted operator* to test case where only defined outside class
         const_char* operator/(int)
+        const_char* operator/(int,const TestOps&)
         const_char* operator%(int)
+        const_char* operator%(int,const TestOps&)
 
         const_char* operator|(int)
+        const_char* operator|(int,const TestOps&)
         const_char* operator&(int)
+        const_char* operator&(int,const TestOps&)
         const_char* operator^(int)
+        const_char* operator^(int,const TestOps&)
         const_char* operator,(int)
+        const_char* operator,(int,const TestOps&)
 
         const_char* operator<<(int)
+        const_char* operator<<(int,const TestOps&)
         const_char* operator>>(int)
+        const_char* operator>>(int,const TestOps&)
 
         const_char* operator==(int)
         const_char* operator!=(int)
@@ -49,6 +60,23 @@ cdef extern from "cpp_operators_helper.h":
 
         const_char* operator[](int)
         const_char* operator()(int)
+    
+    # Defining the operator outside the class does work
+    # but doesn't help when importing from pxd files
+    # (they don't get imported)
+    const_char* operator+(float,const TestOps&)
+    # deliberately omitted operator- to test case where only defined in class
+    const_char* operator*(float,const TestOps&)
+    const_char* operator/(float,const TestOps&)
+    const_char* operator%(float,const TestOps&)
+
+    const_char* operator|(float,const TestOps&)
+    const_char* operator&(float,const TestOps&)
+    const_char* operator^(float,const TestOps&)
+    const_char* operator,(float,const TestOps&)
+
+    const_char* operator<<(float,const TestOps&)
+    const_char* operator>>(float,const TestOps&)
 
     cppclass TruthClass:
         TruthClass()
@@ -124,6 +152,63 @@ def test_binop():
 
     x = cython.operator.comma(t[0], 1)
     out(x, typeof(x))
+    del t
+
+def test_nonmember_binop():
+    """
+    >>> test_nonmember_binop()
+    nonmember binary + [const_char *]
+    nonmember binary - [const_char *]
+    nonmember binary / [const_char *]
+    nonmember binary % [const_char *]
+    nonmember binary & [const_char *]
+    nonmember binary | [const_char *]
+    nonmember binary ^ [const_char *]
+    nonmember binary << [const_char *]
+    nonmember binary >> [const_char *]
+    nonmember binary COMMA [const_char *]
+    nonmember binary2 + [const_char *]
+    nonmember binary2 * [const_char *]
+    nonmember binary2 / [const_char *]
+    nonmember binary2 % [const_char *]
+    nonmember binary2 & [const_char *]
+    nonmember binary2 | [const_char *]
+    nonmember binary2 ^ [const_char *]
+    nonmember binary2 << [const_char *]
+    nonmember binary2 >> [const_char *]
+    nonmember binary2 COMMA [const_char *]
+    """
+    
+    cdef TestOps* t = new TestOps()
+    out(1 + t[0], typeof(1 + t[0]))
+    out(1 - t[0], typeof(1 - t[0]))
+    # * deliberately omitted
+    out(1 / t[0], typeof(1 / t[0]))
+    out(1 % t[0], typeof(1 % t[0]))
+    out(1 & t[0], typeof(1 & t[0]))
+    out(1 | t[0], typeof(1 | t[0]))
+    out(1 ^ t[0], typeof(1 ^ t[0]))
+    out(1 << t[0], typeof(1 << t[0]))
+    out(1 >> t[0], typeof(1 >> t[0]))
+    
+    x = cython.operator.comma(1, t[0])
+    out(x, typeof(x))
+    
+    # now test float operators defined outside class
+    out(1. + t[0], typeof(1. + t[0]))
+    # operator - deliberately omitted
+    out(1. * t[0], typeof(1. * t[0]))
+    out(1. / t[0], typeof(1. / t[0]))
+    out(1. % t[0], typeof(1. % t[0]))
+    out(1. & t[0], typeof(1. & t[0]))
+    out(1. | t[0], typeof(1. | t[0]))
+    out(1. ^ t[0], typeof(1. ^ t[0]))
+    out(1. << t[0], typeof(1. << t[0]))
+    out(1. >> t[0], typeof(1. >> t[0]))
+    
+    # for some reason we need a cdef here - not sure this is quite right
+    y = cython.operator.comma(1., t[0])
+    out(y, typeof(y))
     del t
 
 def test_cmp():

--- a/tests/run/cpp_operators_helper.h
+++ b/tests/run/cpp_operators_helper.h
@@ -1,6 +1,8 @@
 #define UN_OP(op) const char* operator op () { return "unary "#op; }
 #define POST_UN_OP(op) const char* operator op (int x) { x++; return "post "#op; }
 #define BIN_OP(op) const char* operator op (int x) { x++; return "binary "#op; }
+#define NONMEMBER_BIN_OP(op) const char* operator op (int x, const TestOps&) { x++; return "nonmember binary "#op; }
+#define NONMEMBER_BIN_OP2(op) const char* operator op (double x, const TestOps&) { x++; return "nonmember binary2 "#op; }
 
 #define COMMA ,
 
@@ -45,6 +47,34 @@ public:
     BIN_OP(());
 
 };
+
+NONMEMBER_BIN_OP(+)
+NONMEMBER_BIN_OP(-)
+NONMEMBER_BIN_OP(*)
+NONMEMBER_BIN_OP(/)
+NONMEMBER_BIN_OP(%)
+
+NONMEMBER_BIN_OP(<<)
+NONMEMBER_BIN_OP(>>)
+
+NONMEMBER_BIN_OP(|)
+NONMEMBER_BIN_OP(&)
+NONMEMBER_BIN_OP(^)
+NONMEMBER_BIN_OP(COMMA)
+
+NONMEMBER_BIN_OP2(+)
+NONMEMBER_BIN_OP2(-)
+NONMEMBER_BIN_OP2(*)
+NONMEMBER_BIN_OP2(/)
+NONMEMBER_BIN_OP2(%)
+
+NONMEMBER_BIN_OP2(<<)
+NONMEMBER_BIN_OP2(>>)
+
+NONMEMBER_BIN_OP2(|)
+NONMEMBER_BIN_OP2(&)
+NONMEMBER_BIN_OP2(^)
+NONMEMBER_BIN_OP2(COMMA)
 
 class TruthClass {
 public:

--- a/tests/run/libcpp_all.pyx
+++ b/tests/run/libcpp_all.pyx
@@ -91,3 +91,23 @@ cdef const_vector_to_list(const vector[double]& cv):
         lst.append(cython.operator.dereference(iter))
         cython.operator.preincrement(iter)
     return lst
+
+def complex_operators():
+    """
+    >>> complex_operators()
+    [-1.0, 0.0, 0.0, 2.0, 0.0, 2.0]
+    """
+    cdef libcpp.complex.complex[double] a = libcpp.complex.complex[double](0.0,1.0)
+    cdef libcpp.complex.complex[double] r1=a*a
+    cdef libcpp.complex.complex[double] r2=a*2.0
+    cdef libcpp.complex.complex[double] r3=2.0*a
+    return [r1.real(), r1.imag(), r2.real(), r2.imag(), r3.real(), r3.imag()]
+
+def pair_comparison():
+    """
+    >>> pair_comparison()
+    [False, True, False, True, False]
+    """
+    cdef pair[double, double] p1 = pair[double, double](1.0,2.0)
+    cdef pair[double, double] p2 = pair[double, double](2.0,2.0)
+    return [p1==p2,p1==p1,p1>p2,p1<p2,p2>p2]


### PR DESCRIPTION
This allows non-member operators to be specified with cppclasses, and ensures they're looked up correctly when used.

```
cdef extern from "somefile.hpp":
  cdef cppclass C:
     C operator+(int, const C&) # this line now creates something usable
  # alternative existing syntax outside the class
  C operator*(int const C&)
```

The reason this is useful is because, although non-member operators could be defined outside the class (as shown for operator*, above) they aren't easily accessible when cimporting for .pxd files (which is probably a separate bug).

Looking at the C++ standard library wrappings, people seem to have assumed that this method of wrapping non-member operators already works and written operators in this form.

I've also defined appropriate tests, and updated the documentation.
