### PR TITLE
undef unwanted defines from longintrepr.h

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -45,6 +45,10 @@
 #endif
 #if CYTHON_USE_PYLONG_INTERNALS
   #include "longintrepr.h"
+  /* These short defines can easily conflict with other code */
+  #undef SHIFT
+  #undef BASE
+  #undef MASK
 #endif
 
 #if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x02070600 && !defined(Py_OptimizeFlag)


### PR DESCRIPTION
Python's `longintrepr.h` defines macros `SHIFT`, `BASE` and `MASK`. These short names can easily lead to conflicts if other headers use them. Now that the `longintrepr.h` include has moved up in the Cython-generated files, we really don't want these macros. This fix is in particular needed for http://bugseng.com/products/ppl/