### PR TITLE
More pypy3 fixes

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -74,7 +74,11 @@ static PyObject* __Pyx__Coroutine_Yield_From_Generic(__pyx_CoroutineObject *gen,
     if (__Pyx_Coroutine_CheckExact(source_gen)) {
         retval = __Pyx_Generator_Next(source_gen);
     } else {
+#if CYTHON_USE_TYPE_SLOTS
         retval = Py_TYPE(source_gen)->tp_iternext(source_gen);
+#else
+        retval = PyIter_Next(source_gen);
+#endif
     }
     if (retval) {
         gen->yieldfrom = source_gen;

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -203,7 +203,7 @@ static CYTHON_INLINE const char* __Pyx_PyObject_AsString(PyObject* o) {
     return __Pyx_PyObject_AsStringAndSize(o, &ignore);
 }
 
-#if CYTHON_COMPILING_IN_CPYTHON && (__PYX_DEFAULT_STRING_ENCODING_IS_ASCII || __PYX_DEFAULT_STRING_ENCODING_IS_DEFAULT)
+#if __PYX_DEFAULT_STRING_ENCODING_IS_ASCII || __PYX_DEFAULT_STRING_ENCODING_IS_DEFAULT
 #if !CYTHON_PEP393_ENABLED
 static const char* __Pyx_PyUnicode_AsStringAndSize(PyObject* o, Py_ssize_t *length) {
     char* defenc_c;
@@ -251,7 +251,7 @@ static CYTHON_INLINE const char* __Pyx_PyUnicode_AsStringAndSize(PyObject* o, Py
 
 // Py3.7 returns a "const char*" for unicode strings
 static CYTHON_INLINE const char* __Pyx_PyObject_AsStringAndSize(PyObject* o, Py_ssize_t *length) {
-#if CYTHON_COMPILING_IN_CPYTHON && (__PYX_DEFAULT_STRING_ENCODING_IS_ASCII || __PYX_DEFAULT_STRING_ENCODING_IS_DEFAULT)
+#if __PYX_DEFAULT_STRING_ENCODING_IS_ASCII || __PYX_DEFAULT_STRING_ENCODING_IS_DEFAULT
     if (
 #if PY_MAJOR_VERSION < 3 && __PYX_DEFAULT_STRING_ENCODING_IS_ASCII
             __Pyx_sys_getdefaultencoding_not_ascii &&

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -26,7 +26,14 @@ run.datetime_pxd
 run.datetime_cimport
 run.datetime_members
 run.extern_builtins_T258
+run.line_trace
+run.line_profile_test
+run.pstats_profile_test
+run.longintrepr
 
 # refcounting-specific tests
 double_dealloc_T796
+run.exceptionrefcount
+run.capiimpl
+run.refcount_in_meth
 

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -54,6 +54,16 @@ except ImportError:
         def __call__(self, *args, **kwargs):
             return self._GeneratorWrapper(self._gen(*args, **kwargs))
 
+try:
+    from sys import getrefcount
+except ImportError:
+    from cpython.ref cimport PyObject
+    def getrefcount(obj):
+        gc.collect()
+        # PyPy needs to execute a bytecode to run the finalizers
+        exec('', {}, {})
+        return (<PyObject*>obj).ob_refcnt
+
 
 # compiled exec()
 def exec(code_string, l, g):
@@ -1867,7 +1877,7 @@ class CoroutineTest(unittest.TestCase):
 
     def test_for_2(self):
         tup = (1, 2, 3)
-        refs_before = sys.getrefcount(tup)
+        refs_before = getrefcount(tup)
 
         async def foo():
             async for i in tup:
@@ -1878,7 +1888,7 @@ class CoroutineTest(unittest.TestCase):
 
             run_async(foo())
 
-        self.assertEqual(sys.getrefcount(tup), refs_before)
+        self.assertEqual(getrefcount(tup), refs_before)
 
     def test_for_3(self):
         class I(object):
@@ -1886,7 +1896,7 @@ class CoroutineTest(unittest.TestCase):
                 return self
 
         aiter = I()
-        refs_before = sys.getrefcount(aiter)
+        refs_before = getrefcount(aiter)
 
         async def foo():
             async for i in aiter:
@@ -1898,7 +1908,7 @@ class CoroutineTest(unittest.TestCase):
 
             run_async(foo())
 
-        self.assertEqual(sys.getrefcount(aiter), refs_before)
+        self.assertEqual(getrefcount(aiter), refs_before)
 
     def test_for_4(self):
         class I(object):
@@ -1909,7 +1919,7 @@ class CoroutineTest(unittest.TestCase):
                 return ()
 
         aiter = I()
-        refs_before = sys.getrefcount(aiter)
+        refs_before = getrefcount(aiter)
 
         async def foo():
             async for i in aiter:
@@ -1921,7 +1931,7 @@ class CoroutineTest(unittest.TestCase):
 
             run_async(foo())
 
-        self.assertEqual(sys.getrefcount(aiter), refs_before)
+        self.assertEqual(getrefcount(aiter), refs_before)
 
     def test_for_5(self):
         class I(object):
@@ -1971,8 +1981,8 @@ class CoroutineTest(unittest.TestCase):
 
         manager = Manager()
         iterable = Iterable()
-        mrefs_before = sys.getrefcount(manager)
-        irefs_before = sys.getrefcount(iterable)
+        mrefs_before = getrefcount(manager)
+        irefs_before = getrefcount(iterable)
 
         async def main():
             nonlocal I
@@ -1985,8 +1995,8 @@ class CoroutineTest(unittest.TestCase):
         run_async(main())
         self.assertEqual(I, 111011)
 
-        self.assertEqual(sys.getrefcount(manager), mrefs_before)
-        self.assertEqual(sys.getrefcount(iterable), irefs_before)
+        self.assertEqual(getrefcount(manager), mrefs_before)
+        self.assertEqual(getrefcount(iterable), irefs_before)
 
         ##############
 


### PR DESCRIPTION
Here are some more fixes to improve pypy{,3} support.

Note that the `gc.collect(); exec('')` trick in getrefcount() could probably be generalised to any test that tries to check refcounts.