### PR TITLE
Un-disable Python3-specific slots on pypy3.5

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -694,7 +694,7 @@ property_accessor_signatures = {
 #
 #------------------------------------------------------------------------------------------
 
-PyNumberMethods_Py3_GUARD = "PY_MAJOR_VERSION < 3 || CYTHON_COMPILING_IN_PYPY"
+PyNumberMethods_Py3_GUARD = "PY_MAJOR_VERSION < 3 || (CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x03050000)"
 
 PyNumberMethods = (
     MethodSlot(binaryfunc, "nb_add", "__add__"),


### PR DESCRIPTION
Context: we (the pypy devs) are working on pypy3 compatibility with Python 3.5, including C-API support, with a first 3.5-compatible release expected in a few weeks. 

The previous releases of pypy3 (implementing 3.2 and 3.3) hadn't updated their nb_* slots definitions to Python 3, but this has been fixed in the pypy3 nightlies, so the pypy3-specific workaround is no longer necessary.