### PR TITLE
Adding tests for "pure python mode" part 10

### DIFF
--- a/docs/examples/tutorial/pure/exceptval.py
+++ b/docs/examples/tutorial/pure/exceptval.py
@@ -1,0 +1,7 @@
+import cython
+
+@cython.exceptval(-1)
+def func(x: cython.int) -> cython.int:
+    if x < 0:
+        raise ValueError("need integer >= 0")
+    return x + 1

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -167,13 +167,9 @@ Static typing
         ...
 
   This can be combined with the ``@cython.exceptval()`` decorator for non-Python
-  return types::
+  return types:
 
-    @cython.exceptval(-1):
-    def func(x : cython.int) -> cython.int:
-        if x < 0:
-            raise ValueError("need integer >= 0")
-        return x+1
+  .. literalinclude:: ../../examples/tutorial/pure/exceptval.py
 
   Since version 0.27, Cython also supports the variable annotations defined
   in `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_. This allows to


### PR DESCRIPTION
It allowed me to find a small syntax error: there was a colon after the decorator.