### PR TITLE
Attempt to use a faster exception value for return type annotations that check for exceptions

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -143,7 +143,7 @@ _directive_defaults = {
     'initializedcheck' : True,
     'embedsignature' : False,
     'locals' : {},
-    'exceptval' : (None, False),  # (except value, check=False)
+    'exceptval' : None,  # (except value=None, check=True)
     'auto_cpdef': False,
     'auto_pickle': None,
     'cdivision': False, # was True before 0.12

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -113,7 +113,7 @@ returns = wraparound = boundscheck = initializedcheck = nonecheck = \
     unraisable_tracebacks = freelist = \
         lambda _: _EmptyDecoratorAndManager()
 
-exceptval = lambda _=None, check=False: _EmptyDecoratorAndManager()
+exceptval = lambda _=None, check=True: _EmptyDecoratorAndManager()
 
 optimization = _Optimization()
 

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -146,6 +146,56 @@ def call_struct_io(s : MyStruct) -> MyStruct:
     return struct_io(s)
 
 
+@cython.test_assert_path_exists(
+    "//CFuncDefNode",
+    "//CFuncDefNode//DefNode",
+    "//CFuncDefNode[@return_type]",
+    "//CFuncDefNode[@return_type.is_struct_or_union = True]",
+)
+@cython.ccall
+def struct_convert(d) -> MyStruct:
+    """
+    >>> d = struct_convert(dict(x=1, y=2, data=3))
+    >>> sorted(d.items())
+    [('data', 3.0), ('x', 1), ('y', 2)]
+    >>> struct_convert({})  # make sure we can raise exceptions through struct return values
+    Traceback (most recent call last):
+    ValueError: No value specified for struct attribute 'x'
+    """
+    return d
+
+
+@cython.test_assert_path_exists(
+    "//CFuncDefNode",
+    "//CFuncDefNode//DefNode",
+    "//CFuncDefNode[@return_type]",
+    "//CFuncDefNode[@return_type.is_int = True]",
+)
+@cython.ccall
+def exception_default(raise_exc : cython.bint = False) -> cython.int:
+    """
+    >>> exception_default(raise_exc=False)
+    10
+    >>> exception_default(raise_exc=True)
+    Traceback (most recent call last):
+    ValueError: huhu!
+    """
+    if raise_exc:
+        raise ValueError("huhu!")
+    return 10
+
+
+def call_exception_default(raise_exc=False):
+    """
+    >>> call_exception_default(raise_exc=False)
+    10
+    >>> call_exception_default(raise_exc=True)
+    Traceback (most recent call last):
+    ValueError: huhu!
+    """
+    return exception_default(raise_exc)
+
+
 _WARNINGS = """
 8:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 8:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
@@ -156,4 +206,6 @@ _WARNINGS = """
 # BUG:
 46:6: 'pytypes_cpdef' redeclared
 121:0: 'struct_io' redeclared
+156:0: 'struct_convert' redeclared
+175:0: 'exception_default' redeclared
 """

--- a/tests/run/extern_impl_excvalue.srctree
+++ b/tests/run/extern_impl_excvalue.srctree
@@ -13,17 +13,20 @@ setup(
 
 ######## foo.pxd ########
 
-cdef void bar() except *
+cdef int bar() except *
 
 ######## foo.pyx ########
 
 cdef extern from "bar_impl.c":
-    void bar() except *
+    int bar() except *
 
 ######## bar_impl.c ########
 
-static void bar() {}
+static int bar() { return -1; }
 
 ######## a.pyx ########
 
+cimport cython
 from foo cimport bar
+
+assert bar() == -1


### PR DESCRIPTION
Inside of a module, it is safe to convert a function declared
```
    cdef int func() except *:
        ...
```
into
```
    cdef int func() except? -1:
        ...
```
because a) we need an exception return value anyway and b) there will always be an explicit exception check afterwards. Thus, changing the function implementation itself is safe.

Changing the function declaration and its calls is only safe if we can be sure that we changed the function signature, though. This requires control of the function implementation. We must exclude functions that are only declared but not implemented since we do not control their signature and it is not safe to assume a specific exception return value if it is not declared.

The implementation also excludes methods, as they might have to match a parent method (if available). It might be possible to extend this to methods since `cdef int method(self) except *` in a base class method is actually compatible with `cdef int method(self) except? -1` in a subclass.