### PR TITLE
Gradually enabling PEP8 checks on Travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ matrix:
     - python: 3.7
       dist: xenial    # Required for Python 3.7
       sudo: required  # travis-ci/travis-ci#9069
+      env: TEST_CODE_STYLE=1
+    - python: 3.7
+      dist: xenial    # Required for Python 3.7
+      sudo: required  # travis-ci/travis-ci#9069
       env: BACKEND=c
     - python: 3.7
       dist: xenial    # Required for Python 3.7
@@ -144,9 +148,14 @@ install:
 before_script: ccache -s || true
 
 script:
+  - if [ "$TEST_CODE_STYLE" = "1" ]; then
+      STYLE_ARGS="--no-unit --no-doctest --no-file --no-pyregr --no-examples";
+    else
+      STYLE_ARGS=--no-code-style;
+    fi
   - PYTHON_DBG="python$( python -c 'import sys; print("%d.%d" % sys.version_info[:2])' )-dbg"
-  - if $PYTHON_DBG -V >&2; then CFLAGS="-O0 -ggdb" $PYTHON_DBG runtests.py -vv Debugger --backends=$BACKEND; fi
+  - if $PYTHON_DBG -V >&2; then CFLAGS="-O0 -ggdb" $PYTHON_DBG runtests.py -vv $STYLE_ARGS Debugger --backends=$BACKEND; fi
   - if [ "$BACKEND" = "cpp" -a -n "${TRAVIS_PYTHON_VERSION##2.6*}" ]; then pip install pythran; fi
   - if [ "$BACKEND" = "c" -a -n "${TRAVIS_PYTHON_VERSION##2*}" ]; then pip install mypy; fi
   - CFLAGS="-O2 -ggdb -Wall -Wextra $(python -c 'import sys; print("-fno-strict-aliasing" if sys.version_info[0] == 2 else "")')" python setup.py build_ext -i
-  - CFLAGS="-O0 -ggdb -Wall -Wextra" python runtests.py -vv -x Debugger --backends=$BACKEND -j7
+  - CFLAGS="-O0 -ggdb -Wall -Wextra" python runtests.py -vv $STYLE_ARGS -x Debugger --backends=$BACKEND -j7

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -230,7 +230,7 @@ class DistutilsInfo(object):
                     break
                 line = line[1:].lstrip()
                 kind = next((k for k in ("distutils:","cython:") if line.startswith(k)), None)
-                if not kind is None:
+                if kind is not None:
                     key, _, value = [s.strip() for s in line[len(kind):].partition('=')]
                     type = distutils_settings.get(key, None)
                     if line.startswith("cython:") and type is None: continue

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -113,7 +113,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             env.doc = self.doc = None
         elif Options.embed_pos_in_docstring:
             env.doc = EncodedString(u'File: %s (starting at line %s)' % Nodes.relative_position(self.pos))
-            if not self.doc is None:
+            if self.doc is not None:
                 env.doc = EncodedString(env.doc + u'\n' + self.doc)
                 env.doc.encoding = self.doc.encoding
         else:

--- a/Demos/overflow_perf_run.py
+++ b/Demos/overflow_perf_run.py
@@ -16,7 +16,7 @@ def run_tests(N):
         print(func.__name__)
         for type in ['int', 'unsigned int', 'long long', 'unsigned long long', 'object']:
             if func == most_orthogonal:
-                if type == 'object' or np == None:
+                if type == 'object' or np is None:
                     continue
                 type_map = {'int': 'int32', 'unsigned int': 'uint32', 'long long': 'int64', 'unsigned long long': 'uint64'}
                 shape = N, 3

--- a/runtests.py
+++ b/runtests.py
@@ -1968,6 +1968,10 @@ def main():
     if options.with_cython and sys.version_info[0] >= 3:
         sys.path.insert(0, options.cython_dir)
 
+    # requires glob with the wildcard.
+    if sys.version_info < (3, 5) or cmd_args:
+        options.code_style = False
+
     WITH_CYTHON = options.with_cython
 
     coverage = None

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 numpy
 jupyter
 coverage
+pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,9 @@ envlist = py26, py27, py32, py33, py34, pypy
 setenv = CFLAGS=-O0 -ggdb
 commands =
     {envpython} runtests.py -vv
+
+[pycodestyle]
+ignore = W, E
+select = E711, E714
+max-line-length = 300
+format = pylint


### PR DESCRIPTION
Maybe this should be discussed on the Cython dev mailing list. Even so, I'll open the PR so that we have some code, as a basis to discuss.

As someone who is knowledgeable in Cython but not a Cython developer, I'm in a good position to say that formatting could help reading this codebase for newcomers, especially when files are commonly made of thousands of lines.

I believe that it should be possible to contribute to Cython without having a brain that is the size of a planet, or without spending dozens of hours understanding the control flow with a debugger, because the project have already a very good structure.

Maybe this can start by a bit of formatting (I also would like to make a "For Cython dev" section in the documentation, with quite more info than in the Wiki, but that will be for another time).

I'm clearly aware that a PEP8 checking that is too strict will have a great impact on what can be done in this project. Having to wait a long time for the build, then having build fail for something like "expected 2 blank lines, found one" can be really annoying, I have to admit.

I'm also aware that Cython is a REALLY big (and cool, let's not forget it) project. Formatting everything at once will be very harmful.

This is why I'm proposing that we enable PEP8 checking on Travis, one rule at a time, through pull requests.

Here, for example, all the warning and errors have been disabled except for:

* E711 comparison to None should be 'if cond is None:'
* E714 test for object identity should be 'is not'

Which I believe are reasonable rules.

It will be possible to do then other PR, enabling other rules and being able to discuss if we should really enable them.

On my laptop, running the pep8 check takes 20 seconds, which is a lot less than running the documentation tests, so I believe that we shouldn't run too much into a failed build because of PEP8.

#### On a more technical side, for this PR:

* I use `glob` with the `recursive` keyword. This is available only for Python 3.5+. Should I find a workaround for other versions (even though the job on Travis uses Python 3.6)?

* Should I add a "whitelist" for files right now, or do we wait to see if some files really need to be whitelisted (I'm thinking about `Naming.py` for example).

