### PR TITLE
Fixed invalid Unicode character.

### DIFF
--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -207,7 +207,7 @@ class AnnotationCCodeWriter(CCodeWriter):
 
     def _save_annotation_body(self, cython_code, generated_code, covered_lines=None):
         outlist = [u'<div class="cython">']
-        pos_comment_marker = u'/* \N{HORIZONTAL ELLIPSIS} */\n'
+        pos_comment_marker = u'/* \n{HORIZONTAL ELLIPSIS} */\n'
         new_calls_map = dict(
             (name, 0) for name in
             'refnanny trace py_macro_api py_c_api pyx_macro_api pyx_c_api error_goto'.split()


### PR DESCRIPTION
Installation would fail due to `\N` character:
```SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 3-25: unknown Unicode character name```