### PR TITLE
Add support for the typeid operator

### DIFF
--- a/Cython/Compiler/CythonScope.py
+++ b/Cython/Compiler/CythonScope.py
@@ -67,7 +67,9 @@ class CythonScope(ModuleScope):
         name_path = qname.split(u'.')
         scope = self
         while len(name_path) > 1:
-            scope = scope.lookup_here(name_path[0]).as_module
+            scope = scope.lookup_here(name_path[0])
+            if scope:
+                scope = scope.as_module
             del name_path[0]
             if scope is None:
                 return None

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -635,6 +635,7 @@ class InterpretCompilerDirectives(CythonTransform, SkipDeclarations):
         'operator.predecrement' : ExprNodes.inc_dec_constructor(True, '--'),
         'operator.postincrement': ExprNodes.inc_dec_constructor(False, '++'),
         'operator.postdecrement': ExprNodes.inc_dec_constructor(False, '--'),
+        'operator.typeid'       : ExprNodes.TypeidNode,
 
         # For backwards compatibility.
         'address': ExprNodes.AmpersandNode,

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1030,6 +1030,7 @@ class ModuleScope(Scope):
     # cpp                  boolean            Compiling a C++ file
     # is_cython_builtin    boolean            Is this the Cython builtin scope (or a child scope)
     # is_package           boolean            Is this a package module? (__init__)
+    # typeid_variables     int                Used by the typeid() exception handler
 
     is_module_scope = 1
     has_import_star = 0
@@ -1069,6 +1070,7 @@ class ModuleScope(Scope):
         self.cached_builtins = []
         self.undeclared_cached_builtins = []
         self.namespace_cname = self.module_cname
+        self.typeid_variables = 0
         self._cached_tuple_types = {}
         for var_name in ['__builtins__', '__name__', '__file__', '__doc__', '__path__']:
             self.declare_var(EncodedString(var_name), py_object_type, None)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1030,7 +1030,6 @@ class ModuleScope(Scope):
     # cpp                  boolean            Compiling a C++ file
     # is_cython_builtin    boolean            Is this the Cython builtin scope (or a child scope)
     # is_package           boolean            Is this a package module? (__init__)
-    # typeid_variables     int                Used by the typeid() exception handler
 
     is_module_scope = 1
     has_import_star = 0
@@ -1070,7 +1069,6 @@ class ModuleScope(Scope):
         self.cached_builtins = []
         self.undeclared_cached_builtins = []
         self.namespace_cname = self.module_cname
-        self.typeid_variables = 0
         self._cached_tuple_types = {}
         for var_name in ['__builtins__', '__name__', '__file__', '__doc__', '__path__']:
             self.declare_var(EncodedString(var_name), py_object_type, None)

--- a/Cython/Includes/libcpp/typeindex.pxd
+++ b/Cython/Includes/libcpp/typeindex.pxd
@@ -1,0 +1,15 @@
+from libcpp cimport bool
+from .typeinfo cimport type_info
+
+# This class is C++11-only
+cdef extern from "<typeindex>" namespace "std" nogil:
+    cdef cppclass type_index:
+        type_index(const type_info &)
+        const char* name()
+        size_t hash_code()
+        bool operator==(const type_index &)
+        bool operator!=(const type_index &)
+        bool operator<(const type_index &)
+        bool operator<=(const type_index &)
+        bool operator>(const type_index &)
+        bool operator>=(const type_index &)

--- a/Cython/Includes/libcpp/typeinfo.pxd
+++ b/Cython/Includes/libcpp/typeinfo.pxd
@@ -1,0 +1,10 @@
+from libcpp cimport bool
+
+cdef extern from "<typeinfo>" namespace "std" nogil:
+    cdef cppclass type_info:
+        const char* name()
+        int before(const type_info&)
+        bool operator==(const type_info&)
+        bool operator!=(const type_info&)
+        # C++11-only
+        size_t hash_code()

--- a/Cython/Parser/Grammar
+++ b/Cython/Parser/Grammar
@@ -167,6 +167,7 @@ memory_view_index: ':' [':'] [NUMBER]
 address: '&' factor
 cast: '<' type ['?'] '>' factor
 size_of: 'sizeof' '(' (type) ')'
