### PR TITLE
Correctly parse dependencies of "cimport foo,bar"

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -342,8 +342,8 @@ def strip_string_literals(code, prefix='__Pyx_L'):
     return "".join(new_code), literals
 
 
-dependancy_regex = re.compile(r"(?:^from +([0-9a-zA-Z_.]+) +cimport)|"
-                              r"(?:^cimport +([0-9a-zA-Z_.]+)\b)|"
+dependency_regex = re.compile(r"(?:^from +([0-9a-zA-Z_.]+) +cimport)|"
+                              r"(?:^cimport +([0-9a-zA-Z_.]+(?: *, *[0-9a-zA-Z_.]+)*))|"
                               r"(?:^cdef +extern +from +['\"]([^'\"]+)['\"])|"
                               r"(?:^include +['\"]([^'\"]+)['\"])", re.M)
 
@@ -412,12 +412,12 @@ def parse_dependencies(source_filename):
     cimports = []
     includes = []
     externs  = []
-    for m in dependancy_regex.finditer(source):
-        cimport_from, cimport, extern, include = m.groups()
+    for m in dependency_regex.finditer(source):
+        cimport_from, cimport_list, extern, include = m.groups()
         if cimport_from:
             cimports.append(cimport_from)
-        elif cimport:
-            cimports.append(cimport)
+        elif cimport_list:
+            cimports.extend(x.strip() for x in cimport_list.split(","))
         elif extern:
             externs.append(literals[extern])
         else:

--- a/tests/compile/distutils_libraries_T845.srctree
+++ b/tests/compile/distutils_libraries_T845.srctree
@@ -13,6 +13,7 @@ ext_modules = [
 
 ext_modules = cythonize(ext_modules)
 
+assert len(ext_modules[0].libraries) == 2
 assert ext_modules[1].libraries == ["lib_x"]
 assert ext_modules[2].libraries == ["lib_y"]
 
@@ -23,8 +24,7 @@ assert ext_modules[2].libraries == ["lib_y"]
 # distutils: libraries = lib_y
 
 ######## a.pyx ########
-cimport libx
-cimport liby
+cimport libx , liby
 
 ######## x.pyx ########
 cimport libx


### PR DESCRIPTION
Cython does not correctly handle the dependencies in case of a statement like
```
cimport foo, bar
```
(only `foo` is considered)