### PR TITLE
errno.h on FreeBSD contains ENOATTR instead of ENODATA

### DIFF
--- a/Cython/Includes/libc/errno.pxd
+++ b/Cython/Includes/libc/errno.pxd
@@ -61,6 +61,7 @@ cdef extern from "<errno.h>" nogil:
         EBFONT
         ENOSTR
         ENODATA
+        ENOATTR
         ETIME
         ENOSR
         ENONET


### PR DESCRIPTION
So allow for that value in this enumeration.
Added immediately after ENODATA

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>