### PR TITLE
Added a C++ example in the cython tutorial.

### DIFF
--- a/docs/examples/tutorial/primes/primes_cpp.pyx
+++ b/docs/examples/tutorial/primes/primes_cpp.pyx
@@ -1,0 +1,21 @@
+# distutils: language=c++
+
+from libcpp.vector cimport vector
+
+def primes(int nb_primes):
+    cdef int n, i
+    cdef vector[int] p
+    p.reserve(nb_primes)  # allocate memory for 'nb_primes' elements.
+
+    n = 2
+    while p.size() < nb_primes:  # size() for vectors is similar to len()
+        for i in p:
+            if n % i == 0:
+                break
+        else:
+            p.push_back(n)  # push_back is similar to append()
+        n += 1
+
+    # Vectors are automatically converted to Python
+    # lists when converted to Python objects.
+    return p

--- a/docs/src/tutorial/cython_tutorial.rst
+++ b/docs/src/tutorial/cython_tutorial.rst
@@ -331,6 +331,37 @@ everywhere. Adding types makes your code less readable, so use them with
 moderation.
 
 
+Primes with C++
+===============
+
+With Cython, it is also possible to take advantage of the C++ language, notably,
+part of the C++ standard library is directly importable from Cython code.
+
+Let's see what our :file:`primes.pyx` becomes when
+using `vector <http://en.cppreference.com/w/cpp/container/vector>`_ from the C++
+standard library.
+
+.. note::
+
+    Vector in C++ is a data structure which represents
+    a `stack <https://en.wikipedia.org/wiki/Stack_(abstract_data_type)>`_.
+    There is a method `reserve` available which will avoid copies if you know in advance
+    how many elements you are going to put in the vector. For more details
+    see `this page from cppreference <http://en.cppreference.com/w/cpp/container/vector>`_.
+
+.. literalinclude:: ../../examples/tutorial/primes/primes_cpp.pyx
+    :linenos:
+
+The first line is a compiler directive. It tells Cython to compile your code to C++.
+This will enable the use of the C++ standard library.
+Note that this isn't possible to compile Cython code to C++ with `pyximport`. You
+should use a :file:`setup.py` or a notebook to run this example.
+
+You can see that the API of a vector is similar to the API of a Python list,
+and can sometimes be used as a drop-in replacement in Cython.
+
+For more details about using C++ with Cython, see :ref:`wrapping-cplusplus`.
+
 Language Details
 ================
 


### PR DESCRIPTION
It may be a bit advanced to show C++ to people who are starting to learn Cython, but since the API is quite close to the Python list API for this example, I supposed that it would be easy to understand. 

It may also be possible to put this in **Using C++ in Cython** and add a link to it in the Cython tutorial.
Something like: "It is also possible to use C++ in Cython and use vector as a drop in replacement for the python list in this example. See :ref:...".