+type_id: 'typeid' '(' (type) ')'
 new_expr: 'new' type '(' [arglist] ')'
 
 # TODO: Restrict cdef_stmt to "top-level" statements.

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -18,6 +18,8 @@ static void __Pyx_CppExn2PyErr() {
     PyErr_SetString(PyExc_MemoryError, exn.what());
   } catch (const std::bad_cast& exn) {
     PyErr_SetString(PyExc_TypeError, exn.what());
+  } catch (const std::bad_typeid& exn) {
+    PyErr_SetString(PyExc_TypeError, exn.what());
   } catch (const std::domain_error& exn) {
     PyErr_SetString(PyExc_ValueError, exn.what());
   } catch (const std::invalid_argument& exn) {

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -545,6 +545,8 @@ The translation is performed according to the following table
 +-----------------------+---------------------+
 | ``bad_cast``          | ``TypeError``       |
 +-----------------------+---------------------+
+| ``bad_typeid``        | ``TypeError``       |
++-----------------------+---------------------+
 | ``domain_error``      | ``ValueError``      |
 +-----------------------+---------------------+
 | ``invalid_argument``  | ``ValueError``      |
@@ -600,6 +602,28 @@ you can declare it using the Python @staticmethod decorator, i.e.::
     cdef extern from "Rectangle.h" namespace "shapes":
         @staticmethod
         void do_something()
+
+RTTI and typeid()
+=================
+
+Cython has support for the ``typeid(...)`` operator. To use it, you need to import
+it and the ``libcpp.typeinfo`` module first:
+
+    from cython.operator cimport typeid
+    from libcpp.typeinfo cimport type_info
+
+The ``typeid(...)`` operator returns an object of the type ``const type_info &``.
+
+If you want to store a type_info value in a C variable, you will need to store it
+as a pointer rather than a reference:
+
+    cdef const type_info* info = &typeid(MyClass)
+
+If an invalid type is passed to ``typeid``, it will throw an ``std::bad_typeid``
+exception which is converted into a ``TypeError`` exception in Python.
+
+An additional C++11-only RTTI-related class, ``std::type_index``, is available
+in ``libcpp.typeindex``.
 
 
 Caveats and Limitations

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -4,10 +4,11 @@
 from cython cimport typeof
 
 cimport cython.operator
-from cython.operator cimport dereference as deref
+from cython.operator cimport typeid, dereference as deref
 
 from libc.string cimport const_char
 from libcpp cimport bool
+cimport libcpp.typeinfo
 
 cdef out(s, result_type=None):
     print '%s [%s]' % (s.decode('ascii'), result_type)
@@ -50,11 +51,14 @@ cdef extern from "cpp_operators_helper.h":
         const_char* operator[](int)
         const_char* operator()(int)
 
-    cppclass TruthClass:
+    cdef cppclass TruthClass:
         TruthClass()
         TruthClass(bool)
         bool operator bool()
         bool value
+
+cdef cppclass TruthSubClass(TruthClass):
+    pass
 
 def test_unops():
     """
@@ -182,3 +186,29 @@ def test_bool_cond():
     assert (TruthClass(False) and TruthClass(True)).value == False
     assert (TruthClass(True) and TruthClass(False)).value == False
     assert (TruthClass(True) and TruthClass(True)).value == True
+
+def test_typeid_op():
+    """
+    >>> test_typeid_op()
+    """
+    cdef TruthClass* test_1 = new TruthClass()
+    cdef TruthSubClass* test_2 = new TruthSubClass()
+    cdef TruthClass* test_3 = <TruthClass*> test_2
+    cdef TruthClass* test_4 = <TruthClass*> 0
+
+    assert typeid(TruthClass).name()
+    assert typeid(test_1).name()
+    assert typeid(TruthSubClass).name()
+    assert typeid(test_2).name()
+    assert typeid(TruthClass).name()
+    assert typeid(test_3).name()
+    assert typeid(TruthSubClass).name()
+    assert typeid(deref(test_2)).name()
+
+    try:
+        typeid(deref(test_4))
+        assert False
+    except TypeError:
+        assert True
+
+    del test_1, test_2

--- a/tests/run/cpp_operators_helper.h
+++ b/tests/run/cpp_operators_helper.h
@@ -50,6 +50,7 @@ class TruthClass {
 public:
   TruthClass() : value(false) {}
   TruthClass(bool value) : value(value) {}
+  virtual ~TruthClass() {};
   operator bool() { return value; }
   bool value;
 };


### PR DESCRIPTION
This pull request adds the C++ `typeid(...)` operator to Cython, available by cimporting:

```cython
from cython.operator cimport typeid
cimport libcpp.typeinfo
```

(the operator requires the `libcpp.typeinfo.type_info` type and you cannot use it without the `<typeinfo>` header included)

`std::bad_typeid` exceptions thrown by `typeid()` are caught.

Relevant documentation and a test has also been added.