### PR TITLE
check for build_ext object in import check

### DIFF
--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -2,16 +2,16 @@ import sys
 
 if 'setuptools' in sys.modules:
     try:
-        from setuptools.command import build_ext as _build_ext
+        from setuptools.command.build_ext import build_ext as _build_ext
     except ImportError:
         # We may be in the process of importing setuptools, which tries
         # to import this.
-        from distutils.command import build_ext as _build_ext
+        from distutils.command.build_ext import build_ext as _build_ext
 else:
-    from distutils.command import build_ext as _build_ext
+    from distutils.command.build_ext import build_ext as _build_ext
 
 
-class build_ext(_build_ext.build_ext, object):
+class build_ext(_build_ext, object):
     def finalize_options(self):
         if self.distribution.ext_modules:
             from Cython.Build.Dependencies import cythonize

--- a/Cython/Distutils/old_build_ext.py
+++ b/Cython/Distutils/old_build_ext.py
@@ -27,7 +27,7 @@ except Exception:
 if not from_setuptools and not from_pyximport:
     warnings.warn(
         "Cython.Distutils.old_build_ext does not properly handle dependencies "
-        "and is deprectated.")
+        "and is deprecated.")
 
 try:
     from __builtin__ import basestring


### PR DESCRIPTION
When setuptools imports from Cython (Python 3.5), setuptools.command.build_ext is defined, but setuptools.command.build_ext has no attribute .build_ext yet, causing the `_build_ext.build_ext` to fail with an AttributeError.

By attempting to import the object, rather than its containing module, the check is more thorough.

This appears to be necessary to build any extensions with setuptools on Python 3.5 with Cython 0.25a0.