### PR TITLE
Improve libcpp.unordered_map API

### DIFF
--- a/Cython/Includes/libcpp/unordered_map.pxd
+++ b/Cython/Includes/libcpp/unordered_map.pxd
@@ -65,3 +65,5 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         #value_compare value_comp()
         void max_load_factor(float)
         float max_load_factor()
+        void reserve(size_t)
+        size_t bucket_count()


### PR DESCRIPTION
Hi.

This PR improve the API provided by `libcpp unordered_map`.

I only add `reserve` and `bucket_count` to the  API cause it was needed on my side. But there is other missing functions. Let me know if you prefer a patch with the exhaustive API.