### PR TITLE
MAINT: Using Py3 print call in tests/testsupport/cythonarrayutil.pxi

### DIFF
--- a/tests/testsupport/cythonarrayutil.pxi
+++ b/tests/testsupport/cythonarrayutil.pxi
@@ -3,7 +3,7 @@ cimport cython
 from cython.view cimport array
 
 cdef void callback(void *data):
-    print "callback called"
+    print("callback called")
     free(data)
 
 def create_array(shape, mode, use_callback=False):


### PR DESCRIPTION
On Windows, with Python 3, certain doc tests that expect to see 'callback called' printed fail because it did  not. 

Failures are sporadic. Not sure if this change is going to fix that, but the `print "callback called"` seemed not right.