### PR TITLE
Fix Python 2 and 3 have diffrent default encoding

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -138,7 +138,8 @@ def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
     tempfilename = make_command_file(path_to_debug_info, no_import=no_import)
     logger.info("Launching %s with command file: %s and gdb_argv: %s",
         options.gdb, tempfilename, gdb_argv)
-    logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, open(tempfilename).read())
+    tempfile_fd = open(tempfilename)
+    logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, tempfile_fd.read())
     logger.info("Spawning %s...", options.gdb)
     p = subprocess.Popen([options.gdb, '-command', tempfilename] + gdb_argv)
     logger.info("Spawned %s (pid %d)", options.gdb, p.pid)
@@ -151,6 +152,8 @@ def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
             pass
         else:
             break
+    logger.debug("Closing temp command file with fd: %s", tempfile_fd)
+    tempfile_fd.close()
     logger.debug("Removing temp command file: %s", tempfilename)
     os.remove(tempfilename)
     logger.debug("Removed temp command file: %s", tempfilename)

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -138,22 +138,21 @@ def main(path_to_debug_info=None, gdb_argv=None, no_import=False):
     tempfilename = make_command_file(path_to_debug_info, no_import=no_import)
     logger.info("Launching %s with command file: %s and gdb_argv: %s",
         options.gdb, tempfilename, gdb_argv)
-    tempfile_fd = open(tempfilename)
-    logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, tempfile_fd.read())
-    logger.info("Spawning %s...", options.gdb)
-    p = subprocess.Popen([options.gdb, '-command', tempfilename] + gdb_argv)
-    logger.info("Spawned %s (pid %d)", options.gdb, p.pid)
-    while True:
-        try:
-            logger.debug("Waiting for gdb (pid %d) to exit...", p.pid)
-            ret = p.wait()
-            logger.debug("Wait for gdb (pid %d) to exit is done. Returned: %r", p.pid, ret)
-        except KeyboardInterrupt:
-            pass
-        else:
-            break
-    logger.debug("Closing temp command file with fd: %s", tempfile_fd)
-    tempfile_fd.close()
+    with open(tempfilename) as tempfile:
+        logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, tempfile.read())
+        logger.info("Spawning %s...", options.gdb)
+        p = subprocess.Popen([options.gdb, '-command', tempfilename] + gdb_argv)
+        logger.info("Spawned %s (pid %d)", options.gdb, p.pid)
+        while True:
+            try:
+                logger.debug("Waiting for gdb (pid %d) to exit...", p.pid)
+                ret = p.wait()
+                logger.debug("Wait for gdb (pid %d) to exit is done. Returned: %r", p.pid, ret)
+            except KeyboardInterrupt:
+                pass
+            else:
+                break
+        logger.debug("Closing temp command file with fd: %s", tempfile.fileno())
     logger.debug("Removing temp command file: %s", tempfilename)
     os.remove(tempfilename)
     logger.debug("Removed temp command file: %s", tempfilename)

--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -18,6 +18,13 @@ import collections
 
 import gdb
 
+try:  # py3k
+    UNICODE = unicode
+    BYTES = str
+except NameError:  # py2k
+    UNICODE = str
+    BYTES = bytes
+
 try:
     from lxml import etree
     have_lxml = True
@@ -689,7 +696,8 @@ class CyImport(CythonCommand):
     completer_class = gdb.COMPLETE_FILENAME
 
     def invoke(self, args, from_tty):
-        args = args.encode(_filesystemencoding)
+        if isinstance(args, BYTES):
+            args = args.decode(_filesystemencoding)
         for arg in string_to_argv(args):
             try:
                 f = open(arg)

--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -842,7 +842,9 @@ class CyBreak(CythonCommand):
                 gdb.execute('break %s' % func.pf_cname)
 
     def invoke(self, function_names, from_tty):
-        argv = string_to_argv(function_names.encode('UTF-8'))
+        if isinstance(function_names, BYTES):
+            function_names = function_names.decode(_filesystemencoding)
+        argv = string_to_argv(function_names)
         if function_names.startswith('-p'):
             argv = argv[1:]
             python_breakpoints = True

--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -18,10 +18,10 @@ import collections
 
 import gdb
 
-try:  # py3k
+try:  # python 2
     UNICODE = unicode
     BYTES = str
-except NameError:  # py2k
+except NameError:  # python 3
     UNICODE = str
     BYTES = bytes
 


### PR DESCRIPTION
```
/usr/local/lib/python3.5/dist-packages/Cython-0.25.2-py3.5-linux-x86_64.egg/Cython/Debugger/Cygdb.py:141: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/tmp7zs49q09' mode='r' encoding='UTF-8'>
  logger.debug('Command file (%s) contains: """\n%s"""', tempfilename, open(tempfilename).read())
GNU gdb (Ubuntu 7.11.1-0ubuntu1~16.04) 7.11.1
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
Python Exception <class 'TypeError'> argument 1 must be str, not bytes: 
/tmp/tmp7zs49q09:21: Error in sourced command file:
Error occurred in Python command: argument 1 must be str, not bytes
```

fixed.