### PR TITLE
Put the pip installation first.

### DIFF
--- a/docs/src/quickstart/install.rst
+++ b/docs/src/quickstart/install.rst
@@ -33,19 +33,19 @@ according to the system used:
 .. dagss tried other forms of ReST lists and they didn't look nice
 .. with rst2latex.
 
+The simplest way of installing Cython is by using ``pip``:
+
+::
+
+  pip install Cython
+
+
 The newest Cython release can always be downloaded from
 http://cython.org.  Unpack the tarball or zip file, enter the
 directory, and then run::
 
   python setup.py install
 
-If you have ``pip`` set up on your system (e.g. in a virtualenv or a
-recent Python version), you should be able to fetch Cython from PyPI
-and install it using
-
-::
-
-  pip install Cython
 
 For one-time builds, e.g. for CI/testing, on platforms that are not covered
 by one of the wheel packages provided on PyPI, it is substantially faster


### PR DESCRIPTION
I think it's not a big change, but it makes more sense to put the prefered way of installation first.