### PR TITLE
Add declarations for C++11/14 smart pointer factories (make_shared & make_unique)

### DIFF
--- a/Cython/Includes/libcpp/memory.pxd
+++ b/Cython/Includes/libcpp/memory.pxd
@@ -85,3 +85,9 @@ cdef extern from "<memory>" namespace "std" nogil:
         shared_ptr[T] lock()
         bool owner_before[Y](const weak_ptr[Y]&)
         bool owner_before[Y](const shared_ptr[Y]&)
+
+    # Smart pointer non-member operations
+    shared_ptr[T] make_shared[T](...) except +
+
+    # Temporaries used for exception handling break generated code
+    unique_ptr[T] make_unique[T](...) # except +


### PR DESCRIPTION
This makes it possible to use a new idiom to wrap C++ classes if the target compiler can be assumed to support C++14:

```
from libcpp.memory cimport unique_ptr, make_unique

from cython.operator cimport dereference as deref

cdef extern from *:
    cdef cppclass Rectangle:
        void draw()

cdef class PyRectangle:

    cdef unique_ptr[Rectangle] thisptr

    def __cinit__(self):
        self.thisptr = make_unique[Rectangle]()

    def draw(self):
        deref(self.thisptr).draw()
```

No more worries about forgotten `__dealloc__` functions, very clean and expressive code.

I was thinking of adding a test, but this requires `-std=c++14` support from the compiler, which is probably too much for now. At the same time, I couldn't figure out how one could add a test that is only cythonized, not compiled.

Also, maybe this example is worth to be added to the documentation?

Many thanks!