### PR TITLE
documentation __dealloc__ should be def not cdef

### DIFF
--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -409,9 +409,9 @@ compatible types.::
     cdef class OwnedPointer:
         cdef void* ptr
 
-        cdef __dealloc__(self):
-            if ptr != NULL:
-                free(ptr)
+        def __dealloc__(self):
+        if self.ptr != NULL:
+            free(self.ptr)
 
         @staticmethod
         cdef create(void* ptr):

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -410,8 +410,8 @@ compatible types.::
         cdef void* ptr
 
         def __dealloc__(self):
-        if self.ptr != NULL:
-            free(self.ptr)
+            if self.ptr != NULL:
+                free(self.ptr)
 
         @staticmethod
         cdef create(void* ptr):


### PR DESCRIPTION
Hi,

I tried to compile the `OwnedPointer` at http://docs.cython.org/en/latest/src/userguide/extension_types.html#c-methods
It failed to compile telling me that special methods must be declared with 'def', not 'cdef'.

Thanks