### PR TITLE
Specify license in cython-mode.el's header

### DIFF
--- a/Tools/cython-mode.el
+++ b/Tools/cython-mode.el
@@ -1,5 +1,7 @@
 ;;; cython-mode.el --- Major mode for editing Cython files
 
+;; License: Apache-2.0
+
 ;;; Commentary:
 
 ;; This should work with python-mode.el as well as either the new


### PR DESCRIPTION
Emacs lisp packages are often distributed by themselves, so it
is important to specify the license in the Elisp library itself.