### PR TITLE
Add st_birthtime to struct stat

### DIFF
--- a/Cython/Includes/posix/stat.pxd
+++ b/Cython/Includes/posix/stat.pxd
@@ -18,6 +18,11 @@ cdef extern from "<sys/stat.h>" nogil:
         time_t  st_mtime
         time_t  st_ctime
 
+        # st_birthtime exists on *BSD and OS X.
+        # Under Linux, defining it here does not hurt. Compilation under Linux
+        # will only (and rightfully) fail when attempting to use the field.
+        time_t  st_birthtime
+
 # POSIX prescribes including both <sys/stat.h> and <unistd.h> for these
 cdef extern from "<unistd.h>" nogil:
     int fchmod(int, mode_t)


### PR DESCRIPTION
This is available on OS X, FreeBSD and NetBSD. On Linux, the definition
itself will not result in any errors. However, code that does attempt to
st_birthtime under Linux will now fail at C compile time rather than
Cython compile time.