### PR TITLE
Allow cast(...) to python types.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9625,8 +9625,7 @@ class TypecastNode(ExprNode):
                 return CoerceIntToBytesNode(self.operand, env)
             elif self.operand.type.can_coerce_to_pyobject(env):
                 self.result_ctype = py_object_type
-                base_type = self.base_type.analyse(env)
-                self.operand = self.operand.coerce_to(base_type, env)
+                self.operand = self.operand.coerce_to(self.type, env)
             else:
                 if self.operand.type.is_ptr:
                     if not (self.operand.type.base_type.is_void or self.operand.type.base_type.is_struct):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2707,7 +2707,8 @@ class TransformBuiltinMethods(EnvTransform):
                 else:
                     type = node.args[0].analyse_as_type(self.current_env())
                     if type:
-                        node = ExprNodes.TypecastNode(node.function.pos, type=type, operand=node.args[1])
+                        node = ExprNodes.TypecastNode(
+                            node.function.pos, type=type, operand=node.args[1], typecheck=False)
                     else:
                         error(node.args[0].pos, "Not a type")
             elif function == u'sizeof':

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -136,7 +136,9 @@ def cmod(a, b):
 
 # Emulated language constructs
 
-def cast(type, *args):
+def cast(type, *args, **kwargs):
+    kwargs.pop('typecheck', None)
+    assert not kwargs
     if hasattr(type, '__call__'):
         return type(*args)
     else:

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -287,6 +287,15 @@ Further Cython functions and declarations
 
     T = cython.typedef(cython.p_int)   # ctypedef int* T
 
+* ``cast`` will (unsafely) reinterpret an expression type. ``cython.cast(T, t)``
+  is equivalent to ``<T>t``. The first attribute must be a type, the second is
+  the expression to cast. Specifying the optional keyword argument
+  ``typecheck=True`` has the semantics of ``<T?>t``.
+
+  ::
+
+    t1 = cython.cast(T, t)
+    t2 = cython.cast(T, t, typecheck=True)
 
 .. _magic_attributes_pxd:
 


### PR DESCRIPTION
Currently `cython.cast('list', l)` will fail because of missing `typecheck` attr. Similarly, `cython.cast('MyType', o)` will fail because of missing `base_type` attr. The cause is that `ParseTreeTransforms` creates the `TypecastNode` directly from the type. Also, it forgets to set the `typecheck` attr (maybe I could add an optional kwattr to the cast function, say `cython.cast('list', l, typecheck=True)`).