### PR TITLE
add ext_opts parameter to cythonize (fixes #1480)

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -638,7 +638,7 @@ def create_dependency_tree(ctx=None, quiet=False):
 
 # This may be useful for advanced users?
 def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=False, language=None,
-                          exclude_failures=False):
+                          exclude_failures=False, ext_opts={}):
     if language is not None:
         print('Please put "# distutils: language=%s" in your .pyx or .pxd file(s)' % language)
     if exclude is None:
@@ -720,6 +720,11 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
                     for key, value in base.values.items():
                         if key not in kwds:
                             kwds[key] = value
+                for key, value in ext_opts.items():
+                    if key not in kwds:
+                        kwds[key] = value
+                    elif isinstance(kwds[key], list):
+                        kwds[key] += value if isinstance(value, list) else [value]
 
                 sources = [file]
                 if template is not None:
@@ -764,7 +769,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
 
 # This is the user-exposed entry point.
 def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, force=False, language=None,
-              exclude_failures=False, **options):
+              exclude_failures=False, ext_opts={}, **options):
     """
     Compile a set of source modules into C/C++ files and return a list of distutils
     Extension objects for them.
@@ -790,6 +795,11 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
     be used without compilation.
 
     Additional compilation options can be passed as keyword arguments.
+
+    To add C/C++ compilation options to all generated Extension objects, pass
+    a dictionary object as 'ext_opts'. For example:
+    'ext_opts={"include_dirs":numpy.get_include()}'
+
     """
     if exclude is None:
         exclude = []
@@ -810,7 +820,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
         quiet=quiet,
         exclude_failures=exclude_failures,
         language=language,
-        aliases=aliases)
+        aliases=aliases,
+        ext_opts=ext_opts)
     deps = create_dependency_tree(ctx, quiet=quiet)
     build_dir = getattr(options, 'build_dir', None)
 

--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -72,7 +72,7 @@ is up to date with its main source file and dependencies.
 Configuring the C-Build
 ------------------------
 
-If you have include files in non-standard places you can pass an
+If you have Cython include files in non-standard places you can pass an
 ``include_path`` parameter to ``cythonize``::
 
     from distutils.core import setup
@@ -83,10 +83,18 @@ If you have include files in non-standard places you can pass an
         ext_modules = cythonize("src/*.pyx", include_path = [...]),
     )
 
+To add C/C++ compiler options, e.g. the search path for C header files,
+pass a dictionary object as ``add_opts`` parameter. The dictionary
+values will be appended to the options of the generated Extension
+objects. Check the `distutils documentation`_ for a description of
+possible options.  Some useful options to know about
+are ``include_dirs``, ``libraries``, and ``library_dirs`` which specify where
+to find the ``.h`` and library files when linking to external libraries.
+
 Often, Python packages that offer a C-level API provide a way to find
 the necessary include files, e.g. for NumPy::
 
-    include_path = [numpy.get_include()]
+    add_opts={'include_path' = numpy.get_include()}
 
 Note for Numpy users.  Despite this, you will still get warnings like the
 following from the compiler, because Cython is using a deprecated Numpy API::
@@ -95,7 +103,8 @@ following from the compiler, because Cython is using a deprecated Numpy API::
 
 For the time being, it is just a warning that you can ignore.
 
-If you need to specify compiler options, libraries to link with or other
+If you need to specify individual compiler options per Cython module,
+libraries to link with or other
 linker options you will need to create ``Extension`` instances manually
 (note that glob syntax can still be used to specify multiple extensions
 in one line)::
@@ -150,9 +159,7 @@ as follows::
     )
 
 The :class:`Extension` class takes many options, and a fuller explanation can
-be found in the `distutils documentation`_. Some useful options to know about
-are ``include_dirs``, ``libraries``, and ``library_dirs`` which specify where
-to find the ``.h`` and library files when linking to external libraries.
+be found in the `distutils documentation`_.
 
 .. _distutils documentation: http://docs.python.org/extending/building.html
 


### PR DESCRIPTION
Trying to set default `Extension()` options by passing them to `cythonize()`
is a common mistake, being made even in the Cython docs (see #1480). This patch
adds the capability to append to the generated Extension options by passing a
dictionary as parameter `ext_opts` to `cythonize()`, and updates the documtentation
accordingly.