### PR TITLE
Only use [[fallthrough]] in C++11 and beyond

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -513,7 +513,7 @@
 
 
 #ifndef CYTHON_FALLTHROUGH
-  #ifdef __cplusplus
+  #if __cplusplus >= 201103L
     #if __has_cpp_attribute(fallthrough)
       #define CYTHON_FALLTHROUGH [[fallthrough]]
     #elif __has_cpp_attribute(clang::fallthrough)


### PR DESCRIPTION
In this code:
```C
  #ifdef __cplusplus
    #if __has_cpp_attribute(fallthrough)
      #define CYTHON_FALLTHROUGH [[fallthrough]]
    #elif __has_cpp_attribute(clang::fallthrough)
      #define CYTHON_FALLTHROUGH [[clang::fallthrough]]
    #endif
  #endif
```
Cython checks for the presence of the `fallthrough` attribute but that doesn't mean that the C++11 attribute syntax `[[fallthrough]]` is understood.

GCC 7.2.0 for example gives warnings when compiling with `-std=gnu++98`:
```
build/cythonized/sage/libs/lcalc/lcalc_Lfunction.cpp:515:48: warning: c++11 attributes only available with -std=c++11 or -std=gnu++11
       #define CYTHON_FALLTHROUGH [[fallthrough]]
                                                ^
build/cythonized/sage/libs/lcalc/lcalc_Lfunction.cpp:3428:9: note: in expansion of macro 'CYTHON_FALLTHROUGH'
         CYTHON_FALLTHROUGH;
         ^~~~~~~~~~~~~~~~~~
```