### PR TITLE
Removed mention of a version so old that nobody should be concerned.

### DIFF
--- a/docs/src/tutorial/clibraries.rst
+++ b/docs/src/tutorial/clibraries.rst
@@ -158,7 +158,7 @@ We can thus change the init function as follows:
    exception instance in order to raise it may actually fail because
    we are running out of memory.  Luckily, CPython provides a C-API
    function ``PyErr_NoMemory()`` that safely raises the right
-   exception for us.  Since version 0.14.1, Cython automatically
+   exception for us.  Cython automatically
    substitutes this C-API call whenever you write ``raise
    MemoryError`` or ``raise MemoryError()``.  If you use an older
    version, you have to cimport the C-API function from the standard

--- a/docs/src/tutorial/cython_tutorial.rst
+++ b/docs/src/tutorial/cython_tutorial.rst
@@ -77,7 +77,7 @@ It is shipped and installed with Cython and can be used like this::
     >>> import helloworld
     Hello World
 
-Since Cython 0.11, the :ref:`Pyximport<pyximport>` module also has experimental
+The :ref:`Pyximport<pyximport>` module also has experimental
 compilation support for normal Python modules.  This allows you to
 automatically run Cython on every .pyx and .py module that Python
 imports, including the standard library and installed packages.

--- a/docs/src/tutorial/external.rst
+++ b/docs/src/tutorial/external.rst
@@ -92,7 +92,7 @@ names like this::
       char* strstr(const char*, const char*)
 
 However, this prevents Cython code from calling it with keyword
-arguments (supported since Cython 0.19).  It is therefore preferable
+arguments.  It is therefore preferable
 to write the declaration like this instead:
 
 .. literalinclude:: ../../examples/tutorial/external/keyword_args.pyx

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -334,7 +334,7 @@ to make the names match again.
 Using C arrays for fixed size lists
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since Cython 0.22, C arrays can automatically coerce to Python lists or tuples.
+C arrays can automatically coerce to Python lists or tuples.
 This can be exploited to replace fixed size Python lists in Python code by C
 arrays when compiled.  An example:
 

--- a/docs/src/tutorial/strings.rst
+++ b/docs/src/tutorial/strings.rst
@@ -260,7 +260,7 @@ not modify a string they return, for example:
 
 .. literalinclude:: ../../examples/tutorial/string/someheader.h
 
-Since version 0.18, Cython has support for the ``const`` modifier in
+Cython has support for the ``const`` modifier in
 the language, so you can declare the above functions straight away as
 follows:
 
@@ -296,7 +296,7 @@ bytes most of which tend to be 0.
 
 Again, no bounds checking is done if slice indices are provided, so
 incorrect indices lead to data corruption and crashes.  However, using
-negative indices is possible since Cython 0.17 and will inject a call
+negative indices is possible and will inject a call
 to :c:func:`strlen()` in order to determine the string length.
 Obviously, this only works for 0-terminated strings without internal
 null bytes.  Text encoded in UTF-8 or one of the ISO-8859 encodings is
@@ -475,7 +475,7 @@ Single bytes and characters
 The Python C-API uses the normal C :c:type:`char` type to represent
 a byte value, but it has two special integer types for a Unicode code
 point value, i.e. a single Unicode character: :c:type:`Py_UNICODE`
-and :c:type:`Py_UCS4`.  Since version 0.13, Cython supports the
+and :c:type:`Py_UCS4`.  Cython supports the
 first natively, support for :c:type:`Py_UCS4` is new in Cython 0.15.
 :c:type:`Py_UNICODE` is either defined as an unsigned 2-byte or
 4-byte integer, or as :c:type:`wchar_t`, depending on the platform.

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -347,7 +347,7 @@ inherit from multiple extension types provided that the usual Python rules for
 multiple inheritance are followed (i.e. the C layouts of all the base classes
 must be compatible).
 
-Since Cython 0.13.1, there is a way to prevent extension types from
+There is a way to prevent extension types from
 being subtyped in Python.  This is done via the ``final`` directive,
 usually set on an extension type using a decorator::
 

--- a/docs/src/userguide/pypy.rst
+++ b/docs/src/userguide/pypy.rst
@@ -1,7 +1,7 @@
 Porting Cython code to PyPy
 ===========================
 
-Since version 0.17, Cython has basic support for cpyext, the layer in
+Cython has basic support for cpyext, the layer in
 `PyPy <http://pypy.org/>`_ that emulates CPython's C-API.  This is
 achieved by making the generated C code adapt at C compile time, so
 the generated code will compile in both CPython and PyPy unchanged.

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -371,7 +371,7 @@ For example::
 The pxd files in ``/Cython/Includes/libcpp`` also work as good examples on
 how to declare C++ classes.
 
-Since Cython 0.17, the STL containers coerce from and to the
+The STL containers coerce from and to the
 corresponding Python builtin types.  The conversion is triggered
 either by an assignment to a typed variable (including typed function
 arguments) or by an explicit cast, e.g.::


### PR DESCRIPTION
The doc has many sentences starting by 
> Since Cython 0.xxxxx

or 
> Since version 0.xxxxx

I think the ones that are too old are not useful for the readers. I would like too remove all mentions of Cython versions below 0.xxx but I don't know what this xxx should be. 

Any idea?