### PR TITLE
make C char* string literals "const" unless specified otherwise

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1180,11 +1180,6 @@ class GlobalState(object):
     def get_interned_identifier(self, text):
         return self.get_py_string_const(text, identifier=True)
 
-    def as_c_string_literal(self, byte_string):
-        value = StringEncoding.split_string_literal(
-            StringEncoding.escape_byte_string(byte_string.byteencode()))
-        return '"%s"' % value
-
     def new_string_const(self, text, byte_string):
         cname = self.new_string_const_cname(byte_string)
         c = StringConst(cname, text, byte_string)
@@ -1643,9 +1638,6 @@ class CCodeWriter(object):
                             is_str=False, unicode_value=None):
         return self.globalstate.get_py_string_const(
             text, identifier, is_str, unicode_value).cname
-
-    def as_c_string_literal(self, text):
-        return self.globalstate.as_c_string_literal(text)
 
     def get_argument_default_const(self, type):
         return self.globalstate.get_py_const(type).cname

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1180,6 +1180,11 @@ class GlobalState(object):
     def get_interned_identifier(self, text):
         return self.get_py_string_const(text, identifier=True)
 
+    def as_c_string_literal(self, byte_string):
+        value = StringEncoding.split_string_literal(
+            StringEncoding.escape_byte_string(byte_string.byteencode()))
+        return '"%s"' % value
+
     def new_string_const(self, text, byte_string):
         cname = self.new_string_const_cname(byte_string)
         c = StringConst(cname, text, byte_string)
@@ -1313,7 +1318,7 @@ class GlobalState(object):
                 conditional = True
                 decls_writer.putln("#if PY_MAJOR_VERSION %s 3" % (
                     (2 in c.py_versions) and '<' or '>='))
-            decls_writer.putln('static char %s[] = "%s";' % (
+            decls_writer.putln('static const char %s[] = "%s";' % (
                 cname, StringEncoding.split_string_literal(c.escaped_value)))
             if conditional:
                 decls_writer.putln("#endif")
@@ -1638,6 +1643,9 @@ class CCodeWriter(object):
                             is_str=False, unicode_value=None):
         return self.globalstate.get_py_string_const(
             text, identifier, is_str, unicode_value).cname
+
+    def as_c_string_literal(self, text):
+        return self.globalstate.as_c_string_literal(text)
 
     def get_argument_default_const(self, type):
         return self.globalstate.get_py_const(type).cname

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1324,7 +1324,7 @@ class BytesNode(ConstNode):
         elif dst_type in (PyrexTypes.c_char_ptr_type, PyrexTypes.c_const_char_ptr_type):
             node.type = dst_type
             return node
-        elif dst_type in (PyrexTypes.c_uchar_ptr_type, PyrexTypes.c_const_uchar_ptr_type):
+        elif dst_type in (PyrexTypes.c_uchar_ptr_type, PyrexTypes.c_const_uchar_ptr_type, PyrexTypes.c_void_ptr_type):
             node.type = (PyrexTypes.c_const_char_ptr_type if dst_type == PyrexTypes.c_const_uchar_ptr_type
                          else PyrexTypes.c_char_ptr_type)
             return CastNode(node, dst_type)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1344,7 +1344,7 @@ class BytesNode(ConstNode):
             result = code.get_string_const(self.value)
         else:
             # not const => use plain C string literal and cast to mutable type
-            literal = code.as_c_string_literal(self.value)
+            literal = self.value.as_c_string_literal()
             # C++ may require a cast
             result = typecast(self.type, PyrexTypes.c_void_ptr_type, literal)
         self.result_code = result

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1949,12 +1949,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 "static struct PyGetSetDef %s[] = {" %
                 env.getset_table_cname)
             for entry in env.property_entries:
