### PR TITLE
Deprecate the 'property …:' syntax, as suggested in #462

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1294,6 +1294,10 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
         self._properties.pop()
         return node
 
+    def visit_PropertyNode(self, node):
+        warning(node.pos, "'property %s:' syntax is deprecated, use '@property'" % node.name, 2)
+        return node
+
     def visit_DefNode(self, node):
         scope_type = self.scope_type
         node = self.visit_FuncDefNode(node)


### PR DESCRIPTION
As a follow-up on #462, this deprecates the old-style pyx-only syntax for properties.

I couldn’t find out how to check if the “property” name has been redefined before in this pass, it seems this analysis is done later in the pipeline, so I didn’t implement the other suggested fix.