### PR TITLE
Inter-class/file calling of fused functions may result into calling t…

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1030,7 +1030,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("struct %s %s;" % (
                     type.base_type.vtabstruct_cname,
                     Naming.obj_base_cname))
-            for method_entry in scope.cfunc_entries:
+            for method_entry in sorted(scope.cfunc_entries):
                 if not method_entry.is_inherited:
                     code.putln("%s;" % method_entry.type.declaration_code("(*%s)" % method_entry.cname))
             code.putln("};")


### PR DESCRIPTION
…he wrong function

An example from my testcase:
Calling "setFullFlags" from "hirnwichse_main.pyx" will actually call "regWriteWithOpWords".
This results into undefined behaviour.

For some reason (I don't know why, because I don't know the cython source well enough) this only happens when those different classes are in different .pyx/.pxd files.

Here's a snippet of the resulting C-code from a testcase (without the patch):

hirnwichse_main.c:
```
struct __pyx_vtabstruct_9registers_Registers {
  void (*__pyx_fuse_0setFullFlags)(struct __pyx_obj_9registers_Registers *, uint8_t, uint32_t);
  void (*__pyx_fuse_1setFullFlags)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_2setFullFlags)(struct __pyx_obj_9registers_Registers *, uint32_t, uint32_t);
  void (*__pyx_fuse_0regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint16_t);
  void (*__pyx_fuse_1regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_2regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint64_t);
};
```

registers.c:
```
struct __pyx_vtabstruct_9registers_Registers {
  void (*__pyx_fuse_0regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint16_t);
  void (*__pyx_fuse_1regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_2regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint64_t);
  void (*__pyx_fuse_0setFullFlags)(struct __pyx_obj_9registers_Registers *, uint8_t, uint32_t);
  void (*__pyx_fuse_1setFullFlags)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_2setFullFlags)(struct __pyx_obj_9registers_Registers *, uint32_t, uint32_t);
};
```

With the patch, both look like:
```
struct __pyx_vtabstruct_9registers_Registers {
  void (*__pyx_fuse_0regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint16_t);
  void (*__pyx_fuse_0setFullFlags)(struct __pyx_obj_9registers_Registers *, uint8_t, uint32_t);
  void (*__pyx_fuse_1regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_1setFullFlags)(struct __pyx_obj_9registers_Registers *, uint16_t, uint32_t);
  void (*__pyx_fuse_2regWriteWithOpWords)(struct __pyx_obj_9registers_Registers *, uint16_t, uint64_t);
  void (*__pyx_fuse_2setFullFlags)(struct __pyx_obj_9registers_Registers *, uint32_t, uint32_t);
};
```

Signed-off-by: Christian Inci <chris.gh@broke-the-inter.net>