### PR TITLE
Adding tests for "pure python mode" part 13

### DIFF
--- a/docs/examples/tutorial/pure/cclass.py
+++ b/docs/examples/tutorial/pure/cclass.py
@@ -1,0 +1,16 @@
+import cython
+
+
+@cython.cclass
+class A:
+    cython.declare(a=cython.int, b=cython.int)
+    c = cython.declare(cython.int, visibility='public')
+    d = cython.declare(cython.int)  # private by default.
+    e = cython.declare(cython.int, visibility='readonly')
+
+    def __init__(self, a, b, c, d=5, e=3):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = e

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -130,14 +130,9 @@ Static typing
 
   .. literalinclude:: ../../examples/tutorial/pure/cython_declare2.py
 
-  It can also be used to define extension type private, readonly and public attributes::
+  It can also be used to define extension type private, readonly and public attributes:
 
-    @cython.cclass
-    class A:
-        cython.declare(a=cython.int, b=cython.int)
-        c = cython.declare(cython.int, visibility='public')
-        d = cython.declare(cython.int, 5)  # private by default.
-        e = cython.declare(cython.int, 5, visibility='readonly')
+  .. literalinclude:: ../../examples/tutorial/pure/cclass.py
 
 * ``@cython.locals`` is a decorator that is used to specify the types of local
   variables in the function body (including the arguments):


### PR DESCRIPTION
It seems that this one is failing.

From the output, it seems that Cython generate incorrect code when using a initial value for an attribute with `cython.declare`.

What should we do?