### PR TITLE
Extend integer types for large file support on 32-bit systems 

### DIFF
--- a/Cython/Includes/posix/resource.pxd
+++ b/Cython/Includes/posix/resource.pxd
@@ -24,7 +24,7 @@ cdef extern from "sys/resource.h" nogil:
     enum: RLIMIT_STACK
     enum: RLIMIT_AS
 
-    ctypedef unsigned long rlim_t
+    ctypedef unsigned long long rlim_t
 
     cdef struct rlimit:
         rlim_t rlim_cur

--- a/Cython/Includes/posix/types.pxd
+++ b/Cython/Includes/posix/types.pxd
@@ -1,17 +1,24 @@
 cdef extern from "sys/types.h":
-    ctypedef long blkcnt_t
-    ctypedef long blksize_t
-    ctypedef long clockid_t
-    ctypedef long dev_t
-    ctypedef long gid_t
-    ctypedef long id_t
-    ctypedef unsigned long ino_t
-    ctypedef long mode_t
-    ctypedef long nlink_t
-    ctypedef long off_t
-    ctypedef long pid_t
-    ctypedef long sigset_t
-    ctypedef long suseconds_t
-    ctypedef long time_t
-    ctypedef long timer_t
-    ctypedef long uid_t
+    # Some types get extra long for large file support (_FILE_OFFSET_BITS).
+    # As well as the types below, it affects rlim_t (see resource.pxd)
+    # also fsfilcnt_t / fsblkcnt_t for statvfs(), but cython doesn't expose it
+    # <https://web.archive.org/web/20000903062829/http://ftp.sas.com/standards/large.file/x_open.20Mar96.html#2.2.2>
+    #
+    # time_t could also be 64-bit.  OpenBSD changed it already.
+
+    ctypedef long long              blkcnt_t
+    ctypedef long                   blksize_t
+    ctypedef long                   clockid_t
+    ctypedef long                   dev_t
+    ctypedef long                   gid_t
+    ctypedef long                   id_t
+    ctypedef unsigned long long     ino_t
+    ctypedef long                   mode_t
+    ctypedef long                   nlink_t
+    ctypedef long long              off_t
+    ctypedef long                   pid_t
+    ctypedef long                   sigset_t
+    ctypedef long                   suseconds_t
+    ctypedef long long              time_t
+    ctypedef long                   timer_t
+    ctypedef long                   uid_t

--- a/Cython/Includes/posix/types.pxd
+++ b/Cython/Includes/posix/types.pxd
@@ -5,7 +5,7 @@ cdef extern from "sys/types.h":
     ctypedef long dev_t
     ctypedef long gid_t
     ctypedef long id_t
-    ctypedef long ino_t
+    ctypedef unsigned long ino_t
     ctypedef long mode_t
     ctypedef long nlink_t
     ctypedef long off_t


### PR DESCRIPTION
Disclaimer: from code inspection only.  Effect not verified.

"When your code mixes different types in arithmetic code, Cython must
know about the correct signedness and the approximate longness in
order to infer the appropriate result type.
...
If the type is declared too small and Cython considers it smaller
than other types it is used together with, Cython may infer the wrong
type for an expression and may end up generating incorrect coercion
code. You may or may not get a warning."

Some types get extra long for large file support (_FILE_OFFSET_BITS).

https://web.archive.org/web/20000903062829/http://ftp.sas.com/standards/large.file/x_open.20Mar96.html#2.2.2

time_t could also be 64-bit.  OpenBSD changed it already.