### PR TITLE
set IGNORE_EXCEPTION_DETAIL on MyException test

### DIFF
--- a/tests/run/builtin_type_inheritance_T608.pyx
+++ b/tests/run/builtin_type_inheritance_T608.pyx
@@ -117,7 +117,7 @@ cdef class MyDict(dict):
 
 cdef class MyException(Exception):
     """
-    >>> raise MyException(3)
+    >>> raise MyException(3) # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     MyException: 3


### PR DESCRIPTION
Test is failing on Python 3 because output is:

    builtin_type_inheritance_T608.MyException: 3

on py3, but

     MyException: 3

on py2

IGNORE_EXCEPTION_DETAIL ignores the module prefix on py3.