### PR TITLE
Add failing test for assignment of properties

### DIFF
--- a/tests/run/cdef_class_property_decorator_T264.pyx
+++ b/tests/run/cdef_class_property_decorator_T264.pyx
@@ -21,6 +21,8 @@ cdef class Prop:
     DELETING '2'
     >>> p.prop
     GETTING 'None'
+    >>> p.alias_prop
+    GETTING 'None'
     """
     cdef _value
     def __init__(self):
@@ -49,3 +51,5 @@ cdef class Prop:
     def prop(self):
         print("DELETING '%s'" % self._value)
         self._value = None
+
+    alias_prop = prop


### PR DESCRIPTION
In Python, you can create an alias for a property (in my case, it's a deprecated attribute):

```python
class Prop:
    @property
    def prop(self):
        return 1

    alias_prop = prop
```

This works in Cython cdef classes in 0.23.4 and earlier, but not in master, after #462.

Unfortunately, I'm not familiar enough with the Cython internals to figure out how to fix it. The error for the assignment is:

> 'prop' is not a constant, variable or function identifier