### PR TITLE
Fix cythonize(source_filename, cache=True) under Python 3

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -111,7 +111,8 @@ def nonempty(it, error_msg="expected non-empty iterator"):
 @cached_function
 def file_hash(filename):
     path = os.path.normpath(filename.encode("UTF-8"))
-    m = hashlib.md5(str(len(path)) + ":")
+    prefix = (str(len(path)) + ":").encode("UTF-8")
+    m = hashlib.md5(prefix)
     m.update(path)
     f = open(filename, 'rb')
     try:
@@ -565,13 +566,13 @@ class DependencyTree(object):
 
     def transitive_fingerprint(self, filename, extra=None):
         try:
-            m = hashlib.md5(__version__)
-            m.update(file_hash(filename))
+            m = hashlib.md5(__version__.encode('UTF-8'))
+            m.update(file_hash(filename).encode('UTF-8'))
             for x in sorted(self.all_dependencies(filename)):
                 if os.path.splitext(x)[1] not in ('.c', '.cpp', '.h'):
-                    m.update(file_hash(x))
+                    m.update(file_hash(x).encode('UTF-8'))
             if extra is not None:
-                m.update(str(extra))
+                m.update(str(extra).encode('UTF-8'))
             return m.hexdigest()
         except IOError:
             return None


### PR DESCRIPTION
The hash digest cannot be computed under Python 3 because of a few missing string `encode` calls (to get  hashable bytes). Here is a example when trying to enable the cythonize cache to build scikit-learn:

```
Traceback (most recent call last):
  File "setup.py", line 268, in <module>
    setup_package()
  File "setup.py", line 264, in setup_package
    setup(**metadata)
  File "/home/ogrisel/.virtualenvs/py35/lib/python3.5/site-packages/numpy/distutils/core.py", line 135, in setup
    config = configuration()
  File "setup.py", line 135, in configuration
    config.add_subpackage('sklearn')
  File "/home/ogrisel/.virtualenvs/py35/lib/python3.5/site-packages/numpy/distutils/misc_util.py", line 1000, in add_subpackage
    caller_level = 2)
  File "/home/ogrisel/.virtualenvs/py35/lib/python3.5/site-packages/numpy/distutils/misc_util.py", line 969, in get_subpackage
    caller_level = caller_level + 1)
  File "/home/ogrisel/.virtualenvs/py35/lib/python3.5/site-packages/numpy/distutils/misc_util.py", line 906, in _get_configuration_from_setup_py
    config = setup_module.configuration(*args)
  File "sklearn/setup.py", line 82, in configuration
    maybe_cythonize_extensions(top_path, config)
  File "/home/ogrisel/code/scikit-learn/sklearn/_build_utils/__init__.py", line 84, in maybe_cythonize_extensions
    config.ext_modules = cythonize(config.ext_modules, cache='/home/ogrisel/.cycache')
  File "/home/ogrisel/code/cython/Cython/Build/Dependencies.py", line 876, in cythonize
    fingerprint = deps.transitive_fingerprint(source, extra)
  File "/home/ogrisel/code/cython/Cython/Build/Dependencies.py", line 568, in transitive_fingerprint
    m = hashlib.md5(__version__)
TypeError: Unicode-objects must be encoded before hashing
```

This PR fixes the issue. I am not sure where to add a test for this.

Auxiliary question: the cache option of Cython does not seem to be documented anywhere (and apparently is not tested either). Is this a supported feature or are there known issues?