### PR TITLE
A few more wrappers in libcpp.algorithm and libcpp.vector

### DIFF
--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -7,12 +7,24 @@ cdef extern from "<algorithm>" namespace "std" nogil:
     bool binary_search[Iter, T, Compare](Iter first, Iter last, const T& value,
                                          Compare comp)
 
+    Iter lower_bound[Iter, T](Iter first, Iter last, const T& value)
+    Iter lower_bound[Iter, T, Compare](Iter first, Iter last, const T& value,
+                                       Compare comp)
+
+    Iter upper_bound[Iter, T](Iter first, Iter last, const T& value)
+    Iter upper_bound[Iter, T, Compare](Iter first, Iter last, const T& value,
+                                       Compare comp)
+
     void partial_sort[Iter](Iter first, Iter middle, Iter last)
     void partial_sort[Iter, Compare](Iter first, Iter middle, Iter last,
                                      Compare comp)
 
     void sort[Iter](Iter first, Iter last)
     void sort[Iter, Compare](Iter first, Iter last, Compare comp)
+
+    # Removing duplicates
+    Iter unique[Iter](Iter first, Iter last)
+    Iter unique[Iter, BinaryPredicate](Iter first, Iter last, BinaryPredicate p)
 
     # Binary heaps (priority queues)
     void make_heap[Iter](Iter first, Iter last)
@@ -29,4 +41,3 @@ cdef extern from "<algorithm>" namespace "std" nogil:
 
     # Copy
     OutputIter copy[InputIter,OutputIter](InputIter,InputIter,OutputIter)
-

--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -8,6 +8,7 @@ cdef extern from "<vector>" namespace "std" nogil:
             iterator operator--()
             iterator operator+(size_t)
             iterator operator-(size_t)
+            size_t operator-(iterator)
             bint operator==(iterator)
             bint operator!=(iterator)
             bint operator<(iterator)


### PR DESCRIPTION
A straightforward addition of std::unique(), std::lower_bound(), std::upper_bound() and std::vector::iterator::operator-(iterator).

Tested with this code: http://pastebin.com/fzySXX2A (output: http://pastebin.com/9yEFVkuC ), both with and without c++11 (setup.py: http://pastebin.com/87MH0VtR and http://pastebin.com/RSeKSaEW )