### PR TITLE
Add libraries_sort_key option to sort libraries

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -694,6 +694,10 @@ def create_extension_list(patterns, exclude=[], ctx=None, aliases=None, quiet=Fa
                 if ext_language and 'language' not in kwds:
                     kwds['language'] = ext_language
 
+                if 'libraries' in kwds:
+                    kwds['libraries'] = sorted(kwds['libraries'],
+                            key=ctx.options.libraries_sort_key)
+
                 module_list.append(exn_type(
                         name=module_name,
                         sources=sources,

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -707,6 +707,14 @@ def main(command_line = 0):
 #
 #------------------------------------------------------------------------
 
+def default_sort_key(x):
+    """
+    Sort key which doesn't change the order when sorting (recall that
+    Python's sort is stable). This cannot be a lambda function, since
+    those cannot be pickled.
+    """
+    return 0
+
 default_options = dict(
     show_version = 0,
     use_listing_file = 0,
@@ -734,4 +742,5 @@ default_options = dict(
     common_utility_include_dir = None,
     output_dir=None,
     build_dir=None,
+    libraries_sort_key=default_sort_key,
 )

--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -122,10 +122,24 @@ in one line)::
 
 If your options are static (for example you do not need to call a tool like
 ``pkg-config`` to determine them) you can also provide them directly in your
-.pyx source file using a special comment block at the start of the file::
+.pyx or .pxd source file using a special comment block at the start of the file::
 
     # distutils: libraries = spam eggs
     # distutils: include_dirs = /opt/food/include
+
+If you cimport multiple .pxd files defining libraries, then Cython
+merges the list of libraries, so this works as expected (similarly
+with other options, like ``include_dirs`` above).
+There is one caveat: for libraries, the order often matters.
+Since it's usually not practical to control the order of cimporting,
+you can use the option ``libraries_sort_key`` to ``cythonize()``:
+it allows you to provide a function to be used as "key" function for
+sorting libraries. In the example below, the libraries will always be
+linked in the order ``-lfirst -lsecond -lthird``, no matter in which
+order Cython sees them::
+
+    library_order = ["first", "second", "third"]
+    ext_modules = cythonize(..., libraries_sort_key = lambda lib: library_order.index(lib))
 
 If you have some C files that have been wrapped with Cython and you want to
 compile them into your extension, you can define the distutils ``sources``

--- a/tests/compile/libraries_sort_key.srctree
+++ b/tests/compile/libraries_sort_key.srctree
@@ -1,0 +1,24 @@
+PYTHON setup.py build_ext --inplace
+
+######## setup.py ########
+
+from Cython.Build import cythonize
+from Cython.Distutils.extension import Extension
+
+ext_modules = [
+    Extension("foo", ["foo.pyx"], libraries=["d", "b"]),
+]
+
+ext_modules = cythonize(ext_modules, libraries_sort_key=lambda x:x)
+
+assert ext_modules[0].libraries == ["a", "b", "c", "d", "e"]
+
+######## a.pxd ########
+# distutils: libraries = e d a
+
+######## b.pxd ########
+# distutils: libraries = d c
+
+######## foo.pyx ########
+cimport a
+cimport b


### PR DESCRIPTION
It's well known that the order of libraries matters when linking:
```
gcc ... -lfoo -lbar ...
```
is not the same as
```
gcc ... -lbar -lfoo ...
```
(for some reason, this matters particularly much for Cygwin)

However, when multiple libraries are declared in Cython using
```
# distutils: libraries = foo
```
in multiple .pxd files, there is no real guarantee what the final library order will be. So we need a mechanism to sort the list of libraries. I propose a new option `libraries_sort_key` which is used to sort the list of libraries. The default sort key is `lambda x:0`, which means that nothing will change since Python's sort is stable.

Sage already has a mechanism to do this by changing the extensions before feeding them to distutils. However, it would be better to make this part of Cython (such that the order also appears correctly in the JSON metadata dump).