### PR TITLE
Added more info on pyximport in compilation.rst

### DIFF
--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -505,7 +505,7 @@ influence the compilation of Cython or Python files.
 Dependency Handling
 --------------------
 
-Since :mod:`pyximport` does not use `cythonize()` internally, it currently
+Since :mod:`pyximport` does not use :func:`cythonize()` internally, it currently
 requires a different setup for dependencies.  It is possible to declare that
 your module depends on multiple files, (likely ``.h`` and ``.pxd`` files).
 If your Cython module is named ``foo`` and thus has the filename
@@ -523,6 +523,10 @@ directly.
 Limitations
 ------------
 
+:mod:`pyximport` does not use :func:`cythonize()`. Thus it is not
+possible to do things like using compiler directives at
+the top of Cython files or compiling Cython code to C++.
+
 Pyximport does not give you any control over how your Cython file is
 compiled.  Usually the defaults are fine.  You might run into problems if
 you wanted to write your program in half-C, half-Cython and build them
@@ -536,8 +540,9 @@ was supposed to.
 
 Basic module reloading support is available with the option ``reload_support=True``.
 Note that this will generate a new module filename for each build and thus
-end up loading multiple shared libraries into memory over time.  CPython does
-not support reloading shared libraries as such.
+end up loading multiple shared libraries into memory over time.  CPython have limited
+support for reloading shared libraries as such,
+see `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_.
 
 Pyximport puts both your ``.c`` file and the platform-specific binary into
 a separate build directory, usually ``$HOME/.pyxblx/``.  To copy it back

--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -540,7 +540,7 @@ was supposed to.
 
 Basic module reloading support is available with the option ``reload_support=True``.
 Note that this will generate a new module filename for each build and thus
-end up loading multiple shared libraries into memory over time.  CPython have limited
+end up loading multiple shared libraries into memory over time. CPython has limited
 support for reloading shared libraries as such,
 see `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_.
 

--- a/docs/src/reference/compilation.rst
+++ b/docs/src/reference/compilation.rst
@@ -492,6 +492,59 @@ on end user side as it hooks into their import system.  The best way
 to cater for end users is to provide pre-built binary packages in the
 `wheel <https://wheel.readthedocs.io/>`_ packaging format.
 
+
+Arguments
+---------
+
+The function ``pyximport.install()`` can take several arguments to
+influence the compilation of Cython or Python files.
+
+.. autofunction:: pyximport.install
+
+
+Dependency Handling
+--------------------
+
+Since :mod:`pyximport` does not use `cythonize()` internally, it currently
+requires a different setup for dependencies.  It is possible to declare that
+your module depends on multiple files, (likely ``.h`` and ``.pxd`` files).
+If your Cython module is named ``foo`` and thus has the filename
+:file:`foo.pyx` then you should create another file in the same directory
+called :file:`foo.pyxdep`.  The :file:`modname.pyxdep` file can be a list of
+filenames or "globs" (like ``*.pxd`` or ``include/*.h``).  Each filename or
+glob must be on a separate line.  Pyximport will check the file date for each
+of those files before deciding whether to rebuild the module.  In order to
+keep track of the fact that the dependency has been handled, Pyximport updates
+the modification time of your ".pyx" source file.  Future versions may do
+something more sophisticated like informing distutils of the dependencies
+directly.
+
+
+Limitations
+------------
+
+Pyximport does not give you any control over how your Cython file is
+compiled.  Usually the defaults are fine.  You might run into problems if
+you wanted to write your program in half-C, half-Cython and build them
+into a single library.
+
+Pyximport does not hide the Distutils/GCC warnings and errors generated
+by the import process.  Arguably this will give you better feedback if
+something went wrong and why.  And if nothing went wrong it will give you
+the warm fuzzy feeling that pyximport really did rebuild your module as it
+was supposed to.
+
+Basic module reloading support is available with the option ``reload_support=True``.
+Note that this will generate a new module filename for each build and thus
+end up loading multiple shared libraries into memory over time.  CPython does
+not support reloading shared libraries as such.
+
+Pyximport puts both your ``.c`` file and the platform-specific binary into
+a separate build directory, usually ``$HOME/.pyxblx/``.  To copy it back
+into the package hierarchy (usually next to the source file) for manual
+reuse, you can pass the option ``inplace=True``.
+
+
 Compiling with ``cython.inline``
 =================================
 


### PR DESCRIPTION
A note in the `userguide/source_files_and_compilation.rst` states:

```
.. note:: See :ref:`compilation-reference` reference section for more details
```
and links to the reference guide.

But  `userguide/source_files_and_compilation.rst` was the file with the most information on pyximport. I fixed it.

Maybe replacing `userguide/source_files_and_compilation.rst` by `reference/compilation.rst`  would make sense  since `reference/compilation.rst` is the only file in the reference guide which is not empty? This way the reference guide would be entirely empty with just links to the userguide.