### PR TITLE
[Docs][Ready for Review] Added documentation on extension class instanciation from existing pointer

### DIFF
--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -554,10 +554,8 @@ contructors, this necessitates the use of factory functions. For example, ::
         cdef my_c_struct *_ptr
         cdef bint ptr_owner
 
-        def __cinit__(self, owner=False):
-            # On cinit, do not create new structure but set pointer to NULL
-            self._ptr = NULL
-            self.ptr_owner = owner
+        def __cinit__(self):
+            self.ptr_owner = False
 
         def __dealloc__(self):
             # De-allocate if not null and flag is set
@@ -583,8 +581,9 @@ contructors, this necessitates the use of factory functions. For example, ::
             the extension type to ``free`` the structure pointed to by ``_ptr``
             when the wrapper object is deallocated."""
             # Call to __new__ bypasses __init__ constructor
-            cdef WrapperClass wrapper = WrapperClass.__new__(WrapperClass, owner=True)
+            cdef WrapperClass wrapper = WrapperClass.__new__(WrapperClass)
             wrapper._ptr = _ptr
+            wrapper.ptr_owner = owner
             return wrapper
 
         @staticmethod

--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -88,6 +88,8 @@ complaining about the signature mismatch.
     It often helps to directly call ``__new__()`` in this function to bypass the
     call to the ``__init__()`` constructor.
 
+    See :ref:`existing-pointers-instantiation` for an example.
+
 .. Note::
 
     Older Cython files may use :meth:`__new__` rather than :meth:`__cinit__`. The two are synonyms.


### PR DESCRIPTION
A common use case for extension types is to instantiate them from existing C/C++ pointers without copying. The documentation is not very clear on how to do this - there is a mention of 'factory function' in [extension type reference documentation](http://cython.readthedocs.io/en/latest/src/reference/extension_types.html?highlight=factory) but no example.

This is one of the most frequently asked questions on Q/A forums and websites like stack overflow with many new users struggling to get this right the first time, or why it doesn't work for extension types from pointers but does for extension types from native types. I also struggled with this when first starting to use Cython.

This example should help with this common question. The example code works as-is and can be compiled directly with cython to see how it works. Also added a link to the guide section from the reference document.

Let me know if anything else is needed and many thanks for the awesome project.