### PR TITLE
Include PySet_Check and PyFrozenSet_Check to CPython includes file

### DIFF
--- a/Cython/Includes/cpython/set.pxd
+++ b/Cython/Includes/cpython/set.pxd
@@ -44,8 +44,14 @@ cdef extern from "Python.h":
     # Return true if p is a set object or a frozenset object but not
     # an instance of a subtype.
 
+    bint PyFrozenSet_Check(object p)
+    # Return true if p is a frozenset object or an instance of a subtype.
+
     bint PyFrozenSet_CheckExact(object p)
     # Return true if p is a frozenset object but not an instance of a subtype.
+
+    bint PySet_Check(object p)
+    # Return true if p is a set object or an instance of a subtype.
 
     object PySet_New(object iterable)
     # Return value: New reference.


### PR DESCRIPTION
Both were added in Python 2.6 so should be available for all supported Python versions.