### PR TITLE
Don't use __Pyx_PyObject_CallMethO on cyfunctions

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1686,11 +1686,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObjec
         return __Pyx_PyFunction_FastCall(func, &arg, 1);
     }
 #endif
-#ifdef __Pyx_CyFunction_USED
-    if (likely(PyCFunction_Check(func) || PyObject_TypeCheck(func, __pyx_CyFunctionType))) {
-#else
     if (likely(PyCFunction_Check(func))) {
-#endif
         if (likely(PyCFunction_GET_FLAGS(func) & METH_O)) {
             // fast and simple case that we are optimising for
             return __Pyx_PyObject_CallMethO(func, arg);

--- a/tests/run/cyfunction_METH_O_GH1728.pyx
+++ b/tests/run/cyfunction_METH_O_GH1728.pyx
@@ -1,0 +1,16 @@
+# cython: binding=True
+# mode: run
+# tag: cyfunction
+
+cdef class TestMethodOneArg:
+    def meth(self, arg):
+        pass
+
+def call_meth(x):
+    """
+    >>> call_meth(TestMethodOneArg())
+    Traceback (most recent call last):
+    ...
+    TypeError: meth() takes exactly one argument (0 given)
+    """
+    return x.meth()


### PR DESCRIPTION
This code
```C
static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObject *arg) {
#if CYTHON_FAST_PYCALL
    if (PyFunction_Check(func)) {
        return __Pyx_PyFunction_FastCall(func, &arg, 1);
    }
#endif
#ifdef __Pyx_CyFunction_USED
    if (likely(PyCFunction_Check(func) || PyObject_TypeCheck(func, __pyx_CyFunctionType))) {
#else
    if (likely(PyCFunction_Check(func))) {
#endif
        if (likely(PyCFunction_GET_FLAGS(func) & METH_O)) {
            // fast and simple case that we are optimising for
            return __Pyx_PyObject_CallMethO(func, arg);
#if CYTHON_FAST_PYCCALL
        } else if (PyCFunction_GET_FLAGS(func) & METH_FASTCALL) {
            return __Pyx_PyCFunction_FastCall(func, &arg, 1);
#endif
        }
    }
    return __Pyx__PyObject_CallOneArg(func, arg);
}
```
is confusing *bound* and *unbound* methods. In particular, it can happen that `func` is a cyfunction (which is like an *unbound* method) but that ` __Pyx_PyObject_CallMethO(func, arg);` is called which assumes that `func` is a *bound* method.

In particular, the following Cython code is buggy when compiled with `binding=True`:
```
cdef class TestMethodOneArg:
    def meth(self, arg):
        pass

def call_meth(x):
    return x.meth()
```
The expected result of `call_meth(TestMethodOneArg())` is a `TypeError` because `meth()` is called without `arg`. The actual result is that `meth()` is called with `self=TestMethodOneArg.meth.__func__` and `arg=x`.

It's not entirely clear what should be fixed (maybe it's already a bug that the unbound method `func` has the `METH_O` flag set?), but simply dropping the check for cyfunctions in the C code above fixes the problem for me.