### PR TITLE
Fix generated `#line` directives on Windows

### DIFF
--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -158,8 +158,11 @@ class SourceDescriptor(object):
 
     def get_escaped_description(self):
         if self._escaped_description is None:
-            self._escaped_description = \
+            esc_desc = \
                 self.get_description().encode('ASCII', 'replace').decode("ASCII")
+            # Use foreward slashes on Windows since these paths
+            # will be used in the #line directives in the C/C++ files.
+            self._escaped_description = esc_desc.replace('\\', '/')
         return self._escaped_description
 
     def __gt__(self, other):


### PR DESCRIPTION
This avoids inadvertently using the backslash path separator in the generated `#line` directives on Windows. Using a backslash in a source file directive can cause compilation errors from using incorrect escape sequences and doesn't have the desired effect regardless of whether or not the compiler accepts the input.