### PR TITLE
Fix importing of namespace packages. Add in a regtest for the same.

### DIFF
--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -249,6 +249,10 @@ class PyxImporter(object):
     def find_module(self, fullname, package_path=None):
         if fullname in sys.modules  and  not pyxargs.reload_support:
             return None  # only here when reload()
+
+        # package_path might be a _NamespacePath. Convert that into a list...
+        if package_path is not None and not isinstance(package_path, list):
+            package_path = list(package_path)
         try:
             fp, pathname, (ext,mode,ty) = imp.find_module(fullname,package_path)
             if fp: fp.close()  # Python should offer a Default-Loader to avoid this double find/open!

--- a/runtests.py
+++ b/runtests.py
@@ -375,6 +375,7 @@ VER_DEP_MODULES = {
                                         ]),
     (3,3) : (operator.lt, lambda x: x in ['build.package_compilation',
                                           'run.yield_from_py33',
+                                          'pyximport.pyximport_namespace',
                                           ]),
     (3,4): (operator.lt, lambda x: x in ['run.py34_signature',
                                          ]),

--- a/tests/pyximport/pyximport_namespace.srctree
+++ b/tests/pyximport/pyximport_namespace.srctree
@@ -1,0 +1,18 @@
+
+PYTHON -c "import basic_test; basic_test.test()"
+
+######## basic_test.py ########
+
+import os.path
+import pyximport
+
+pyximport.install(build_dir=os.path.join(os.path.dirname(__file__), "TEST_TMP"))
+
+def test():
+    import nsmod.mymodule
+    assert nsmod.mymodule.test_string == "TEST"
+    assert not nsmod.mymodule.__file__.rstrip('oc').endswith('.py'), nsmod.mymodule.__file__
+
+######## nsmod/mymodule.pyx ########
+
+test_string = "TEST"


### PR DESCRIPTION
Python 3.3 added in support for namespace packages which are essentially directories with no `__init__.py` file. This pull request adds in support for these into pyximport.

On python2 trying to import a pyx module in a namespace package is still an error (which matches normal python behavior). 

Note that the regtest only works on python3. Not sure how to adjust it for python2 but happy to update this pr if somebody can point me in the right direction...

-- PG