### PR TITLE
Fixed a C++ compiler warning with __Pyx_sst_abs

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -17,7 +17,10 @@
                                v == (type)PY_SSIZE_T_MAX)))  )
 
 // fast and unsafe abs(Py_ssize_t) that ignores the overflow for (-PY_SSIZE_T_MAX-1)
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#if defined __cplusplus
+    #define __Pyx_sst_abs(value) \
+        (::std::abs(value))
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     #define __Pyx_sst_abs(value) \
         (sizeof(int) >= sizeof(Py_ssize_t) ? abs(value) : \
          (sizeof(long) >= sizeof(Py_ssize_t) ? labs(value) : llabs(value)))


### PR DESCRIPTION
This fix should be pretty straightforward; C++ code that included the usage of `__Pyx_sst_abs` used to produce a warning:

    warning: absolute value function 'abs' given an argument of type 'const Py_ssize_t' (aka 'const long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
    note: use function 'std::abs' instead

This is because, while the correct one of `abs` / `labs` is be selected, code for the other is still generated, and thus triggers the warning.

In addition, the `defined (__STDC_VERSION__)` check didn't catch any version of C++, so C++ always got the _truly ancient_ version of the code.