-                if entry.doc:
-                    doc_code = "%s" % code.get_string_const(entry.doc)
+                doc = entry.doc
+                if doc:
+                    if doc.is_unicode:
+                        doc = doc.as_utf8_string()
+                    doc_code = doc.as_c_string_literal()
                 else:
                     doc_code = "0"
                 code.putln(
-                    '{(char *)"%s", %s, %s, %s, 0},' % (
+                    '{(char *)"%s", %s, %s, (char *)%s, 0},' % (
                         entry.name,
                         entry.getter_cname or "0",
                         entry.setter_cname or "0",

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -29,7 +29,7 @@ from .PyrexTypes import py_object_type, error_type
 from .Symtab import (ModuleScope, LocalScope, ClosureScope,
     StructOrUnionScope, PyClassScope, CppClassScope, TemplateScope)
 from .Code import UtilityCode
-from .StringEncoding import EncodedString, escape_byte_string, split_string_literal
+from .StringEncoding import EncodedString
 from . import Future
 from . import Options
 from . import DebugFlags
@@ -3318,12 +3318,12 @@ class DefNodeWrapper(FuncDefNode):
             docstr = entry.doc
 
             if docstr.is_unicode:
-                docstr = docstr.utf8encode()
+                docstr = docstr.as_utf8_string()
 
             code.putln(
-                'static char %s[] = "%s";' % (
+                'static char %s[] = %s;' % (
                     entry.doc_cname,
-                    split_string_literal(escape_byte_string(docstr))))
+                    docstr.as_c_string_literal()))
 
             if entry.is_special:
                 code.putln('#if CYTHON_COMPILING_IN_CPYTHON')

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -351,8 +351,8 @@ class IterationTransform(Visitor.EnvTransform):
                     base=ExprNodes.BytesNode(
                         slice_node.pos, value=bytes_value,
                         constant_result=bytes_value,
-                        type=PyrexTypes.c_char_ptr_type).coerce_to(
-                            PyrexTypes.c_uchar_ptr_type, self.current_env()),
+                        type=PyrexTypes.c_const_char_ptr_type).coerce_to(
+                            PyrexTypes.c_const_uchar_ptr_type, self.current_env()),
                     start=None,
                     stop=ExprNodes.IntNode(
                         slice_node.pos, value=str(len(bytes_value)),
@@ -2315,12 +2315,12 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
 
     Pyx_strlen_func_type = PyrexTypes.CFuncType(
         PyrexTypes.c_size_t_type, [
-            PyrexTypes.CFuncTypeArg("bytes", PyrexTypes.c_char_ptr_type, None)
+            PyrexTypes.CFuncTypeArg("bytes", PyrexTypes.c_const_char_ptr_type, None)
         ])
 
     Pyx_Py_UNICODE_strlen_func_type = PyrexTypes.CFuncType(
         PyrexTypes.c_size_t_type, [
-            PyrexTypes.CFuncTypeArg("unicode", PyrexTypes.c_py_unicode_ptr_type, None)
+            PyrexTypes.CFuncTypeArg("unicode", PyrexTypes.c_const_py_unicode_ptr_type, None)
         ])
 
     PyObject_Size_func_type = PyrexTypes.CFuncType(
@@ -3253,8 +3253,8 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
     PyUnicode_AsEncodedString_func_type = PyrexTypes.CFuncType(
         Builtin.bytes_type, [
             PyrexTypes.CFuncTypeArg("obj", Builtin.unicode_type, None),
-            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_char_ptr_type, None),
-            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_const_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_const_char_ptr_type, None),
             ])
 
     PyUnicode_AsXyzString_func_type = PyrexTypes.CFuncType(
@@ -3321,30 +3321,30 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
 
     PyUnicode_DecodeXyz_func_ptr_type = PyrexTypes.CPtrType(PyrexTypes.CFuncType(
         Builtin.unicode_type, [
-            PyrexTypes.CFuncTypeArg("string", PyrexTypes.c_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("string", PyrexTypes.c_const_char_ptr_type, None),
             PyrexTypes.CFuncTypeArg("size", PyrexTypes.c_py_ssize_t_type, None),
-            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_char_ptr_type, None),
-            ]))
+            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_const_char_ptr_type, None),
+        ]))
 
     _decode_c_string_func_type = PyrexTypes.CFuncType(
         Builtin.unicode_type, [
-            PyrexTypes.CFuncTypeArg("string", PyrexTypes.c_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("string", PyrexTypes.c_const_char_ptr_type, None),
             PyrexTypes.CFuncTypeArg("start", PyrexTypes.c_py_ssize_t_type, None),
             PyrexTypes.CFuncTypeArg("stop", PyrexTypes.c_py_ssize_t_type, None),
-            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_char_ptr_type, None),
-            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_const_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_const_char_ptr_type, None),
             PyrexTypes.CFuncTypeArg("decode_func", PyUnicode_DecodeXyz_func_ptr_type, None),
-            ])
+        ])
 
     _decode_bytes_func_type = PyrexTypes.CFuncType(
         Builtin.unicode_type, [
             PyrexTypes.CFuncTypeArg("string", PyrexTypes.py_object_type, None),
             PyrexTypes.CFuncTypeArg("start", PyrexTypes.c_py_ssize_t_type, None),
             PyrexTypes.CFuncTypeArg("stop", PyrexTypes.c_py_ssize_t_type, None),
-            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_char_ptr_type, None),
-            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_const_char_ptr_type, None),
+            PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_const_char_ptr_type, None),
             PyrexTypes.CFuncTypeArg("decode_func", PyUnicode_DecodeXyz_func_ptr_type, None),
