### PR TITLE
Formatted runtests.py to make it respect the pep8 conventions of try...except.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -101,13 +101,17 @@ def get_distutils_distro(_cache=[]):
     if sys.platform == 'win32':
         # TODO: Figure out why this hackery (see http://thread.gmane.org/gmane.comp.python.cython.devel/8280/).
         config_files = distutils_distro.find_config_files()
-        try: config_files.remove('setup.cfg')
-        except ValueError: pass
+        try:
+            config_files.remove('setup.cfg')
+        except ValueError:
+            pass
         distutils_distro.parse_config_files(config_files)
 
         cfgfiles = distutils_distro.find_config_files()
-        try: cfgfiles.remove('setup.cfg')
-        except ValueError: pass
+        try:
+            cfgfiles.remove('setup.cfg')
+        except ValueError:
+            pass
         distutils_distro.parse_config_files(cfgfiles)
     _cache.append(distutils_distro)
     return distutils_distro
@@ -1216,8 +1220,10 @@ def run_forked_test(result, run_func, test_name, fork=True):
             raise Exception("Tests in module '%s' exited with status %d" %
                             (module_name, result_code))
     finally:
-        try: os.unlink(result_file)
-        except: pass
+        try:
+            os.unlink(result_file)
+        except:
+            pass
 
 class PureDoctestTestCase(unittest.TestCase):
     def __init__(self, module_name, module_path):
@@ -2160,8 +2166,10 @@ def runtests(options, cmd_args, coverage=None):
     if xml_output_dir:
         from Cython.Tests.xmlrunner import XMLTestRunner
         if not os.path.exists(xml_output_dir):
-            try: os.makedirs(xml_output_dir)
-            except OSError: pass  # concurrency issue?
+            try:
+                os.makedirs(xml_output_dir)
+            except OSError:
+                pass  # concurrency issue?
         test_runner = XMLTestRunner(output=xml_output_dir,
                                     verbose=options.verbosity > 0)
         if options.failfast:


### PR DESCRIPTION
In https://www.python.org/dev/peps/pep-0008/#other-recommendations it says that it's recommended to unpack (expand?), anyway, write on 4 lines the try...except instead of using two lines.