### PR TITLE
Support python 2's almost-raw ur'' literals

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -920,7 +920,7 @@ def p_string_literal(s, kind_override=None):
             if is_python3_source and not has_non_ascii_literal_characters and check_for_non_ascii_characters(systr):
                 has_non_ascii_literal_characters = True
         elif sy == 'ESCAPE':
-            if is_raw:
+            if is_raw and (is_python3_source or systr[1] not in u'Uu'):
                 chars.append(systr)
                 if is_python3_source and not has_non_ascii_literal_characters \
                        and check_for_non_ascii_characters(systr):


### PR DESCRIPTION
>Python 2 allows ur'' literals to contain `\u` and `\U` escapes which are actually parsed as unicode escapes instead of literally '\\' 'u'.

I was going to write test cases but I'm not sure where to put them! This does actually fix the problem I was having where code relied on this, though.