### PR TITLE
Change temp type used for buffer indexing to ssize_t

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -28,7 +28,7 @@ from . import Nodes
 from .Nodes import Node, utility_code_for_imports
 from . import PyrexTypes
 from .PyrexTypes import py_object_type, c_long_type, typecast, error_type, \
-    unspecified_type
+    unspecified_type, c_ssize_t_type
 from . import TypeSlots
 from .Builtin import list_type, tuple_type, set_type, dict_type, type_type, \
      unicode_type, str_type, bytes_type, bytearray_type, basestring_type, slice_type
@@ -3876,7 +3876,7 @@ class IndexNode(ExprNode):
     def buffer_lookup_code(self, code):
         "ndarray[1, 2, 3] and memslice[1, 2, 3]"
         # Assign indices to temps
-        index_temps = [code.funcstate.allocate_temp(i.type, manage_ref=False)
+        index_temps = [code.funcstate.allocate_temp(c_ssize_t_type, manage_ref=False)
                            for i in self.indices]
 
         for temp, index in zip(index_temps, self.indices):


### PR DESCRIPTION
Using 64-bit Python 2.7 on branch HEAD 3a85795dff01ff73c4b418c8bb6af92e7ee7eef0

When compiling a file that uses memoryviews, 64-bit MSVC outputs this warning:

```
.../with_cython.cpp(2819) : warning C4244: '+=' : conversion from 'Py_ssize_t' to 'long', possible loss of data
```

This warning refers to part of the buffer indexing code for a typed memoryview, which
computes the index (offset) values into the buffer when the given values are negative.

```
if (__pyx_t_2 < 0) {
  __pyx_t_2 += __pyx_v_section->BlockLight.shape[0];  /* warning */
  if (unlikely(__pyx_t_2 < 0)) __pyx_t_5 = 0;
} else if (unlikely(__pyx_t_2 >= __pyx_v_section->BlockLight.shape[0])) __pyx_t_5 = 0;
if (__pyx_t_3 < 0) {
  __pyx_t_3 += __pyx_v_section->BlockLight.shape[1];  /* warning */
  if (unlikely(__pyx_t_3 < 0)) __pyx_t_5 = 1;
} else if (unlikely(__pyx_t_3 >= __pyx_v_section->BlockLight.shape[1])) __pyx_t_5 = 1;
if (__pyx_t_4 < 0) {
  __pyx_t_4 += __pyx_v_section->BlockLight.shape[2];  /* warning */
  if (unlikely(__pyx_t_4 < 0)) __pyx_t_5 = 2;
} else if (unlikely(__pyx_t_4 >= __pyx_v_section->BlockLight.shape[2])) __pyx_t_5 = 2;
if (unlikely(__pyx_t_5 != -1)) {
  __Pyx_RaiseBufferIndexError(__pyx_t_5);
  {__pyx_filename = __pyx_f[0]; __pyx_lineno = 76; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
}
```

After about an hour of research, learning about how Cython works by reading its
source code and with judicious use of `PrintTree()`, I've reached the following conclusion:

The cause of the problem is the variables `__pyx_t_[2,3,4]` which are typed `long`.
These are temporary variables created by `IndexNode.buffer_lookup_code`. The
types of the temps are taken from the types of the expressions found in the subscript.
To avoid truncating them, the type of the temps *should* be `ssize_t`, which is the same type as the elements of an ndarray's or a memoryview's `shape`.

(I expect that if the type of the expression is `char`, I might encounter a bug
where using a negative value to access an array larger than 256 on a dimension
gives a value from the wrong location.)

This patch changes `IndexNode.buffer_lookup_code` to always use `ssize_t` for
the type of its index temps.

--

Sidenote: I thought at first that this was just MSVC complaining again that my `long`
isn't long enough, but as it turned out, this looks like it can affect any
compiler - I tried casting an index expression to `<char>` and got the expected
`conversion from 'Py_ssize_t' to 'char', possible loss of data` warning,
confirming that the value isn't long enough for reasons unrelated to MSVC.