### PR TITLE
Repair compile time complex expressions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1672,7 +1672,7 @@ class ImagNode(AtomicExprNode):
         node = ImagNode(self.pos, value=self.value)
         if dst_type.is_pyobject:
             node.is_temp = 1
-            node.type = PyrexTypes.py_object_type
+            node.type = Builtin.complex_type
         # We still need to perform normal coerce_to processing on the
         # result, because we might be coercing to an extension type,
         # in which case a type test node will be needed.

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -11879,9 +11879,9 @@ class CmpNode(object):
                 error(self.pos, "complex types are unordered")
                 new_common_type = error_type
             elif type1.is_pyobject:
-                new_common_type = type1
+                new_common_type = Builtin.complex_type if type1.subtype_of(Builtin.complex_type) else py_object_type
             elif type2.is_pyobject:
-                new_common_type = type2
+                new_common_type = Builtin.complex_type if type2.subtype_of(Builtin.complex_type) else py_object_type
             else:
                 new_common_type = PyrexTypes.widest_numeric_type(type1, type2)
         elif type1.is_numeric and type2.is_numeric:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -11866,16 +11866,16 @@ class CmpNode(object):
         new_common_type = None
 
         # catch general errors
-        if type1 == str_type and (type2.is_string or type2 in (bytes_type, unicode_type)) or \
-               type2 == str_type and (type1.is_string or type1 in (bytes_type, unicode_type)):
+        if (type1 == str_type and (type2.is_string or type2 in (bytes_type, unicode_type)) or
+                type2 == str_type and (type1.is_string or type1 in (bytes_type, unicode_type))):
             error(self.pos, "Comparisons between bytes/unicode and str are not portable to Python 3")
             new_common_type = error_type
 
         # try to use numeric comparisons where possible
         elif type1.is_complex or type2.is_complex:
-            if op not in ('==', '!=') \
-               and (type1.is_complex or type1.is_numeric) \
-               and (type2.is_complex or type2.is_numeric):
+            if (op not in ('==', '!=')
+                    and (type1.is_complex or type1.is_numeric)
+                    and (type2.is_complex or type2.is_numeric)):
                 error(self.pos, "complex types are unordered")
                 new_common_type = error_type
             elif type1.is_pyobject:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1649,15 +1649,15 @@ class IdentifierStringNode(StringNode):
 class ImagNode(AtomicExprNode):
     #  Imaginary number literal
     #
-    #  value   float    imaginary part
+    #  value   string    imaginary part (float value)
 
     type = PyrexTypes.c_double_complex_type
 
     def calculate_constant_result(self):
-        self.constant_result = complex(0.0, self.value)
+        self.constant_result = complex(0.0, float(self.value))
 
     def compile_time_value(self, denv):
-        return complex(0.0, self.value)
+        return complex(0.0, float(self.value))
 
     def analyse_types(self, env):
         self.type.create_declaration_utility_code(env)

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -771,6 +771,15 @@ def wrap_compile_time_constant(pos, value):
         return ExprNodes.IntNode(pos, value=rep, constant_result=value)
     elif isinstance(value, float):
         return ExprNodes.FloatNode(pos, value=rep, constant_result=value)
+    elif isinstance(value, complex):
+        node = ExprNodes.ImagNode(pos, value=repr(value.imag), constant_result=complex(0.0, value.imag))
+        if value.real:
+            # FIXME: should we care about -0.0 ?
+            # probably not worth using the '-' operator for negative imag values
+            node = ExprNodes.binop_node(
+                pos, '+', ExprNodes.FloatNode(pos, value=repr(value.real), constant_result=value.real), node,
+                constant_result=value)
+        return node
     elif isinstance(value, _unicode):
         return ExprNodes.UnicodeNode(pos, value=EncodedString(value))
     elif isinstance(value, _bytes):

--- a/tests/run/complex_numbers_T305.pyx
+++ b/tests/run/complex_numbers_T305.pyx
@@ -1,6 +1,32 @@
 # ticket: 305
 
+from cpython.object cimport Py_EQ, Py_NE
+
 cimport cython
+
+
+cdef class Complex3j:
+    """
+    >>> Complex3j() == 3j
+    True
+    >>> Complex3j() == Complex3j()
+    True
+    >>> Complex3j() != 3j
+    False
+    >>> Complex3j() != 3
+    True
+    >>> Complex3j() != Complex3j()
+    False
+    """
+    def __richcmp__(a, b, int op):
+        if op == Py_EQ or op == Py_NE:
+            if isinstance(a, Complex3j):
+                eq = isinstance(b, Complex3j) or b == 3j
+            else:
+                eq = isinstance(b, Complex3j) and a == 3j
+            return eq if op == Py_EQ else not eq
+        return NotImplemented
+
 
 def test_object_conversion(o):
     """
@@ -13,6 +39,7 @@ def test_object_conversion(o):
     cdef double complex b = o
     return (a, b)
 
+
 def test_arithmetic(double complex z, double complex w):
     """
     >>> test_arithmetic(2j, 4j)
