### PR TITLE
Rewrite __Pyx_sst_abs using only preprocessor macros, and add a case for 64-bit MSVC

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -17,7 +17,7 @@
                                v == (type)PY_SSIZE_T_MAX)))  )
 
 // fast and unsafe abs(Py_ssize_t) that ignores the overflow for (-PY_SSIZE_T_MAX-1)
-#if __cplusplus >= 201103L
+#if defined (__cplusplus) && __cplusplus >= 201103L
     #define __Pyx_sst_abs(value) std::abs(value)
 #elif SIZEOF_INT >= SIZEOF_SIZE_T
     #define __Pyx_sst_abs(value) abs(value)

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -25,7 +25,7 @@
     #define __Pyx_sst_abs(value) labs(value)
 #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     #define __Pyx_sst_abs(value) llabs(value)
-#elif defined (_M_X64)
+#elif defined (_MSC_VER) && defined (_M_X64)
     // abs() is defined for long, but 64-bits type on MSVC is long long.
     // Use MS-specific _abs64 instead.
     #define __Pyx_sst_abs(value) _abs64(value)

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -17,15 +17,20 @@
                                v == (type)PY_SSIZE_T_MAX)))  )
 
 // fast and unsafe abs(Py_ssize_t) that ignores the overflow for (-PY_SSIZE_T_MAX-1)
-#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define __Pyx_sst_abs(value) \
-        (sizeof(int) >= sizeof(Py_ssize_t) ? abs(value) : \
-         (sizeof(long) >= sizeof(Py_ssize_t) ? labs(value) : llabs(value)))
+#if __cplusplus >= 201103L
+    #define __Pyx_sst_abs(value) std::abs(value)
+#elif SIZEOF_INT >= SIZEOF_SIZE_T
+    #define __Pyx_sst_abs(value) abs(value)
+#elif SIZEOF_LONG >= SIZEOF_SIZE_T
+    #define __Pyx_sst_abs(value) labs(value)
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define __Pyx_sst_abs(value) llabs(value)
+#elif defined (_M_X64)
+    // abs() is defined for long, but 64-bits type on MSVC is long long.
+    // Use MS-specific _abs64 instead.
+    #define __Pyx_sst_abs(value) _abs64(value)
 #else
-    #define __Pyx_sst_abs(value) \
-        (sizeof(int) >= sizeof(Py_ssize_t) ? abs(value) : \
-         (sizeof(long) >= sizeof(Py_ssize_t) ? labs(value) : \
-          ((value<0) ? -value : value)))
+    #define __Pyx_sst_abs(value) ((value<0) ? -value : value))
 #endif
 
 static CYTHON_INLINE char* __Pyx_PyObject_AsString(PyObject*);


### PR DESCRIPTION
Comparing `sizeof(Py_ssize_t)` to different sizes at compile time results in warnings or errors when the C++ compiler tries to find a function matching `abs(value)` (Per the standard library spec, no functions match if `ssize_t` is a typedef of `long long`). Luckily, `pyport.h` provides some SIZEOF macros we can use at preprocess time. __Pyx_sst_abs is now conditionally defined to a much shorter expression.

64-bit MSVC is one case where `ssize_t` is a `long long`. Instead of falling back to `((value<0) ? -value : value))`, I added a check for 64-bit MSVC that calls the MS-specific function `_abs64(long long)`

This change also includes the change given by PR #402, improved with a check against the available C++ version as `std::abs` is only available on C++11.

Have only tested this with 64-bit Python 2.7, 64-bit MSVC 2008. Let's see if Travis passes it.