### PR TITLE
Cpp copy added to libcpp/algorithm.pxd

### DIFF
--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -26,3 +26,7 @@ cdef extern from "<algorithm>" namespace "std" nogil:
 
     void sort_heap[Iter](Iter first, Iter last)
     void sort_heap[Iter, Compare](Iter first, Iter last, Compare comp)
+
+    # Copy
+    OutputIter copy[InputIter,OutputIter](InputIter,InputIter,OutputIter)
+


### PR DESCRIPTION
Expose C++'s copy in <algorithm>

With pull request #454, this can be used in Cython code to copy stuff amongst c++ containers.