### PR TITLE
WIP: MAINT: avoid numpy internals in {sg}et_array_base

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ Other changes
   package size to about half of its previous size.  This makes the compiler
   slightly slower, by about 5-7%.
 
+* ``set_array_base`` now calls ``PyArray_SetBaseObject``. Also modified
+  ``get_array_base`` to remove direct access to NumPy internals.
 
 0.28.4 (2018-07-08)
 ===================

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -719,6 +719,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_CheckAxis (ndarray, int *, int)
     npy_intp PyArray_OverflowMultiplyList (npy_intp *, int)
     int PyArray_CompareString (char *, char *, size_t)
+    int PyArray_SetBaseObject(object, object)
 
 
 # Typedefs that matches the runtime dtype objects in
@@ -973,22 +974,12 @@ cdef extern from "numpy/ufuncobject.h":
 
     int _import_umath() except -1
 
+cdef inline void set_array_base(object arr, object base):
+    Py_INCREF(base)
+    PyArray_SetBaseObject(arr, base)
 
-cdef inline void set_array_base(ndarray arr, object base):
-     cdef PyObject* baseptr
-     if base is None:
-         baseptr = NULL
-     else:
-         Py_INCREF(base) # important to do this before decref below!
-         baseptr = <PyObject*>base
-     Py_XDECREF(arr.base)
-     arr.base = baseptr
-
-cdef inline object get_array_base(ndarray arr):
-    if arr.base is NULL:
-        return None
-    else:
-        return <object>arr.base
+cdef inline object get_array_base(object arr):
+    return <object>arr.base
 
 
 # Versions of the import_* functions which are more suitable for

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -395,7 +395,7 @@ cdef extern from "numpy/arrayobject.h":
     npy_intp PyArray_DIM(ndarray, size_t)
     npy_intp PyArray_STRIDE(ndarray, size_t)
 
-    # object PyArray_BASE(ndarray) wrong refcount semantics
+    object PyArray_BASE(ndarray) #wrong refcount semantics?
     # dtype PyArray_DESCR(ndarray) wrong refcount semantics
     int PyArray_FLAGS(ndarray)
     npy_intp PyArray_ITEMSIZE(ndarray)
@@ -719,7 +719,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_CheckAxis (ndarray, int *, int)
     npy_intp PyArray_OverflowMultiplyList (npy_intp *, int)
     int PyArray_CompareString (char *, char *, size_t)
-    int PyArray_SetBaseObject(object, object)
+    int PyArray_SetBaseObject(ndarray, object)
 
 
 # Typedefs that matches the runtime dtype objects in
@@ -974,13 +974,15 @@ cdef extern from "numpy/ufuncobject.h":
 
     int _import_umath() except -1
 
-cdef inline void set_array_base(object arr, object base):
+cdef inline void set_array_base(ndarray arr, object base):
     Py_INCREF(base)
     PyArray_SetBaseObject(arr, base)
 
-cdef inline object get_array_base(object arr):
-    return <object>arr.base
-
+cdef inline object get_array_base(ndarray arr):
+    base = PyArray_BASE(arr)
+    # Do we need to convert NULL -> None?
+    # Do we need to incref base or is that done by cython?
+    return base
 
 # Versions of the import_* functions which are more suitable for
 # Cython code.

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -975,14 +975,12 @@ cdef extern from "numpy/ufuncobject.h":
     int _import_umath() except -1
 
 cdef inline void set_array_base(ndarray arr, object base):
-    Py_INCREF(base)
+    Py_INCREF(base) # important to do this before decref below!
     PyArray_SetBaseObject(arr, base)
 
 cdef inline object get_array_base(ndarray arr):
     base = PyArray_BASE(arr)
-    # Do we need to convert NULL -> None?
-    # Do we need to incref base or is that done by cython?
-    return base
+    return <object>base
 
 # Versions of the import_* functions which are more suitable for
 # Cython code.


### PR DESCRIPTION
In the discussion of issue #2498, it seems cython uses direct access of ndarray structure base attribute in `set_array_base` and `get_array_base`. This bypasses much of the NumPy error checks, and can lead to violating assumptions NumPy makes as to the correctness of the base attribute.

This PR refactors the functions to use NumPy APIs. I am not sure it is correct, I could find no tests for the functionality, and truthfully struggle to see when these functions could be properly used. I would prefer to deprecate them.

NumPy uses the base attribute internally when 
- creating a view by sharing the data attribute of both self and base, or 
- in creating temporary buffer data in ufuncs via writeback semantics. 

The simple code in these functions does none of the data attribute manipulations done by those two internal uses.