### PR TITLE
COMPAT: From the next release PyPy fixed tp_basicsize of PyType_Type

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3020,7 +3020,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if sizeof_objstruct != objstruct:
             if not condition:
                 code.putln("")  # start in new line
-            code.putln("#if CYTHON_COMPILING_IN_PYPY")
+            code.putln("#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x050B0000")
             code.putln('sizeof(%s),' % objstruct)
             code.putln("#else")
             code.putln('sizeof(%s),' % sizeof_objstruct)


### PR DESCRIPTION
PyPy had a bug that the ``tp_basicsize`` of ``PyType_Type`` was wrong. From the next release, this will be fixed. The pull request pins the work-around to previous versions of PyPy