### PR TITLE
Add basic extension type metaclass support

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1845,6 +1845,8 @@ class NameNode(AtomicExprNode):
         return None
 
     def analyse_target_declaration(self, env):
+        if self.name in ['__metaclass__', '__dict__'] and env.is_c_class_scope:
+            error(self.pos, "'%s' must be declared with 'cdef'" % self.name)
         if not self.entry:
             self.entry = env.lookup_here(self.name)
         if not self.entry:
@@ -8486,7 +8488,7 @@ class Py3ClassNode(ExprNode):
         else:
             mkw = 'NULL'
         if self.metaclass:
-            metaclass = self.metaclass.result()
+            metaclass = "((PyObject *) %s)" % self.metaclass.result()
         else:
             metaclass = "((PyObject*)&__Pyx_DefaultClassType)"
         code.putln(
@@ -8572,7 +8574,7 @@ class PyClassNamespaceNode(ExprNode, ModuleNameMixin):
         else:
             mkw = '(PyObject *) NULL'
         if self.metaclass:
-            metaclass = self.metaclass.result()
+            metaclass = "((PyObject *) %s)" % self.metaclass.result()
         else:
             metaclass = "(PyObject *) NULL"
         code.putln(

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -16,6 +16,7 @@ from .PyrexTypes import CPtrType
 from . import Future
 
 from . import Annotate
+from . import Builtin
 from . import Code
 from . import Naming
 from . import Nodes
@@ -1185,6 +1186,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         slot_func = scope.mangle_internal("tp_new")
         type = scope.parent_type
         base_type = type.base_type
+        is_metaclass = type.subtype_of(Builtin.builtin_types['type'])
 
         have_entries, (py_attrs, py_buffers, memoryview_slices) = \
                         scope.get_refcounted_entries()
@@ -1223,6 +1225,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             "static PyObject *%s(PyTypeObject *t, %sPyObject *a, %sPyObject *k) {" % (
                 slot_func, unused_marker, unused_marker))
 
+        needs_error_cleanup = False
         need_self_cast = (type.vtabslot_cname or
                           (py_buffers or memoryview_slices or py_attrs) or
                           cpp_class_attrs)
@@ -1263,13 +1266,20 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("if (unlikely(!o)) return 0;")
         if freelist_size and not base_type:
             code.putln('}')
+        if is_metaclass and new_func_entry and new_func_entry.is_special:
+            needs_error_cleanup = True
+            code.putln("Py_ssize_t al = PyTuple_GET_SIZE(a);")
+            code.putln("if (al == 1 && o == ((PyObject*)t)) {")
+            code.putln("o = PyTuple_GET_ITEM(a, 0);")
+            code.putln("if(unlikely(!o) < 0) goto bad;")
+            code.putln("}")
         if need_self_cast:
             code.putln("p = %s;" % type.cast_code("o"))
         #if need_self_cast:
         #    self.generate_self_cast(scope, code)
 
         # from this point on, ensure DECREF(o) on failure
-        needs_error_cleanup = False
+        #needs_error_cleanup = False
 
         if type.vtabslot_cname:
             vtab_base_type = type
@@ -1288,7 +1298,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 entry.cname, entry.type.empty_declaration_code()))
 
         for entry in py_attrs:
-            if entry.name == "__dict__":
+            if entry.name == "__dict__" and not type.subtype_of(Builtin.builtin_types['type']):
                 needs_error_cleanup = True
                 code.put("p->%s = PyDict_New(); if (unlikely(!p->%s)) goto bad;" % (
                     entry.cname, entry.cname))
@@ -1311,6 +1321,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             else:
                 cinit_args = "o, a, k"
             needs_error_cleanup = True
+            if is_metaclass and new_func_entry and new_func_entry.is_special:
+                code.putln("if (al == 1) {")
+                code.putln("a = %s;" % Naming.empty_tuple)
+                code.putln("}")
             code.putln("if (unlikely(%s(%s) < 0)) goto bad;" % (
                 new_func_entry.func_cname, cinit_args))
 
@@ -2741,6 +2755,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             if entry.visibility != 'extern':
                 for slot in TypeSlots.slot_table:
                     slot.generate_dynamic_init_code(scope, code)
