### PR TITLE
Multithreaded callback

### DIFF
--- a/Demos/mt_callback/Makefile
+++ b/Demos/mt_callback/Makefile
@@ -1,0 +1,11 @@
+all:
+	python Setup.py build_ext --inplace
+
+test:   all
+	python run_mt_cheeses.py
+
+clean:
+	@echo Cleaning Demos/callback
+	@rm -f mt_cheeses.c mt_cheeses.h *.o *.so *~ core
+	@rm -rf build
+

--- a/Demos/mt_callback/README.txt
+++ b/Demos/mt_callback/README.txt
@@ -1,0 +1,19 @@
+Callback from C-Threads
+------------------------
+This project illustrates calling a python callback from a c-thread (posix) using cython as glue.
+Since the Python interpreter is not aware of the c-threads , we need to create a Python thread state for each C-thread.
+We achieve this in Cython by creating a Python thread-pool and map the callbacks coming in from the C-threads to the threads in the pool.
+
+1. Makefile
+   make all   - builds the C-extension python module by compiling the cython code and c-code .   
+   make test  - performs 'make all'  and runs the test python module run_mt_cheeses.py
+
+2. mt_cheeses_c_cb.h - contains c function declarations exported by mt_cheesefinder.c (c library) and mt_cheese.pyx ( cython library)
+3. mt_cheeses.pyx - cython code defines c-functions to be called from c-code and calls python callbacks registered by python code. 
+4. mt_cheesefinder.c - C library code which creates 10 pthreads and calls python functions through the c-extension exported by cython.
+5. run_mt_cheeses.py - This is the sample Python code which implementes callback functions and registers with cython code , so that they could be called from mt_cheesefinder.c.
+6. Setup.py  - Uses distutils to build cython code and c-code into python extension.
+
+This code is built on top of Cython/Demos/callback in github. The example cheesefinder implements a callback from c , however this does not work
+as-is when the callback is called from a posix thread for the reasons cited above in introduction.  
+Hence I built this to illustrate the required changes.

--- a/Demos/mt_callback/Setup.py
+++ b/Demos/mt_callback/Setup.py
@@ -1,0 +1,11 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+
+setup(
+  name = 'mt_callback',
+  ext_modules=cythonize([
+    Extension("mt_cheeses", ["mt_cheeses.pyx", "mt_cheesefinder.c"],
+               libraries=["pthread"] )
+    ]),
+)

--- a/Demos/mt_callback/mt_cheesefinder.c
+++ b/Demos/mt_callback/mt_cheesefinder.c
@@ -1,0 +1,49 @@
+#include "mt_cheesefinder.h"
+#include <pthread.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdio.h>
+
+//Each thread represents a mouse which steals cheese from the Python
+void *steal_cheese_thr(void* user_data)
+{
+   long tid = (long) user_data;
+   int i;
+
+   while(1) {
+	   if ( cheeses_action_handler("all_cheeses", user_data) == 1 ){
+	      printf("[%ld]PASS: all_cheeses found!\n", tid);
+	   } else {
+	      printf("[%ld] FAILED: no cheese left !\n" ,tid);
+	   }
+
+	   if (cheeses_action_handler("cheddar", user_data) == 0 ) {
+	      printf("[%ld]PASS: out of cheddar!\n", tid);
+	   } else {
+	      printf("[%ld]FAILED: cheddar found!!\n",tid);
+	   }
+
+	   if (cheeses_action_handler("provlone", user_data) == 0 ) {
+	      printf("[%ld]PASS: provlone found !!\n", tid);
+	   } else {
+	      printf("[%ld]FAILED: out of provlone !!\n",tid);
+	   }
+           sleep(1);
+   }
+
+}
+
+//Initialize 10 mouse threads.This function is called from the Python side
+void cheeses_init_pthreads(void)
+{
+   pthread_t thr[10];
+   int i;
+   for ( i = 0 ; i < 10 ; i++ )
+   {
+      //Create thread to periodically steal cheese from the python
+      printf("C-code creating steal_cheese_thr thread[%d] !\n", i);
+      pthread_create(&thr[i], NULL, steal_cheese_thr , (void*)i );
+      pthread_detach(thr[i]);
+    }
+}
+

