### PR TITLE
PyPy3: Register module cleanup with atexit

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1040,7 +1040,7 @@ static int __Pyx_RegisterCleanup(void); /*proto*/
 //@substitute: naming
 //@requires: ImportExport.c::ModuleImport
 
-#if PY_MAJOR_VERSION < 3
+#if PY_MAJOR_VERSION < 3 || CYTHON_COMPILING_IN_PYPY
 static PyObject* ${cleanup_cname}_atexit(PyObject *module, CYTHON_UNUSED PyObject *unused) {
     ${cleanup_cname}(module);
     Py_INCREF(Py_None); return Py_None;
@@ -1113,7 +1113,7 @@ bad:
 #else
 // fake call purely to work around "unused function" warning for __Pyx_ImportModule()
 static int __Pyx_RegisterCleanup(void) {
-    if ((0)) __Pyx_ImportModule(NULL);
+    (void)__Pyx_ImportModule; /* unused */
     return 0;
 }
 #endif


### PR DESCRIPTION
@scoder I think you forgot this bit. Is this fix OK with you?

PS: Also, add the the `(void)something;` trick to your pocket.