-            ])
+        ])
 
     _decode_cpp_string_func_type = None  # lazy init
 
@@ -3436,8 +3436,8 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
                         PyrexTypes.CFuncTypeArg("string", string_type, None),
                         PyrexTypes.CFuncTypeArg("start", PyrexTypes.c_py_ssize_t_type, None),
                         PyrexTypes.CFuncTypeArg("stop", PyrexTypes.c_py_ssize_t_type, None),
-                        PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_char_ptr_type, None),
-                        PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_char_ptr_type, None),
+                        PyrexTypes.CFuncTypeArg("encoding", PyrexTypes.c_const_char_ptr_type, None),
+                        PyrexTypes.CFuncTypeArg("errors", PyrexTypes.c_const_char_ptr_type, None),
                         PyrexTypes.CFuncTypeArg("decode_func", self.PyUnicode_DecodeXyz_func_ptr_type, None),
                     ])
             helper_func_type = self._decode_cpp_string_func_type
@@ -3509,14 +3509,14 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             encoding = node.value
             node = ExprNodes.BytesNode(
                 node.pos, value=BytesLiteral(encoding.utf8encode()),
-                type=PyrexTypes.c_char_ptr_type)
+                type=PyrexTypes.c_const_char_ptr_type)
         elif isinstance(node, (ExprNodes.StringNode, ExprNodes.BytesNode)):
             encoding = node.value.decode('ISO-8859-1')
             node = ExprNodes.BytesNode(
-                node.pos, value=node.value, type=PyrexTypes.c_char_ptr_type)
+                node.pos, value=node.value, type=PyrexTypes.c_const_char_ptr_type)
         elif node.type is Builtin.bytes_type:
             encoding = None
-            node = node.coerce_to(PyrexTypes.c_char_ptr_type, self.current_env())
+            node = node.coerce_to(PyrexTypes.c_const_char_ptr_type, self.current_env())
         elif node.type.is_string:
             encoding = None
         else:

--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -136,6 +136,9 @@ class EncodedString(_unicode):
     def contains_surrogates(self):
         return string_contains_surrogates(self)
 
+    def as_utf8_string(self):
+        return BytesLiteral(self.utf8encode())
+
 
 def string_contains_surrogates(ustring):
     """
@@ -176,6 +179,10 @@ class BytesLiteral(_bytes):
         return self.decode('ISO-8859-1')
 
     is_unicode = False
+
+    def as_c_string_literal(self):
+        value = split_string_literal(escape_byte_string(self))
+        return '"%s"' % value
 
 
 char_from_escape_sequence = {

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -416,14 +416,12 @@ class DocStringSlot(SlotDescriptor):
     #  Descriptor for the docstring slot.
 
     def slot_code(self, scope):
-        if scope.doc is not None:
-            if scope.doc.is_unicode:
-                doc = scope.doc.utf8encode()
-            else:
-                doc = scope.doc.byteencode()
-            return '"%s"' % StringEncoding.escape_byte_string(doc)
-        else:
+        doc = scope.doc
+        if doc is None:
             return "0"
+        if doc.is_unicode:
+            doc = doc.as_utf8_string()
+        return doc.as_c_string_literal()
 
 
 class SuiteSlot(SlotDescriptor):

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -310,7 +310,7 @@ static CYTHON_INLINE float __PYX_NAN() {
 # endif
 #endif
 
-typedef struct {PyObject **p; char *s; const Py_ssize_t n; const char* encoding;
+typedef struct {PyObject **p; const char *s; const Py_ssize_t n; const char* encoding;
                 const char is_unicode; const char is_str; const char intern; } __Pyx_StringTabEntry; /*proto*/
 
 /////////////// ForceInitThreads.proto ///////////////

--- a/tests/run/charptr_decode.pyx
+++ b/tests/run/charptr_decode.pyx
@@ -4,7 +4,7 @@ cimport cython
 ############################################################
 # tests for char* slicing
 
-cdef char* cstring = "abcABCqtp"
+cdef const char* cstring = "abcABCqtp"
 
 @cython.test_assert_path_exists("//PythonCapiCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -37,8 +37,8 @@ def slice_charptr_decode_unknown_encoding():
     >>> print(str(slice_charptr_decode_unknown_encoding()).replace("u'", "'"))
     ('abcABCqtp', 'abcABCqtp', 'abc', 'abcABCqt')
     """
