### PR TITLE
Fix a compiler crash when casting to a memoryview

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10130,7 +10130,9 @@ class CythonArrayNode(ExprNode):
         return self.get_cython_array_type(env)
 
     def get_cython_array_type(self, env):
-        return env.global_scope().context.cython_scope.viewscope.lookup("array").type
+        cython_scope = env.global_scope().context.cython_scope
+        cython_scope.load_cythonscope()
+        return cython_scope.viewscope.lookup("array").type
 
     def generate_result_code(self, code):
         from . import Buffer


### PR DESCRIPTION
Before this patch, the compiler would crash on this simple program:

    <double[:4]>NULL

or on any other cast to a memoryview without first explicitly declaring a memoryview variable.

The error message was this:

```
cython_memviews.pyx:1:0: Compiler crash in AnalyseExpressionsTransform

File 'Nodes.py', line 430, in analyse_expressions: StatListNode(cython_memviews.pyx:1:0)
File 'Nodes.py', line 4746, in analyse_expressions: ExprStatNode(cython_memviews.pyx:1:0)
File 'ExprNodes.py', line 519, in analyse_expressions: CythonArrayNode(cython_memviews.pyx:1:0,
    is_temp = True,
    mode = 'c',
    use_managed_ref = True)
File 'ExprNodes.py', line 10108, in analyse_types: CythonArrayNode(cython_memviews.pyx:1:0,
    is_temp = True,
    mode = 'c',
    use_managed_ref = True)
File 'ExprNodes.py', line 10123, in get_cython_array_type: CythonArrayNode(cython_memviews.pyx:1:0,
    is_temp = True,
    mode = 'c',
    use_managed_ref = True)

Compiler crash traceback from this point on:
  File "[...]/.local/lib64/python3.4/site-packages/Cython/Compiler/ExprNodes.py", line 10123, in get_cython_array_type
    return env.global_scope().context.cython_scope.viewscope.lookup("array").type
AttributeError: 'CythonScope' object has no attribute 'viewscope'
```