### PR TITLE
Optimize string comparisons

### DIFF
--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -193,11 +193,19 @@ static CYTHON_INLINE int __Pyx_PyUnicode_Equals(PyObject* s1, PyObject* s2, int 
             goto return_ne;
         }
 #if CYTHON_COMPILING_IN_CPYTHON
+#if PY_MAJOR_VAERSION < 3
         if (((PyUnicodeObject*)s1)->hash != ((PyUnicodeObject*)s2)->hash
             && ((PyUnicodeObject*)s1)->hash != -1 && ((PyUnicodeObject*)s2)->hash != -1)
         {
             goto return_ne;
         }
+#else
+        if (((PyASCIIObject*)s1)->hash != ((PyASCIIObject*)s2)->hash
+            && ((PyASCIIObject*)s1)->hash != -1 && ((PyASCIIObject*)s2)->hash != -1)
+        {
+            goto return_ne;
+        }
+#endif
 #endif
         // len(s1) == len(s2) >= 1  (empty string is interned, and "s1 is not s2")
         kind = __Pyx_PyUnicode_KIND(s1);

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -193,15 +193,15 @@ static CYTHON_INLINE int __Pyx_PyUnicode_Equals(PyObject* s1, PyObject* s2, int 
             goto return_ne;
         }
 #if CYTHON_COMPILING_IN_CPYTHON
-#if PY_MAJOR_VAERSION < 3
-        if (((PyUnicodeObject*)s1)->hash != ((PyUnicodeObject*)s2)->hash
-            && ((PyUnicodeObject*)s1)->hash != -1 && ((PyUnicodeObject*)s2)->hash != -1)
+#if CYTHON_PEP393_ENABLED
+        if (((PyASCIIObject*)s1)->hash != ((PyASCIIObject*)s2)->hash
+            && ((PyASCIIObject*)s1)->hash != -1 && ((PyASCIIObject*)s2)->hash != -1)
         {
             goto return_ne;
         }
 #else
-        if (((PyASCIIObject*)s1)->hash != ((PyASCIIObject*)s2)->hash
-            && ((PyASCIIObject*)s1)->hash != -1 && ((PyASCIIObject*)s2)->hash != -1)
+        if (((PyUnicodeObject*)s1)->hash != ((PyUnicodeObject*)s2)->hash
+            && ((PyUnicodeObject*)s1)->hash != -1 && ((PyUnicodeObject*)s2)->hash != -1)
         {
             goto return_ne;
         }

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -14,6 +14,7 @@ static int __Pyx_InitStrings(__Pyx_StringTabEntry *t); /*proto*/
 //////////////////// InitStrings ////////////////////
 
 static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
+    long hash;
     while (t->p) {
         #if PY_MAJOR_VERSION < 3
         if (t->is_unicode) {
@@ -38,6 +39,9 @@ static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
         #endif
         if (!*t->p)
             return -1;
+        hash = PyObject_Hash(*t->p);
+        if (hash == -1)
+            PyErr_Clear();
         ++t;
     }
     return 0;

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -263,13 +263,6 @@ static CYTHON_INLINE int __Pyx_PyBytes_Equals(PyObject* s1, PyObject* s2, int eq
         Py_ssize_t length = PyBytes_GET_SIZE(s1);
         if (length != PyBytes_GET_SIZE(s2))
             return (equals == Py_NE);
-#if CYTHON_COMPILING_IN_CPYTHON
-        if (((PyBytesObject*)s1)->ob_shash != ((PyBytesObject*)s2)->ob_shash
-            && ((PyBytesObject*)s1)->ob_shash != -1 && ((PyBytesObject*)s2)->ob_shash != -1)
-        {
-            return (equals == Py_NE);
-        }
-#endif
         // len(s1) == len(s2) >= 1  (empty string is interned, and "s1 is not s2")
         ps1 = PyBytes_AS_STRING(s1);
         ps2 = PyBytes_AS_STRING(s2);
@@ -278,6 +271,13 @@ static CYTHON_INLINE int __Pyx_PyBytes_Equals(PyObject* s1, PyObject* s2, int eq
         } else if (length == 1) {
             return (equals == Py_EQ);
         } else {
+#if CYTHON_COMPILING_IN_CPYTHON
+            if (((PyBytesObject*)s1)->ob_shash != ((PyBytesObject*)s2)->ob_shash
+                && ((PyBytesObject*)s1)->ob_shash != -1 && ((PyBytesObject*)s2)->ob_shash != -1)
+            {
+                return (equals == Py_NE);
+            }
+#endif
             int result = memcmp(ps1, ps2, (size_t)length);
             return (equals == Py_EQ) ? (result == 0) : (result != 0);
         }

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -188,6 +188,13 @@ static CYTHON_INLINE int __Pyx_PyUnicode_Equals(PyObject* s1, PyObject* s2, int 
         if (length != __Pyx_PyUnicode_GET_LENGTH(s2)) {
             goto return_ne;
         }
+#if CYTHON_COMPILING_IN_CPYTHON
+        if (((PyUnicodeObject*)s1)->hash != ((PyUnicodeObject*)s2)->hash
+            && ((PyUnicodeObject*)s1)->hash != -1 && ((PyUnicodeObject*)s2)->hash != -1)
+        {
+            goto return_ne;
+        }
+#endif
         // len(s1) == len(s2) >= 1  (empty string is interned, and "s1 is not s2")
         kind = __Pyx_PyUnicode_KIND(s1);
         if (kind != __Pyx_PyUnicode_KIND(s2)) {
@@ -252,6 +259,13 @@ static CYTHON_INLINE int __Pyx_PyBytes_Equals(PyObject* s1, PyObject* s2, int eq
         Py_ssize_t length = PyBytes_GET_SIZE(s1);
         if (length != PyBytes_GET_SIZE(s2))
             return (equals == Py_NE);
+#if CYTHON_COMPILING_IN_CPYTHON
+        if (((PyBytesObject*)s1)->ob_shash != ((PyBytesObject*)s2)->ob_shash
+            && ((PyBytesObject*)s1)->ob_shash != -1 && ((PyBytesObject*)s2)->ob_shash != -1)
+        {
+            return (equals == Py_NE);
+        }
+#endif
         // len(s1) == len(s2) >= 1  (empty string is interned, and "s1 is not s2")
         ps1 = PyBytes_AS_STRING(s1);
         ps2 = PyBytes_AS_STRING(s2);


### PR DESCRIPTION
Avoid doing the bulk compare if string hashes are initialized and unequal.

Let comparisons against literals take advantage of this optimization by initializing their hashes at import time.

The following benchmark yields a 10% speedup on the best case, and a 2% slowdown on the very worst case (albeit a somewhat contrived worst case). On average, I'd expect it to be an overall improvement in-between those numbers:

``` python
import timeit
import cython

@cython.ccall
@cython.locals(x=bytes)
def f(x):
   return x in (b'1234', b'4321', b'2321')

def main():
   print timeit.timeit(lambda:f(b'4242'), number=100000000)
```

While subtle, it could make a significant difference in string-heavy code.