### PR TITLE
Removing oudated pages from the table of content in the documenation main page.

### DIFF
--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -11,11 +11,7 @@ Contents:
    :maxdepth: 2
 
    compilation
-   extension_types
-   interfacing_with_other_code
-   special_mention
-   limitations
-   directives
+
 
 Indices and tables
 ------------------


### PR DESCRIPTION
Those pages still exist, so we shouldn't have any dead link issues with this PR.