### PR TITLE
Adding tests for "Unicode and passing strings" part 10

### DIFF
--- a/docs/examples/tutorial/string/cpp_string.pyx
+++ b/docs/examples/tutorial/string/cpp_string.pyx
@@ -1,0 +1,12 @@
+# distutils: language = c++
+
+from libcpp.string cimport string
+
+def get_bytes():
+    py_bytes_object = b'hello world'
+    cdef string s = py_bytes_object
+
+    s.append('abc')
+    py_bytes_object = s
+    return py_bytes_object
+

--- a/docs/src/tutorial/strings.rst
+++ b/docs/src/tutorial/strings.rst
@@ -365,18 +365,9 @@ C++ strings
 
 When wrapping a C++ library, strings will usually come in the form of
 the :c:type:`std::string` class.  As with C strings, Python byte strings
-automatically coerce from and to C++ strings::
+automatically coerce from and to C++ strings:
 
-    # distutils: language = c++
-
-    from libcpp.string cimport string
-
-    cdef string s = py_bytes_object
-    try:
-        s.append('abc')
-        py_bytes_object = s
-    finally:
-        del s
+.. literalinclude:: ../../examples/tutorial/string/cpp_string.pyx
 
 The memory management situation is different than in C because the
 creation of a C++ string makes an independent copy of the string


### PR DESCRIPTION
There was a bug in the example. The string is stack allocated, so there was no need to call `del` on it. The C++ compiler was complaining, so I removed it.