### PR TITLE
Removed the mode "test" for the tests because it's not a real test mode.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -618,7 +618,7 @@ class TestBuilder(object):
                     test_class = CythonUnitTestCase
                 else:
                     test_class = CythonRunTestCase
-            elif mode in ['compile', 'error', 'test']:
+            elif mode in ['compile', 'error']:
                 test_class = CythonCompileTestCase
             else:
                 raise KeyError('Invalid test mode: ' + mode)

--- a/tests/run/simpcall.pyx
+++ b/tests/run/simpcall.pyx
@@ -1,4 +1,4 @@
-# mode: test
+# mode: run
 
 def f(x, y):
     x = y


### PR DESCRIPTION
I think it was just a small mistake because the mode `test` was only used in one file and in `runtests.py` is treated like the mode `compile`. 

Since this file has docstrings, I think mode: `run` is more appropriate.