### PR TITLE
Cpp limits

### DIFF
--- a/Cython/Includes/libcpp/limits.pxd
+++ b/Cython/Includes/libcpp/limits.pxd
@@ -1,0 +1,61 @@
+cdef extern from "limits" namespace "std" nogil:
+   enum float_round_style:
+        round_indeterminate       = -1
+        round_toward_zero         = 0
+        round_to_nearest          = 1
+        round_toward_infinity     = 2
+        round_toward_neg_infinity = 3
+        
+   enum float_denorm_style:
+        denorm_indeterminate  = -1
+        denorm_absent         = 0
+        denorm_present        = 1
+
+   #The static methods can be called as, e.g. numeric_limits[int].round_error(), etc.
+   #The const data members should be declared as static.  Cython currently doesn't allow that
+   #and/or I can't figure it out, so you must instantiate an object to access, e.g.
+   #cdef numeric_limits[double] lm
+   #print lm.round_style
+   cdef cppclass numeric_limits[T]:
+    const bint is_specialized
+    @staticmethod
+    T min()
+    @staticmethod
+    T max()
+    const int digits
+    const int  digits10
+    const bint is_signed
+    const bint is_integer
+    const bint is_exact
+    const int radix
+    @staticmethod
+    T epsilon()
+    @staticmethod
+    T round_error()
+
+    const int  min_exponent
+    const int  min_exponent10
+    const int  max_exponent
+    const int  max_exponent10
+  
+    const bint has_infinity
+    const bint has_quiet_NaN
+    const bint has_signaling_NaN
+    const float_denorm_style has_denorm
+    const bint has_denorm_loss
+    @staticmethod
+    T infinity()
+    @staticmethod
+    T quiet_NaN()
+    @staticmethod
+    T signaling_NaN()
+    @staticmethod
+    T denorm_min()
+
+    const bint is_iec559
+    const bint is_bounded
+    const bint is_modulo
+
+    const bint traps
+    const bint tinyness_before
+    const float_round_style round_style

--- a/tests/run/libcpp_all.pyx
+++ b/tests/run/libcpp_all.pyx
@@ -13,6 +13,7 @@ cimport libcpp.set
 cimport libcpp.stack
 cimport libcpp.vector
 cimport libcpp.complex
+cimport libcpp.limits
 
 from libcpp.deque  cimport *
 from libcpp.list   cimport *
@@ -23,6 +24,7 @@ from libcpp.set    cimport *
 from libcpp.stack  cimport *
 from libcpp.vector cimport *
 from libcpp.complex cimport *
+from libcpp.limits cimport *
 
 cdef libcpp.deque.deque[int]   d1 = deque[int]()
 cdef libcpp.list.list[int]     l1 = list[int]()
@@ -91,3 +93,17 @@ cdef const_vector_to_list(const vector[double]& cv):
         lst.append(cython.operator.dereference(iter))
         cython.operator.preincrement(iter)
     return lst
+
+cdef double dmax = numeric_limits[double].max()
+cdef double dmin = numeric_limits[double].min()
+cdef double deps = numeric_limits[double].epsilon()
+cdef double dqnan = numeric_limits[double].quiet_NaN()
+cdef double dsnan = numeric_limits[double].signaling_NaN()
+cdef double dinf = numeric_limits[double].infinity()
+
+cdef int imax = numeric_limits[int].max()
+cdef int imin = numeric_limits[int].min()
+cdef int ieps = numeric_limits[int].epsilon()
+cdef int iqnan = numeric_limits[int].quiet_NaN()
+cdef int isnan = numeric_limits[int].signaling_NaN()
+cdef int iinf = numeric_limits[int].infinity()


### PR DESCRIPTION
I'm working on wrapping a C++ library where numeric_limits is needed.  This .pxd works for my purposes.

One caveat is that Cython doesn't appear to support static member variables, so I've declared them non-static.  I've documented that a user must then create an object of that type in order to access those values.   I'm guessing such access are edge cases, but that having the static function is useful.