### PR TITLE
Revert "test: assert that isinf returns -1 for negative infinity"

### DIFF
--- a/tests/run/numpy_math.pyx
+++ b/tests/run/numpy_math.pyx
@@ -37,8 +37,7 @@ def test_fp_classif():
     assert not npmath.isnan(d_zero)
     assert not npmath.isnan(f_zero)
 
-    assert npmath.isinf(npmath.INFINITY) == 1
-    assert npmath.isinf(-npmath.INFINITY) == -1
+    assert npmath.isinf(npmath.INFINITY)
     assert npmath.isnan(npmath.NAN)
 
     assert npmath.signbit(npmath.copysign(1., -1.))


### PR DESCRIPTION
This reverts commit 24cf7c9671b45e891a6c35b4f576fff3dff5c00e.

According to the numpy documentation npy_isinf merely provides an
equivalent of C99 isinf, which in turn is only required to return a
non-zero value for a given infinite argument.

The original commit breaks the test when compiled with clang & libc++.

cc @larsmans