### PR TITLE
Fix CFLAGS environ in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,6 @@
 envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
-setenv = CFLAGS="-O0 -ggdb"
+setenv = CFLAGS=-O0 -ggdb
 commands =
     {envpython} runtests.py -vv


### PR DESCRIPTION
Was trying to run tox tests but failing with

~~~
error: invalid integral value '0 -ggdb' in '-O0 -ggdb'
error: invalid integral value '0 -ggdb' in '-O0 -ggdb'
error: command 'clang' failed with exit status 1
~~~

(Full log can be found [here](http://d.pr/f/1fkBi+).)

I removed the quotes around the CFLAGS env value, and the tox tests seem to work now.