### PR TITLE
Silence a warning about applying unary minus to an unsigned integer

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -685,7 +685,7 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
             const digit* digits = ((PyLongObject*)x)->ob_digit;
             switch (Py_SIZE(x)) {
                 case  0: return ({{TYPE}}) 0;
-                case -1: __PYX_VERIFY_RETURN_INT({{TYPE}}, sdigit, (sdigit) -digits[0])
+                case -1: __PYX_VERIFY_RETURN_INT({{TYPE}}, sdigit, (sdigit) (-(sdigit)digits[0]))
                 case  1: __PYX_VERIFY_RETURN_INT({{TYPE}},  digit, +digits[0])
                 {{for _size in (2, 3, 4)}}
                 {{for _case in (-_size, _size)}}


### PR DESCRIPTION
This showed up on MSVC after https://github.com/cython/cython/pull/493. Moving the cast made it so that we were applying a unary minus to an unsigned integer. The code should be correct now.

An alternative would be to define a general size preserving unary minus macro that checks sizeof and branches on that and then lets the optimizer get rid of dead branches. Either one requires the optimizer to do something intelligent though.