### PR TITLE
Late includes

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -988,6 +988,7 @@ class GlobalState(object):
         'global_var',
         'string_decls',
         'decls',
+        'late_includes',
         'all_the_rest',
         'pystring_table',
         'cached_builtins',

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -129,6 +129,14 @@ A few more tricks and tips:
     cdef extern from *:
         ...
 
+* If the header file needs to reference any variable declared by Cython
+  itself, add a pipe symbol (``|``) in front of the name.
+  This way, Cython will generate the ``#include "spam.h"`` statement
+  after all declarations of Cython variables::
+
+    cdef extern from "|spam.h":
+        ...
+
 Implementing functions in C
 ---------------------------
 


### PR DESCRIPTION
This pull request adds support for a late ``#include``. My proposed syntax is to add a leading pipe to the filename:
```
cdef extern from "|spam.h":
    ...
```

For this `cdef extern` block, Cython will generate the `#include` statement *after* its own variable declarations. So it can be used if the C code in `spam.h` needs to refer to Cython variables.

`cysignals` has a use-case which is currently "solved" by some ugly hack involving `.pxi` files (for which I need #483). If this pull request is accepted, `cysignals` would no longer need to rely on `.pxi` files: https://github.com/sagemath/cysignals/pull/49

Of course, there are plenty of bikeshedding opportunities for the syntax, but I care about the feature, not the syntax. I chose the leading pipe because it is unlikely to occur in actual filenames. (Also: think of the pipe as "piping" the Cython variables into the header file).