### PR TITLE
Added tests for the convolve with the memoryviews in the docs.

### DIFF
--- a/docs/examples/memoryviews/C_func_file.c
+++ b/docs/examples/memoryviews/C_func_file.c
@@ -1,3 +1,5 @@
+#include "C_func_file.h"
+
 void multiply_by_10_in_C(double arr[], unsigned int n)
 {
     for (int i = 0; i < n; i++) {

--- a/docs/examples/memoryviews/C_func_file.h
+++ b/docs/examples/memoryviews/C_func_file.h
@@ -1,1 +1,6 @@
+#ifndef C_FUNC_FILE_H
+#define C_FUNC_FILE_H
+
 void multiply_by_10_in_C(double arr[], unsigned int n);
+
+#endif

--- a/docs/examples/memoryviews/C_func_file.h
+++ b/docs/examples/memoryviews/C_func_file.h
@@ -1,0 +1,1 @@
+void multiply_by_10_in_C(double arr[], unsigned int n);

--- a/docs/examples/memoryviews/memview_to_c.pyx
+++ b/docs/examples/memoryviews/memview_to_c.pyx
@@ -1,5 +1,5 @@
-# distutils: sources=./C_func_file.c
-# distutils: include_dirs=./
+# distutils: sources = C_func_file.c
+# distutils: include_dirs = ./
 
 cdef extern from "C_func_file.h":
     void multiply_by_10_in_C(double *, unsigned int)

--- a/docs/examples/memoryviews/memview_to_c.pyx
+++ b/docs/examples/memoryviews/memview_to_c.pyx
@@ -1,5 +1,6 @@
-# distutils: sources = C_func_file.c
-# distutils: include_dirs = ./
+cdef extern from "C_func_file.c":
+    # C is include here so that it doesn't need to be compiled externally
+    pass
 
 cdef extern from "C_func_file.h":
     void multiply_by_10_in_C(double *, unsigned int)

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -706,9 +706,10 @@ array with an external C function implemented in :file:`C_func_file.c`:
 .. literalinclude:: ../../examples/memoryviews/C_func_file.c
     :linenos:
 
-This file comes with a header file called :file:`C_func_file.h` containing::
+This file comes with a header file called :file:`C_func_file.h` containing:
 
-    void multiply_by_10_in_C(double arr[], unsigned int n);
+.. literalinclude:: ../../examples/memoryviews/C_func_file.h
+    :linenos:
 
 where ``arr`` points to the array and ``n`` is its size.
 

--- a/runtests.py
+++ b/runtests.py
@@ -518,28 +518,26 @@ class ErrorWriter(object):
 
 
 class TestBuilder(object):
-    def __init__(self, rootdir, workdir, selectors, exclude_selectors, annotate,
-                 cleanup_workdir, cleanup_sharedlibs, cleanup_failures,
-                 with_pyregr, cython_only, languages, test_bugs, fork, language_level,
-                 test_determinism,
+    def __init__(self, rootdir, workdir, selectors, exclude_selectors, options,
+                 with_pyregr, languages, test_bugs, language_level,
                  common_utility_dir, pythran_dir=None,
                  default_mode='run',
-                 add_embedded_test=True):
+                 add_embedded_test=False):
         self.rootdir = rootdir
         self.workdir = workdir
         self.selectors = selectors
         self.exclude_selectors = exclude_selectors
-        self.annotate = annotate
-        self.cleanup_workdir = cleanup_workdir
-        self.cleanup_sharedlibs = cleanup_sharedlibs
-        self.cleanup_failures = cleanup_failures
+        self.annotate = options.annotate_source
+        self.cleanup_workdir = options.cleanup_workdir
+        self.cleanup_sharedlibs = options.cleanup_sharedlibs
+        self.cleanup_failures = options.cleanup_failures
         self.with_pyregr = with_pyregr
-        self.cython_only = cython_only
+        self.cython_only = options.cython_only
         self.languages = languages
         self.test_bugs = test_bugs
-        self.fork = fork
+        self.fork = options.fork
         self.language_level = language_level
-        self.test_determinism = test_determinism
+        self.test_determinism = options.test_determinism
         self.common_utility_dir = common_utility_dir
         self.pythran_dir = pythran_dir
         self.default_mode = default_mode
@@ -2134,25 +2132,16 @@ def runtests(options, cmd_args, coverage=None):
 
     if options.filetests and languages:
         filetests = TestBuilder(ROOTDIR, WORKDIR, selectors, exclude_selectors,
-                                options.annotate_source, options.cleanup_workdir,
-                                options.cleanup_sharedlibs, options.cleanup_failures,
-                                options.pyregr,
-                                options.cython_only, languages, test_bugs,
-                                options.fork, options.language_level,
-                                options.test_determinism,
-                                common_utility_dir, options.pythran_dir)
+                                options, options.pyregr, languages, test_bugs,
+                                options.language_level, common_utility_dir,
+                                options.pythran_dir, add_embedded_test=True)
         test_suite.addTest(filetests.build_suite())
     if options.examples and languages:
         filetests = TestBuilder(options.examples_dir, WORKDIR, selectors, exclude_selectors,
-                                options.annotate_source, options.cleanup_workdir,
-                                options.cleanup_sharedlibs, options.cleanup_failures,
-                                options.pyregr,
-                                options.cython_only, languages, test_bugs,
-                                options.fork, options.language_level,
-                                options.test_determinism,
-                                common_utility_dir, options.pythran_dir,
-                                default_mode='compile',
-                                add_embedded_test=False)
+                                options, options.pyregr, languages, test_bugs,
+                                options.language_level, common_utility_dir,
+                                options.pythran_dir,
+                                default_mode='compile')
         test_suite.addTest(filetests.build_suite())
 
     if options.system_pyregr and languages:
@@ -2161,13 +2150,9 @@ def runtests(options, cmd_args, coverage=None):
             sys_pyregr_dir = os.path.join(os.path.dirname(sys.executable), 'Lib', 'test')  # source build
         if os.path.isdir(sys_pyregr_dir):
             filetests = TestBuilder(ROOTDIR, WORKDIR, selectors, exclude_selectors,
-                                    options.annotate_source, options.cleanup_workdir,
-                                    options.cleanup_sharedlibs, options.cleanup_failures,
-                                    True,
-                                    options.cython_only, languages, test_bugs,
-                                    options.fork, sys.version_info[0],
-                                    options.test_determinism,
-                                    common_utility_dir)
+                                    options, True, languages, test_bugs,
+                                    sys.version_info[0], common_utility_dir,
+                                    add_embedded_test=True)
             sys.stderr.write("Including CPython regression tests in %s\n" % sys_pyregr_dir)
             test_suite.addTest(filetests.handle_directory(sys_pyregr_dir, 'pyregr'))
 


### PR DESCRIPTION
I added tests for the examples directory. For the moment it only covers the memoryview tests. 

I would like some feedback on the approach and if it's good, I'll enable more tests for files in the examples directory.

I added a else close when checking the value of `mode` because I think it'll more clear for people who are getting into the `runtests.py` (I know I wanted a compile test, so I looked for the string 'compile' and it took me a while to figure out where the mode was tested).