### PR TITLE
Travis-CI: Setup macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
-language: python
+os: linux
 dist: trusty
 sudo: false
+
+addons:
+  apt:
+    packages:
+      - gdb
+      - python-dbg
+      - python3-dbg
 
 cache:
   pip: true
   directories:
     - $HOME/.ccache
 
+language: python
 python:
   - 2.7
   - 3.6
@@ -30,26 +38,36 @@ env:
     - BACKEND=c
     - BACKEND=cpp
 
-branches:
-  only:
-    - master
-    - release
-
-install:
-  - python -c 'import sys; print("Python %s" % (sys.version,))'
-  - if [ -n "${TRAVIS_PYTHON_VERSION##*-dev}" -a -n "${TRAVIS_PYTHON_VERSION##2.6*}" ]; then pip install -r test-requirements.txt $( [ -z "${TRAVIS_PYTHON_VERSION##pypy*}" ] || echo " -r test-requirements-cpython.txt" ) ; fi
-  - CFLAGS="-O2 -ggdb -Wall -Wextra $(python -c 'import sys; print("-fno-strict-aliasing" if sys.version_info[0] == 2 else "")')" python setup.py build
-
-before_script: ccache -s
-
-script:
-  - PYTHON_DBG="python$( python -c 'import sys; print("%d.%d" % sys.version_info[:2])' )-dbg"
-  - if $PYTHON_DBG -V >&2; then CFLAGS="-O0 -ggdb" $PYTHON_DBG runtests.py -vv Debugger --backends=$BACKEND; fi
-  - if [ false && "$BACKEND" = "cpp" ]; then pip install pythran; fi  # disabled: needs Pythran > 0.8.1
-  - CFLAGS="-O2 -ggdb -Wall -Wextra $(python -c 'import sys; print("-fno-strict-aliasing" if sys.version_info[0] == 2 else "")')" python setup.py build_ext -i
-  - CFLAGS="-O0 -ggdb -Wall -Wextra" python runtests.py -vv -x Debugger --backends=$BACKEND -j7
-
 matrix:
+  include:
+    - os: osx
+      osx_image: xcode6.4
+      env: BACKEND=c PY=2
+      python: 2
+      language: c
+      compiler: clang
+      cache: false
+    - os: osx
+      osx_image: xcode6.4
+      env: BACKEND=cpp PY=2
+      python: 2
+      language: cpp
+      compiler: clang
+      cache: false
+    - os: osx
+      osx_image: xcode6.4
+      env: BACKEND=c PY=3
+      python: 3
+      language: c
+      compiler: clang
+      cache: false
+    - os: osx
+      osx_image: xcode6.4
+      env: BACKEND=cpp PY=3
+      python: 3
+      language: cpp
+      compiler: clang
+      cache: false
   allow_failures:
     - python: pypy
     - python: pypy3
@@ -61,9 +79,30 @@ matrix:
     - python: pypy3
       env: BACKEND=cpp
 
-addons:
-  apt:
-    packages:
-      - gdb
-      - python-dbg
-      - python3-dbg
+branches:
+  only:
+    - master
+    - release
+
+before_install:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then # Install Miniconda
+      curl -s -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda$PY-latest-MacOSX-x86_64.sh;
+      bash miniconda.sh -b -p $HOME/miniconda && rm miniconda.sh;
+      export PATH="$HOME/miniconda/bin:$PATH"; hash -r;
+      #conda install --quiet --yes nomkl --file=test-requirements.txt --file=test-requirements-cpython.txt;
+    fi
+
+install:
+  - python -c 'import sys; print("Python %s" % (sys.version,))'
+  - if [ -n "${TRAVIS_PYTHON_VERSION##*-dev}" -a -n "${TRAVIS_PYTHON_VERSION##2.6*}" ]; then pip install -r test-requirements.txt $( [ -z "${TRAVIS_PYTHON_VERSION##pypy*}" ] || echo " -r test-requirements-cpython.txt" ) ; fi
+  - CFLAGS="-O2 -ggdb -Wall -Wextra $(python -c 'import sys; print("-fno-strict-aliasing" if sys.version_info[0] == 2 else "")')" python setup.py build
+
+before_script: ccache -s || true
+
+script:
+  - PYTHON_DBG="python$( python -c 'import sys; print("%d.%d" % sys.version_info[:2])' )-dbg"
+  - if $PYTHON_DBG -V >&2; then CFLAGS="-O0 -ggdb" $PYTHON_DBG runtests.py -vv Debugger --backends=$BACKEND; fi
+  - if [ false && "$BACKEND" = "cpp" ]; then pip install pythran; fi  # disabled: needs Pythran > 0.8.1
+  - CFLAGS="-O2 -ggdb -Wall -Wextra $(python -c 'import sys; print("-fno-strict-aliasing" if sys.version_info[0] == 2 else "")')" python setup.py build_ext -i
+  - CFLAGS="-O0 -ggdb -Wall -Wextra" python runtests.py -vv -x Debugger --backends=$BACKEND -j7

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -512,13 +512,22 @@
       #define CYTHON_FALLTHROUGH [[fallthrough]]
     #elif __has_cpp_attribute(clang::fallthrough)
       #define CYTHON_FALLTHROUGH [[clang::fallthrough]]
