### PR TITLE
C++ fixes

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -257,7 +257,7 @@ class CythonMagics(Magics):
 
         if need_cythonize:
             c_include_dirs = args.include
-            c_src_files = map(str, args.src)
+            c_src_files = list(map(str, args.src))
             if 'numpy' in code:
                 import numpy
                 c_include_dirs.append(numpy.get_include())

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4102,7 +4102,7 @@ def best_match(arg_types, functions, pos=None, env=None, args=None):
                 [pattern.type.deduce_template_params(actual) for (pattern, actual) in zip(func_type.args, arg_types)],
                 {})
             if deductions is None:
-                errors.append((func, "Unable to deduce type parameters for %s given %s" % (pattern.type, actual)))
+                errors.append((func, "Unable to deduce type parameters for %s given (%s)" % (func_type, ', '.join(map(str, arg_types)))))
             elif len(deductions) < len(func_type.templates):
                 errors.append((func, "Unable to deduce type parameter %s" % (
                     ", ".join([param.name for param in set(func_type.templates) - set(deductions.keys())]))))


### PR DESCRIPTION
I am not sure where to add a test for this: the repro code looks like:

```
from libcpp.vector cimport vector
cimport numpy as np

cdef f(vector[np.int64_t]& out_vector):
    cdef size_t count = 5  # any value
    cdef np.int64_t value = 0  # any value

    out_vector.insert(out_vector.end(), count, value)
```
 
This uses the following dispatch: `iterator insert(const_iterator pos, size_type count, const T& value)`

The problem is that the template dispatch is tried first:
```
template< class InputIt >
iterator insert(const_iterator pos, InputIt first, InputIt last)
```
but this fails to specialize because `size_t` is not an input iterator. This tries to add a possible error to the list; however, the code references undefined variables (in Py3).