--- a/Demos/mt_callback/mt_cheesefinder.h
+++ b/Demos/mt_callback/mt_cheesefinder.h
@@ -1,0 +1,14 @@
+#ifndef MT_CHEESES_C_CB_H
+#define MT_CHEESES_C_CB_H
+/* 
+** This file contains c-callbacks called from the C-code as well as from Python-code
+*/
+
+
+//C function implmented in cython. called from the c-code e.g. mytest.c 
+extern int cheeses_action_handler(char *cheese_name, void *user_data);
+
+//C function implmented in c-lib . called from the python code e.g run_mt_cheeses.py
+extern void cheeses_init_pthreads(void);
+
+#endif

--- a/Demos/mt_callback/mt_cheeses.pyx
+++ b/Demos/mt_callback/mt_cheeses.pyx
@@ -1,0 +1,45 @@
+#
+# Cython wrapper for multithreaded cheesefinder API
+#
+
+from threading import Thread
+from multiprocessing.pool import ThreadPool
+
+cdef extern from "mt_cheesefinder.h" nogil:
+     void cheeses_init_pthreads()   
+
+actions = dict();
+pool = ThreadPool(processes=10)
+
+#Function to initialize C side and start pthreads
+cpdef cheeses_init() :
+    print("Initializing C threads from python\n");
+    cheeses_init_pthreads();
+    
+#register python callbacks to be called from the c side
+def reg( action,func ):
+    print ( "Action registered for %s" % (action));
+    if action not in actions:
+       actions[action] = dict();
+    actions[action] = func;
+
+#un-register python callbacks to be called from the c side
+def unreg(action):
+    del(actions[action]);
+    if not actions[action]:
+       del(actions[action]);
+
+#python function calling the specified call-back
+def action_handler( action ):
+    if action in actions:
+       async_result = pool.apply_async( actions[action] )
+       return async_result.get()
+    else:
+       return 0
+
+#c-function wrapping python function
+cdef public int cheeses_action_handler(char *name, void *user_data) with gil:
+    cdef int ret;
+    ret  =  action_handler( name );
+    return ret;
+

--- a/Demos/mt_callback/run_mt_cheeses.py
+++ b/Demos/mt_callback/run_mt_cheeses.py
@@ -1,0 +1,33 @@
+#Test file to check if call backs work
+import mt_cheeses
+import time
+
+x = 0
+def steal_all_cheeses():
+    global x
+    print("Python Found! Stealing Cheese from Python: %d" % (x))
+    x += 1
+    return 1
+
+def steal_cheddar():
+    print "Python - no cheddar!"
+    return 0  #Boohoo! no cheddar
+
+def steal_provolone():
+    print "Python Found! Stealing provolone!"
+    return 1 #Yahoo! provolone found
+
+
+#register handler
+mt_cheeses.reg( "all_cheeses", steal_all_cheeses )
+mt_cheeses.reg( "cheddar", steal_cheddar )
+mt_cheeses.reg( "provolone", steal_provolone )
+
+#call callbacks
+mt_cheeses.cheeses_init()
+
+#keep the program alive
+while True:
+   time.sleep(5); 
+   
+


### PR DESCRIPTION
This project illustrates calling a python callback from a c-thread (posix) using cython as glue.
Since the Python interpreter is not aware of the c-threads , we need to create a Python thread state for each C-thread.
We achieve this in Cython by creating a Python thread-pool and map the callbacks coming in from the C-threads to the threads in the pool.
This code is built on top pf Stefan Behnel's Cython/Demos/callback in github. Stefan's example cheesefinder implements a callback from c , however this does not work
as-is when the callback is called from a posix thread for the reasons cited above . 