### PR TITLE
numpy arrays are no longer omitted from locals()

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -975,6 +975,9 @@ class BufferType(BaseType):
         self.negative_indices = negative_indices
         self.cast = cast
 
+    def can_coerce_to_pyobject(self,env):
+        return True
+
     def as_argument_type(self):
         return self
 

--- a/tests/run/locals.pyx
+++ b/tests/run/locals.pyx
@@ -103,3 +103,13 @@ def pass_on_locals(f):
     f(locals())
     f(l=locals())
     f(l=locals(), a=1)
+    
+def locals_arrays(object[double, ndim=1] a):
+    """
+    >>> import numpy as np
+    >>> sorted(locals_arrays(np.arange(5,dtype='double')))
+    ['a', 'b']
+    """
+    cdef object[double, ndim=1] b = a.copy()
+    
+    return locals()


### PR DESCRIPTION
For example, the following code
```

def f():
  cdef int a = 1
  cdef np.ndarray[double, ndim=1] b = np.zeros(3)
  c = tuple()
  return locals()
```

would only return `a` and `c` in locals.


I fix this by making BufferType coercable to pyobject (I think this is a reasonable thing to do, and it doesn't seem to break anything else, but I could be missing a good reason why it wasn't)

Also adds a testcase