### PR TITLE
Don’t crash when a C class isn’t defined in the pxd

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2185,6 +2185,8 @@ class AlignFunctionDefinitions(CythonTransform):
         if pxd_def is None:
             pxd_def = self.scope.lookup(node.class_name)
         if pxd_def:
+            if not pxd_def.defined_in_pxd:
+                return node
             outer_scope = self.scope
             self.scope = pxd_def.type.scope
         self.visitchildren(node)

--- a/tests/errors/pure_cclass_without_body.pxd
+++ b/tests/errors/pure_cclass_without_body.pxd
@@ -1,0 +1,3 @@
+# mode: error
+
+cdef class Test

--- a/tests/errors/pure_cclass_without_body.py
+++ b/tests/errors/pure_cclass_without_body.py
@@ -1,0 +1,8 @@
+# mode: error
+
+class Test(object):
+    pass
+
+_ERRORS = u"""
+3:5: C class 'Test' is declared but not defined
+"""


### PR DESCRIPTION
Fixes #279.