### PR TITLE
Let IPython magic only import things in `"__all__"`

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -95,15 +95,16 @@ class CythonMagics(Magics):
     def _import_all(self, module):
         mdict = module.__dict__
         if '__all__' in mdict:
-            for k in mdict['__all__']:
-                if k in mdict:
-                    self.shell.push({k:mdict[k]})
-                else:
-                    raise AttributeError("'module' object has no attribute '%s'" % k)
+            keys = mdict['__all__']
         else:
-            for k, v in mdict.items():
-                if not k.startswith('__'):
-                    self.shell.push({k:v})
+            keys = [k for k in mdict if not k.startswith('_')]
+
+        for k in keys:
+            try:
+                self.shell.push({k: mdict[k]})
+            except KeyError:
+                msg = "'module' object has no attribute '%s'" % k
+                raise AttributeError(msg)
 
     @cell_magic
     def cython_inline(self, line, cell):

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -87,7 +87,7 @@ from .Dependencies import cythonize
 class CythonMagics(Magics):
 
     def __init__(self, shell):
-        super(CythonMagics,self).__init__(shell)
+        super(CythonMagics, self).__init__(shell)
         self._reloads = {}
         self._code_cache = {}
         self._pyximport_installed = False
@@ -237,7 +237,7 @@ class CythonMagics(Magics):
             ...
         """
         args = magic_arguments.parse_argstring(self.cython, line)
-        code = cell if cell.endswith('\n') else cell+'\n'
+        code = cell if cell.endswith('\n') else cell + '\n'
         lib_dir = os.path.join(get_ipython_cache_dir(), 'cython')
         quiet = True
         key = code, line, sys.version_info, sys.executable, cython_version
@@ -275,14 +275,14 @@ class CythonMagics(Magics):
             with io.open(pyx_file, 'w', encoding='utf-8') as f:
                 f.write(code)
             extension = Extension(
-                name = module_name,
-                sources = [pyx_file] + c_src_files,
-                include_dirs = c_include_dirs,
-                library_dirs = args.library_dirs,
-                extra_compile_args = args.compile_args,
-                extra_link_args = args.link_args,
-                libraries = args.lib,
-                language = 'c++' if args.cplus else 'c',
+                name=module_name,
+                sources=[pyx_file] + c_src_files,
+                include_dirs=c_include_dirs,
+                library_dirs=args.library_dirs,
+                extra_compile_args=args.compile_args,
+                extra_link_args=args.link_args,
+                libraries=args.lib,
+                language='c++' if args.cplus else 'c',
             )
             build_extension = self._get_build_extension()
             try:
@@ -302,7 +302,7 @@ class CythonMagics(Magics):
 
         if not have_module:
             build_extension.build_temp = os.path.dirname(pyx_file)
-            build_extension.build_lib  = lib_dir
+            build_extension.build_lib = lib_dir
             build_extension.run()
             self._code_cache[key] = module_name
 
@@ -370,10 +370,10 @@ class CythonMagics(Magics):
         return html
 
 __doc__ = __doc__.format(
-                # rST doesn't see the -+ flag as part of an option list, so we
-                # hide it from the module-level docstring.
-                CYTHON_DOC = dedent(CythonMagics.cython.__doc__\
-                            .replace('-+, --cplus','--cplus    ')),
-                CYTHON_INLINE_DOC = dedent(CythonMagics.cython_inline.__doc__),
-                CYTHON_PYXIMPORT_DOC = dedent(CythonMagics.cython_pyximport.__doc__),
+    # rST doesn't see the -+ flag as part of an option list, so we
+    # hide it from the module-level docstring.
+    CYTHON_DOC=dedent(CythonMagics.cython.__doc__\
+                                  .replace('-+, --cplus', '--cplus    ')),
+    CYTHON_INLINE_DOC=dedent(CythonMagics.cython_inline.__doc__),
+    CYTHON_PYXIMPORT_DOC=dedent(CythonMagics.cython_pyximport.__doc__),
 )


### PR DESCRIPTION
Make the IPython cell magic only import things in `"__all__"` when `"__all__"` exits in the cython cell.
I feel that this makes the cython cells not to pollute the space names unintentionally.

BTW, not clear why the import only skip the variables starts with `__`. In Python, from module import star will also skip the single underscores `_`.