### PR TITLE
Support dependencies in conditional compilation

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -357,10 +357,13 @@ def strip_string_literals(code, prefix='__Pyx_L'):
     return "".join(new_code), literals
 
 
-dependency_regex = re.compile(r"(?:^from +([0-9a-zA-Z_.]+) +cimport)|"
-                              r"(?:^cimport +([0-9a-zA-Z_.]+(?: *, *[0-9a-zA-Z_.]+)*))|"
-                              r"(?:^cdef +extern +from +['\"]([^'\"]+)['\"])|"
-                              r"(?:^include +['\"]([^'\"]+)['\"])", re.M)
+# We need to allow spaces to allow for conditional compilation like
+# IF ...:
+#     cimport ...
+dependency_regex = re.compile(r"(?:^\s*from +([0-9a-zA-Z_.]+) +cimport)|"
+                              r"(?:^\s*cimport +([0-9a-zA-Z_.]+(?: *, *[0-9a-zA-Z_.]+)*))|"
+                              r"(?:^\s*cdef +extern +from +['\"]([^'\"]+)['\"])|"
+                              r"(?:^\s*include +['\"]([^'\"]+)['\"])", re.M)
 
 
 def normalize_existing(base_path, rel_paths):

--- a/tests/compile/conditional_dependencies.srctree
+++ b/tests/compile/conditional_dependencies.srctree
@@ -1,0 +1,41 @@
+PYTHON setup.py build_ext --inplace
+
+######## setup.py ########
+
+from Cython.Build import cythonize
+ext_modules = cythonize("foo.pyx")
+assert set(ext_modules[0].depends) == set(["a.h", "b.h", "c.h", "d.h"])
+
+######## foo.pyx ########
+IF 1:
+    cimport a
+    from b cimport something
+
+    include "c.pxi"
+
+    cdef extern from "d.h":
+        pass
+
+######## a.pxd ########
+cdef extern from "a.h":
+    pass
+
+######## b.pxd ########
+cdef extern from "b.h":
+    cdef void something()
+
+######## c.pxi ########
+cdef extern from "c.h":
+    pass
+
+######## a.h ########
+/* empty */
+
+######## b.h ########
+/* empty */
+
+######## c.h ########
+/* empty */
+
+######## d.h ########
+/* empty */


### PR DESCRIPTION
We should support finding dependencies in conditional compilation like
```
IF some_condition:
    cimport foo
```
Note that the dependencies will always be dependencies unconditionally (independent of the condition), since the dependency-checking code doesn't actually parse the files.

CC @anntzer