### PR TITLE
Update language_basics.rst: corrected an example

### DIFF
--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -106,7 +106,7 @@ can group them into a :keyword:`cdef` block like this::
             int tons
 
         int i
-        float f
+        float a
         Spam *p
 
         void f(Spam *s):


### PR DESCRIPTION
The example
```cython
cdef:
    struct Spam:
        int tons

    int i
    float f
    Spam *p

    void f(Spam *s):
        print(s.tons, "Tons of spam")
```
produces the error
```
Error compiling Cython file:
------------------------------------------------------------
...

    int i
    float f
    Spam *p

    void f(Spam *s):
   ^
------------------------------------------------------------

/home/fabian/.cache/ipython/cython/_cython_magic_1754f7a2d1965e143dc9fe6d26b00c19.pyx:10:4: Function signature does not match previous declaration
```
because of `float f`and `void f`. This is solved by e.g. renaming `float f` to `float a`.