### PR TITLE
Fixed __Pyx_sst_abs with C++11

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -18,6 +18,7 @@
 
 // fast and unsafe abs(Py_ssize_t) that ignores the overflow for (-PY_SSIZE_T_MAX-1)
 #if defined (__cplusplus) && __cplusplus >= 201103L
+    #include <cstdlib>
     #define __Pyx_sst_abs(value) std::abs(value)
 #elif SIZEOF_INT >= SIZEOF_SIZE_T
     #define __Pyx_sst_abs(value) abs(value)


### PR DESCRIPTION
Some compilers appear to require you to explicitly `#include <cstdlib>` before
providing `std::abs`.

Fix for #403 