### PR TITLE
Buffer checker supports the format string 'e' (for np.float16)

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -333,7 +333,9 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef unsigned long long npy_uint96
     ctypedef unsigned long long npy_uint128
 
-    ctypedef npy_uint16   npy_half
+    ctypedef struct npy_half:
+        npy_uint16 value
+
     ctypedef npy_half     npy_float16
     ctypedef float        npy_float32
     ctypedef double       npy_float64

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -42,6 +42,7 @@ cdef extern from "numpy/arrayobject.h":
         NPY_ULONG
         NPY_LONGLONG
         NPY_ULONGLONG
+        NPY_HALF
         NPY_FLOAT
         NPY_DOUBLE
         NPY_LONGDOUBLE
@@ -271,6 +272,7 @@ cdef extern from "numpy/arrayobject.h":
                 elif t == NPY_ULONG:       f = "L"
                 elif t == NPY_LONGLONG:    f = "q"
                 elif t == NPY_ULONGLONG:   f = "Q"
+                elif t == NPY_HALF:        f = "e"
                 elif t == NPY_FLOAT:       f = "f"
                 elif t == NPY_DOUBLE:      f = "d"
                 elif t == NPY_LONGDOUBLE:  f = "g"
@@ -331,6 +333,8 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef unsigned long long npy_uint96
     ctypedef unsigned long long npy_uint128
 
+    ctypedef npy_uint16   npy_half
+    ctypedef npy_half     npy_float16
     ctypedef float        npy_float32
     ctypedef double       npy_float64
     ctypedef long double  npy_float80
@@ -741,6 +745,7 @@ ctypedef npy_uint64     uint64_t
 #ctypedef npy_uint96     uint96_t
 #ctypedef npy_uint128    uint128_t
 
+ctypedef npy_float16    float16_t
 ctypedef npy_float32    float32_t
 ctypedef npy_float64    float64_t
 #ctypedef npy_float80    float80_t
@@ -844,6 +849,7 @@ cdef inline char* _util_dtypestring(dtype descr, char* f, char* end, int* offset
             elif t == NPY_ULONG:       f[0] = 76  #"L"
             elif t == NPY_LONGLONG:    f[0] = 113 #"q"
             elif t == NPY_ULONGLONG:   f[0] = 81  #"Q"
+            elif t == NPY_HALF:        f[0] = 101 #"e"
             elif t == NPY_FLOAT:       f[0] = 102 #"f"
             elif t == NPY_DOUBLE:      f[0] = 100 #"d"
             elif t == NPY_LONGDOUBLE:  f[0] = 103 #"g"

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -324,7 +324,7 @@ static const char* __Pyx_BufFmt_DescribeTypeChar(char ch, int is_complex) {
 static size_t __Pyx_BufFmt_TypeCharToStandardSize(char ch, int is_complex) {
   switch (ch) {
     case '?': case 'c': case 'b': case 'B': case 's': case 'p': return 1;
-    case 'h': case 'H': return 2;
+    case 'e': case 'h': case 'H': return 2;
     case 'i': case 'I': case 'l': case 'L': return 4;
     case 'q': case 'Q': return 8;
     case 'f': return (is_complex ? 8 : 4);
@@ -343,7 +343,7 @@ static size_t __Pyx_BufFmt_TypeCharToStandardSize(char ch, int is_complex) {
 static size_t __Pyx_BufFmt_TypeCharToNativeSize(char ch, int is_complex) {
   switch (ch) {
     case 'c': case 'b': case 'B': case 's': case 'p': return 1;
-    case 'h': case 'H': return sizeof(short);
+    case 'e': case 'h': case 'H': return sizeof(short);
     case 'i': case 'I': return sizeof(int);
     case 'l': case 'L': return sizeof(long);
     #ifdef HAVE_LONG_LONG
@@ -374,7 +374,7 @@ typedef struct { char c; PY_LONG_LONG x; } __Pyx_st_longlong;
 static size_t __Pyx_BufFmt_TypeCharToAlignment(char ch, CYTHON_UNUSED int is_complex) {
   switch (ch) {
     case '?': case 'c': case 'b': case 'B': case 's': case 'p': return 1;
-    case 'h': case 'H': return sizeof(__Pyx_st_short) - sizeof(short);
+    case 'e': case 'h': case 'H': return sizeof(__Pyx_st_short) - sizeof(short);
     case 'i': case 'I': return sizeof(__Pyx_st_int) - sizeof(int);
     case 'l': case 'L': return sizeof(__Pyx_st_long) - sizeof(long);
 #ifdef HAVE_LONG_LONG
@@ -408,7 +408,7 @@ typedef struct { PY_LONG_LONG x; char c; } __Pyx_pad_longlong;
 static size_t __Pyx_BufFmt_TypeCharToPadding(char ch, CYTHON_UNUSED int is_complex) {
   switch (ch) {
     case '?': case 'c': case 'b': case 'B': case 's': case 'p': return 1;
-    case 'h': case 'H': return sizeof(__Pyx_pad_short) - sizeof(short);
+    case 'e': case 'h': case 'H': return sizeof(__Pyx_pad_short) - sizeof(short);
     case 'i': case 'I': return sizeof(__Pyx_pad_int) - sizeof(int);
     case 'l': case 'L': return sizeof(__Pyx_pad_long) - sizeof(long);
 #ifdef HAVE_LONG_LONG
@@ -432,6 +432,8 @@ static char __Pyx_BufFmt_TypeCharToGroup(char ch, int is_complex) {
     case 'l': case 'q': case 's': case 'p':
         return 'I';
     case 'B': case 'H': case 'I': case 'L': case 'Q':
+        return 'U';
+    case 'e':
         return 'U';
     case 'f': case 'd': case 'g':
         return (is_complex ? 'C' : 'R');
@@ -754,7 +756,7 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
         CYTHON_FALLTHROUGH;
       case 'c': case 'b': case 'B': case 'h': case 'H': case 'i': case 'I':
       case 'l': case 'L': case 'q': case 'Q':
-      case 'f': case 'd': case 'g':
+      case 'e': case 'f': case 'd': case 'g':
       case 'O': case 'p':
         if (ctx->enc_type == *ts && got_Z == ctx->is_complex &&
             ctx->enc_packmode == ctx->new_packmode) {

--- a/tests/memoryview/numpy_memoryview.pyx
+++ b/tests/memoryview/numpy_memoryview.pyx
@@ -26,6 +26,13 @@ def get_array():
 
 a = get_array()
 
+def get_float16_array():
+    cdef np.ndarray[np.float16_t, ndim=3] a
+    a = np.arange(8 * 14 * 11, dtype=np.float16).reshape(8, 14, 11)
+    return a
+
+_ = get_float16_array()
+
 def ae(*args):
     "assert equals"
     for x in args:


### PR DESCRIPTION
Because cython doesn't support ['e' format string](https://docs.python.org/3/library/struct.html#format-characters) and lacks `np.float16_t` as well,  it becomes difficult to accelerate float16 conversion in https://github.com/tensorflow/tensorflow/pull/19212 . Hence the PR is opened to solve the problem: pass a `np.float16` array from python to cython. 

Note that we don't hope to support arithmetical operation for float16 in the PR.

I'm not familiar with cython, any suggestion / help will be appreciated.