### PR TITLE
Now uses specialised functions for complex abs

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -100,21 +100,39 @@ builtin_function_table = [
                         PyrexTypes.c_uint_type, [
                             PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_int_type, None)
                             ],
-                        is_strict_signature = True)),
+                        is_strict_signature = True, nogil=True)),
     BuiltinFunction('abs',        None,    None,   "__Pyx_abs_long",
                     utility_code = UtilityCode.load("abs_long", "Builtins.c"),
                     func_type = PyrexTypes.CFuncType(
                         PyrexTypes.c_ulong_type, [
                             PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_long_type, None)
                             ],
-                        is_strict_signature = True)),
+                        is_strict_signature = True, nogil=True)),
     BuiltinFunction('abs',        None,    None,   "__Pyx_abs_longlong",
                     utility_code = UtilityCode.load("abs_longlong", "Builtins.c"),
                     func_type = PyrexTypes.CFuncType(
                         PyrexTypes.c_ulonglong_type, [
                             PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_longlong_type, None)
                         ],
-                        is_strict_signature = True)),
+                        is_strict_signature = True, nogil=True)),
+    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_double_complex_type.funcsuffix),
+                    func_type = PyrexTypes.CFuncType(
+                        PyrexTypes.c_double_type, [
+                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_double_complex_type, None)
+                            ],
+                            is_strict_signature = True, nogil=True)),
+    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_float_complex_type.funcsuffix),
+                    func_type = PyrexTypes.CFuncType(
+                        PyrexTypes.c_float_type, [
+                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_float_complex_type, None)
+                            ],
+                            is_strict_signature = True, nogil=True)),
+    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_longdouble_complex_type.funcsuffix),
+                    func_type = PyrexTypes.CFuncType(
+                        PyrexTypes.c_longdouble_type, [
+                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_longdouble_complex_type, None)
+                            ],
+                            is_strict_signature = True, nogil=True)),
     BuiltinFunction('abs',        "O",    "O",     "PyNumber_Absolute"),
     #('all',       "",     "",      ""),
     #('any',       "",     "",      ""),

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -115,24 +115,17 @@ builtin_function_table = [
                             PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_longlong_type, None)
                         ],
                         is_strict_signature = True, nogil=True)),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_double_complex_type.funcsuffix),
+    ] + list(
+    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(t.funcsuffix),
                     func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_double_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_double_complex_type, None)
+                        t.real_type, [
+                            PyrexTypes.CFuncTypeArg("arg", t, None)
                             ],
-                            is_strict_signature = True, nogil=True)),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_float_complex_type.funcsuffix),
-                    func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_float_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_float_complex_type, None)
-                            ],
-                            is_strict_signature = True, nogil=True)),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(PyrexTypes.c_longdouble_complex_type.funcsuffix),
-                    func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_longdouble_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_longdouble_complex_type, None)
-                            ],
-                            is_strict_signature = True, nogil=True)),
+                            is_strict_signature = True, nogil=True)) 
+                        for t in (PyrexTypes.c_float_complex_type,
+                                  PyrexTypes.c_double_complex_type,
+                                  PyrexTypes.c_longdouble_complex_type)
+                        ) + [
     BuiltinFunction('abs',        "O",    "O",     "PyNumber_Absolute"),
     #('all',       "",     "",      ""),
     #('any',       "",     "",      ""),

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -94,29 +94,18 @@ builtin_function_table = [
                     is_strict_signature = True),
     BuiltinFunction('abs',        "f",    "f",     "fabsf",
                     is_strict_signature = True),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_abs_int",
-                    utility_code = UtilityCode.load("abs_int", "Builtins.c"),
-                    func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_uint_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_int_type, None)
-                            ],
-                        is_strict_signature = True, nogil=True)),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_abs_long",
-                    utility_code = UtilityCode.load("abs_long", "Builtins.c"),
-                    func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_ulong_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_long_type, None)
-                            ],
-                        is_strict_signature = True, nogil=True)),
-    BuiltinFunction('abs',        None,    None,   "__Pyx_abs_longlong",
-                    utility_code = UtilityCode.load("abs_longlong", "Builtins.c"),
-                    func_type = PyrexTypes.CFuncType(
-                        PyrexTypes.c_ulonglong_type, [
-                            PyrexTypes.CFuncTypeArg("arg", PyrexTypes.c_longlong_type, None)
-                        ],
-                        is_strict_signature = True, nogil=True)),
     ] + list(
-    BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(t.funcsuffix),
+        # uses getattr to get PyrexTypes.c_uint_type etc to allow easy iteration over a list
+        BuiltinFunction('abs',        None,    None,   "__Pyx_abs_{0}".format(t),
+                    utility_code = UtilityCode.load("abs_{0}".format(t), "Builtins.c"),
+                    func_type = PyrexTypes.CFuncType(
+                        getattr(PyrexTypes,"c_u{0}_type".format(t)), [
+                            PyrexTypes.CFuncTypeArg("arg", getattr(PyrexTypes,"c_{0}_type".format(t)), None)
+                            ],
+                        is_strict_signature = True, nogil=True))
+                            for t in ("int", "long", "longlong")
+             ) + list(
+        BuiltinFunction('abs',        None,    None,   "__Pyx_c_abs{0}".format(t.funcsuffix),
                     func_type = PyrexTypes.CFuncType(
                         t.real_type, [
                             PyrexTypes.CFuncTypeArg("arg", t, None)

--- a/tests/run/builtin_abs.pyx
+++ b/tests/run/builtin_abs.pyx
@@ -120,3 +120,14 @@ def float_abs(float a):
     5.5
     """
     return abs(a)
+
+@cython.test_assert_path_exists("//ReturnStatNode//NameNode[@entry.name = 'abs']",
+                                "//ReturnStatNode//NameNode[@entry.cname = '__Pyx_c_abs_double']")
+def complex_abs(complex a):
+    """
+    >>> complex_abs(-5j)
+    5.0
+    >>> complex_abs(-5.5j)
+    5.5
+    """
+    return abs(a)


### PR DESCRIPTION
This patch avoids `abs(a_complex_number)` casting the complex number back to a Python object and instead uses the `__pyx_c_abs*` functions that are already defined. It also modifies the specialization for `abs` on int and long to not require the GIL.

Also added a test case to confirm it's working

Notes:
* I don't think the correct utility code is loaded for complex abs
  (but it should be loaded by the complex data types hopefully)
  This might be worth someone double checking
* Would probably be worth making double and float abs not require GIL
  (but this is a minor improvement to existing code)