### PR TITLE
Added short_cfilenm option.

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -662,7 +662,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln('static PyObject *%s;' % Naming.preimport_cname)
         code.putln('static int %s;' % Naming.lineno_cname)
         code.putln('static int %s = 0;' % Naming.clineno_cname)
-        code.putln('static const char * %s= %s;' % (Naming.cfilenm_cname, Naming.file_c_macro))
+        if Options.short_cfilenm is not None:
+            cfilenm_expr = Options.short_cfilenm
+        else:
+            cfilenm_expr = Naming.file_c_macro
+        code.putln('static const char *%s= %s;' % (Naming.cfilenm_cname, cfilenm_expr))
         code.putln('static const char *%s;' % Naming.filename_cname)
 
     def generate_extern_c_macro_definition(self, code):

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -15,6 +15,10 @@ gcc_branch_hints = True
 pre_import = None
 docstrings = True
 
+# This expression will be used as cfilenm in Exception traceback messages
+# instead of __FILE__. Must be None, or str.
+short_cfilenm = None
+
 # Decref global variables in this module on exit for garbage collection.
 # 0: None, 1+: interned objects, 2+: cdef globals, 3+: types objects
 # Mostly for reducing noise for Valgrind, only executes at process exit


### PR DESCRIPTION
## Motivation

In my project, [openage](https://github.com/sfttech/openage), the build system does absolute-path compiler invocations, which leads to excessively long and redundant Cython exception traceback messages like this one (newlines inserted for readability):

```
File "openage/cppinterface/setup_checker.pyx", line 12,
in openage.cppinterface.setup_checker.check
(/home/mic/git/openage/openage/cppinterface/setup_checker.cpp:662)
```
## PR

So I added an option, `Cython.Compiler.Options.short_cfilenm`, which, if set to a non-None value, replaces the expression that's used to generate the C filename in the exception traceback:

```
from Cython.Compiler import Options
Options.short_cfilenm = '"cpp"'
from Cython.Build import cythonize
cythonize(...)
```

After this, the traceback message is a much more pleasant, entirely redundancy-free

```
File "openage/cppinterface/setup_checker.pyx", line 12,
in openage.cppinterface.setup_checker.check (cpp:662)
```

For now, the option is not exposed via the CLI, because I didn't know whether that would be desirable.
If documentation is needed, please point me at the file I need to edit.
