### PR TITLE
Add a pass transforming Python-style properties in cdef class into Cython-style properties

### DIFF
--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -171,7 +171,7 @@ def create_pipeline(context, mode, exclude_classes=()):
     from .ParseTreeTransforms import CreateClosureClasses, MarkClosureVisitor, DecoratorTransform
     from .ParseTreeTransforms import InterpretCompilerDirectives, TransformBuiltinMethods
     from .ParseTreeTransforms import ExpandInplaceOperators, ParallelRangeTransform
-    from .ParseTreeTransforms import CalculateQualifiedNamesTransform
+    from .ParseTreeTransforms import CalculateQualifiedNamesTransform, PropertyTransform
     from .TypeInference import MarkParallelAssignments, MarkOverflowingArithmetic
     from .ParseTreeTransforms import AdjustDefByDirectives, AlignFunctionDefinitions
     from .ParseTreeTransforms import RemoveUnreachableCode, GilCheck
@@ -216,6 +216,7 @@ def create_pipeline(context, mode, exclude_classes=()):
         RemoveUnreachableCode(context),
         ConstantFolding(),
         FlattenInListTransform(),
+        PropertyTransform(context),
         DecoratorTransform(context),
         ForwardDeclareTypes(context),
         AnalyseDeclarationsTransform(context),

--- a/tests/run/cdef_class_property_decorator_T264.pyx
+++ b/tests/run/cdef_class_property_decorator_T264.pyx
@@ -1,0 +1,51 @@
+# mode: run
+# ticket: 264
+# tag: property, decorator
+
+cdef class Prop:
+    """
+    >>> p = Prop()
+    >>> p.prop
+    GETTING 'None'
+    >>> p.prop = 1
+    SETTING '1' (previously: 'None')
+    >>> p.prop
+    GETTING '1'
+    1
+    >>> p.prop = 2
+    SETTING '2' (previously: '1')
+    >>> p.prop
+    GETTING '2'
+    2
+    >>> del p.prop
+    DELETING '2'
+    >>> p.prop
+    GETTING 'None'
+    """
+    cdef _value
+    def __init__(self):
+        self._value = None
+
+    @property
+    def prop(self):
+        print("FAIL")
+        return 0
+
+    @prop.getter
+    def prop(self):
+        print("FAIL")
+
+    @property
+    def prop(self):
+        print("GETTING '%s'" % self._value)
+        return self._value
+
+    @prop.setter
+    def prop(self, value):
+        print("SETTING '%s' (previously: '%s')" % (value, self._value))
+        self._value = value
+
+    @prop.deleter
+    def prop(self):
+        print("DELETING '%s'" % self._value)
+        self._value = None

--- a/tests/run/pure_cdef_class_property_decorator_T264.pxd
+++ b/tests/run/pure_cdef_class_property_decorator_T264.pxd
@@ -1,0 +1,6 @@
+# mode: run
+# ticket: 264
+# tag: property, decorator
+
+cdef class Prop:
+    cdef _value

--- a/tests/run/pure_cdef_class_property_decorator_T264.py
+++ b/tests/run/pure_cdef_class_property_decorator_T264.py
@@ -1,0 +1,51 @@
+# mode: run
+# ticket: 264
+# tag: property, decorator
+
+class Prop(object):
+    """
+    >>> p = Prop()
+    >>> p.prop
+    GETTING 'None'
+    >>> p.prop = 1
+    SETTING '1' (previously: 'None')
+    >>> p.prop
+    GETTING '1'
+    1
+    >>> p.prop = 2
+    SETTING '2' (previously: '1')
+    >>> p.prop
+    GETTING '2'
+    2
+    >>> del p.prop
+    DELETING '2'
+    >>> p.prop
+    GETTING 'None'
+    """
+
+    def __init__(self):
+        self._value = None
+
+    @property
+    def prop(self):
+        print("FAIL")
+        return 0
+
+    @prop.getter
+    def prop(self):
+        print("FAIL")
+
+    @property
+    def prop(self):
+        print("GETTING '%s'" % self._value)
+        return self._value
+
+    @prop.setter
+    def prop(self, value):
+        print("SETTING '%s' (previously: '%s')" % (value, self._value))
+        self._value = value
+
+    @prop.deleter
+    def prop(self):
+        print("DELETING '%s'" % self._value)
+        self._value = None


### PR DESCRIPTION
This makes properties work properly in cdef classes, and gives them the
exact same AST as the “property something:” blocks, whose syntax should
probably be deprecated now.

Fixes T264.

Note: this is the v2 version of this patch, the first one was sent to the cython-devel ML and is now obsolete. The differences are a simpler and more efficient code that doesn’t leak, and another test for pure mode.