### PR TITLE
Allow pointer access to 64-bit arrays

### DIFF
--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -75,6 +75,8 @@ cdef extern from *:  # Hard-coded utility code hack.
         char *as_chars
         unsigned long *as_ulongs
         long *as_longs
+        unsigned long long *as_ulonglongs
+        long long *as_longlongs
         short *as_shorts
         unsigned short *as_ushorts
         Py_UNICODE *as_pyunicodes

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -47,6 +47,10 @@ struct arrayobject {
         char *as_chars;
         unsigned long *as_ulongs;
         long *as_longs;
+#if PY_MAJOR_VERSION >= 3
+        unsigned long long *as_ulonglongs;
+        long long *as_longlongs;
+#endif
         short *as_shorts;
         unsigned short *as_ushorts;
         Py_UNICODE *as_pyunicodes;

--- a/docs/src/tutorial/array.rst
+++ b/docs/src/tutorial/array.rst
@@ -132,6 +132,8 @@ Data fields
     data.as_uints
     data.as_longs
     data.as_ulongs
+    data.as_longlongs  # requires Python >=3
+    data.as_ulonglongs  # requires Python >=3
     data.as_floats
     data.as_doubles
     data.as_pyunicodes


### PR DESCRIPTION
Add support for `array.array`s of int64s or uint64s (type codes `q`/`Q`).