### PR TITLE
appveyor no longer builds msi installers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,14 +60,14 @@ install:
 
 build: off
 build_script:
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setupegg.py build"
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setupegg.py --quiet bdist_wheel"
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setupegg.py --quiet bdist_msi"
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setupegg.py --quiet bdist_wininst"
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py build"
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py --quiet bdist_wheel"
+# - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py --quiet bdist_msi"
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py --quiet bdist_wininst"
 
 test: off
 test_script:
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setupegg.py test"
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py test"
 
 artifacts:
   - path: dist\*

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -73,12 +73,17 @@ function InstallPip ($python_home) {
         Write-Host "Executing:" $python_path $GET_PIP_PATH
         Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH"
         Write-Host "pip installation complete"
-   }
-   Write-Host "Upgrading setuptools"
-   $args = "install --upgrade setuptools"
-   Write-Host "Executing:" $pip_path $args
-   Start-Process -FilePath $pip_path -ArgumentList $args -Wait
-   Write-Host "setuptools upgrade complete"
+    }
+    Write-Host "Upgrading setuptools"
+    $args = "install --upgrade setuptools"
+    Write-Host "Executing:" $pip_path $args
+    Try {
+        Start-Process -FilePath $pip_path -ArgumentList $args -Wait
+        Write-Host "setuptools upgrade complete"
+    }
+    Catch {
+        Write-Host "setuptools upgrade failed"
+    }
 }
 
 function InstallPipPackage ($python_home, $pkg) {


### PR DESCRIPTION
bdist_msi will choke on valid version numbers such as 0.23.dev0 which
causes the whole build to fail.