### PR TITLE
Store the input metadata, rather than the output metadata, in create_extension

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -645,10 +645,7 @@ def default_create_extension(template, kwds):
         depends = resolve_depends(kwds['depends'], include_dirs)
         kwds['depends'] = sorted(set(depends + template.depends))
 
-    t = template.__class__
-    ext = t(**kwds)
-    metadata = dict(distutils=kwds, module_name=kwds['name'])
-    return (ext, metadata)
+    return template.__class__(**kwds)
 
 
 # This may be useful for advanced users?
@@ -762,8 +759,12 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
                 module_list.append(m)
 
                 # Store metadata (this will be written as JSON in the
-                # generated C file but otherwise has no purpose)
-                module_metadata[module_name] = metadata
+                # generated C file and may be used to instantiate
+                # extensions when Cython is not installed)
+                module_metadata[module_name] = {
+                    'module_name': module_name,
+                    'distutils': kwds,
+                }
 
                 if file not in m.sources:
                     # Old setuptools unconditionally replaces .pyx with .c

--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -174,12 +174,8 @@ This function takes 2 arguments ``template`` and ``kwds``, where
 ``template`` is the :class:`Extension` object given as input to Cython
 and ``kwds`` is a :class:`dict` with all keywords which should be used
 to create the :class:`Extension`.
-The function ``create_extension`` must return a 2-tuple
-``(extension, metadata)``, where ``extension`` is the created
-:class:`Extension` and ``metadata`` is metadata which will be written
-as JSON at the top of the generated C files. This metadata is only used
-for debugging purposes, so you can put whatever you want in there
-(as long as it can be converted to JSON).
+The function ``create_extension`` returns the :class:`Extension` object
+that will be passed to distutils for compilation.
 The default function (defined in ``Cython.Build.Dependencies``) is::
 
     def default_create_extension(template, kwds):
@@ -188,10 +184,7 @@ The default function (defined in ``Cython.Build.Dependencies``) is::
             depends = resolve_depends(kwds['depends'], include_dirs)
             kwds['depends'] = sorted(set(depends + template.depends))
 
-        t = template.__class__
-        ext = t(**kwds)
-        metadata = dict(distutils=kwds, module_name=kwds['name'])
-        return (ext, metadata)
+        return template.__class__(**kwds)
 
 In case that you pass a string instead of an :class:`Extension` to
 ``cythonize()``, the ``template`` will be an :class:`Extension` without


### PR DESCRIPTION
Code such as https://gist.github.com/robertwb/25ab9838cc2b9b21eed646834cf4a108 could then use this hook to tailor extensions to the environment, and the generated C could be kept more platform independent. 

@jdemeyer 