### PR TITLE
Add an include guard to Python type structs

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1015,6 +1015,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         # extension type.
         if not type.scope:
             return # Forward declared but never defined
+        api_name = Naming.h_guard_prefix + self.api_name(type.entry)
+        if type.entry.visibility == 'public':
+            code.putln("#ifndef %s" % api_name)
+            code.putln("#define %s" % api_name)
         header, footer = \
             self.sue_header_footer(type, "struct", type.objstruct_cname)
         code.putln(header)
@@ -1048,6 +1052,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if type.objtypedef_cname is not None:
             # Only for exposing public typedef name.
             code.putln("typedef struct %s %s;" % (type.objstruct_cname, type.objtypedef_cname))
+        if type.entry.visibility == 'public':
+            code.putln("#endif /* !%s */" % api_name)
 
     def generate_c_class_declarations(self, env, code, definition):
         for entry in env.c_class_entries:


### PR DESCRIPTION
I've got a bit of non-Cython code that uses public extension types made in Cython, and would like to use it inside of a Cython module. However, if I use this code and `cimport` the module with the public extension type at the same time, then I run in to a problem where the `struct`s for the types are getting declared twice. This little include guard helps alleviate that problem.