### PR TITLE
Enforce single module initialisation despite PEP 489 allowing to re-execute a module

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -753,6 +753,10 @@ static int __Pyx_copy_spec_to_module(PyObject *spec, PyObject *moddict, const ch
 static PyObject* ${pymodule_create_func_cname}(PyObject *spec, CYTHON_UNUSED PyModuleDef *def) {
     PyObject *module = NULL, *moddict, *modname;
 
+    // For now, we only have exactly one module instance.
+    if (${module_cname})
+        return __Pyx_NewRef({module_cname});
+
     modname = PyObject_GetAttrString(spec, "name");
     if (unlikely(!modname)) goto bad;
 

--- a/runtests.py
+++ b/runtests.py
@@ -350,8 +350,6 @@ VER_DEP_MODULES = {
                                          'run.mod__spec__',
                                          'run.pep526_variable_annotations',  # typing module
                                          ]),
-    (99,): (operator.lt, lambda x: x in ['run.mod__spec__',  # actually Py3.5, but currently disabled
-                                         ]),
 }
 
 INCLUDE_DIRS = [ d for d in os.getenv('INCLUDE', '').split(os.pathsep) if d ]

--- a/tests/bugs.txt
+++ b/tests/bugs.txt
@@ -12,6 +12,9 @@ temp_sideeffects_T654    # not really a bug, Cython warns about it
 inherited_final_method
 cimport_alias_subclass
 
+# PEP-489 is currently disabled
+run.mod__spec__
+
 # CPython regression tests that don't current work:
 pyregr.test_signal
 pyregr.test_capi


### PR DESCRIPTION
This is a hack to re-enable PEP-489 support while enforcing single module execution. It the module exec function is run more than once, it would otherwise overwrite and recreate the entire module state, lose lots of references and probably just crash.