### PR TITLE
Use correct macros to check GCC version

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2062,7 +2062,7 @@ proto="""
 #endif
 
 #if defined(__cplusplus) && CYTHON_CCOMPLEX \
-        && (defined(_WIN32) || defined(__clang__) || (defined(__GNUC__) && GCC_VERSION >= 40400) || __cplusplus >= 201103)
+        && (defined(_WIN32) || defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 5 || __GNUC__ == 4 && __GNUC_MINOR__ >= 4 )) || __cplusplus >= 201103)
     #define __Pyx_SET_CREAL(z,x) ((z).real(x))
     #define __Pyx_SET_CIMAG(z,y) ((z).imag(y))
 #else


### PR DESCRIPTION
Use [documented variables](https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html) to check GCC version (`GCC_VERSION` doesn't actually work).