### PR TITLE
use NULL instead of 1 for the default value of C pointers

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2406,7 +2406,7 @@ class CPtrType(CPointerBaseType):
             return {}
 
     def invalid_value(self):
-        return "1"
+        return "NULL"
 
     def find_cpp_operation_type(self, operator, operand_type=None):
         if self.base_type.is_cpp_class:

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -2,6 +2,7 @@
 
 cimport cython.parallel
 from cython.parallel import prange, threadid
+from cython.view cimport array
 from libc.stdlib cimport malloc, calloc, free, abort
 from libc.stdio cimport puts
 
@@ -737,3 +738,11 @@ def test_clean_temps():
     except Exception, e:
         print e.args[0]
 
+def test_pointer_temps():
+    cdef Py_ssize_t i
+    cdef double* f
+
+    cdef double[:] arr = array(format="d", shape=(10,))
+
+    for i in prange(100, nogil=True, num_threads=1):
+        f = &arr[0]


### PR DESCRIPTION
On my MacOS 10.12 box, the test I added fails on the current master branch with the following error:

```
sequential_parallel.cpp:15612:22: error: cannot initialize a variable of type 'double *' with an rvalue of type 'int'
            double * __pyx_parallel_temp0 = 1;
```

It looks like this is only a problem in C++ mode, which I guess is why this hasn't been caught until now.

Please let me know if you would prefer an alternate solution.