### PR TITLE
Pass am empty dict instead of a f_globals reference to profilers.

### DIFF
--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -249,7 +249,7 @@ static int __Pyx_TraceSetupAndCall(PyCodeObject** code,
             tstate,                          /*PyThreadState *tstate*/
             *code,                           /*PyCodeObject *code*/
             $moddict_cname,                  /*PyObject *globals*/
-            0                                /*PyObject *locals*/
+            PyDict_New()                     /*PyObject *locals*/
         );
         if (*frame == NULL) return 0;
         if (CYTHON_TRACE && (*frame)->f_trace == NULL) {


### PR DESCRIPTION
The code right now creates a frame containing a reference to f_globals in f_locals. This is because of
https://github.com/python/cpython/blob/2.7/Objects/frameobject.c#L732

If a profiler accesses `frame.f_locals` (from python) it will trigger 
`frame_getlocals` https://github.com/python/cpython/blob/02e03672e6766b1da847b1635982a70346780744/Objects/frameobject.c#L56
`PyFrame_FastToLocals` https://github.com/python/cpython/blob/02e03672e6766b1da847b1635982a70346780744/Objects/frameobject.c#L867
which will call `map_to_dict` with (pseudocode)
`map_to_dict(f.co_code.co_varnames, len(f.co_code.co_varnames), f.f_locals, f.f_localsplus, 0)`
which will remove everything from f_locals which is also in `f.co_code.co_varnames`.
As f_locals == f_globals in the current setup that modifies the global namespace. 

In our case we have a function
```
def foo(foo):
  pass
```
if a function call to this function is profiled the function will be removed from the global namespace (as it shares it's name with one of it's parameter names).