### PR TITLE
fixes #2422

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -809,8 +809,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
             elif name:
                 module_name = name
 
-            if module_name == 'cython':
-                raise ValueError('cython is a special module, cannot be used as a module name')
+            Utils.raise_error_if_module_name_forbidden(module_name)
 
             if module_name not in seen:
                 try:

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -469,6 +469,8 @@ def run_pipeline(source, options, full_module_name=None, context=None):
     abs_path = os.path.abspath(source)
     full_module_name = full_module_name or context.extract_module_name(source, options)
 
+    Utils.raise_error_if_module_name_forbidden(full_module_name)
+
     if options.relative_path_in_code_position_comments:
         rel_path = full_module_name.replace('.', os.sep) + source_ext
         if not abs_path.endswith(rel_path):

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -487,3 +487,9 @@ def add_metaclass(metaclass):
         orig_vars.pop('__weakref__', None)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
+
+
+def raise_error_if_module_name_forbidden(full_module_name):
+    #it is bad idea to call the pyx-file cython.pyx, so fail early
+    if full_module_name == 'cython'  or full_module_name.endswith('.cython'):
+        raise ValueError('cython is a special module, cannot be used as a module name')

--- a/tests/build/cythonize_cython.srctree
+++ b/tests/build/cythonize_cython.srctree
@@ -1,0 +1,50 @@
+PYTHON -c "import cythonize_tests"
+PYTHON -c "import cython_tests"
+
+######## cythonize_tests.py ########
+
+from Cython.Build.Cythonize import main as cythonize
+
+for test_case in ["cython.pyx", "src/cython.pyx", "src2/cython.pyx"]:
+    try:
+        cythonize([test_case])
+    except ValueError:
+        pass
+    else:
+        assert False, "ValueError not raised - forbidding cythonize "+test_case+" doesn't work"
+
+try:
+    cythonize(["notcython.pys"])
+except ValueError:
+    assert False, "ValueError raised - forbidding cythonize notcython.pyx should work"
+else:
+    pass
+
+######## cython_tests.py ########
+
+
+from Cython.Compiler.Main import main as cython
+import sys
+
+for test_case in ["cython.pyx", "src/cython.pyx", "src2/cython.pyx"]:
+    sys.argv=["cython", test_case]  #cython.py will extract parameters from sys.argv
+    try:
+        cython(command_line=1)
+    except ValueError:
+        pass
+    else:
+        assert False, "ValueError not raised - forbidding cython "+test_case+" doesn't work"
+
+sys.argv=["cython", "notcython.pyx"]  #cython.py will extract parameters from sys.argv
+try:
+    cython(["notcython.pys"])
+except ValueError:
+    assert False, "ValueError raised - forbidding cythonize notcython.pyx should work"
+else:
+    pass
+
+######## cython.pyx ########
+######## src/__init__.py ########
+######## src/cython.pyx ########
+######## notcython.pyx ########
+######## src2/cython.pyx ########


### PR DESCRIPTION
1) unifies handling of "cython cython.pyx" and "cythonize cython.pyx" - both raise an error now.

2) makes the check robuster, also "cythonize xxx/cython.pyx" fails now.
Fixes #2422 