### PR TITLE
docs: Fixed tests under windows.

### DIFF
--- a/tests/windows_bugs.txt
+++ b/tests/windows_bugs.txt
@@ -24,3 +24,4 @@ test_grammar
 queue
 queue2
 queue3
+lunch

--- a/tests/windows_bugs.txt
+++ b/tests/windows_bugs.txt
@@ -18,3 +18,9 @@ numpy_parallel
 py_unicode_type
 
 test_grammar
+
+# Those tests don't work because MSVC wants to link to the c-algorithms library
+# when compiling and we don't want to download c-algorithms just for those tests.
+queue
+queue2
+queue3


### PR DESCRIPTION
Following up on #2327 

I'm not a big user of windows, so everything I'm saying is guesses and stuff I found online.

The bug message was the following:
```
[00:09:23]    Creating library C:\projects\cython\TEST_TMP\6\clibraries\c\queue2\queue2.cp36-win32.lib and object C:\projects\cython\TEST_TMP\6\clibraries\c\queue2\queue2.cp36-win32.exp
[00:09:23] queue2.obj : error LNK2001: unresolved external symbol _queue_new
[00:09:23] C:\projects\cython\TEST_TMP\6\clibraries\c\queue2\queue2.cp36-win32.pyd : fatal error LNK1120: 1 unresolved externals
```

At first glance, I though the mistake was 
https://github.com/cython/cython/blob/09e9b502f63ecc966635fedadb84f3a40fe18925/docs/examples/tutorial/clibraries/cqueue.pxd#L3

Because it didn't use backward slashes like on windows paths. After some research online, it seems that msvc support forward slashes for includes. So my thinking now is that msvc invoke the linker and want to link against **c-algorithms'** library. The object file doesn't exist (and never will since we don't want to download **c-algorithms** just for that) and the linker is not happy.

So with my limited understanding of the issue, the best course of action seemed to exclude those tests from the windows build. 