### PR TITLE
Hide some parts of stack trace in __PYX_ERR macro

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2145,8 +2145,9 @@ class CCodeWriter(object):
     def error_goto(self, pos):
         lbl = self.funcstate.error_label
         self.funcstate.use_label(lbl)
-        return "{%s goto %s;}" % (
-            self.set_error_info(pos),
+        return "__PYX_ERR(%s, %s, %s)" % (
+            self.lookup_filename(pos[0]),
+            pos[1],
             lbl)
 
     def error_goto_if(self, cond, pos):


### PR DESCRIPTION
I'm always using Cython for seeing how this or that piece of code in Python will be represented using Python C API, so my changes are devoted to improving (in a way) readability of the resulting C code. The idea is the following. The resulting code is full of the constructions like this

```c
{__pyx_filename = __pyx_f[0]; __pyx_lineno = 4; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
```

They are always catching your eye and distract attention from other pieces of automatically generated code. I suggest we hide each constructions like that in the macro like this

```c
__PYX_ERR(0, 4, __pyx_L1_error)
```

The `__PYX_ERR` macro looks in the following way

```c
#define __PYX_ERR(f_index, lineno, Ln_error) \\
{ \\
  %s = %s[f_index]; %s = lineno; %sgoto Ln_error; \\
}
```