### PR TITLE
Vector cleanups

### DIFF
--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -2,13 +2,20 @@ cdef extern from "<vector>" namespace "std" nogil:
     cdef cppclass vector[T,ALLOCATOR=*]:
         ctypedef T value_type
         ctypedef ALLOCATOR allocator_type
+
+        # these should really be allocator_type.size_type and
+        # allocator_type.difference_type to be true to the C++ definition
+        # but cython doesn't support defered access on template arguments
+        ctypedef size_t size_type
+        ctypedef ptrdiff_t difference_type
+
         cppclass iterator:
             T& operator*()
             iterator operator++()
             iterator operator--()
-            iterator operator+(size_t)
-            iterator operator-(size_t)
-            size_t operator-(iterator)
+            iterator operator+(size_type)
+            iterator operator-(size_type)
+            difference_type operator-(iterator)
             bint operator==(iterator)
             bint operator!=(iterator)
             bint operator<(iterator)
@@ -19,8 +26,8 @@ cdef extern from "<vector>" namespace "std" nogil:
             T& operator*()
             iterator operator++()
             iterator operator--()
-            iterator operator+(size_t)
-            iterator operator-(size_t)
+            iterator operator+(size_type)
+            iterator operator-(size_type)
             bint operator==(reverse_iterator)
             bint operator!=(reverse_iterator)
             bint operator<(reverse_iterator)
@@ -33,10 +40,10 @@ cdef extern from "<vector>" namespace "std" nogil:
             pass
         vector() except +
         vector(vector&) except +
-        vector(size_t) except +
-        vector(size_t, T&) except +
+        vector(size_type) except +
+        vector(size_type, T&) except +
         #vector[input_iterator](input_iterator, input_iterator)
-        T& operator[](size_t)
+        T& operator[](size_type)
         #vector& operator=(vector&)
         bint operator==(vector&, vector&)
         bint operator!=(vector&, vector&)
@@ -44,13 +51,13 @@ cdef extern from "<vector>" namespace "std" nogil:
         bint operator>(vector&, vector&)
         bint operator<=(vector&, vector&)
         bint operator>=(vector&, vector&)
-        void assign(size_t, const T&)
+        void assign(size_type, const T&)
         void assign[input_iterator](input_iterator, input_iterator) except +
-        T& at(size_t) except +
+        T& at(size_type) except +
         T& back()
         iterator begin()
         const_iterator const_begin "begin"()
-        size_t capacity()
+        size_type capacity()
         void clear()
         bint empty()
         iterator end()
@@ -59,19 +66,19 @@ cdef extern from "<vector>" namespace "std" nogil:
         iterator erase(iterator, iterator)
         T& front()
         iterator insert(iterator, const T&) except +
-        void insert(iterator, size_t, const T&) except +
-        void insert[Iter](iterator, Iter, Iter) except +
-        size_t max_size()
+        iterator insert(iterator, size_type, const T&) except +
+        iterator insert[Iter](iterator, Iter, Iter) except +
+        size_type max_size()
         void pop_back()
         void push_back(T&) except +
         reverse_iterator rbegin()
-        const_reverse_iterator const_rbegin "rbegin"()
+        const_reverse_iterator const_rbegin "crbegin"()
         reverse_iterator rend()
-        const_reverse_iterator const_rend "rend"()
-        void reserve(size_t)
-        void resize(size_t) except +
-        void resize(size_t, T&) except +
-        size_t size()
+        const_reverse_iterator const_rend "crend"()
+        void reserve(size_type)
+        void resize(size_type) except +
+        void resize(size_type, T&) except +
+        size_type size()
         void swap(vector&)
 
         # C++11 methods

--- a/tests/run/cpp_stl_vector.pyx
+++ b/tests/run/cpp_stl_vector.pyx
@@ -195,3 +195,18 @@ def test_typedef_vector(L):
     vb.insert(vb.begin(), vb2.begin(), vb2.end())
 
     return vi, vi.at(0), vb, vb.at(0)
+
+
+def test_insert():
+    """
+    >>> test_insert()
+    """
+    cdef vector[int] v
+    cdef vector[int].size_type count = 5
+    cdef int value = 0
+
+    v.insert(v.end(), count, value)
+
+    assert v.size() == count
+    for element in v:
+        assert element == value, '%s != %s' % (element, count)


### PR DESCRIPTION
Adds test case for #1596

While I was there, I noticed that there was no `size_type` or `difference_type`.

This test fails (with `size_type` switched to `size_t`) before my commit with the same crash I was seeing.