### PR TITLE
Add a directive for dynamic class attributes

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -132,6 +132,7 @@ directive_defaults = {
     'c_string_encoding': '',
     'type_version_tag': True,   # enables Py_TPFLAGS_HAVE_VERSION_TAG on extension types
     'unraisable_tracebacks': False,
+    'dynamic_attributes': False, # enables a __dict__ attribute on cdef classes, has a performance penalty however.
 
     # set __file__ and/or __path__ to known source/target path at import time (instead of not having them available)
     'set_initial_path' : None,  # SOURCEFILE or "/full/path/to/module"

--- a/tests/compile/dynamic_attributes.pyx
+++ b/tests/compile/dynamic_attributes.pyx
@@ -1,0 +1,14 @@
+# mode: compile
+
+cimport cython
+
+cdef class Spam:
+    pass
+
+@cython.dynamic_attributes(True)
+cdef class SuperSpam:
+    pass
+
+@cython.dynamic_attributes(True)
+cdef public class UltraSpam [type UltraSpam_Type, object UltraSpam_Object]:
+    pass


### PR DESCRIPTION
This pull request adds a new `dynamic_attributes` directive to Cython. It will give `cdef` classes a `__dict__`, which will let you dynamically add properties to instances of them from Python. Opt-in, because it's got a performance penalty on classes that use it. (I can't find it again, but I found a message on the mailing list with benchmarks showing significant performance hits for `cpdef` functions if a class has a __dict__).

A compile test has also been added.