+    #elif __has_cpp_attribute(gnu::fallthrough)
+      #define CYTHON_FALLTHROUGH [[gnu::fallthrough]]
     #endif
   #endif
 
   #ifndef CYTHON_FALLTHROUGH
-    #if (defined(__GNUC__) || defined(__clang__)) && __has_attribute(fallthrough)
+    #if __has_attribute(fallthrough)
       #define CYTHON_FALLTHROUGH __attribute__((fallthrough))
     #else
+      #define CYTHON_FALLTHROUGH
+    #endif
+  #endif
+
+  #if defined(__clang__ ) && defined(__apple_build_version__)
+    #if __apple_build_version__ < 7000000 /* Xcode < 7.0 */
+      #undef  CYTHON_FALLTHROUGH
       #define CYTHON_FALLTHROUGH
     #endif
   #endif

--- a/Demos/embed/Makefile
+++ b/Demos/embed/Makefile
@@ -1,6 +1,7 @@
 # Makefile for creating our standalone Cython program
 PYTHON := python
 PYVERSION := $(shell $(PYTHON) -c "import sys; print(sys.version[:3])")
+PYPREFIX := $(shell $(PYTHON) -c "import sys; print(sys.prefix)")
 
 INCDIR := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc())")
 PLATINCDIR := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True))")
@@ -31,5 +32,5 @@ clean:
 	@rm -f *~ *.o *.so core core.* *.c embedded test.output
 
 test: clean all
-	LD_LIBRARY_PATH=$(LIBDIR1):$$LD_LIBRARY_PATH ./embedded > test.output
+	PYTHONHOME=$(PYPREFIX) LD_LIBRARY_PATH=$(LIBDIR1):$$LD_LIBRARY_PATH ./embedded > test.output
 	$(PYTHON) assert_equal.py embedded.output test.output

--- a/runtests.py
+++ b/runtests.py
@@ -2088,6 +2088,13 @@ def runtests(options, cmd_args, coverage=None):
         sys.stderr.write("Backends: %s\n" % ','.join(backends))
     languages = backends
 
+    if 'TRAVIS' in os.environ and sys.platform == 'darwin' and 'cpp' in languages:
+        bugs_file_name = 'travis_macos_cpp_bugs.txt'
+        exclude_selectors += [
+            FileListExcluder(os.path.join(ROOTDIR, bugs_file_name),
+                             verbose=verbose_excludes)
+        ]
+
     if options.use_common_utility_dir:
         common_utility_dir = os.path.join(WORKDIR, 'utility_code')
         if not os.path.exists(common_utility_dir):

--- a/runtests.py
+++ b/runtests.py
@@ -253,7 +253,6 @@ def update_cpp11_extension(ext):
         update cpp11 extensions that will run on versions of gcc >4.8
     """
     gcc_version = get_gcc_version(ext.language)
-    compiler_version = gcc_version.group(1)
     if gcc_version is not None:
         compiler_version = gcc_version.group(1)
         if float(compiler_version) > 4.8:

--- a/tests/travis_macos_cpp_bugs.txt
+++ b/tests/travis_macos_cpp_bugs.txt
@@ -1,0 +1,9 @@
+complex_numbers_T305
+complex_numbers_c99_T398
+complex_numbers_cpp
+complex_numbers_cxx_T398
+cpdef_extern_func
+cpp_classes_def
+cpp_smart_ptr
+cpp_stl_conversion
+cpp_stl_function


### PR DESCRIPTION
Summary:

* Fixed minor issues in the testsuite and runtest script.
* Update `CYTHON_FALLTHROUGH` to works with old Apple Clang.
* Extend Travis-CI build matrix to macOS using Anaconda Python (Miniconda).

Details:

* The macOS build matrix uses Python 2 for now and test dependencies are not installed for the runs to finish as quickly as possible (the macOS build infrastructure is slower than the Linux one). It should be trivial to add Python 3 and/or test dependencies.

* I'm using the oldest macOS image available in Travis-CI, which is the same image currently used by conda-forge builds. Newer images (maybe newest?) could be added to the build matrix, however this would delay even further the builds to finish (Travis-CI macOS workers are always under pressure).

* It took me quite a while to get the `CYTHON_FALLTHROUGH` beast right. I had to special case old Apple Clang to get things working on Travis-CI. Please don't play games with it unless you REALLY know what you are doing, or at least email/mention me.

* The `BACKEND=cpp` builds are expected to fail on macOS with this old OS image. After you review this PR, we can add it to know failures, and fix the errors in the near future.