### PR TITLE
Pass first arg of visitproc as PyObject*

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1495,10 +1495,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         for entry in py_attrs:
             var_code = "p->%s" % entry.cname
+            var_as_pyobject = PyrexTypes.typecast(py_object_type, entry.type, var_code)
             code.putln("if (%s) {" % var_code)
-            if entry.type.is_extension_type:
-                var_code = "((PyObject*)%s)" % var_code
-            code.putln("e = (*v)(%s, a); if (e) return e;" % var_code)
+            code.putln("e = (*v)(%s, a); if (e) return e;" % var_as_pyobject)
             code.putln("}")
 
         # Traverse buffer exporting objects.


### PR DESCRIPTION
Similar to #1621, this avoids some compiler warnings like
```
build/cythonized/sage/categories/category_singleton.c:3133:14: warning: passing argument 1 of ‘v’ from incompatible pointer type
     e = (*v)(p->_parent_class_of_category, a); if (e) return e;
              ^
build/cythonized/sage/categories/category_singleton.c:3133:14: note: expected ‘struct PyObject *’ but argument is of type ‘struct PyTypeObject *’
```