### PR TITLE
Fixing the casting_python test under windows.

### DIFF
--- a/docs/examples/userguide/language_basics/casting_python.pyx
+++ b/docs/examples/userguide/language_basics/casting_python.pyx
@@ -1,14 +1,13 @@
 from cpython.ref cimport PyObject
-from libc.stdint cimport uintptr_t
 
 python_string = "foo"
 
 cdef void* ptr = <void*>python_string
-cdef uintptr_t adress_in_c = <uintptr_t>ptr
+cdef Py_ssize_t adress_in_c = <Py_ssize_t>ptr
 address_from_void = adress_in_c        # address_from_void is a python int
 
 cdef PyObject* ptr2 = <PyObject*>python_string
-cdef uintptr_t address_in_c2 = <uintptr_t>ptr2
+cdef Py_ssize_t address_in_c2 = <Py_ssize_t>ptr2
 address_from_PyObject = address_in_c2  # address_from_PyObject is a python int
 
 assert address_from_void == address_from_PyObject == id(python_string)


### PR DESCRIPTION
Appveyor says that `cimport_openmp` doesn't work, but the tag is there, so the test should not run.

``` python
# tag: openmp
# You can ignore the previous line.
# It's for internal testing of the Cython documentation.

from cython.parallel cimport parallel
cimport openmp

cdef int num_threads

openmp.omp_set_dynamic(1)
with nogil, parallel():
    num_threads = openmp.omp_get_num_threads()
    # ...
```

Maybe the openmp tag is used only when the test is a `run` test?