### PR TITLE
ENH: Restructure libcpp.vector and cover API with tests

### DIFF
--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -113,18 +113,19 @@ cdef extern from "<vector>" namespace "std" nogil:
             bint operator>=(const_reverse_iterator)
 
         vector() except +
-        vector(vector&) except +
+        vector(const vector&) except +
         vector(size_type) except +
-        vector(size_type, T&) except +
-        #vector[InputIt](InputIt, InputIt)
+        vector(size_type, const T&) except +
+        # type (vector&) is needed here so that Cython can compile templated definition
+        vector& vector[InputIt](InputIt, InputIt) except +
         T& operator[](size_type)
         #vector& operator=(vector&)
-        bint operator==(vector&, vector&)
-        bint operator!=(vector&, vector&)
-        bint operator<(vector&, vector&)
-        bint operator>(vector&, vector&)
-        bint operator<=(vector&, vector&)
-        bint operator>=(vector&, vector&)
+        bint operator==(const vector&, const vector&)
+        bint operator!=(const vector&, const vector&)
+        bint operator<(const vector&, const vector&)
+        bint operator>(const vector&, const vector&)
+        bint operator<=(const vector&, const vector&)
+        bint operator>=(const vector&, const vector&)
         void assign(size_type, const T&)
         void assign[InputIt](InputIt, InputIt) except +
         T& at(size_type) except +
@@ -138,15 +139,15 @@ cdef extern from "<vector>" namespace "std" nogil:
         iterator end()
         const_iterator const_end "end"()
         const_iterator cend()
-        iterator erase(iterator)
-        iterator erase(iterator, iterator)
+        iterator erase(iterator) except +
+        iterator erase(iterator, iterator) except +
         T& front()
         iterator insert(iterator, const T&) except +
         iterator insert(iterator, size_type, const T&) except +
         iterator insert[InputIt](iterator, InputIt, InputIt) except +
         size_type max_size()
         void pop_back()
-        void push_back(T&) except +
+        void push_back(const T&) except +
         reverse_iterator rbegin()
         const_reverse_iterator const_rbegin "rbegin"()
         const_reverse_iterator crbegin()
@@ -155,7 +156,7 @@ cdef extern from "<vector>" namespace "std" nogil:
         const_reverse_iterator crend()
         void reserve(size_type) except +
         void resize(size_type) except +
-        void resize(size_type, T&) except +
+        void resize(size_type, const T&) except +
         size_type size()
         void swap(vector&)
 

--- a/tests/run/cpp_stl_vector.pyx
+++ b/tests/run/cpp_stl_vector.pyx
@@ -7,6 +7,74 @@ from cython.operator cimport preincrement as incr
 from libcpp.vector cimport vector
 from libcpp cimport bool as cbool
 
+ctypedef vector[int] ivector
+
+def test_constructors(int canary):
+    """
+    >>> test_constructors(7)
+    ([], [7, 7], [0, 0], [7, 7], [7, 7])
+    """
+    cdef ivector v1 = ivector()
+    cdef ivector v2 = ivector(2, canary)
+    cdef ivector v3 = ivector(2)
+    cdef ivector v4 = ivector(v2.begin(), v2.end())
+    cdef ivector v5 = ivector(v2)
+    return v1, v2, v3, v4, v5
+
+def test_assign(int canary):
+    """
+    >>> test_assign(7)
+    ([7, 7], [7, 7])
+    """
+    cdef ivector v1, v2
+    v1.assign(2, canary)
+    v2.assign(v1.begin(), v1.end())
+    return v1, v2
+
+def test_access(ivector v, int i):
+    """
+    >>> test_access((1, 2, 3), 1)
+    (2, 2, 1, 3)
+    >>> test_access((1, 2, 3), 5)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    IndexError: ...
+    """
+    return v.at(i), v[i], v.front(), v.back()
+
+def test_capacity(ivector v):
+    """
+    >>> all(test_capacity((1, 2, 3)))
+    True
+    """
+    v.reserve(9)
+    v.resize(5)
+    v.resize(7, 0)
+    return not v.empty(), v.size() > 0, v.max_size() > 0, v.capacity() > 0
+
+def test_modifiers():
+    """
+    >>> test_modifiers()
+    (0, 0)
+    """
+    cdef ivector v1 = ivector(3)
+    cdef ivector v2 = ivector(3)
+    v2.insert(v2.end(), 1)
+    v2.insert(v2.end(), v1.begin(), v1.end())
+    v1.clear()
+    v2.pop_back()
+    v2.erase(v2.begin())
+    v2.erase(v2.begin(), v2.end())
+    return v1.size(), v2.size()
+
+def test_swap(ivector v1, ivector v2):
+    """
+    >>> test_swap((1, 2), (3, 4))
+    ([3, 4], [1, 2])
+    """
+    v1.swap(v2)
+    return v1, v2
+
 def simple_test(double x):
     """
     >>> simple_test(55)

--- a/tests/run/cpp_stl_vector_cpp11.pyx
+++ b/tests/run/cpp_stl_vector_cpp11.pyx
@@ -6,6 +6,35 @@ from cython.operator cimport preincrement as incr
 
 from libcpp.vector cimport vector
 
+ctypedef vector[int] ivector
+
+def test_vector_emplace():
+    """
+    >>> test_vector_emplace()
+    [0, 7]
+    """
+    cdef ivector v
+    v.emplace(v.cend())
+    v.emplace(v.cend(), 7)
+    return v
+
+def test_vector_emplace_back():
+    """
+    >>> test_vector_emplace_back()
+    [0, 7]
+    """
+    cdef ivector v
+    v.emplace_back()
+    v.emplace_back(7)
+    return v
+
+def test_vector_shrink_to_fit():
+    """
+    >>> test_vector_shrink_to_fit()
+    """
+    cdef ivector v
+    v.shrink_to_fit()
+
 def const_iteration_test(L):
     """
     >>> const_iteration_test([1,2,4,8])


### PR DESCRIPTION
In particular, add C++11 declarations, more const-correctness.

I have added a new file for testing C++11 methods, I think this can be later used to add more tests for container methods and algorithms, which have been added with C++11 and were not tested before, because otherwise these tests will fail on compilers where the default mode is still not C++11.
