### PR TITLE
Added support for C++11's <forward_list>.

### DIFF
--- a/Cython/Includes/libcpp/forward_list.pxd
+++ b/Cython/Includes/libcpp/forward_list.pxd
@@ -1,0 +1,62 @@
+cdef extern from "<forward_list>" namespace "std" nogil:
+    cdef cppclass forward_list[T,ALLOCATOR=*]:
+        ctypedef T value_type
+        ctypedef ALLOCATOR allocator_type
+
+        # these should really be allocator_type.size_type and
+        # allocator_type.difference_type to be true to the C++ definition
+        # but cython doesn't support deferred access on template arguments
+        ctypedef size_t size_type
+        ctypedef ptrdiff_t difference_type
+
+        cppclass iterator:
+            iterator()
+            iterator(iterator &)
+            T& operator*()
+            iterator operator++()
+            bint operator==(iterator)
+            bint operator!=(iterator)
+        cppclass const_iterator(iterator):
+            pass
+        forward_list() except +
+        forward_list(forward_list&) except +
+        forward_list(size_t, T&) except +
+        #forward_list& operator=(forward_list&)
+        bint operator==(forward_list&, forward_list&)
+        bint operator!=(forward_list&, forward_list&)
+        bint operator<(forward_list&, forward_list&)
+        bint operator>(forward_list&, forward_list&)
+        bint operator<=(forward_list&, forward_list&)
+        bint operator>=(forward_list&, forward_list&)
+        void assign(size_t, T&)
+        T& front()
+        iterator before_begin()
+        const_iterator const_before_begin "before_begin"()
+        iterator begin()
+        const_iterator const_begin "begin"()
+        iterator end()
+        const_iterator const_end "end"()
+        bint empty()
+        size_t max_size()
+        void clear()
+        iterator insert_after(iterator, T&)
+        void insert_after(iterator, size_t, T&)
+        iterator erase_after(iterator)
+        iterator erase_after(iterator, iterator)
+        void push_front(T&)
+        void pop_front()
+        void resize(size_t)
+        void resize(size_t, T&)
+        void swap(forward_list&)
+        void merge(forward_list&)
+        void merge[Compare](forward_list&, Compare)
+        void splice_after(iterator, forward_list&)
+        void splice_after(iterator, forward_list&, iterator)
+        void splice_after(iterator, forward_list&, iterator, iterator)
+        void remove(const T&)
+        void remove_if[Predicate](Predicate)
+        void reverse()
+        void unique()
+        void unique[Predicate](Predicate)
+        void sort()
+        void sort[Compare](Compare)

--- a/tests/run/cpp_stl_forward_list.pyx
+++ b/tests/run/cpp_stl_forward_list.pyx
@@ -1,0 +1,79 @@
+# mode: run
+# tag: cpp, werror, cpp11
+
+from cython.operator cimport dereference as deref
+from cython.operator cimport preincrement as incr
+
+from libcpp.forward_list cimport forward_list
+from libcpp cimport bool as cbool
+
+
+def simple_iteration_test(L):
+    """
+    >>> iteration_test([1,2,4,8])
+    8
+    4
+    2
+    1
+    >>> iteration_test([8,4,2,1])
+    1
+    2
+    4
+    8
+    """
+    cdef forward_list[int] l
+    for a in L:
+        l.push_front(a)
+    for a in l:
+        print(a)
+
+def iteration_test(L):
+    """
+    >>> iteration_test([1,2,4,8])
+    8
+    4
+    2
+    1
+    >>> iteration_test([8,4,2,1])
+    1
+    2
+    4
+    8
+    """
+    l = new forward_list[int]()
+    try:
+        for a in L:
+            l.push_front(a)
+        it = l.begin()
+        while it != l.end():
+            a = deref(it)
+            incr(it)
+            print(a)
+    finally:
+        del l
+
+def test_value_type(x):
+    """
+    >>> test_value_type(2)
+    2.0
+    >>> test_value_type(2.5)
+    2.5
+    """
+    cdef forward_list[double].value_type val = x
+    return val
+
+def test_value_type_complex(x):
+    """
+    >>> test_value_type_complex(2)
+    (2+0j)
+    """
+    cdef forward_list[double complex].value_type val = x
+    return val
+
+
+#  Tests GitHub issue #1788.
+cdef cppclass MyForwardList[T](forward_list):
+    pass
+
+cdef cppclass Ints(MyForwardList[int]):
+    pass


### PR DESCRIPTION
Added preliminary support for `<forward_list>` which is a lightweight, singly-linked list, a C++11 feature.