### PR TITLE
cythonize keep_sources option -> sdist original files

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -878,7 +878,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                 new_sources.append(source)
                 if build_dir:
                     copy_to_build_dir(source)
-        m.sources = new_sources
+        if not hasattr(options, 'keep_sources') or not options.keep_sources:
+            m.sources = new_sources
 
     if hasattr(options, 'cache'):
         if not os.path.exists(options.cache):


### PR DESCRIPTION
Hi,

Thanks for this great project.

In some cases I'm interested in distributing an sdist which contains original .py/.pyx files and not the cythonized versions (.c)
When I know the users have cython it make the setup.py more simple, no need to handle the case cython present/not present ([example](http://stackoverflow.com/questions/4505747/how-should-i-structure-a-python-package-that-contains-cython-code))

So I thought about adding an option "keep_sources" to ```cythonize``` so that it doesn't replace python sources by c sources in the module objects. This lets sdist use the original py/pyx files.

Example of usage: https://gist.github.com/piec/adc5b81f21672f311c0fe2425bd67622

What do you think?

---
**Edit:** Alternative options in the [documentation](http://docs.cython.org/en/latest/src/reference/compilation.html#distributing-cython-modules)
 * "no_cythonize" which would work I suppose but is a bit ugly to add to many packages
 * This kind of thing
```
    extensions = [Extension("*", ["*.pyx"])],
    cmdclass={'build_ext': Cython.Build.build_ext},
```
The sdist is fine but I couldn't get a bdist working [gist](https://gist.github.com/piec/5d93b97b89aa229e48dda0001e4402a1) I think ```Extension("*", ...)``` is only valid in a ```cythonize(...)``` call