### PR TITLE
Treat entries with constant type as constant

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2074,7 +2074,11 @@ class NameNode(AtomicExprNode):
 
     def check_const(self):
         entry = self.entry
-        if entry is not None and not (entry.is_const or entry.is_cfunction or entry.is_builtin):
+        if entry is not None and not (
+                entry.is_const or
+                entry.is_cfunction or
+                entry.is_builtin or
+                entry.type.is_const):
             self.not_const()
             return False
         return True


### PR DESCRIPTION
This should be allowed:
```
cdef extern from *:
    const long N

cdef int arr[N]
```

This is required to fix a testcase in #2016.