### PR TITLE
Added support for non-type template support for literals.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -602,6 +602,13 @@ class ExprNode(Node):
         # type, return that type, else None.
         return None
 
+    def analyse_as_template_parameter(self, env):
+        # If this node can be interpreted as a template parameter,
+        # return that parameter, else None.
+        # Default to type interpretation, specialize
+        # for literals.
+        return self.analyse_as_type(env)
+
     def analyse_as_extension_type(self, env):
         # If this node can be interpreted as a reference to an
         # extension type or builtin type, return its type, else None.
@@ -1135,6 +1142,10 @@ class ConstNode(AtomicExprNode):
     def calculate_result_code(self):
         return str(self.value)
 
+    def analyse_as_template_parameter(self, env):
+        c_value = self.get_constant_c_result_code()
+        return PyrexTypes.TemplatePlaceholderType(c_value)
+
     def generate_result_code(self, code):
         pass
 
@@ -1324,6 +1335,7 @@ class IntNode(ConstNode):
 
     def compile_time_value(self, denv):
         return Utils.str_to_number(self.value)
+
 
 class FloatNode(ConstNode):
     type = PyrexTypes.c_double_type
@@ -3616,7 +3628,6 @@ class IndexNode(_IndexingBaseNode):
             if base_type in (list_type, tuple_type, dict_type):
                 # do the None check explicitly (not in a helper) to allow optimising it away
                 self.base = self.base.as_none_safe_node("'NoneType' object is not subscriptable")
-
         self.wrap_in_nonecheck_node(env, getting)
         return self
 
@@ -3788,7 +3799,7 @@ class IndexNode(_IndexingBaseNode):
         elif isinstance(self.index, TupleNode):
             for arg in self.index.args:
                 positions.append(arg.pos)
-        specific_types = self.parse_index_as_types(env, required=False)
+        specific_types = self.parse_index_as_template_parameters(env, required=False)
 
         if specific_types is None:
             self.index = self.index.analyse_types(env)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -957,6 +957,9 @@ class CBaseTypeNode(Node):
     def analyse_as_type(self, env):
         return self.analyse(env)
 
+    def analyse_as_template_parameter(self, env):
+        return self.analyse_as_type(env)
+
 
 class CAnalysedBaseTypeNode(Node):
     # type            type
@@ -1145,7 +1148,7 @@ class TemplatedTypeNode(CBaseTypeNode):
             else:
                 template_types = []
                 for template_node in self.positional_args:
-                    type = template_node.analyse_as_type(env)
+                    type = template_node.analyse_as_template_parameter(env)
                     if type is None:
                         error(template_node.pos, "unknown type in template argument")
                         type = error_type

--- a/tests/run/cpp_templates_helper.h
+++ b/tests/run/cpp_templates_helper.h
@@ -22,7 +22,7 @@ class Pair {
     T2 _second;
 public:
     Pair() { }
-    Pair(T1 u, T2 v) { _first = u; _second = v; }
+    Pair(T1 u, T2 v): _first(u), _second(v) {}
     T1 first(void) { return _first; }
     T2 second(void) { return _second; }
     bool operator==(Pair<T1,T2> other) { return _first == other._first && _second == other._second; }
@@ -49,4 +49,16 @@ template <class T1, class T2>
 class BinaryAnd {
 public:
     static T1 call(T1 x, T2 y) { return x & y; }
+};
+
+template <typename T, T N = 1>
+class UnaryAnd {
+public:
+    static T call(T value) { return static_cast<T>(value & N); }
+};
+
+template <typename T, T N = 5>
+class UnaryPlus {
+public:
+    static T call(T value) { return static_cast<T>(value + N); }
 };


### PR DESCRIPTION
## Description

This is a fairly minimal, but effective patch to add non-type template support for literals.

Literals include:
- Integers
- Characters
- Booleans
- Floating point numbers.

## Implementation

The implementation is quite simple, as it adds one new function, `analyse_as_template_parameter`, which is called rather than `analyse_as_type`. This function defaults to `analyse_as_type`, however, for literal values, it is overrided to create a `TemplatePlaceholderType` containing the resulting C-code. This creates valid code, and adds no major syntax changes.

## Example

**example.h**

```cpp
template <int N1, int N2>
int function() { return N1 + N2; }
```

**example.pyx**

```cython
cdef extern from "example.h" nogil:
    int function[N1, N2]()

def test():
    assert function[3, 5]() == 5
```

## General Discussion

Although I wanted to add patches from @insertinterestingnamehere, who added previous [patches](https://github.com/cython/cython/pull/426) to allow the use of variables in template parameters and which would work for some non-type template parameters, I was unable to use his patches since Cython fundamentally lacks the concept of `constexpr`, although it closely mimics it with `const`. Furthermore, functions and function pointers (`CFuncType`) cannot be declared const, which would allow the compiler to know they are constexpr.

For example, the following code would be valid on the Cython-end, however, it would produce invalid C++ code without any use-friendly error. Example code is as follows:

**example.h**

```cpp
template <int(*p)(int)>
int function(int a)
{
    return p(a);
}
```

**example.pyx**

```cython
cdef extern from "example.h" nogil:
    int function[T](int)

cdef int p(int a) nogil:
    return a + 2

def test():  
    cdef int a = 2
    cdef int(*func)(int) 
    func = p
    assert function[func](a) == 2
```

Since `func` is mutable, and not `constexpr`, it cannot be used as a template parameter.

## Rationale

This is necessary for some of my patches to add comprehensive C++11 and later support, and adds a simple syntax for basic non-type template support.