### PR TITLE
Fix test_itimer on x32

### DIFF
--- a/tests/run/posix_time.pyx
+++ b/tests/run/posix_time.pyx
@@ -22,7 +22,7 @@ def test_itimer(sec, usec):
     t.it_value.tv_sec = 0
     t.it_value.tv_usec = 0
     ret = setitimer(ITIMER_REAL, &t, NULL)
-    return gtime.it_interval.tv_sec, gtime.it_interval.tv_usec
+    return int(gtime.it_interval.tv_sec), int(gtime.it_interval.tv_usec)
 
 def test_gettimeofday():
     """


### PR DESCRIPTION
On x32, tv_sec and tv_usec are in fact long long rather than the standard long,
and so in Python 2.x are automatically converted to Python longs, causing the
test to fail with:

    Failed example:
        test_itimer(10, 2)
    Expected:
        (10, 2)
    Got:
        (10L, 2L)

To fix this, we should explicitly call the int constructor.