### PR TITLE
Use PyTypeObject* for the builtin type type.

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8691,7 +8691,7 @@ class CnameDecoratorNode(StatNode):
             e.type.typeptr_cname = self.cname + '_type'
             e.type.scope.namespace_cname = e.type.typeptr_cname
 
-            e.as_variable.cname = py_object_type.cast_code(e.type.typeptr_cname)
+            e.as_variable.cname = e.type.typeptr_cname
 
             scope.scope_prefix = self.cname + "_"
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -985,6 +985,7 @@ class BuiltinObjectType(PyObjectType):
     vtabptr_cname = None
     typedef_flag = True
     is_external = True
+    decl_type = 'PyObject'
 
     def __init__(self, name, cname, objstruct_cname=None):
         self.name = name
@@ -992,6 +993,10 @@ class BuiltinObjectType(PyObjectType):
         self.typeptr_cname = "(&%s)" % cname
         self.objstruct_cname = objstruct_cname
         self.is_gc_simple = name in builtin_types_that_cannot_create_refcycles
+        if name == 'type':
+            # Special case the type type, as many C API calls (and other
+            # libraries) actually expect a PyTypeObject* for type arguments.
+            self.decl_type = objstruct_cname
 
     def set_scope(self, scope):
         self.scope = scope
@@ -1079,13 +1084,13 @@ class BuiltinObjectType(PyObjectType):
         if pyrex or for_display:
             base_code = self.name
         else:
-            base_code = public_decl("PyObject", dll_linkage)
+            base_code = public_decl(self.decl_type, dll_linkage)
             entity_code = "*%s" % entity_code
         return self.base_declaration_code(base_code, entity_code)
 
     def cast_code(self, expr_code, to_object_struct = False):
         return "((%s*)%s)" % (
-            to_object_struct and self.objstruct_cname or "PyObject", # self.objstruct_cname may be None
+            to_object_struct and self.objstruct_cname or self.decl_type, # self.objstruct_cname may be None
             expr_code)
 
     def py_type_name(self):

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -948,7 +948,7 @@ class BuiltinScope(Scope):
         var_entry = Entry(name = entry.name,
             type = self.lookup('type').type, # make sure "type" is the first type declared...
             pos = entry.pos,
-            cname = "((PyObject*)%s)" % entry.type.typeptr_cname)
+            cname = entry.type.typeptr_cname)
         var_entry.is_variable = 1
         var_entry.is_cglobal = 1
         var_entry.is_readonly = 1
@@ -1525,7 +1525,7 @@ class ModuleScope(Scope):
         var_entry = Entry(name = entry.name,
             type = Builtin.type_type,
             pos = entry.pos,
-            cname = "((PyObject*)%s)" % entry.type.typeptr_cname)
+            cname = entry.type.typeptr_cname)
         var_entry.is_variable = 1
         var_entry.is_cglobal = 1
         var_entry.is_readonly = 1


### PR DESCRIPTION
Many C API calls, both from CPython and externally, expect
PyTypeObject* for the type argument.  A misdeclaration is
a warning in C, but an error in C++.

The C type of other builtins, such as lists, are not typically
required in function signatures, so they are left as PyObject*.