### PR TITLE
Fix cpdef methods to not emit redeclared warning (see #1874)

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2105,8 +2105,7 @@ class CClassScope(ClassScope):
         if name == "__new__":
             error(pos, "__new__ method of extension type will change semantics "
                 "in a future version of Pyrex and Cython. Use __cinit__ instead.")
-        entry = self.declare_var(name, py_object_type, pos,
-                                 visibility='extern')
+        entry = self.declare_var(name, py_object_type, pos, visibility='ignore')
         special_sig = get_special_method_signature(name)
         if special_sig:
             # Special methods get put in the method table with a particular


### PR DESCRIPTION
@robertwb  after your fix related to #1874, I'm getting these warnings:

```
$ cat tmp.pyx
cdef class Foo:
    cpdef foo(self):
        pass

$ python -m cython tmp.pyx 
warning: tmp.pyx:2:10: 'foo' redeclared 
```