### PR TITLE
Name codeobj deterministically using the name of the function...

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1202,8 +1202,11 @@ class GlobalState(object):
 
     def new_py_const(self, type, prefix='', name_suffix=None):
         cname = self.new_const_cname(prefix, name_suffix=name_suffix)
-        c = PyObjectConst(cname, type)
-        self.py_constants.append(c)
+        try:
+            c = [x for x in self.py_constants if x.cname == cname][0]
+        except IndexError:
+            c = PyObjectConst(cname, type)
+            self.py_constants.append(c)
         return c
 
     def new_string_const_cname(self, bytes_value):

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1140,9 +1140,9 @@ class GlobalState(object):
             c = self.new_num_const(str_value, 'float', value_code)
         return c
 
-    def get_py_const(self, type, prefix='', cleanup_level=None):
+    def get_py_const(self, type, prefix='', cleanup_level=None, name_suffix=None):
         # create a new Python object constant
-        const = self.new_py_const(type, prefix)
+        const = self.new_py_const(type, prefix, name_suffix=name_suffix)
         if cleanup_level is not None \
                 and cleanup_level <= Options.generate_cleanup_code:
             cleanup_writer = self.parts['cleanup_globals']
@@ -1200,8 +1200,8 @@ class GlobalState(object):
         self.num_const_index[(value, py_type)] = c
         return c
 
-    def new_py_const(self, type, prefix=''):
-        cname = self.new_const_cname(prefix)
+    def new_py_const(self, type, prefix='', name_suffix=None):
+        cname = self.new_const_cname(prefix, name_suffix=name_suffix)
         c = PyObjectConst(cname, type)
         self.py_constants.append(c)
         return c
@@ -1220,14 +1220,15 @@ class GlobalState(object):
         cname = cname.replace('+', '_').replace('-', 'neg_').replace('.', '_')
         return cname
 
-    def new_const_cname(self, prefix='', value=''):
-        value = replace_identifier('_', value)[:32].strip('_')
-        used = self.const_cnames_used
-        name_suffix = value
-        while name_suffix in used:
-            counter = used[value] = used[value] + 1
-            name_suffix = '%s_%d' % (value, counter)
-        used[name_suffix] = 1
+    def new_const_cname(self, prefix='', value='', name_suffix=None):
+        if name_suffix is None:
+            value = replace_identifier('_', value)[:32].strip('_')
+            used = self.const_cnames_used
+            name_suffix = value
+            while name_suffix in used:
+                counter = used[value] = used[value] + 1
+                name_suffix = '%s_%d' % (value, counter)
+            used[name_suffix] = 1
         if prefix:
             prefix = Naming.interned_prefixes[prefix]
         else:
@@ -1636,8 +1637,8 @@ class CCodeWriter(object):
     def get_py_float(self, str_value, value_code):
         return self.globalstate.get_float_const(str_value, value_code).cname
 
-    def get_py_const(self, type, prefix='', cleanup_level=None):
-        return self.globalstate.get_py_const(type, prefix, cleanup_level).cname
+    def get_py_const(self, type, prefix='', cleanup_level=None, name_suffix=None):
+        return self.globalstate.get_py_const(type, prefix, cleanup_level, name_suffix=name_suffix).cname
 
     def get_string_const(self, text):
         return self.globalstate.get_string_const(text).cname

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8894,12 +8894,12 @@ class CodeObjectNode(ExprNode):
 
     def calculate_result_code(self, code=None):
         if self.result_code is None:
-            self.result_code = code.get_py_const(py_object_type, 'codeobj', cleanup_level=2)
+            self.result_code = code.get_py_const(py_object_type, 'codeobj', cleanup_level=2, name_suffix=('_%s' % (self.def_node.name,)))
         return self.result_code
 
     def generate_result_code(self, code):
         if self.result_code is None:
-            self.result_code = code.get_py_const(py_object_type, 'codeobj', cleanup_level=2)
+            self.result_code = code.get_py_const(py_object_type, 'codeobj', cleanup_level=2, name_suffix=('_%s' % (self.def_node.name,)))
 
         code = code.get_cached_constants_writer()
         code.mark_pos(self.pos)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1896,6 +1896,7 @@ class FuncDefNode(StatNode, BlockNode):
                 trace_name = self.entry.name + " (wrapper)"
             else:
                 trace_name = self.entry.name
+            code.putln("%s = %s;\n" % (Naming.frame_code_cname, code.get_py_const(py_object_type, 'codeobj', name_suffix='_%s' % (trace_name,))))
             code.put_trace_call(
                 trace_name, self.pos, nogil=not code.funcstate.gil_owned)
             code.funcstate.can_trace = True

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1896,7 +1896,6 @@ class FuncDefNode(StatNode, BlockNode):
                 trace_name = self.entry.name + " (wrapper)"
             else:
                 trace_name = self.entry.name
-            code.putln("%s = %s;\n" % (Naming.frame_code_cname, code.get_py_const(py_object_type, 'codeobj', name_suffix='_%s' % (trace_name,))))
             code.put_trace_call(
                 trace_name, self.pos, nogil=not code.funcstate.gil_owned)
             code.funcstate.can_trace = True


### PR DESCRIPTION
…so that the same codeobj generated during function declaration can be used later in TraceCall (line_profiler depends on this behavior).

(Based on b56135154f546eec34d88342dc1698cf1803492e updated for latest upstream)

Using this patch, the following directives to 'cython':

```
--directive profile=true
--directive linetrace=true
--directive binding=true
```

and the following compile-time define for gcc (or your favorite compiler):

```
-DCYTHON_TRACE=1
```

are sufficient to enable line-based profiling in a Cythonized module using kernprof/line_profiler.