-    cdef char* enc = 'UTF-8'
-    cdef char* error_handling = 'strict'
+    cdef const char* enc = 'UTF-8'
+    cdef const char* error_handling = 'strict'
     return (cstring.decode(enc),
             cstring.decode(enc, error_handling),
             cstring[:3].decode(enc),

--- a/tests/run/charptr_len.pyx
+++ b/tests/run/charptr_len.pyx
@@ -1,7 +1,9 @@
 cimport cython
 
 cdef char* s = b"abcdefg"
+cdef const char* cs = b"abcdefg"
 cdef unsigned char* us = b"abcdefg"
+cdef const unsigned char* cus = b"abcdefg"
 cdef bytes pystr =  b"abcdefg"
 
 
@@ -14,6 +16,17 @@ def lentest_char():
     7
     """
     return len(s)
+
+
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    )
+def lentest_const_char():
+    """
+    >>> lentest_const_char()
+    7
+    """
+    return len(cs)
 
 
 @cython.test_assert_path_exists(
@@ -61,6 +74,17 @@ def lentest_uchar():
     7
     """
     return len(us)
+
+
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    )
+def lentest_const_uchar():
+    """
+    >>> lentest_const_uchar()
+    7
+    """
+    return len(cus)
 
 
 @cython.test_assert_path_exists(

--- a/tests/run/posix_test.pyx
+++ b/tests/run/posix_test.pyx
@@ -3,18 +3,23 @@ from libc.stdio   cimport *
 from posix.unistd cimport *
 from posix.fcntl  cimport *
 
+
 cdef int noisy_function() except -1:
     cdef int ret = 0
-    ret = printf(b"0123456789\n", 0)
-    assert ret == 11
+    ret = printf(b"012%s6789\n", "345")
+    assert ret == 11  # printf()
+    ret = printf(b"012%d6789\n", 345)
+    assert ret == 11  # printf()
+    ret = printf(b"0123456789\n")
+    assert ret == 11  # printf()
     ret = fflush(stdout)
-    assert ret == 0
-    ret = fprintf(stdout, b"0123456789\n", 0)
-    assert ret == 11
+    assert ret == 0  # fflush()
+    ret = fprintf(stdout, b"012%d6789\n", 345)
+    assert ret == 11  # fprintf()
     ret = fflush(stdout)
-    assert ret == 0
+    assert ret == 0  # fflush()
     ret = write(STDOUT_FILENO, b"0123456789\n", 11)
-    assert ret == 11
+    assert ret == 11  # write()
     return  0
 
 
@@ -40,8 +45,8 @@ def test_silent_stdout():
         ret = close(stdout_save)
         assert ret == 0
 
-cdef class silent_fd:
 
+cdef class silent_fd:
     cdef int fd_save, fd
 
     def __cinit__(self, int fd=-1):
@@ -76,6 +81,7 @@ cdef class silent_fd:
             assert ret == 0
             self.fd_save = -1
         return None
+
 
 def test_silent_stdout_ctxmanager():
     """


### PR DESCRIPTION
This also prevents non-const ``char*`` string literals from being interned in the first place.