### PR TITLE
Include except clause for PyTuple_SetItem in CPython-Includes

### DIFF
--- a/Cython/Includes/cpython/tuple.pxd
+++ b/Cython/Includes/cpython/tuple.pxd
@@ -45,7 +45,7 @@ cdef extern from "Python.h":
     # Return value: New reference.
     # Take a slice of the tuple pointed to by p from low to high and return it as a new tuple.
 
-    int PyTuple_SetItem(object  p, Py_ssize_t pos, object  o)
+    int PyTuple_SetItem(object  p, Py_ssize_t pos, object  o) except -1
     # Insert a reference to object o at position pos of the tuple
     # pointed to by p. Return 0 on success. Note: This function
     # ``steals'' a reference to o.


### PR DESCRIPTION
Otherwise this will raise `SystemError: <built-in function ...> returned a result with an error set` when failing. 

For example:

```
%load_ext cython
%%cython
    
from cpython.tuple cimport PyTuple_SetItem

cpdef test():
    cdef Py_ssize_t b = 5
    PyTuple_SetItem((1,2,3), b, 2)
    return 10

test()
```