### PR TITLE
Match Pythran interface when generating index operator

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4192,9 +4192,10 @@ class BufferIndexNode(_IndexingBaseNode):
             # support move-assignation easily.
             # This, we explicitly destroy then in-place new objects in this
             # case.
+            index = '[%s]' if len(self.indices) == 1 else '(%s)'
             code.putln("__Pyx_call_destructor(%s);" % obj)
             code.putln("new (&%s) decltype(%s){%s};" % (obj, obj, self.base.pythran_result()))
-            code.putln("%s(%s) %s= %s;" % (
+            code.putln(("%s" + index + " %s= %s;") % (
                 obj,
                 pythran_indexing_code(self.indices),
                 op,
@@ -4225,7 +4226,8 @@ class BufferIndexNode(_IndexingBaseNode):
         if is_pythran_expr(self.base.type):
             res = self.result()
             code.putln("__Pyx_call_destructor(%s);" % res)
-            code.putln("new (&%s) decltype(%s){%s[%s]};" % (
+            index = '[%s]' if len(self.indices) == 1 else '(%s)'
+            code.putln(("new (&%s) decltype(%s){%s" + index + "};") % (
                 res,
                 res,
                 self.base.pythran_result(),

--- a/Cython/Compiler/Pythran.py
+++ b/Cython/Compiler/Pythran.py
@@ -76,7 +76,8 @@ def pythran_indexing_type(type_, indices):
         raise ValueError("unsupported indexing type %s!" % idx.type)
 
     indexing = ",".join(index_code(idx) for idx in indices)
-    return type_remove_ref("decltype(std::declval<%s>()[%s])" % (pythran_type(type_), indexing))
+    index = '[%s]' if len(indices) == 1 else '(%s)'
+    return type_remove_ref(("decltype(std::declval<%s>()" + index) % (pythran_type(type_), indexing))
 
 
 def pythran_indexing_code(indices):


### PR DESCRIPTION
Otherwise calls to ``a[i,j]`` are turned into ``a[(i,j)]`` in C++, ``,`` being the sequence operator.