### PR TITLE
ENH: update test skip list for pypy

### DIFF
--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -4,30 +4,17 @@
 
 broken_exception
 bufaccess
-buffmt
-exarkun
 memoryview
 memslice
 sequential_parallel
-setjmp
+
 yield_from_pep380
 memoryview_inplace_division
-
-# GIL issues
-# https://bitbucket.org/pypy/pypy/issues/1778/pygilstate_ensure-should-not-deadlock
-run.exceptions_nogil
-run.nogil
-run.with_gil
-run.parallel
-run.pstats_profile_test
 
 # gc issue?
 memoryview_in_subclasses
 external_ref_reassignment
 run.exttype_dealloc
-
-# https://bitbucket.org/pypy/pypy/issue/2023/cpyext-pydict_keys-values-items-does-not
-builtin_subtype_methods_cy3
 
 # bugs in cpyext
 run.special_methods_T561
@@ -39,7 +26,7 @@ run.datetime_pxd
 run.datetime_cimport
 run.datetime_members
 run.extern_builtins_T258
-run.unicode_ascii_auto_encoding
-run.unicode_default_auto_encoding
-run.str_ascii_auto_encoding
-run.str_default_auto_encoding
+
+# refcounting-specific tests
+double_dealloc_T796
+


### PR DESCRIPTION
PyPy HEAD (not the official release) now passes more tests. There are tests not listed here that fail, perhaps this file should only be the ones that segfault?