+                if type.metaclass:
+                    code.putln("((PyObject*)&%s)->ob_type = %s;" % (
+                        typeobj_cname,
+                        type.metaclass.typeptr_cname))
                 code.putln(
                     "if (PyType_Ready(&%s) < 0) %s" % (
                         typeobj_cname,

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1278,6 +1278,7 @@ class CVarDefNode(StatNode):
         if not dest_scope:
             dest_scope = env
         self.dest_scope = dest_scope
+        type_type = Builtin.builtin_types['type']
 
         if self.declarators:
             templates = self.declarators[0].analyse_templates()
@@ -1332,6 +1333,31 @@ class CVarDefNode(StatNode):
             if name == '':
                 error(declarator.pos, "Missing name in declaration.")
                 return
+            if name == '__dict__' and dest_scope.is_c_class_scope:
+                dest_type = dest_scope.parent_type
+                # If you replace the dict of a type with a custom dict, strange behavior will occur.
+                # Since types already have a dict, "PyObject_GenericSetAttr" just needs to be set
+                # in the type declaration.
+                if dest_type.subtype_of(type_type):
+                    dest_type.metaclass_dict = True
+                    continue
+            if name == '__metaclass__' and dest_scope.is_c_class_scope:
+                dest_type = dest_scope.parent_type
+                base_metaclass = dest_type.base_type.metaclass if dest_type.base_type else None
+                if type.subtype_of(type_type):
+                    if base_metaclass and not type.subtype_of(base_metaclass):
+                        error(declarator.pos, "metaclass conflict: the metaclass of a derived class must be a "
+                                              "(non-strict) subclass of the metaclasses of all its bases")
+                        continue
+                    if type == type_type:
+                        # Python silently ignores attempts to set "type" as a metaclass if the base class has a
+                        # metaclass
+                        continue
+                    dest_type.metaclass = type
+                else:
+                    error(declarator.pos, "__metaclass__ must inherit from 'type'")
+                #if dest_scope.name == 'Class': import ipdb;ipdb.set_trace()
+                continue
             if type.is_cfunction:
                 if 'staticmethod' in env.directives:
                     type.is_static_method = True
@@ -4647,6 +4673,17 @@ class CClassDefNode(ClassDefNode):
         code.mark_pos(self.pos)
         if self.body:
             self.body.generate_execution_code(code)
+        # If a metaclass is set, call its __cinit__ and __init__ methods
+        if self.entry.type.metaclass:
+            type = self.entry.type
+            typeobj_cname = type.typeobj_cname
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached("MetaclassInit", "ObjectHandling.c"))
+            code.putln(
+                "if (__Pyx_MetaclassInit(%s, &%s) < 0) %s" % (
+                type.metaclass.typeptr_cname,
+                typeobj_cname,
+                code.error_goto(self.entry.pos)))
 
     def annotate(self, code):
         if self.body:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1143,6 +1143,8 @@ class BuiltinObjectType(PyObjectType):
     vtabptr_cname = None
     typedef_flag = True
     is_external = True
+    metaclass = None
+    metaclass_dict = False
     decl_type = 'PyObject'
 
     def __init__(self, name, cname, objstruct_cname=None):
@@ -1284,6 +1286,8 @@ class PyExtensionType(PyObjectType):
     #  vtabstruct_cname string           Name of C method table struct
     #  vtabptr_cname    string           Name of pointer to C method table
     #  vtable_cname     string           Name of C method table definition
+    #  metaclass        PyExtensionType or None
+    #  metaclass_dict   boolean          Whether an extension metaclass has a modifiable dictionary
     #  defered_declarations [thunk]      Used to declare class hierarchies in order
 
     is_extension_type = 1
@@ -1306,6 +1310,12 @@ class PyExtensionType(PyObjectType):
         self.vtabstruct_cname = None
         self.vtabptr_cname = None
         self.vtable_cname = None
+        if base_type is not None:
+            self.metaclass = base_type.metaclass
+            self.metaclass_dict = base_type.metaclass_dict
+        else:
+            self.metaclass = None
+            self.metaclass_dict = False
         self.is_external = is_external
         self.defered_declarations = []
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1463,7 +1463,8 @@ class ModuleScope(Scope):
         
         if base_type and not type.metaclass:
             type.metaclass = base_type.metaclass
-            type.metaclass_dict = base_type.metaclass_dict
+            if not type.metaclass_dict:
+                type.metaclass_dict = base_type.metaclass_dict
 
         # cdef classes are always exported, but we need to set it to
         # distinguish between unused Cython utility code extension classes

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1853,3 +1853,16 @@ static PyObject* __Pyx_PyNumber_InPlaceMatrixMultiply(PyObject* x, PyObject* y) 
 
 #undef __Pyx_TryMatrixMethod
 #endif
+
+/////////////// MetaclassInit.proto ///////////////
+static int __Pyx_MetaclassInit(PyTypeObject *t, PyTypeObject *o);
+
+/////////////// MetaclassInit ///////////////
+//@substitute: naming
+static int __Pyx_MetaclassInit(PyTypeObject *t, PyTypeObject *o) {
+    PyObject *a = PyTuple_Pack(1, (PyObject *)o);
+    if (unlikely(!a)) return -1;
+    if (unlikely(!t->tp_new(t, a, NULL))) return -1;
+    if (t->tp_init((PyObject *)o, a, NULL) < 0) return -1;
+    return 0;
+}

--- a/docs/src/reference/extension_types.rst
+++ b/docs/src/reference/extension_types.rst
@@ -426,6 +426,28 @@ Dynamic Attributes
 .. note::
     #. This can have a performance penalty, especially when using ``cpdef`` methods in a class.
 
+===========
+Metaclasses
+===========
+
+ * Cython has very basic support for extension type metaclasses, you can define and use them like this ::
+
+    cdef class MyType(type):
+        pass
+    cdef class MyClass:
+        cdef MyType __metaclass__
+
+ * Metaclasses must derive from ``type``
+ * The ``__cinit__`` and ``__init__`` methods of an extension type's metaclass get called, but ``__prepare__`` is not. In normal Python classes, however, it will.
+ * No arguments are passed to ``__cinit__`` or ``__init__`` except for ``self`` when a metaclass is initializing for an extension type, but they will recieve the usual arguments when being used on a normal class.
+ * Unlike other class attributes, subclasses can declare a different type for ``__metaclass__`` if their base class has one already. However, like in pure Python, a derived class' metaclass must also derive from the base class' metaclass.
+ * ``cdef public`` attributes on metaclasses are currently not supported.
+ * You can use the dynamic attributes syntax to make an extension type "monkeypatch-able" ::
+
+     cdef class MyType(type):
+        cdef dict __dict__
+
+
 =========================
 External and Public Types
 =========================

--- a/tests/errors/cdef_metaclass.pyx
+++ b/tests/errors/cdef_metaclass.pyx
@@ -1,0 +1,24 @@
+# mode: error
+
+cdef class MetaclassOne(type):
+    pass
+
+cdef class MetaclassTwo(type):
+    pass
+
+cdef class MetaclassThree(object):
+    pass
+
+cdef class ClassOne:
+    cdef MetaclassOne __metaclass__
+
+cdef class ClassTwo(ClassOne):
+    cdef MetaclassTwo __metaclass__
+
+cdef class ClassThree:
+    cdef MetaclassThree __metaclass__
+
+_ERRORS = """
+ 16:22: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
+ 19:24: __metaclass__ must inherit from 'type'
+"""

--- a/tests/run/cdef_metaclass.pyx
+++ b/tests/run/cdef_metaclass.pyx
@@ -1,0 +1,61 @@
+# mode: run
+
+cdef int dummy_number = 1234
+
+cdef class CustomType(type):
+    cdef int struct_number
+    def __cinit__(self):
+        self.struct_number = 5678
+
+cdef class ClassOne:
+    cdef CustomType __metaclass__
+
+cdef class MonkeypatchableType(type):
+    cdef dict __dict__
+
+cdef class MonkeypatchableClass:
+    """
+    >>> MonkeypatchableClass.foo = 'bar'
+    >>> MonkeypatchableClass.foo
+    'bar'
+    """
+    cdef MonkeypatchableType __metaclass__
+
+cdef class WithProperties(type):
+    cdef dict __dict__
+    @property
+    def dummy_number(self):
+        return dummy_number
+    @dummy_number.setter
+    def dummy_number(self, int val):
+        global dummy_number
+        dummy_number = val
+
+cdef class ClassTwo:
+    cdef WithProperties __metaclass__
+
+cdef class ClassThree(ClassTwo):
+    """
+    >>> ClassThree.dummy_number
+    1234
+    >>> ClassThree.dummy_number = 5678
+    >>> ClassThree.dummy_number
+    5678
+    >>> ClassTwo.dummy_number
+    5678
+    """
+
+class PyBaseClass(metaclass=CustomType):
+    pass
+
+class PyDerivedClass(ClassTwo):
+    pass
+
+def test_struct_number(CustomType cls):
+    """
+    >>> test_struct_number(ClassOne)
+    5678
+    >>> test_struct_number(PyBaseClass)
+    5678
+    """
+    return cls.struct_number


### PR DESCRIPTION
This pull request adds very basic support for metaclasses in extension types, using this syntax:

``` cython
cdef class MyType(type):
    pass
cdef class MyClass:
    cdef MyType __metaclass__
```

This is equivalent to doing `PyVarObject_HEAD_INIT(&MyType, 0)` in a `PyTypeObject` declaration.

Subclasses can declare a different type for `__metaclass__` if their base class has one already unlike with normal attributes - but restrictions on metaclass inheritance like in normal Python have been put in place.

More info has been added to the docs.
# Implementation information

Normally the `tp_new` and `tp_init` of an extension type's `ob_base` doesn't get called, which could result in crashes if a metaclass has custom fields declared as the `__cinit__` doesn't get called. So a little helper function called `__Pyx_MetaclassInit` has been added which takes advantage of the fact you can call `tp_new` with one argument.

``` python
class MyType(type):
    def __new__(*args):
        print("__new__ was called")
        return type.__new__(*args)
class MyClass(metaclass=MyType): pass

# "__new__ was called" gets printed to the console again
MyType(MyClass)
```

It gets called during the execution code phase rather than the type init phase in case the `__cinit__`/`__init__` methods depends on any global variables. `__prepare__` is not called at all from the Cython side of things (not sure if it's needed)

The `cdef dict __dict__` extensible type feature has been adjusted to work on metaclasses, meaning that you can also use this feature to make your extension types "moneypatch-able".
