### PR TITLE
Enable tests on python 3.5-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.5-dev
   - pypy
   - pypy3
 


### PR DESCRIPTION
Enable tests on python 3.5-dev to catch problems with upcoming python releases early.

This test fails because Cython:master currently fails with with Python 3.5.1 and later.  See the [Cython-devel mailing list discussion](https://mail.python.org/pipermail/cython-devel/2016-January/004639.html) for more information.