### PR TITLE
Don't error out when non-const value is passed as const function parameter

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5052,6 +5052,8 @@ class SimpleCallNode(CallNode):
         for i in range(min(max_nargs, actual_nargs)):
             formal_arg = func_type.args[i]
             formal_type = formal_arg.type
+            if formal_type.is_const:
+                formal_type = formal_type.const_base_type
             arg = args[i].coerce_to(formal_type, env)
             if formal_arg.not_none:
                 # C methods must do the None checks at *call* time

--- a/tests/errors/cpp_no_auto_conversion.pyx
+++ b/tests/errors/cpp_no_auto_conversion.pyx
@@ -19,5 +19,5 @@ cdef long long e = constructor_overload(17)
  
 
 _ERRORS = u"""
-18:40: Cannot assign type 'long' to 'const wrapped_int'
+18:40: Cannot assign type 'long' to 'wrapped_int'
 """

--- a/tests/run/non_const_as_const_arg.pyx
+++ b/tests/run/non_const_as_const_arg.pyx
@@ -1,0 +1,10 @@
+cdef double f(const double a, const double b, const double c):
+    return a + b - c
+
+def test_non_const_as_const_arg():
+    """
+    >>> test_non_const_as_const_arg()
+    1.0
+    """
+    cdef double a = 1., b = 1., c = 1.
+    return f(a, b, c)


### PR DESCRIPTION
When function arguments are marked as const, this means that the function should not modify them, not that non-const arguments are not allowed.