### PR TITLE
Fix purepython builtin type strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Bugs fixed
   Note that this can have a performance impact on calls from Cython code.
   (Github issue #1771)
 
+* Fix declarations of builtin or C types using strings in pure python mode.
+  (Github issue #2046)
+
 Other changes
 -------------
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1377,7 +1377,13 @@ def _analyse_name_as_type(name, pos, env):
         return type
 
     global_entry = env.global_scope().lookup_here(name)
-    if global_entry and global_entry.type and global_entry.type.is_extension_type:
+    if global_entry is None:
+        global_entry = env.builtin_scope().lookup_here(name)
+    if global_entry and global_entry.type and (
+            global_entry.type.is_extension_type
+            or global_entry.type.is_struct_or_union
+            or global_entry.type.is_builtin_type
+            or global_entry.type.is_cpp_class):
         return global_entry.type
 
     from .TreeFragment import TreeFragment

--- a/tests/compile/builtinbuffer.py
+++ b/tests/compile/builtinbuffer.py
@@ -1,0 +1,7 @@
+# mode: compile
+import cython
+
+@cython.cclass
+class BuiltinRef:
+    cython.declare(pybuf = 'Py_buffer')
+


### PR DESCRIPTION
This fixes issue #2046 

The underlying issue was that _analyse_name_as_type was not considering either the builtin scope, or other types than extension types. Py_buffer happened to be a builtin type that was a C struct.