### PR TITLE
Fix types of values in libc.limits

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2074,7 +2074,11 @@ class NameNode(AtomicExprNode):
 
     def check_const(self):
         entry = self.entry
-        if entry is not None and not (entry.is_const or entry.is_cfunction or entry.is_builtin):
+        if entry is not None and not (
+                entry.is_const or
+                entry.is_cfunction or
+                entry.is_builtin or
+                entry.type.is_const):
             self.not_const()
             return False
         return True

--- a/Cython/Includes/libc/limits.pxd
+++ b/Cython/Includes/libc/limits.pxd
@@ -1,29 +1,28 @@
 # 5.2.4.2.1 Sizes of integer types <limits.h>
 
 cdef extern from "<limits.h>":
+    const int CHAR_BIT
+    const int MB_LEN_MAX
 
-    enum: CHAR_BIT
-    enum: MB_LEN_MAX
+    const char CHAR_MIN
+    const char CHAR_MAX
 
-    enum:  CHAR_MIN
-    enum:  CHAR_MAX
+    const signed char SCHAR_MIN
+    const signed char SCHAR_MAX
+    const unsigned char UCHAR_MAX
 
-    enum: SCHAR_MIN
-    enum: SCHAR_MAX
-    enum: UCHAR_MAX
+    const short SHRT_MIN
+    const short SHRT_MAX
+    const unsigned short USHRT_MAX
 
-    enum:   SHRT_MIN
-    enum:   SHRT_MAX
-    enum:  USHRT_MAX
+    const int INT_MIN
+    const int INT_MAX
+    const unsigned int UINT_MAX
 
-    enum:    INT_MIN
-    enum:    INT_MAX
-    enum:   UINT_MAX
+    const long LONG_MIN
+    const long LONG_MAX
+    const unsigned long ULONG_MAX
 
-    enum:   LONG_MIN
-    enum:   LONG_MAX
-    enum:  ULONG_MAX
-
-    enum:  LLONG_MIN
-    enum:  LLONG_MAX
-    enum: ULLONG_MAX
+    const long long LLONG_MIN
+    const long long LLONG_MAX
+    const unsigned long long ULLONG_MAX

--- a/tests/run/fstring.pyx
+++ b/tests/run/fstring.pyx
@@ -10,10 +10,7 @@ cimport cython
 import sys
 IS_PYPY = hasattr(sys, 'pypy_version_info')
 
-cdef extern from *:
-    int INT_MAX
-    long LONG_MAX
-    long LONG_MIN
+from libc.limits cimport INT_MAX, LONG_MAX, LONG_MIN
 
 max_int = INT_MAX
 max_long = LONG_MAX
@@ -147,6 +144,15 @@ def format_c_numbers_max(int n, long l):
     s2 = f"{n:012X}:{l:020X}"
     assert isinstance(s2, unicode), type(s2)
     return s1, s2
+
+
+def format_c_number_const():
+    """
+    >>> s = format_c_number_const()
+    >>> s == '{0}'.format(max_long) or s
+    True
+    """
+    return f"{LONG_MAX}"
 
 
 def format_c_number_range(int n):


### PR DESCRIPTION
```
from libc.limits cimport LONG_MAX
print(f"{LONG_MAX}")
```
currently gives `-1` on a 64-bit system because Cython thinks that `LONG_MAX` is of type `int`.

This requires #2020.