### PR TITLE
Further Assignment Operator Fixes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1992,7 +1992,7 @@ class NameNode(AtomicExprNode):
             if null_code and raise_unbound and (entry.type.is_pyobject or memslice_check):
                 code.put_error_if_unbound(self.pos, entry, self.in_nogil_context)
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         #print "NameNode.generate_assignment_code:", self.name ###
         entry = self.entry
         if entry is None:
@@ -2082,8 +2082,11 @@ class NameNode(AtomicExprNode):
                         code.put_giveref(rhs.py_result())
             if not self.type.is_memoryviewslice:
                 if not assigned:
-                    code.putln('%s = %s;' % (
-                        self.result(), rhs.result_as(self.ctype())))
+                    if overloaded_assignment:
+                        code.putln('%s = %s;' % (self.result(), rhs.result()))
+                    else:
+                        code.putln('%s = %s;' % (
+                            self.result(), rhs.result_as(self.ctype())))
                 if debug_disposal_code:
                     print("NameNode.generate_assignment_code:")
                     print("...generating post-assignment code for %s" % rhs)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -672,7 +672,7 @@ class ExprNode(Node):
         else:
             self.generate_subexpr_disposal_code(code)
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         #  Stub method for nodes which are not legal as
         #  the LHS of an assignment. An error will have
         #  been reported earlier.
@@ -3761,7 +3761,7 @@ class IndexNode(ExprNode):
             # Simple case
             code.putln("*%s %s= %s;" % (ptrexpr, op, rhs.result()))
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         generate_evaluation_code = (self.is_memslice_scalar_assignment or
                                     self.memslice_slice)
         if generate_evaluation_code:
@@ -4221,7 +4221,7 @@ class SliceIndexNode(ExprNode):
                     code.error_goto_if_null(result, self.pos)))
         code.put_gotref(self.py_result())
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         self.generate_subexpr_evaluation_code(code)
         if self.type.is_pyobject:
             code.globalstate.use_utility_code(self.set_slice_utility_code)
@@ -6190,7 +6190,7 @@ class AttributeNode(ExprNode):
         else:
             ExprNode.generate_disposal_code(self, code)
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         self.obj.generate_evaluation_code(code)
         if self.is_py_attr:
             code.globalstate.use_utility_code(
@@ -6527,7 +6527,7 @@ class SequenceNode(ExprNode):
             if self.mult_factor:
                 self.mult_factor.generate_disposal_code(code)
 
-    def generate_assignment_code(self, rhs, code):
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False):
         if self.starred_assignment:
             self.generate_starred_assignment_code(rhs, code)
         else:

--- a/tests/run/cpp_assignment_overload.srctree
+++ b/tests/run/cpp_assignment_overload.srctree
@@ -24,6 +24,10 @@ public:
     this->val = other.val;
     return *this;
   }
+  wrapped_int &operator=(const long long val) {
+    this->val = val;
+    return *this;
+  }
 };
 
 
@@ -35,6 +39,7 @@ cdef extern from "assign.cpp" nogil:
         wrapped_int()
         wrapped_int(long long val)
         wrapped_int& operator=(const wrapped_int &other)
+        wrapped_int& operator=(const long long &other)
 
 
 ######## assignment_overload.pyx ########
@@ -44,6 +49,7 @@ from assign cimport wrapped_int
 def test():
     cdef wrapped_int a = wrapped_int(2)
     cdef wrapped_int b = wrapped_int(3)
+    cdef long long c = 4
 
     assert &a != &b
     assert a.val != b.val
@@ -51,3 +57,5 @@ def test():
     a = b
     assert &a != &b
     assert a.val == b.val
+    a = c
+    assert a.val == c

--- a/tests/run/cpp_assignment_overload.srctree
+++ b/tests/run/cpp_assignment_overload.srctree
@@ -59,3 +59,9 @@ def test():
     assert a.val == b.val
     a = c
     assert a.val == c
+
+    a, b, c = 2, 3, 4
+    a = b = c
+    assert &a != &b
+    assert a.val == b.val
+    assert b.val == c


### PR DESCRIPTION
Somehow I missed this in https://github.com/cython/cython/pull/399. This allows assignment from a different type if the corresponding operator= is available.