### PR TITLE
__Pyx_PyInt_TrueDivideObjC: switch comparison order

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -659,7 +659,8 @@ static PyObject* __Pyx_PyInt_{{op}}{{order}}(PyObject *op1, PyObject *op2, CYTHO
                 x = a % b;
                 x += ((x != 0) & ((x ^ b) < 0)) * b;
             {{elif op == 'TrueDivide'}}
-                if (8 * sizeof(long) <= 53 || (__Pyx_sst_abs(size) <= 52 / PyLong_SHIFT) || likely(labs({{ival}}) <= (1L << 53))) {
+                if ((8 * sizeof(long) <= 53 || likely(labs({{ival}}) <= (1L << 53)))
+                    || __Pyx_sst_abs(size) <= 52 / PyLong_SHIFT) {
                     return PyFloat_FromDouble((double)a / (double)b);
                 }
                 return PyLong_Type.tp_as_number->nb_{{slot_name}}(op1, op2);


### PR DESCRIPTION
The current order results in compiler warnings on 32 bit machines, e.g.

src/llfuse.c: In function '__Pyx_PyInt_TrueDivideObjC':
src/llfuse.c:43980:17: warning: left shift count >= width of type
                 if (8 * sizeof(long) <= 53 || (__Pyx_sst_abs(size) <= 52 / PyLong_SHIFT) || likely(labs(a) <= (1L << 53))) {

Switching the order so that the left shift is closer to the sizeof test
avoids the warning, presumably because it makes it easier for the
compiler to see that the left shift is only executed on 64 bit.

Thanks to Christian Neukirchen for doing most of the work!