### PR TITLE
Several fixes to get test suite passing on Cygwin

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -13,6 +13,7 @@ cython.declare(os=object, re=object, operator=object,
 
 import os
 import re
+import shutil
 import sys
 import operator
 import textwrap
@@ -1722,7 +1723,7 @@ class CCodeWriter(object):
                 tmp_path = '%s.tmp%s' % (path, os.getpid())
                 with closing(Utils.open_new_file(tmp_path)) as f:
                     f.write(code)
-                os.rename(tmp_path, path)
+                shutil.move(tmp_path, path)
             code = '#include "%s"\n' % path
         self.put(code)
 

--- a/Cython/Debugger/Tests/TestLibCython.py
+++ b/Cython/Debugger/Tests/TestLibCython.py
@@ -94,6 +94,8 @@ class DebuggerTestCase(unittest.TestCase):
 
             shutil.copy(codefile, self.destfile)
             shutil.copy(cfuncs_file, self.cfuncs_destfile + '.c')
+            shutil.copy(cfuncs_file.replace('.c', '.h'),
+                        self.cfuncs_destfile + '.h')
 
             compiler = ccompiler.new_compiler()
             compiler.compile(['cfuncs.c'], debug=True, extra_postargs=['-fPIC'])

--- a/Cython/Debugger/Tests/cfuncs.h
+++ b/Cython/Debugger/Tests/cfuncs.h
@@ -1,0 +1,1 @@
+void some_c_function(void);

--- a/Cython/Debugger/Tests/codefile
+++ b/Cython/Debugger/Tests/codefile
@@ -1,7 +1,7 @@
 cdef extern from "stdio.h":
     int puts(char *s)
 
-cdef extern:
+cdef extern from "cfuncs.h":
     void some_c_function()
 
 import os

--- a/runtests.py
+++ b/runtests.py
@@ -1993,10 +1993,17 @@ def runtests(options, cmd_args, coverage=None):
         exclude_selectors.append(ShardExcludeSelector(options.shard_num, options.shard_count))
 
     if not test_bugs:
+        bug_files = [
+            ('bugs.txt', True),
+            ('pypy_bugs.txt', IS_PYPY),
+            ('windows_bugs.txt', sys.platform == 'win32'),
+            ('cygwin_bugs.txt', sys.platform == 'cygwin')
+        ]
+
         exclude_selectors += [
-            FileListExcluder(os.path.join(ROOTDIR, bugs_file_name), verbose=verbose_excludes)
-            for bugs_file_name in ['bugs.txt'] + (['pypy_bugs.txt'] if IS_PYPY else []) +
-            (['windows_bugs.txt'] if sys.platform == 'win32' else [])
+            FileListExcluder(os.path.join(ROOTDIR, bugs_file_name),
+                             verbose=verbose_excludes)
+            for bugs_file_name, condition in bug_files if condition
         ]
 
     if sys.platform in ['win32', 'cygwin'] and sys.version_info < (2,6):

--- a/runtests.py
+++ b/runtests.py
@@ -858,8 +858,8 @@ class CythonCompileTestCase(unittest.TestCase):
             ext_compile_flags = CFLAGS[:]
             compiler = COMPILER or sysconfig.get_config_var('CC')
 
-            if self.language == 'c' and compiler == 'gcc':
-                ext_compile_flags.extend(['-std=c89', '-pedantic'])
+            if self.language == 'c' and 'gcc' in compiler:
+                ext_compile_flags.append('-pedantic')
             if  build_extension.compiler == 'mingw32':
                 ext_compile_flags.append('-Wno-format')
             if extra_extension_args is None:

--- a/runtests.py
+++ b/runtests.py
@@ -856,10 +856,7 @@ class CythonCompileTestCase(unittest.TestCase):
                 build_extension.compiler = COMPILER
 
             ext_compile_flags = CFLAGS[:]
-            compiler = COMPILER or sysconfig.get_config_var('CC')
 
-            if self.language == 'c' and 'gcc' in compiler:
-                ext_compile_flags.append('-pedantic')
             if  build_extension.compiler == 'mingw32':
                 ext_compile_flags.append('-Wno-format')
             if extra_extension_args is None:

--- a/runtests.py
+++ b/runtests.py
@@ -1480,7 +1480,6 @@ class EmbedTest(unittest.TestCase):
         os.chdir(self.old_dir)
 
     def test_embed(self):
-        from distutils import sysconfig
         libname = sysconfig.get_config_var('LIBRARY')
         libdir = sysconfig.get_config_var('LIBDIR')
         if not os.path.isdir(libdir) or libname not in os.listdir(libdir):

--- a/tests/compile/callingconvention.srctree
+++ b/tests/compile/callingconvention.srctree
@@ -17,7 +17,7 @@ setup(
 ######## callingconvention.pyx ########
 # mode: compile
 
-cdef extern from "external_callingconvention.h":
+cdef extern from "callingconvention.h":
     pass
 
 cdef extern int f1()
@@ -35,10 +35,19 @@ p2 = f2
 p3 = f3
 p4 = f4
 
+
+######## callingconvention.h ########
+
+#define DLL_EXPORT
+#include "external_callingconvention.h"
+
+
 ######## external_callingconvention.h ########
 
 #ifndef DL_IMPORT
   #define DL_IMPORT(t) t
+#elif defined(DLL_EXPORT)
+  #define DL_IMPORT(t) DL_EXPORT(t)
 #endif
 
 #ifdef __cplusplus

--- a/tests/compile/declarations.srctree
+++ b/tests/compile/declarations.srctree
@@ -17,7 +17,7 @@ setup(
 ######## declarations.pyx ########
 # mode: compile
 
-cdef extern from "external_declarations.h":
+cdef extern from "declarations.h":
     pass
 
 cdef extern char *cp
@@ -48,10 +48,19 @@ cdef char *g():
 f()
 g()
 
+
+######## declarations.h ########
+
+#define DLL_EXPORT
+#include "external_declarations.h"
+
+
 ######## external_declarations.h ########
 
 #ifndef DL_IMPORT
   #define DL_IMPORT(t) t
+#elif defined(DLL_EXPORT)
+  #define DL_IMPORT(t) DL_EXPORT(t)
 #endif
 
 #ifdef __cplusplus

--- a/tests/cygwin_bugs.txt
+++ b/tests/cygwin_bugs.txt
@@ -1,0 +1,1 @@
+int_float_builtins_as_casts_T400_long_double

--- a/tests/cygwin_bugs.txt
+++ b/tests/cygwin_bugs.txt
@@ -1,3 +1,5 @@
+module_api
+
 complex_numbers_c89_T398_long_double
 complex_numbers_T305_long_double
 int_float_builtins_as_casts_T400_long_double

--- a/tests/cygwin_bugs.txt
+++ b/tests/cygwin_bugs.txt
@@ -1,1 +1,3 @@
+complex_numbers_c89_T398_long_double
+complex_numbers_T305_long_double
 int_float_builtins_as_casts_T400_long_double

--- a/tests/run/complex_numbers_T305.pyx
+++ b/tests/run/complex_numbers_T305.pyx
@@ -5,14 +5,13 @@ cimport cython
 def test_object_conversion(o):
     """
     >>> test_object_conversion(2)
-    ((2+0j), (2+0j), (2+0j))
+    ((2+0j), (2+0j))
     >>> test_object_conversion(2j - 0.5)
-    ((-0.5+2j), (-0.5+2j), (-0.5+2j))
+    ((-0.5+2j), (-0.5+2j))
     """
     cdef float complex a = o
     cdef double complex b = o
-    cdef long double complex c = o
-    return (a, b, c)
+    return (a, b)
 
 def test_arithmetic(double complex z, double complex w):
     """

--- a/tests/run/complex_numbers_T305_long_double.pyx
+++ b/tests/run/complex_numbers_T305_long_double.pyx
@@ -1,0 +1,13 @@
+# ticket: 305
+
+cimport cython
+
+def test_object_conversion(o):
+    """
+    >>> test_object_conversion(2)
+    (2+0j)
+    >>> test_object_conversion(2j - 0.5)
+    (-0.5+2j)
+    """
+    cdef long double complex a = o
+    return a

--- a/tests/run/complex_numbers_c89_T398_long_double.pyx
+++ b/tests/run/complex_numbers_c89_T398_long_double.pyx
@@ -1,0 +1,4 @@
+# ticket: 398
+
+cdef extern from "complex_numbers_c89_T398.h": pass
+include "complex_numbers_T305_long_double.pyx"

--- a/tests/run/cpdef_extern_func.pyx
+++ b/tests/run/cpdef_extern_func.pyx
@@ -1,5 +1,6 @@
 # cython: c_string_type=str
 # cython: c_string_encoding=ascii
+# distutils: extra_compile_args=-fpermissive
 
 __doc__ = """
 >>> sqrt(1)

--- a/tests/run/int_float_builtins_as_casts_T400.pyx
+++ b/tests/run/int_float_builtins_as_casts_T400.pyx
@@ -187,24 +187,6 @@ def double_to_float_int(double x):
     return r
 
 
-@cython.test_fail_if_path_exists("//SingleAssignmentNode//TypecastNode")
-@cython.test_assert_path_exists(
-    "//PythonCapiCallNode",
-    "//PythonCapiCallNode/PythonCapiFunctionNode/@cname = 'truncl'",
-)
-def long_double_to_float_int(long double x):
-    """
-    >>> long_double_to_float_int(4.1)
-    4.0
-    >>> long_double_to_float_int(-4.1)
-    -4.0
-    >>> long_double_to_float_int(4)
-    4.0
-    """
-    cdef float r = int(x)
-    return r
-
-
 @cython.test_fail_if_path_exists("//SimpleCallNode")
 @cython.test_assert_path_exists("//PythonCapiCallNode")
 def object_float(x):

--- a/tests/run/int_float_builtins_as_casts_T400_long_double.pyx
+++ b/tests/run/int_float_builtins_as_casts_T400_long_double.pyx
@@ -1,0 +1,21 @@
+# ticket: 400
+
+cimport cython
+
+
+@cython.test_fail_if_path_exists("//SingleAssignmentNode//TypecastNode")
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    "//PythonCapiCallNode/PythonCapiFunctionNode/@cname = 'truncl'",
+)
+def long_double_to_float_int(long double x):
+    """
+    >>> long_double_to_float_int(4.1)
+    4.0
+    >>> long_double_to_float_int(-4.1)
+    -4.0
+    >>> long_double_to_float_int(4)
+    4.0
+    """
+    cdef float r = int(x)
+    return r


### PR DESCRIPTION
See individual commit messages for more details.  I only skipped a tiny handful of tests.  In other cases test files were split up so that I could skip _only_ those cases that depend on `long double` functions on Cygwin (pending any better resolution to that issue).

In other cases a few tests were slightly rewritten to work correctly, and a few fixes to the test runner itself were needed.

I don't think there is any continuous integration being done for Cython on Windows, or Cygwin in particular.  If there's any interest I would be willing to work on setting that up and maintaining it.
