### PR TITLE
[Build/Dependencies] added a comparision for setuptools.Extension class

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -644,9 +644,9 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
     module_metadata = {}
 
     # workaround for setuptools
-    try:
-       from setuptools.extension import Extension as Extension_setuptools
-    except ImportError:
+    if 'setuptools' in sys.modules:
+       Extension_setuptools = sys.modules['setuptools'].Extension
+    else:
          # dummy class, in case we do not have setuptools
          class Extension_setuptools(Extension): pass
 

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -658,7 +658,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
             base = None
             exn_type = Extension
             ext_language = language
-        elif isinstance(pattern, Extension) or isinstance(pattern, Extension_setuptools):
+        elif isinstance(pattern, (Extension, Extension_setuptools)):
             for filepattern in pattern.sources:
                 if os.path.splitext(filepattern)[1] in ('.py', '.pyx'):
                     break


### PR DESCRIPTION
This seems to be necessary since distutils.Extension is an old-style class, which is not comparable that way. If setuptools Extensions are being passed into the function, I got the TypeError being raised at the else block, because the check ```isinstance(pattern, distutils.Extension)``` is False in that case.

I only experience this bug, if installing several dependent setuptools based projects (A depends B and during setup of B, which also uses Cython, this happened).

This PR adds an additional check for Setuptools derived Extensions, which then succeeds.

As a test to reproduce it, the following real-world example (sorry has a lot of dependencies like scipy and matplotlib): 
pip install git+https://github.com/markovmodel/pyemma@dev_release_1.3

installs pyemma, depended on msmtools and bhmm
both deps are using cython and setuptools and in both projects, the TypeError has been raised before application of this patch.