### PR TITLE
In Python 3, an unbound method is just a function

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -617,7 +617,7 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-  #define __Pyx_PyMethod_New(func, self, klass) ((self) ? PyMethod_New(func, self) : PyInstanceMethod_New(func))
+  #define __Pyx_PyMethod_New(func, self, klass) ((self) ? PyMethod_New(func, self) : (Py_INCREF(func), func))
 #else
   #define __Pyx_PyMethod_New(func, self, klass) PyMethod_New(func, self, klass)
 #endif

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -3,6 +3,7 @@
 # tag: cyfunction
 
 import sys
+IS_PY2 = sys.version_info[0] < 3
 IS_PY3 = sys.version_info[0] >= 3
 IS_PY34 = sys.version_info > (3, 4, 0, 'beta', 3)
 
@@ -348,3 +349,21 @@ cdef class TestDecoratedMethods:
         2
         """
         return x
+
+
+cdef class TestUnboundMethodCdef:
+    """
+    >>> C = TestUnboundMethodCdef
+    >>> IS_PY2 or (C.meth is C.__dict__["meth"])
+    True
+    """
+    def meth(self): pass
+
+
+class TestUnboundMethod:
+    """
+    >>> C = TestUnboundMethod
+    >>> IS_PY2 or (C.meth is C.__dict__["meth"])
+    True
+    """
+    def meth(self): pass

--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -1,3 +1,6 @@
+import sys
+IS_PY2 = sys.version_info[0] < 3
+
 import cython
 
 is_compiled = cython.compiled
@@ -360,3 +363,12 @@ class CClass(object):
     def get_attr(self):
         print(cython.typeof(self.attr))
         return self.attr
+
+
+class TestUnboundMethod:
+    """
+    >>> C = TestUnboundMethod
+    >>> IS_PY2 or (C.meth is C.__dict__["meth"])
+    True
+    """
+    def meth(self): pass


### PR DESCRIPTION
In plain Python 3, there is no "unbound method" type, an unbound method is just the function in the class `__dict__`:
```python
In [1]: class P:
   ...:     def meth(self): pass

In [2]: P.meth
Out[2]: <function __main__.P.meth>

In [3]: P.meth is P.__dict__["meth"]
Out[3]: True
```

In Cython, unbound methods instead become instancemethod objects:
```cython
In [3]: %%cython
   ...: cimport cython
   ...: cdef class X:
   ...:     @cython.binding(True)
   ...:     def meth(self): pass
   ...: class Y:
   ...:     def meth(self): pass

In [4]: X.meth
Out[4]: <instancemethod meth at 0x3fff79e0a7c8>

In [5]: Y.meth
Out[5]: <instancemethod meth at 0x3fff7a7bbd38>
```
This uses [PyInstanceMethod_New](https://docs.python.org/3.6/c-api/method.html). That seems wrong because the docs say that this is meant for a `PyCFunction`. Given that Cython functions should be analogous to Python functions, this should be fixed.

Context: this broke SageMath on Python 3 because this causes unbound methods to be no longer hashable (functions are hashable but instancemethods are not).