### PR TITLE
Allow `NULL` to be coerced to a pointer to a fused type

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -850,6 +850,9 @@ class ExprNode(Node):
 
             if src_type.is_fused:
                 error(self.pos, "Type is not specialized")
+            elif src_type.is_null_ptr and dst_type.is_ptr:
+                # NULL can be implicitly cast to any pointer type
+                return self
             else:
                 error(self.pos, "Cannot coerce to a type that is not specialized")
 

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -119,6 +119,38 @@ def test_fused_with_pointer():
     print
     print fused_with_pointer(string_array).decode('ascii')
 
+cdef fused_type1* fused_pointer_except_null(fused_type1 x) except NULL:
+    if fused_type1 is string_t:
+        assert(bool(x))
+    else:
+        assert(x < 10)
+    return &x
+
+def test_fused_pointer_except_null(value):
+    """
+    >>> test_fused_pointer_except_null(1)
+    1
+    >>> test_fused_pointer_except_null(2.0)
+    2.0
+    >>> test_fused_pointer_except_null(b'foo')
+    foo
+    >>> test_fused_pointer_except_null(16)
+    Traceback (most recent call last):
+    AssertionError
+    >>> test_fused_pointer_except_null(15.1)
+    Traceback (most recent call last):
+    AssertionError
+    >>> test_fused_pointer_except_null(b'')
+    Traceback (most recent call last):
+    AssertionError
+    """
+    if isinstance(value, int):
+        print fused_pointer_except_null(<cython.int>value)[0]
+    elif isinstance(value, float):
+        print fused_pointer_except_null(<cython.float>value)[0]
+    elif isinstance(value, bytes):
+        print fused_pointer_except_null(<string_t>value)[0].decode('ascii')
+
 include "cythonarrayutil.pxi"
 
 cpdef cython.integral test_fused_memoryviews(cython.integral[:, ::1] a):


### PR DESCRIPTION
Currently, when `NULL` and a fused type are passed to [ExprNodes.coerce_to](https://github.com/cython/cython/blob/master/Cython/Compiler/ExprNodes.py#L807), the compiler throws the following error:

```

Error compiling Cython file:
------------------------------------------------------------
...
    char
    wchar_t

ctypedef c_char* c_string

cdef c_string check_ptr(c_string ptr) except NULL:
                                          ^
------------------------------------------------------------

test.pyx:9:43: Cannot coerce to a type that is not specialized
```

However, this error is a false positive; `NULL` is assignable to any pointer type, and `c_string` is a pointer type. This PR avoids the false positive by explicitly allowing `NULL` to be coerced to a pointer to a fused type.

The only example I know of in which this error is thrown is when attempting to specify `NULL` as an exception value for a function returning a pointer to a fused type. There are two possible workarounds for this in the current state of Cython. For example, with the following definitions...

```cython
from libc.stddef cimport wchar_t

ctypedef fused any_char:
    char
    wchar_t

ctypedef c_char* any_string
```

One, always checking for errors:
```cython
cdef c_string check_ptr(c_string ptr) except *:
    if ptr is NULL:
        raise ValueError("null pointer")
    return ptr
```

Two, returning the value cast to `void*`:
```cython
cdef void* check_ptr_void(c_string ptr) except NULL:
    if ptr is NULL:
        raise ValueError("null pointer")
    return <void*>ptr
```

`check_ptr(some_string)` produces this C code on call:
```c
__pyx_fuse_1__pyx_f_4test_check_ptr(__pyx_v_some_string); if (unlikely(PyErr_Occurred())) __PYX_ERR(0, 30, __pyx_L1_error)
```

`check_ptr_void(some_string)` produces this C code on call:
```c
__pyx_fuse_0__pyx_f_4test_check_ptr_void(__pyx_v_some_string); if (unlikely(__pyx_t_4 == ((void *)NULL))) __PYX_ERR(0, 24, __pyx_L1_error)
```

`check_ptr_void` avoids a `PyErr_Occurred` call, but it requires casting the return value from `void*` to the desired type, which is not type safe. If you instead attempt to return `c_string`, you get the previously mentioned compliation error.