### PR TITLE
Use c++0x rather than c++11 for unique_ptr tests

### DIFF
--- a/tests/run/cpp_smart_ptr.pyx
+++ b/tests/run/cpp_smart_ptr.pyx
@@ -1,6 +1,6 @@
-# distutils: extra_compile_args=-std=c++11
+# distutils: extra_compile_args=-std=c++0x
 # mode: run
-# tag: cpp
+# tag: cpp, werror
 
 from libcpp.memory cimport unique_ptr, shared_ptr
 


### PR DESCRIPTION
https://github.com/cython/cython/commit/e801a4abb8d3ffba63a1d2a3681a4de41a8546b1 didn't fix the recurring Travis build failure since the default gcc still doesn't support the flag `-std=c++11`. This fixes it by using `-std=c++0x` instead.