### PR TITLE
Allow extension types to be used as template arguments

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5289,7 +5289,7 @@ class SimpleCallNode(CallNode):
             self.is_temp = 1
             # func_type.exception_check = True
 
-        if self.is_temp and self.type.is_reference:
+        if self.is_temp and self.type.is_reference and not self.type.is_extension_type:
             self.type = PyrexTypes.CFakeReferenceType(self.type.ref_base_type)
 
         # Called in 'nogil' context?

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3415,7 +3415,7 @@ class CppClassType(CType):
             return error_type
         has_object_template_param = False
         for value in template_values:
-            if value.is_pyobject:
+            if value.is_pyobject and not value.is_extension_type:
                 has_object_template_param = True
                 error(pos,
                       "Python object type '%s' cannot be used as a template argument" % value)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2196,7 +2196,7 @@ class CppClassScope(Scope):
                 entry.func_cname = "%s::%s" % (self.type.empty_declaration_code(), cname)
         if name != "this" and (defining or name != "<init>"):
             self.var_entries.append(entry)
-        if type.is_pyobject and not allow_pyobject:
+        if type.is_pyobject and not allow_pyobject and not type.is_extension_type:
             error(pos,
                 "C++ class member cannot be a Python object")
         return entry


### PR DESCRIPTION
This PR will allow extension types to be used as template arguments; like in this hypothetical example with a map keeping track of existing wrappers for pointers:

```cython
from libcpp.unordered_map cimport unordered_map

cdef public class CppWrapper[type CppWrapper_Type, object CppWrapper]:
    pass

cdef unordered_map[void *, CppWrapper] wrapper_instances
```

Which Cython would turn into this type:

```c++
std::unordered_map<void *,struct CppWrapper *>
```
