### PR TITLE
Enable overloading the assignment operator.

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2547,7 +2547,7 @@ supported_overloaded_operators = cython.declare(set, set([
     '+', '-', '*', '/', '%',
     '++', '--', '~', '|', '&', '^', '<<', '>>', ',',
     '==', '!=', '>=', '>', '<=', '<',
-    '[]', '()', '!',
+    '[]', '()', '!', '='
 ]))
 
 def p_c_simple_declarator(s, ctx, empty, is_type, cmethod_flag,

--- a/tests/run/cpp_assignment_overload.srctree
+++ b/tests/run/cpp_assignment_overload.srctree
@@ -1,0 +1,43 @@
+# tag: cpp
+
+"""
+PYTHON setup.py build_ext --inplace
+PYTHON -c "from assignment_overload import test; test()"
+"""
+
+######## setup.py ########
+
+from distutils.core import setup
+from Cython.Build import cythonize
+setup(ext_modules=cythonize("*.pyx", language='c++'))
+
+######## assign.cpp ########
+
+class wrapped_int {
+public:
+  long long val;
+  wrapped_int() { val = 0; }
+  wrapped_int(long long val) { this->val = val; }
+  wrapped_int &operator=(const wrapped_int &other) {
+    this->val = other.val;
+    return *this;
+  }
+};
+
+######## assign.pxd ########
+
+cdef extern from "assign.cpp" nogil:
+    cppclass wrapped_int:
+        long long val
+        wrapped_int()
+        wrapped_int(long long val)
+        wrapped_int& operator=(const wrapped_int &other)
+
+######## assignment_overload.pyx ########
+
+from assign cimport wrapped_int
+def test():
+    cdef wrapped_int a=wrapped_int(2), b=wrapped_int(3)
+    a = b
+    assert &a != &b
+    assert a.val == b.val


### PR DESCRIPTION
As near as I can tell, the only thing needed to enable the assignment operator was to add it to the supported operators list. Tests pending.