### PR TITLE
C functions without args should be declared as f(void)

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3190,7 +3190,10 @@ class DefNode(FuncDefNode):
             arg_code_list.append(arg_decl_code(self.star_arg))
         if self.starstar_arg:
             arg_code_list.append(arg_decl_code(self.starstar_arg))
-        arg_code = ', '.join(arg_code_list)
+        if arg_code_list:
+            arg_code = ', '.join(arg_code_list)
+        else:
+            arg_code = 'void'  # No arguments
         dc = self.return_type.declaration_code(self.entry.pyfunc_cname)
 
         decls_code = code.globalstate['decls']

--- a/tests/run/staticmethod.pyx
+++ b/tests/run/staticmethod.pyx
@@ -139,6 +139,14 @@ cdef class ArgsKwargs(object):
         """
         return args + tuple(sorted(kwargs.items()))
 
+    @staticmethod
+    def no_args():
+        """
+        >>> ArgsKwargs().no_args()
+        OK!
+        """
+        print("OK!")
+
 
 class StaticmethodSubclass(staticmethod):
     """


### PR DESCRIPTION
This fixes some `-Wstrict-prototypes` warnings