### PR TITLE
Do not use special dll linkage for "cdef public" functions

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -214,8 +214,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
     def generate_public_declaration(self, entry, h_code, i_code):
         h_code.putln("%s %s;" % (
             Naming.extern_c_macro,
-            entry.type.declaration_code(
-                entry.cname, dll_linkage="DL_IMPORT")))
+            entry.type.declaration_code(entry.cname)))
         if i_code:
             i_code.putln("cdef extern %s" % (
                 entry.type.declaration_code(entry.cname, pyrex=1)))
@@ -2849,7 +2848,7 @@ def generate_cfunction_declaration(entry, env, code, definition):
             dll_linkage = "DL_IMPORT"
         elif entry.visibility == 'public':
             storage_class = Naming.extern_c_macro
-            dll_linkage = "DL_EXPORT"
+            dll_linkage = None
         elif entry.visibility == 'private':
             storage_class = "static"
             dll_linkage = None

--- a/tests/cygwin_bugs.txt
+++ b/tests/cygwin_bugs.txt
@@ -1,5 +1,3 @@
-module_api
-
 complex_numbers_c89_T398_long_double
 complex_numbers_T305_long_double
 int_float_builtins_as_casts_T400_long_double


### PR DESCRIPTION
This is meant to fix the `module_api` Cython test on Cygwin and help with various bugs in SageMath, such as https://trac.sagemath.org/ticket/21459

@embray Please test on Cygwin.