### PR TITLE
Allow C++ class methods to use base class' methods

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6302,7 +6302,7 @@ class AttributeNode(ExprNode):
                         # as an ordinary function.
                         if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
                             cname = entry.func_cname
-                            if entry.type.is_static_method:
+                            if entry.type.is_static_method or env.parent_scope.is_cpp_class_scope:
                                 ctype = entry.type
                             elif type.is_cpp_class:
                                 error(self.pos, "%s not a static member of %s" % (entry.name, type))

--- a/tests/run/cpp_classes_def.pyx
+++ b/tests/run/cpp_classes_def.pyx
@@ -5,6 +5,7 @@
 cdef double pi
 from math import pi
 from libc.math cimport sin, cos
+from libcpp cimport bool
 
 cdef extern from "shapes.h" namespace "shapes":
     cdef cppclass Shape:
@@ -42,6 +43,35 @@ def test_Poly(int n, float radius=1):
     finally:
         del poly
 
+cdef cppclass BaseClass:
+    int n
+    int method():
+        return this.n
+
+cdef cppclass SubClass(BaseClass):
+    bool override
+    __init__(bool override):
+        this.n = 1
+        this.override = override
+    int method():
+        if override:
+            return 0
+        else:
+            return BaseClass.method()
+
+def test_BaseMethods(x):
+    """
+    >>> test_BaseMethods(True)
+    0
+    >>> test_BaseMethods(False)
+    1
+    """
+    cdef SubClass* subClass
+    try:
+        subClass = new SubClass(x)
+        return subClass.method()
+    finally:
+        del subClass
 
 cdef cppclass WithStatic:
     @staticmethod


### PR DESCRIPTION
This little tweak to the (currently undocumented) C++ class feature lets you call a base class' method from the body of a derived class' method, even if you overrode it.

A relevant test has also been added.