### PR TITLE
Add @cython.except_

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2674,7 +2674,8 @@ class DefNode(FuncDefNode):
         self.num_required_kw_args = rk
         self.num_required_args = r
 
-    def as_cfunction(self, cfunc=None, scope=None, overridable=True, returns=None, modifiers=None):
+    def as_cfunction(self, cfunc=None, scope=None, overridable=True, returns=None,
+                     except_directive=None, modifiers=None):
         if self.star_arg:
             error(self.star_arg.pos, "cdef function cannot have star argument")
         if self.starstar_arg:
@@ -2710,7 +2711,9 @@ class DefNode(FuncDefNode):
                     formal_arg.type = type_arg.type
                     formal_arg.name_declarator = name_declarator
         from . import ExprNodes
-        if cfunc_type.exception_value is None:
+        if except_directive:
+            exception_value = except_directive
+        elif cfunc_type.exception_value is None:
             exception_value = None
         else:
             exception_value = ExprNodes.ConstNode(

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -273,6 +273,7 @@ directive_types = {
     'staticmethod' : None,
     'cclass' : None,
     'returns' : type,
+    'except_' : type,
     'set_initial_path': str,
     'freelist': int,
     'c_string_type': one_of('bytes', 'bytearray', 'str', 'unicode'),

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2154,7 +2154,9 @@ class AdjustDefByDirectives(CythonTransform, SkipDeclarations):
                 error(node.pos, "cfunc directive is not allowed here")
             else:
                 node = node.as_cfunction(
-                    overridable=False, returns=self.directives.get('returns'), modifiers=modifiers)
+                    overridable=False, returns=self.directives.get('returns'),
+                    except_directive=self.directives.get('except_'),
+                    modifiers=modifiers)
                 return self.visit(node)
         if 'inline' in modifiers:
             error(node.pos, "Python functions cannot be declared 'inline'")

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2145,7 +2145,9 @@ class AdjustDefByDirectives(CythonTransform, SkipDeclarations):
             modifiers.append('inline')
         if 'ccall' in self.directives:
             node = node.as_cfunction(
-                overridable=True, returns=self.directives.get('returns'), modifiers=modifiers)
+                overridable=True, returns=self.directives.get('returns'),
+                except_directive=self.directives.get('except_'),
+                modifiers=modifiers)
             return self.visit(node)
         if 'cfunc' in self.directives:
             if self.in_py_class:

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -110,7 +110,7 @@ cclass = ccall = cfunc = _EmptyDecoratorAndManager()
 returns = wraparound = boundscheck = initializedcheck = nonecheck = \
     overflowcheck = embedsignature = cdivision = cdivision_warnings = \
     always_allows_keywords = profile = linetrace = infer_type = \
-    unraisable_tracebacks = freelist = \
+    unraisable_tracebacks = freelist = except_ =\
         lambda arg: _EmptyDecoratorAndManager()
 
 optimization = _Optimization()

--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -5,7 +5,6 @@ is_compiled = cython.compiled
 NULL = 5
 _NULL = NULL
 
-
 def test_sizeof():
     """
     >>> test_sizeof()
@@ -228,6 +227,22 @@ def call_ccall(x):
     ret = c_call(x)
     return ret, cython.typeof(ret)
 
+
+@cython.ccall
+@cython.returns(cython.long)
+@cython.except_(-1)
+def ccall_except(x):
+    """
+    >>> ccall_except(41)
+    42
+    >>> ccall_except(0) #doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError
+    """
+    if x == 0:
+        raise ValueError
+    return x+1
 
 @cython.cfunc
 @cython.inline

--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -244,6 +244,26 @@ def ccall_except(x):
         raise ValueError
     return x+1
 
+
+@cython.cfunc
+@cython.returns(cython.long)
+@cython.except_(-1)
+def cdef_except(x):
+    """
+    >>> call_cdef_except(41)
+    42
+    >>> call_cdef_except(0) #doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError
+    """
+    if x == 0:
+        raise ValueError
+    return x+1
+
+def call_cdef_except(x):
+    return cdef_except(x)
+
 @cython.cfunc
 @cython.inline
 @cython.returns(cython.double)


### PR DESCRIPTION
This PR adds a new directive to specify the "except" value for cdef/cpdef functions when using the pure python mode.

I don't know much about the Cython internals, so in case there is a better/cleaner way to do it, please comment :)