### PR TITLE
Transfered keyword only arguments.

### DIFF
--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -208,6 +208,37 @@ In the interests of clarity, it is probably a good idea to always be explicit
 about object parameters in C functions.
 
 
+Keyword-only Arguments
+----------------------
+
+As in Python 3, ``def`` functions can have keyword-only arguments
+listed after a ``"*"`` parameter and before a ``"**"`` parameter if any::
+
+    def f(a, b, *args, c, d = 42, e, **kwds):
+        ...
+
+    # We cannot call f with less verbosity than this.
+    foo = f(4, "bar", c=68, e=1.0)
+
+*  As shown above, the ``c``, ``d`` and ``e`` arguments can not be
+   passed as positional arguments and must be passed as keyword arguments.
+
+*  Furthermore, ``c`` and ``e`` are required keyword arguments
+   since they do not have a default value.
+
+If the parameter name after the ``"*"`` is omitted, the function will
+not accept any extra positional arguments::
+
+    def g(a, b, *, c, d):
+        ...
+
+    # We cannot call g with less verbosity than this.
+    foo = g(4.0, "something", c=68, d="other")
+
+Shown above, the signature takes exactly two positional
+parameters and has two required keyword parameters
+
+
 Error return values
 -------------------
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -220,14 +220,13 @@ listed after a ``"*"`` parameter and before a ``"**"`` parameter if any::
     # We cannot call f with less verbosity than this.
     foo = f(4, "bar", c=68, e=1.0)
 
-*  As shown above, the ``c``, ``d`` and ``e`` arguments can not be
-   passed as positional arguments and must be passed as keyword arguments.
+As shown above, the ``c``, ``d`` and ``e`` arguments can not be
+passed as positional arguments and must be passed as keyword arguments.
+Furthermore, ``c`` and ``e`` are **required** keyword arguments
+since they do not have a default value.
 
-*  Furthermore, ``c`` and ``e`` are required keyword arguments
-   since they do not have a default value.
-
-If the parameter name after the ``"*"`` is omitted, the function will
-not accept any extra positional arguments::
+A single ``"*"`` without argument name can be used to
+terminate the list of positional arguments::
 
     def g(a, b, *, c, d):
         ...


### PR DESCRIPTION
Copy pasting and also extended the examples.