### PR TITLE
Added a warning on pyximport when defaulting to python 2.x and the interpreter is 3.x

### DIFF
--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -52,6 +52,7 @@ import imp
 import os
 import sys
 from zipimport import zipimporter, ZipImportError
+import warnings
 
 mod_name = "pyximport"
 
@@ -105,6 +106,12 @@ def get_distutils_extension(modname, pyxfilename, language_level=None):
         extension_mod = Extension(name = modname, sources=[pyxfilename])
         if language_level is not None:
             extension_mod.cython_directives = {'language_level': language_level}
+        else:
+            if sys.version_info[0] == 3:
+                warnings.warn("Your interpreter is using Python 3 but you didn't set "
+                              "language_level when calling `pyximport.install()`.\n"
+                              "The Python 2 semantics are going to be used. \nIf you "
+                              "want the Python 3 semantics, use `language_level=3`.")
     return extension_mod,setup_args
 
 


### PR DESCRIPTION
I know that we cannot change the default language_level to the python version of the interpreter because we need to be backward compatible, but having python 2 as default when using python 3.x violate the [rule of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). 

To be backward compatible and avoid users confusion, I added a warning which is displayed only when the user doesn't use the argument `language_level` and that the user uses python 3.

I would like to put the same kind of warning for cythonize, but it's a bit more complicated since there is the parsing of the compiler directives at the top of the file.

See #2300  and #2299 .