### PR TITLE
Allow multiple inheritance without __dict__

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -1,3 +1,66 @@
+/////////////// PyType_Ready.proto ///////////////
+
+static int __Pyx_PyType_Ready(PyTypeObject *t);
+
+/////////////// PyType_Ready ///////////////
+
+// Wrapper around PyType_Ready() with some runtime checks and fixes
+// to deal with multiple inheritance.
+static int __Pyx_PyType_Ready(PyTypeObject *t) {
+    // Loop over all bases (except the first) and check that those
+    // really are heap types. Otherwise, it would not be safe to
+    // subclass them.
+    //
+    // We also check tp_dictoffset: it is unsafe to inherit
+    // tp_dictoffset from a base class because the object structures
+    // would not be compatible. So, if our extension type doesn't set
+    // tp_dictoffset (i.e. there is no __dict__ attribute in the object
+    // structure), we need to check that none of the base classes sets
+    // it either.
+    PyObject *bases = t->tp_bases;
+    if (bases)
+    {
+        Py_ssize_t i, n = PyTuple_GET_SIZE(bases);
+        for (i = 1; i < n; i++)  /* Skip first base */
+        {
+            PyTypeObject *b = (PyTypeObject*)PyTuple_GET_ITEM(bases, i);
+            if (!PyType_HasFeature(b, Py_TPFLAGS_HEAPTYPE))
+            {
+                PyErr_Format(PyExc_TypeError, "base class '%.200s' is not a heap type",
+                             b->tp_name);
+                return -1;
+            }
+            if (t->tp_dictoffset == 0 && b->tp_dictoffset)
+            {
+                PyErr_Format(PyExc_TypeError,
+                    "extension type '%.200s' has no __dict__ slot, but base type '%.200s' has: "
+                    "either add 'cdef dict __dict__' to the extension type "
+                    "or add '__slots__ = [...]' to the base type",
+                    t->tp_name, b->tp_name);
+                return -1;
+            }
+        }
+    }
+
+#if PY_VERSION_HEX >= 0x03050000
+    // As of https://bugs.python.org/issue22079
+    // PyType_Ready enforces that all bases of a non-heap type are
+    // non-heap. We know that this is the case for the solid base but
+    // other bases are heap allocated and are kept alive through the
+    // tp_bases reference.
+    // Other than this check, the Py_TPFLAGS_HEAPTYPE flag is unused
+    // in PyType_Ready().
+    t->tp_flags |= Py_TPFLAGS_HEAPTYPE;
+#endif
+
+    int r = PyType_Ready(t);
+
+#if PY_VERSION_HEX >= 0x03050000
+    t->tp_flags &= ~Py_TPFLAGS_HEAPTYPE;
+#endif
+
+    return r;
+}
 
 /////////////// CallNextTpDealloc.proto ///////////////
 

--- a/tests/run/cdef_multiple_inheritance_errors.srctree
+++ b/tests/run/cdef_multiple_inheritance_errors.srctree
@@ -1,0 +1,74 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import runner"
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(ext_modules=cythonize("*.pyx"))
+
+######## notheaptype.pyx ########
+
+cdef class Base:
+    pass
+
+Obj = type(object())
+
+cdef class Foo(Base, Obj):
+    pass
+
+######## wrongbase.pyx ########
+
+cdef class Base:
+    pass
+
+Str = type("")
+
+cdef class X(Base, Str):
+    pass
+
+######## badmro.pyx ########
+
+class Py(object):
+    pass
+
+cdef class X(object, Py):
+    pass
+
+######## nodict.pyx ########
+
+cdef class Base:
+    pass
+
+class Py(object):
+    pass
+
+cdef class X(Base, Py):
+    pass
+
+######## runner.py ########
+
+try:
+    import notheaptype
+    assert False
+except TypeError as msg:
+    assert str(msg) == "base class 'object' is not a heap type"
+
+try:
+    import wrongbase
+    assert False
+except TypeError as msg:
+    assert str(msg) == "best base 'str' must be equal to first base 'wrongbase.Base'"
+
+try:
+    import badmro
+    assert False
+except TypeError as msg:
+    assert str(msg).startswith("Cannot create a consistent method resolution")
+
+try:
+    import nodict
+    assert False
+except TypeError as msg:
+    assert str(msg) == "extension type 'nodict.X' has no __dict__ slot, but base type 'Py' has: either add 'cdef dict __dict__' to the extension type or add '__slots__ = [...]' to the base type"

--- a/tests/run/cdef_multiple_inheritance_nodict.pyx
+++ b/tests/run/cdef_multiple_inheritance_nodict.pyx
@@ -1,0 +1,48 @@
+# Copied from cdef_multiple_inheritance.pyx
+# but with __slots__ and without __dict__
+
+cdef class CBase(object):
+    cdef int a
+    cdef c_method(self):
+        return "CBase"
+    cpdef cpdef_method(self):
+        return "CBase"
+
+class PyBase(object):
+    __slots__ = []
+    def py_method(self):
+        return "PyBase"
+
+cdef class Both(CBase, PyBase):
+    """
+    >>> b = Both()
+    >>> b.py_method()
+    'PyBase'
+    >>> b.cp_method()
+    'Both'
+    >>> b.call_c_method()
+    'Both'
+
+    >>> isinstance(b, CBase)
+    True
+    >>> isinstance(b, PyBase)
+    True
+    """
+    cdef c_method(self):
+        return "Both"
+    cpdef cp_method(self):
+        return "Both"
+    def call_c_method(self):
+        return self.c_method()
+
+cdef class BothSub(Both):
+    """
+    >>> b = BothSub()
+    >>> b.py_method()
+    'PyBase'
+    >>> b.cp_method()
+    'Both'
+    >>> b.call_c_method()
+    'Both'
+    """
+    pass


### PR DESCRIPTION
If none of the base classes has a `__dict__` slot (i.e. `tp_dictoffset` is 0), then it is safe to inherit from those with a `cdef class` without a `__dict__`. Unfortunately, we cannot check this condition at compile-time so it must be done at run-time.

Since we are adding run-time checks anyway, we also verify that the base types are actually heap types.