### PR TITLE
Add `typeobj` to `dtype`

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -19,7 +19,7 @@ DEF _buffer_format_string_len = 255
 cimport cpython.buffer as pybuf
 from cpython.ref cimport Py_INCREF, Py_XDECREF
 from cpython.mem cimport PyObject_Malloc, PyObject_Free
-from cpython.object cimport PyObject
+from cpython.object cimport PyObject, PyTypeObject
 from cpython.type cimport type
 cimport libc.stdio as stdio
 
@@ -164,6 +164,7 @@ cdef extern from "numpy/arrayobject.h":
     ctypedef class numpy.dtype [object PyArray_Descr]:
         # Use PyDataType_* macros when possible, however there are no macros
         # for accessing some of the fields, so some are defined.
+        cdef PyTypeObject* typeobj;
         cdef char kind
         cdef char type
         # Numpy sometimes mutates this without warning (e.g. it'll


### PR DESCRIPTION
Allows users to get the underlying `typeobj` (e.g. `numpy.float64`) from the `dtype`.

ref: https://docs.scipy.org/doc/numpy-1.15.0/reference/c-api.types-and-structures.html#c.PyArray_Descr
ref: https://docs.scipy.org/doc/numpy-1.15.0/reference/c-api.types-and-structures.html#c.PyArray_Descr.typeobj