### PR TITLE
Do not warn for "cache" option

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -756,4 +756,5 @@ default_options = dict(
     common_utility_include_dir = None,
     output_dir=None,
     build_dir=None,
+    cache=None,
 )


### PR DESCRIPTION
Get rid of the warning
```
UserWarning: got unknown compilation option, please remove: cache
```
when calling `cythonize(..., cache=something)`.