### PR TITLE
FROM_PY_FUNCTION: Cast to sdigit after unary minus, not before

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -659,7 +659,8 @@ static PyObject* __Pyx_PyInt_{{op}}{{order}}(PyObject *op1, PyObject *op2, CYTHO
                 x = a % b;
                 x += ((x != 0) & ((x ^ b) < 0)) * b;
             {{elif op == 'TrueDivide'}}
-                if (8 * sizeof(long) <= 53 || (__Pyx_sst_abs(size) <= 52 / PyLong_SHIFT) || likely(labs({{ival}}) <= (1L << 53))) {
+                if ((8 * sizeof(long) <= 53 || likely(labs({{ival}}) <= (1L << 53)))
+                    || __Pyx_sst_abs(size) <= 52 / PyLong_SHIFT) {
                     return PyFloat_FromDouble((double)a / (double)b);
                 }
                 return PyLong_Type.tp_as_number->nb_{{slot_name}}(op1, op2);

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -658,7 +658,7 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
             const digit* digits = ((PyLongObject*)x)->ob_digit;
             switch (Py_SIZE(x)) {
                 case  0: return ({{TYPE}}) 0;
-                case -1: __PYX_VERIFY_RETURN_INT({{TYPE}}, sdigit, -(sdigit) digits[0])
+                case -1: __PYX_VERIFY_RETURN_INT({{TYPE}}, sdigit, (sdigit) -digits[0])
                 case  1: __PYX_VERIFY_RETURN_INT({{TYPE}},  digit, +digits[0])
                 {{for _size in (2, 3, 4)}}
                 {{for _case in (-_size, _size)}}


### PR DESCRIPTION
The current cast isn't doing anything, because the unary minus implicitly
upcasts to int again, resulting in warnings about potentially value altering
conversions on 32 bit systems.

Fixes issue #877.