### PR TITLE
Ensure that extension's include_dirs is a list

### DIFF
--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -86,7 +86,7 @@ class build_ext(_build_ext.build_ext):
          "generate debug information for cygdb"),
         ('cython-compile-time-env', None,
             "cython compile time environment"),
-            
+
         # For backwards compatibility.
         ('pyrex-cplus', None,
          "generate C++ source files"),
@@ -109,7 +109,7 @@ class build_ext(_build_ext.build_ext):
     boolean_options.extend([
         'cython-cplus', 'cython-create-listing', 'cython-line-directives',
         'cython-c-in-temp', 'cython-gdb',
-        
+
         # For backwards compatibility.
         'pyrex-cplus', 'pyrex-create-listing', 'pyrex-line-directives',
         'pyrex-c-in-temp', 'pyrex-gdb',
@@ -127,7 +127,7 @@ class build_ext(_build_ext.build_ext):
         self.cython_gdb = False
         self.no_c_in_traceback = 0
         self.cython_compile_time_env = None
-    
+
     def __getattr__(self, name):
         if name[:6] == 'pyrex_':
             return getattr(self, 'cython_' + name[6:])
@@ -236,6 +236,10 @@ class build_ext(_build_ext.build_ext):
                     includes.append(i)
         except AttributeError:
             pass
+
+        # In case extension.include_dirs is a generator, evaluate it and keep
+        # result
+        extension.include_dirs = list(extension.include_dirs)
         for i in extension.include_dirs:
             if not i in includes:
                 includes.append(i)


### PR DESCRIPTION
This change allows to pass generator (e.g. `itertools.chain`) as `include_dirs` if for some reason evaluation of include directories needs to be delayed e.g. due to simultaneous dependency on *cython* and *numpy*.

Since version 18.0 of *setuptools* it's possible to seamlessly install cython extensions and depend on *Cython* via `setup_requires`. However, due to the way it's implemented (via delayed import of `Cython.Distutils.build_ext`), it's hard to modify how the extensions are compiled without recreating the whole `build_ext` from scratch. One of the canonical examples where custom builder is required is passing `numpy.get_include()` to `include_dirs`.

With this change and following pseudo-code:

```
def delayed_numpy_inc():
    import numpy
    yield numpy.get_include()

import itertools
for extension in extensions:
    extension.include_dirs = itertools.chain(delayed_numpy_inc(),
                                             list(ext_name.include_dirs))
...
setup(
    ...
    setup_requires=['numpy', 'cython'],
    extensions=extensions,
    ...
)
```

it's possible to "pip install" a package that contains cython extensions, which use numpy, without having either *cython* or *numpy* installed.