### PR TITLE
Fix incorrect use of flags in re.sub()

### DIFF
--- a/tests/run/extstarargs.pyx
+++ b/tests/run/extstarargs.pyx
@@ -90,7 +90,7 @@ __doc__ = u"""
 
 import sys, re
 if sys.version_info >= (2,6):
-    __doc__ = re.sub(u"(ELLIPSIS[^>]*Error: )[^\n]*\n", u"\\1...\n", __doc__, re.M)
+    __doc__ = re.sub(u"(ELLIPSIS[^>]*Error: )[^\n]*\n", u"\\1...\n", __doc__)
 
 cdef sorteditems(d):
     l = list(d.items())


### PR DESCRIPTION
`tests/run/extstarargs.pyx` read:
```python
    __doc__ = re.sub(u"(ELLIPSIS[^>]*Error: )[^\n]*\n", u"\\1...\n", __doc__, re.M)
```
But the 4th argument of re.sub() is supposed to be maximum number of substitutions, not flags.
Moreover, `re.M` affects only semantics of `^` and `$`, so it wouldn't have any effect on this regexp.