### PR TITLE
Fix classmethod creation for (upcoming) PyPy{,3} 5.9

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1216,14 +1216,14 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method); /*proto*/
 //////////////////// ClassMethod ////////////////////
 
 static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
-#if CYTHON_COMPILING_IN_PYPY
+#if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM <= 0x05080000
     if (PyObject_TypeCheck(method, &PyWrapperDescr_Type)) {
         // cdef classes
         return PyClassMethod_New(method);
     }
 #else
-#if CYTHON_COMPILING_IN_PYSTON
-    // special C-API function only in Pyston
+#if CYTHON_COMPILING_IN_PYSTON || CYTHON_COMPILING_IN_PYPY
+    // special C-API function only in Pyston and PyPy >= 5.9
     if (PyMethodDescr_Check(method)) {
 #else
     // It appears that PyMethodDescr_Type is not exposed anywhere in the CPython C-API


### PR DESCRIPTION
__Pyx_Method_ClassMethod() used a hack on PyPy that relied on bugs in cpyext. The bugs have been fixed for the upcoming 5.9 release, which broke classmethod creation. This patch, together with the addition of `PyMethodDescr_Check` to pypy's C-API, fixes it.

Can you please include it in 0.27.1?