### PR TITLE
sigset_t is not an integral type

### DIFF
--- a/Cython/Includes/posix/types.pxd
+++ b/Cython/Includes/posix/types.pxd
@@ -22,7 +22,8 @@ cdef extern from "<sys/types.h>":
     ctypedef long nlink_t
     ctypedef long off_t
     ctypedef long pid_t
-    ctypedef long sigset_t
+    ctypedef struct sigset_t:
+        pass
     ctypedef long suseconds_t
     ctypedef long time_t
     ctypedef long timer_t


### PR DESCRIPTION
In order to avoid having Cython generate `__Pyx_PyInt_From_sigset_t()`, we declare `sigset_t` as `struct` instead of `long`.