### PR TITLE
REL: pass license argument to setuptools.setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,6 +298,7 @@ setup(
 
     .. _Pyrex: http://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/
     """),
+    license='Apache',
     classifiers=[
         dev_status(),
         "Intended Audience :: Developers",


### PR DESCRIPTION
Otherwise, `pip show cython` says `License: UNKNOWN`.

It may be preferable to include the Apache license version number, though none of `numpy`, `scipy`, or `matplotlib` do. They simply write `BSD`. Both here and there, omitting the version number leaves ambiguity, because compatibility with GPL depends on the license version. Nonetheless, it is simpler to just note the license name. After all, this is metadata that people read quickly, and should thus remain uncluttered.

Admittedly, this duplicates information contained in the trove classifiers.