### PR TITLE
Patch to add front() and back(), as per issue #2123.

### DIFF
--- a/Cython/Includes/libcpp/string.pxd
+++ b/Cython/Includes/libcpp/string.pxd
@@ -63,6 +63,8 @@ cdef extern from "<string>" namespace "std" nogil:
 
         char& at(size_t)
         char& operator[](size_t)
+        char& front()
+        char& back()
         int compare(const string&)
 
         string& append(const string&)

--- a/tests/run/cpp_stl_string_cpp11.pyx
+++ b/tests/run/cpp_stl_string_cpp11.pyx
@@ -1,0 +1,16 @@
+# mode: run
+# tag: cpp, werror, cpp11
+# distutils: extra_compile_args=-std=c++11
+
+from libcpp.string cimport string
+
+b_asdf = b'asdf'
+
+def test_element_access(char *py_str):
+    """
+    >>> test_element_access(b_asdf)
+    ('a', 'f')
+    """
+    cdef string s
+    s = string(py_str)
+    return chr(s.front()), chr(s.back())


### PR DESCRIPTION
Adds the C++11 functions `front()` and `back()` to `std::string`, as well as unittests for functionality.