### PR TITLE
pyximport: remove obsolete version check

### DIFF
--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -55,8 +55,6 @@ from zipimport import zipimporter, ZipImportError
 
 mod_name = "pyximport"
 
-assert sys.hexversion >= 0x2030000, "need Python 2.3 or later"
-
 PYX_EXT = ".pyx"
 PYXDEP_EXT = ".pyxdep"
 PYXBLD_EXT = ".pyxbld"


### PR DESCRIPTION
The file is syntactically correct only in Python ≥ 2.6, so the version check would never be run.