### PR TITLE
Add Python Raw memory helper functions

### DIFF
--- a/Cython/Includes/cpython/mem.pxd
+++ b/Cython/Includes/cpython/mem.pxd
@@ -1,3 +1,5 @@
+from cpython.version cimport PY_VERSION_HEX
+
 cdef extern from "Python.h":
 
     #####################################################################
@@ -21,6 +23,15 @@ cdef extern from "Python.h":
     # allocator as shown in the previous example, the allocated memory
     # for the I/O buffer escapes completely the Python memory
     # manager."
+
+    IF PY_VERSION_HEX >= 0x03040000:
+        void* PyMem_RawMalloc(size_t n) nogil
+        void* PyMem_RawRealloc(void *p, size_t n) nogil
+        void PyMem_RawFree(void *p) nogil
+    ELSE:
+        void* PyMem_RawMalloc "PyMem_Malloc" (size_t n) nogil
+        void* PyMem_RawRealloc "PyMem_Realloc" (void *p, size_t n) nogil
+        void PyMem_RawFree "PyMem_Free" (void *p) nogil
 
     # The following function sets, modeled after the ANSI C standard,
     # but specifying behavior when requesting zero bytes, are

--- a/Cython/Includes/cpython/mem.pxd
+++ b/Cython/Includes/cpython/mem.pxd
@@ -1,10 +1,5 @@
 from cpython.version cimport PY_VERSION_HEX
 
-cdef extern from *:
-    void* PyMem_RawMalloc(size_t n) nogil
-    void* PyMem_RawRealloc(void *p, size_t n) nogil
-    void PyMem_RawFree(void *p) nogil
-
 cdef extern from "Python.h":
 
     #####################################################################
@@ -34,6 +29,7 @@ cdef extern from "Python.h":
     # available for allocating and releasing memory from the Python
     # heap:
 
+    void* PyMem_RawMalloc(size_t n) nogil
     void* PyMem_Malloc(size_t n)
     # Allocates n bytes and returns a pointer of type void* to the
     # allocated memory, or NULL if the request fails. Requesting zero
@@ -41,6 +37,7 @@ cdef extern from "Python.h":
     # PyMem_Malloc(1) had been called instead. The memory will not
     # have been initialized in any way.
 
+    void* PyMem_RawRealloc(void *p, size_t n) nogil
     void* PyMem_Realloc(void *p, size_t n)
     # Resizes the memory block pointed to by p to n bytes. The
     # contents will be unchanged to the minimum of the old and the new
@@ -50,6 +47,7 @@ cdef extern from "Python.h":
     # NULL, it must have been returned by a previous call to
     # PyMem_Malloc() or PyMem_Realloc().
 
+    void PyMem_RawFree(void *p) nogil
     void PyMem_Free(void *p)
     # Frees the memory block pointed to by p, which must have been
     # returned by a previous call to PyMem_Malloc() or

--- a/Cython/Includes/cpython/mem.pxd
+++ b/Cython/Includes/cpython/mem.pxd
@@ -1,5 +1,10 @@
 from cpython.version cimport PY_VERSION_HEX
 
+cdef extern from *:
+    void* PyMem_RawMalloc(size_t n) nogil
+    void* PyMem_RawRealloc(void *p, size_t n) nogil
+    void PyMem_RawFree(void *p) nogil
+
 cdef extern from "Python.h":
 
     #####################################################################
@@ -23,15 +28,6 @@ cdef extern from "Python.h":
     # allocator as shown in the previous example, the allocated memory
     # for the I/O buffer escapes completely the Python memory
     # manager."
-
-    IF PY_VERSION_HEX >= 0x03040000:
-        void* PyMem_RawMalloc(size_t n) nogil
-        void* PyMem_RawRealloc(void *p, size_t n) nogil
-        void PyMem_RawFree(void *p) nogil
-    ELSE:
-        void* PyMem_RawMalloc "PyMem_Malloc" (size_t n) nogil
-        void* PyMem_RawRealloc "PyMem_Realloc" (void *p, size_t n) nogil
-        void PyMem_RawFree "PyMem_Free" (void *p) nogil
 
     # The following function sets, modeled after the ANSI C standard,
     # but specifying behavior when requesting zero bytes, are

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -441,7 +441,7 @@ class __Pyx_FakeReference {
   #define PyObject_Realloc(p)  PyMem_Realloc(p)
 #endif
 
-#if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX < 0x03040000
+#if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX < 0x030400A1
   #define PyMem_RawMalloc(n)           PyMem_Malloc(n)
   #define PyMem_RawRealloc(p, n)       PyMem_Realloc(p, n)
   #define PyMem_RawFree(p)             PyMem_Free(p)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -441,6 +441,12 @@ class __Pyx_FakeReference {
   #define PyObject_Realloc(p)  PyMem_Realloc(p)
 #endif
 
+#if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX < 0x03040000
+  #define PyMem_RawMalloc(n)           PyMem_Malloc(n)
+  #define PyMem_RawRealloc(p, n)       PyMem_Realloc(p, n)
+  #define PyMem_RawFree(p)             PyMem_Free(p)
+#endif
+
 #if CYTHON_COMPILING_IN_PYSTON
   // special C-API functions only in Pyston
   #define __Pyx_PyCode_HasFreeVars(co)  PyCode_HasFreeVars(co)


### PR DESCRIPTION
In Python 3.4+, Raw memory helper functions were added to wrap, track, and check `malloc` and `free` calls for C memory outside of the GIL. These have the same API as the existing `PyMem_*` calls except they use Raw and never require the GIL. For Python 2/3 compatibility, export the existing `PyMem_` functions on Python 2 as `PyMem_Raw` where they act basically equivalently. These are especially important as Python 3.6 changed the existing `PyMem_` functions to allocate from pymalloc instead of the C allocator meaning the GIL must now be held with them. So these are Python 2/3 alternatives that can be relied on to not require the GIL.