### PR TITLE
Constants in float.pxd are not integers.

### DIFF
--- a/Cython/Includes/libc/float.pxd
+++ b/Cython/Includes/libc/float.pxd
@@ -2,42 +2,42 @@
 
 cdef extern from "float.h":
 
-    enum: FLT_RADIX
+    const float FLT_RADIX
 
-    enum:  FLT_MANT_DIG
-    enum:  DBL_MANT_DIG
-    enum: LDBL_MANT_DIG
+    const float FLT_MANT_DIG
+    const double DBL_MANT_DIG
+    const long double LDBL_MANT_DIG
 
-    enum: DECIMAL_DIG
+    const double DECIMAL_DIG
 
-    enum:  FLT_DIG
-    enum:  DBL_DIG
-    enum: LDBL_DIG
+    const float FLT_DIG
+    const double DBL_DIG
+    const long double LDBL_DIG
 
-    enum:  FLT_MIN_EXP
-    enum:  DBL_MIN_EXP
-    enum: LDBL_MIN_EXP
+    const float FLT_MIN_EXP
+    const double DBL_MIN_EXP
+    const long double LDBL_MIN_EXP
 
-    enum:  FLT_MIN_10_EXP
-    enum:  DBL_MIN_10_EXP
-    enum: LDBL_MIN_10_EXP
+    const float FLT_MIN_10_EXP
+    const double DBL_MIN_10_EXP
+    const long double LDBL_MIN_10_EXP
 
-    enum:  FLT_MAX_EXP
-    enum:  DBL_MAX_EXP
-    enum: LDBL_MAX_EXP
+    const float FLT_MAX_EXP
+    const double DBL_MAX_EXP
+    const long double LDBL_MAX_EXP
 
-    enum:  FLT_MAX_10_EXP
-    enum:  DBL_MAX_10_EXP
-    enum: LDBL_MAX_10_EXP
+    const float FLT_MAX_10_EXP
+    const double DBL_MAX_10_EXP
+    const long double LDBL_MAX_10_EXP
 
-    enum:  FLT_MAX
-    enum:  DBL_MAX
-    enum: LDBL_MAX
+    const float FLT_MAX
+    const double DBL_MAX
+    const long double LDBL_MAX
 
-    enum:  FLT_EPSILON
-    enum:  DBL_EPSILON
-    enum: LDBL_EPSILON
+    const float FLT_EPSILON
+    const double DBL_EPSILON
+    const long double LDBL_EPSILON
 
-    enum:  FLT_MIN
-    enum:  DBL_MIN
-    enum: LDBL_MIN
+    const float FLT_MIN
+    const double DBL_MIN
+    const long double LDBL_MIN


### PR DESCRIPTION
See discussion on cython-users.