### PR TITLE
Fix calling va_arg function with a NULL argument from generated C++ code

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -65,7 +65,7 @@ static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
             if (!py_level)
                 goto bad;
             module = PyObject_CallFunctionObjArgs(py_import,
-                name, global_dict, empty_dict, list, py_level, NULL);
+                name, global_dict, empty_dict, list, py_level, (PyObject *)NULL);
             Py_DECREF(py_level);
             #else
             module = PyImport_ImportModuleLevelObject(


### PR DESCRIPTION
C++ allows NULL to be a literal 0 [1], and this actually happens on some Linux
systems when linux/stddef.h happens to be included [2]. When 0 is passed to a
variadic function as a 7th or later argument, it is passed on the stack, and
Clang encodes this on AMD64 with "mov dword ptr [rsp], 0" because it is an
int, a 32 bit type. This sets lower 32 bits to zero, but leaves upper 32 bits unchanged.
When they happen to be non zero, the called function that expects the last
argument to be a zero pointer reads past the last intended argument and
eventually segfaults.

[1] https://en.cppreference.com/w/cpp/types/NULL
[2] https://stackoverflow.com/a/31285400/1687334
[3] https://godbolt.org/g/o4Av7Q

---

Here is another reference on why NULL should not be used with variadic
functions: [4].  Here it also affects MSVC: [5].

[4] https://en.wikibooks.org/wiki/C_Programming/stdarg.h#Type_safety
[5] https://social.msdn.microsoft.com/Forums/vstudio/en-US/35f9d81d-5d4b-4445-bbfd-9ba7c36e2501/

---

There are a couple more cases when this and similar functions may be called with `NULL` from generated C++ code, but none of them pass more than 6 arguments and stumble upon this issue.