@@ -24,6 +51,7 @@ def test_arithmetic(double complex z, double complex w):
     """
     return +z, -z+0, z+w, z-w, z*w, z/w
 
+
 def test_div(double complex a, double complex b, expected):
     """
     >>> big = 2.0**1023
@@ -33,6 +61,7 @@ def test_div(double complex a, double complex b, expected):
     # Can't count on good c99 complex division :(
     if '_c99_' not in __name__:
         assert a / b == expected, (a / b, expected)
+
 
 def test_pow(double complex z, double complex w, tol=None):
     """
@@ -55,6 +84,7 @@ def test_pow(double complex z, double complex w, tol=None):
     else:
         return abs(z**w / <object>z ** <object>w - 1) < tol
 
+
 def test_int_pow(double complex z, int n, tol=None):
     """
     >>> [test_int_pow(complex(0, 1), k, 1e-15) for k in range(-4, 5)]
@@ -71,6 +101,7 @@ def test_int_pow(double complex z, int n, tol=None):
     else:
         return abs(z**n / <object>z ** <object>n - 1) < tol
 
+
 @cython.cdivision(False)
 def test_div_by_zero(double complex z):
     """
@@ -82,6 +113,7 @@ def test_div_by_zero(double complex z):
     ZeroDivisionError: float division
     """
     return 1/z
+
 
 def test_coercion(int a, float b, double c, float complex d, double complex e):
     """
@@ -101,29 +133,34 @@ def test_coercion(int a, float b, double c, float complex d, double complex e):
     z = e; print z
     return z + a + b + c + d + e
 
+
 def test_compare(double complex a, double complex b):
     """
     >>> test_compare(3, 3)
-    (True, False)
+    (True, False, False, False, False, True)
     >>> test_compare(3j, 3j)
-    (True, False)
+    (True, False, True, True, True, False)
     >>> test_compare(3j, 4j)
-    (False, True)
+    (False, True, True, False, True, True)
     >>> test_compare(3, 4)
-    (False, True)
+    (False, True, False, False, False, True)
     """
-    return a == b, a != b
+    return a == b, a != b, a == 3j, 3j == b, a == Complex3j(), Complex3j() != b
+
 
 def test_compare_coerce(double complex a, int b):
     """
     >>> test_compare_coerce(3, 4)
-    (False, True)
+    (False, True, False, False, False, True)
     >>> test_compare_coerce(4+1j, 4)
-    (False, True)
+    (False, True, False, True, False, True)
     >>> test_compare_coerce(4, 4)
-    (True, False)
+    (True, False, False, False, False, True)
+    >>> test_compare_coerce(3j, 4)
+    (False, True, True, False, True, False)
     """
-    return a == b, a != b
+    return a == b, a != b, a == 3j, 4+1j == a, a == Complex3j(), Complex3j() != a
+
 
 def test_literal():
     """

--- a/tests/run/complex_numbers_T305.pyx
+++ b/tests/run/complex_numbers_T305.pyx
@@ -4,6 +4,8 @@ from cpython.object cimport Py_EQ, Py_NE
 
 cimport cython
 
+DEF C21 = 2-1j
+
 
 cdef class Complex3j:
     """
@@ -137,15 +139,17 @@ def test_coercion(int a, float b, double c, float complex d, double complex e):
 def test_compare(double complex a, double complex b):
     """
     >>> test_compare(3, 3)
-    (True, False, False, False, False, True)
+    (True, False, False, False, False, True, False)
     >>> test_compare(3j, 3j)
-    (True, False, True, True, True, False)
+    (True, False, True, True, True, False, False)
     >>> test_compare(3j, 4j)
-    (False, True, True, False, True, True)
+    (False, True, True, False, True, True, False)
     >>> test_compare(3, 4)
-    (False, True, False, False, False, True)
+    (False, True, False, False, False, True, False)
+    >>> test_compare(2-1j, 4)
+    (False, True, False, False, False, True, True)
     """
-    return a == b, a != b, a == 3j, 3j == b, a == Complex3j(), Complex3j() != b
+    return a == b, a != b, a == 3j, 3j == b, a == Complex3j(), Complex3j() != b, a == C21
 
 
 def test_compare_coerce(double complex a, int b):
@@ -165,9 +169,10 @@ def test_compare_coerce(double complex a, int b):
 def test_literal():
     """
     >>> test_literal()
-    (5j, (1-2.5j))
+    (5j, (1-2.5j), (2-1j))
     """
-    return 5j, 1-2.5j
+    return 5j, 1-2.5j, C21
+
 
 def test_real_imag(double complex z):
     """


### PR DESCRIPTION
Complex values are not currently evaluated at compile time at all because they are stored as strings but used like floats.
Based on #1777 (first three commits).