### PR TITLE
Check sys.path for .pxi files too

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -269,7 +269,7 @@ class Context(object):
         # Search list of include directories for filename.
         # Reports an error and returns None if not found.
         path = self.search_include_directories(filename, "", pos,
-                                               include=True)
+                                               include=True, sys_path=True)
         if not path:
             error(pos, "'%s' not found" % filename)
         return path


### PR DESCRIPTION
By analogy with `.pxd` files, Cython should also search `sys.path` for `.pxi` files.

This makes it feasible for packages to install `.pxi` files in `site-packages` which can then be included by other packages.
