### PR TITLE
Replace "int(val) == 0" by "not val" for gdb.Value instances

### DIFF
--- a/Cython/Debugger/libpython.py
+++ b/Cython/Debugger/libpython.py
@@ -286,7 +286,7 @@ class PyObjectPtr(object):
         return PyTypeObjectPtr(self.field('ob_type'))
 
     def is_null(self):
-        return 0 == int(self._gdbval)
+        return not self._gdbval
 
     def is_optimized_out(self):
         '''
@@ -989,7 +989,7 @@ class PyFrameObjectPtr(PyObjectPtr):
         if self.is_optimized_out():
             return None
         f_trace = self.field('f_trace')
-        if int(f_trace) != 0:
+        if f_trace:
             # we have a non-NULL f_trace:
             return self.f_lineno
         else:


### PR DESCRIPTION
Recent versions of `gdb` do not convert every `gdb.Value` to `int`. To check for NULL pointers, use `not value` instead of `int(value) == 0`.