### PR TITLE
Pass metaclass as PyObject* (and not PyTypeObject*)

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8493,7 +8493,7 @@ class Py3ClassNode(ExprNode):
         else:
             mkw = 'NULL'
         if self.metaclass:
-            metaclass = self.metaclass.result()
+            metaclass = self.metaclass.py_result()
         else:
             metaclass = "((PyObject*)&__Pyx_DefaultClassType)"
         code.putln(
@@ -8579,7 +8579,7 @@ class PyClassNamespaceNode(ExprNode, ModuleNameMixin):
         else:
             mkw = '(PyObject *) NULL'
         if self.metaclass:
-            metaclass = self.metaclass.result()
+            metaclass = self.metaclass.py_result()
         else:
             metaclass = "(PyObject *) NULL"
         code.putln(


### PR DESCRIPTION
In the functions `__Pyx_Py3MetaclassPrepare` and `__Pyx_Py3ClassCreate`, the `metaclass` argument is of type `PyObject*` but it is sometimes passed as `PyTypeObject*`. This gives compiler warnings of the form
```
build/cythonized/sage/misc/classcall_metaclass.c:3077:36: warning: passing argument 1 of ‘__Pyx_Py3ClassCreate’ from incompatible pointer type
   __pyx_t_4 = __Pyx_Py3ClassCreate(__pyx_ptype_4sage_4misc_19classcall_metaclass_ClasscallMetaclass, __pyx_n_s_C3, __pyx_t_1, __pyx_t_3, __pyx_t_2, 1, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 524, __pyx_L1_error)                                                                                                                         
                                    ^                                                                                                                                   
build/cythonized/sage/misc/classcall_metaclass.c:926:18: note: expected ‘struct PyObject *’ but argument is of type ‘struct PyTypeObject *’                             
 static PyObject *__Pyx_Py3ClassCreate(PyObject *metaclass, PyObject *name, PyObject *bases, PyObject *dict,
```