### PR TITLE
Allow passing define macros without specified values as commented directives

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -209,7 +209,9 @@ class DistutilsInfo(object):
                     if type in (list, transitive_list):
                         value = parse_list(value)
                         if key == 'define_macros':
-                            value = [tuple(macro.split('=')) for macro in value]
+                            value = [tuple(macro.split('='))
+                                     if '=' in macro else (macro, None)
+                                     for macro in value]
                     self.values[key] = value
         elif exn is not None:
             for key in distutils_settings:

--- a/tests/run/define_macro.pyx
+++ b/tests/run/define_macro.pyx
@@ -1,0 +1,11 @@
+#distutils: define_macros = DEFINE_NO_VALUE, DEFINE_WITH_VALUE=0
+
+cdef extern from "define_macro_helper.h" nogil:
+    int VAL;
+
+def test():
+    """
+    >>> test()
+    1
+    """
+    return VAL

--- a/tests/run/define_macro_helper.h
+++ b/tests/run/define_macro_helper.h
@@ -1,0 +1,6 @@
+#pragma once
+#ifdef DEFINE_NO_VALUE
+#define VAL (DEFINE_WITH_VALUE + 1)
+#else
+#define VAL DEFINE_WITH_VALUE
+#endif


### PR DESCRIPTION
This makes it so that define macros without a specified value can be passed using commented distutils directives in Cython source files. There's no way to do that with the current syntax. This makes it so that macros listed without a value are defined without a value. See the test case for an example.