### PR TITLE
Do not evaluate DEF statements inside of IF blocks with false condiions

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2160,9 +2160,10 @@ def p_DEF_statement(s):
     name = p_ident(s)
     s.expect('=')
     expr = p_compile_time_expr(s)
-    value = expr.compile_time_value(denv)
-    #print "p_DEF_statement: %s = %r" % (name, value) ###
-    denv.declare(name, value)
+    if s.compile_time_eval:
+        value = expr.compile_time_value(denv)
+        #print "p_DEF_statement: %s = %r" % (name, value) ###
+        denv.declare(name, value)
     s.expect_newline("Expected a newline", ignore_semicolon=True)
     return Nodes.PassStatNode(pos)
 

--- a/tests/run/ct_IF.pyx
+++ b/tests/run/ct_IF.pyx
@@ -42,3 +42,33 @@ def h():
     ELSE:
         i = 3
     return i
+
+
+def control_flow_DEF1():
+    """
+    >>> control_flow_DEF1()
+    B should be 2.
+    2
+    """
+    IF YES:
+        DEF B=2
+        print('B should be 2.')
+    ELSE:
+        DEF B=3
+        print('B should be 3.')
+    return B
+
+
+def control_flow_DEF2():
+    """
+    >>> control_flow_DEF2()
+    B should be 3.
+    3
+    """
+    IF NO:
+        DEF B=2
+        print('B should be 2.')
+    ELSE:
+        DEF B=3
+        print('B should be 3.')
+    return B


### PR DESCRIPTION
Fixes #1796 

Since this is a backwards incompatible fix that might introduce hard to detect bugs on user side, I nominate it for the next major release instead of a bug-fix release.