### PR TITLE
make __name__ of Compiler.Scanning.Method accessible from Python code

### DIFF
--- a/Cython/Compiler/Scanning.pxd
+++ b/Cython/Compiler/Scanning.pxd
@@ -9,7 +9,7 @@ cdef initial_compile_time_env()
 
 cdef class Method:
     cdef object name
-    cdef object __name__
+    cdef readonly object __name__
 
 @cython.final
 cdef class CompileTimeScope:


### PR DESCRIPTION
Current master branch of Cython does not work when Plex.Scanner.trace is enabled. For example, the following code
```python
import Cython.Compiler.Scanning
Cython.Compiler.Scanning.trace_scanner = 1
import cython
cython.inline("return 2")
```
generates the following output and error messages
```
State 3, 1/0:'bol' -->
State 48
State 48, 1/0:u'p' -->
blocked
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-0f503002be7a> in <module>()
----> 1 cython.inline("return 2")
[omitted]
/Plex/Actions.c:1545)()

AttributeError: 'Cython.Compiler.Scanning.Method' object has no attribute '__name__'
```

Marking the __name__ as readonly can fix this.
