### PR TITLE
Experimental support for jedi 0.9.0

### DIFF
--- a/Cython/Tests/TestJediTyper.py
+++ b/Cython/Tests/TestJediTyper.py
@@ -84,7 +84,7 @@ class TestJediTyper(TransformTest):
         self.assertFalse(types)
         self.assertEqual({'a': set(['int']), 'i': set(['int'])}, variables)
 
-    def _test_conflicting_types_in_function(self):
+    def test_conflicting_types_in_function(self):
         code = '''\
         def func(a, b):
             print(a)
@@ -99,7 +99,7 @@ class TestJediTyper(TransformTest):
         self.assertIn(('func', (1, 0)), types)
         variables = types.pop(('func', (1, 0)))
         self.assertFalse(types)
-        self.assertEqual({'a': set(['int', 'str']), 'i': set(['int'])}, variables)
+        self.assertEqual({'a': set(['float', 'int', 'str']), 'b': set(['int'])}, variables)
 
     def _test_typing_function_char_loop(self):
         code = '''\

--- a/Tools/jedi-typer.py
+++ b/Tools/jedi-typer.py
@@ -11,7 +11,7 @@ from itertools import chain
 import jedi
 from jedi.parser.tree import Module, ImportName
 from jedi.evaluate.representation import Function, Instance, Class
-from jedi.evaluate.iterable import Array,Generator, GeneratorComprehension
+from jedi.evaluate.iterable import ArrayMixin, GeneratorComprehension
 
 from Cython.Utils import open_source_file
 
@@ -52,7 +52,7 @@ def analyse(source_path=None, code=None):
                     type_name = 'object'
                 else:
                     type_name = name_type.base.obj.__name__
-            elif isinstance(name_type, Array):
+            elif isinstance(name_type, ArrayMixin):
                 type_name = name_type.type
             elif isinstance(name_type, GeneratorComprehension):
                 type_name = None

--- a/Tools/jedi-typer.py
+++ b/Tools/jedi-typer.py
@@ -44,9 +44,11 @@ def analyse(source_path=None, code=None):
         try:
             names = scoped_names[key]
         except KeyError:
-            names = scoped_names[key] = defaultdict(set)        
+            names = scoped_names[key] = defaultdict(set)
+                
+        position = statement.start_pos if statement.name in names else None
 
-        for name_type in evaluator.find_types(scope, statement.name, search_global=True):
+        for name_type in evaluator.find_types(scope, statement.name, position=position ,search_global=True):
             if isinstance(name_type, Instance):
                 if isinstance(name_type.base, Class):
                     type_name = 'object'

--- a/runtests.py
+++ b/runtests.py
@@ -1943,7 +1943,7 @@ def runtests(options, cmd_args, coverage=None):
 
     try:
         import jedi
-        if not ([0, 8, 1] <= list(map(int, re.findall('[0-9]+', jedi.__version__ or '0'))) < [0, 9]):
+        if not ([0, 8, 1] <= list(map(int, re.findall('[0-9]+', jedi.__version__ or '0'))) <= [0, 9, 0]):
             raise ImportError
     except (ImportError, AttributeError, TypeError):
         exclude_selectors.append(RegExSelector('Jedi'))

--- a/runtests.py
+++ b/runtests.py
@@ -1943,7 +1943,7 @@ def runtests(options, cmd_args, coverage=None):
 
     try:
         import jedi
-        if not ([0, 8, 1] <= list(map(int, re.findall('[0-9]+', jedi.__version__ or '0'))) <= [0, 9, 0]):
+        if not ([0, 9] <= list(map(int, re.findall('[0-9]+', jedi.__version__ or '0')))):
             raise ImportError
     except (ImportError, AttributeError, TypeError):
         exclude_selectors.append(RegExSelector('Jedi'))


### PR DESCRIPTION
Allow jedi-typer to support both jedi 0.8.x and jedi 0.9.0.
It compiled and passed all 4 tests. However, in order to further improve the jedi-typer, some more tests are needed. But add more features and tests might break the original jedi-typer and it is difficult to maintain the code that supports both 0.8.x and 0.9.0 API. 
So this patch only aims for getting jedi-typer works with current jedi 0.9.0 while having similar functionality of current jedi-typer.
