### PR TITLE
Support two-element slicing with literal None

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4808,30 +4808,30 @@ class SliceIndexNode(ExprNode):
             #      if (__pyx_v_VARNAME == Py_None) { __pyx_t_TMPIDX = PY_SSIZE_T_MAX; } else { __pyx_t_TMPIDX = __Pyx_PyIndex_AsSsize_t(__pyx_v_VARNAME); }
             c_int = PyrexTypes.c_py_ssize_t_type
             if self.start:
-                # self.start = CondExprNode(
-                #     self.start.pos,
-                #     true_val = IntNode(self.start.pos, value = '0'),
-                #     false_val = self.start,
-                #     test = PrimaryCmpNode(
-                #         self.start.pos,
-                #         operand1 = self.start,
-                #         operator = 'is',
-                #         operand2 = NoneNode(self.pos)
-                #     )
-                # )
+                self.start = CondExprNode(
+                    self.start.pos,
+                    true_val = IntNode(self.start.pos, value = '0'),
+                    false_val = self.start,
+                    test = PrimaryCmpNode(
+                        self.start.pos,
+                        operand1 = self.start,
+                        operator = '==',
+                        operand2 = NoneNode(self.start.pos)
+                    )
+                )
                 self.start = self.start.coerce_to(c_int, env)
             if self.stop:
-                # self.stop = CondExprNode(
-                #     self.stop.pos,
-                #     true_val = IntNode(self.start.pos, value = 'PY_SSIZE_T_MAX'),
-                #     false_val = self.stop,
-                #     test = PrimaryCmpNode(
-                #         self.stop.pos,
-                #         operand1 = self.stop,
-                #         operator = 'is',
-                #         operand2 = NoneNode(self.pos)
-                #     )
-                # )
+                self.stop = CondExprNode(
+                    self.stop.pos,
+                    true_val = IntNode(self.stop.pos, value = 'PY_SSIZE_T_MAX'),
+                    false_val = self.stop,
+                    test = PrimaryCmpNode(
+                        self.stop.pos,
+                        operand1 = self.stop,
+                        operator = '==',
+                        operand2 = NoneNode(self.stop.pos)
+                    )
+                )
                 self.stop = self.stop.coerce_to(c_int, env)
         self.is_temp = 1
         return self

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4781,8 +4781,7 @@ class SliceIndexNode(ExprNode):
                         self.stop.pos,
                         value = 'PY_SSIZE_T_MAX',
                         # See: github.com/python/cpython/blob/2.7/Python/sysmodule.c#L1446
-                        constant_result = sys.maxsize,
-                        type = PyrexTypes.c_py_ssize_t_type
+                        constant_result = sys.maxsize
                     ),
                     false_val = stop_ref,
                     test = PrimaryCmpNode(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4808,8 +4808,30 @@ class SliceIndexNode(ExprNode):
             #      if (__pyx_v_VARNAME == Py_None) { __pyx_t_TMPIDX = PY_SSIZE_T_MAX; } else { __pyx_t_TMPIDX = __Pyx_PyIndex_AsSsize_t(__pyx_v_VARNAME); }
             c_int = PyrexTypes.c_py_ssize_t_type
             if self.start:
+                # self.start = CondExprNode(
+                #     self.start.pos,
+                #     true_val = IntNode(self.start.pos, value = '0'),
+                #     false_val = self.start,
+                #     test = PrimaryCmpNode(
+                #         self.start.pos,
+                #         operand1 = self.start,
+                #         operator = 'is',
+                #         operand2 = NoneNode(self.pos)
+                #     )
+                # )
                 self.start = self.start.coerce_to(c_int, env)
             if self.stop:
+                # self.stop = CondExprNode(
+                #     self.stop.pos,
+                #     true_val = IntNode(self.start.pos, value = 'PY_SSIZE_T_MAX'),
+                #     false_val = self.stop,
+                #     test = PrimaryCmpNode(
+                #         self.stop.pos,
+                #         operand1 = self.stop,
+                #         operator = 'is',
+                #         operand2 = NoneNode(self.pos)
+                #     )
+                # )
                 self.stop = self.stop.coerce_to(c_int, env)
         self.is_temp = 1
         return self

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4806,6 +4806,7 @@ class SliceIndexNode(ExprNode):
             #      if (__pyx_v_VARNAME == Py_None) { __pyx_t_TMPIDX = 0; } else { __pyx_t_TMPIDX = __Pyx_PyIndex_AsSsize_t(__pyx_v_VARNAME); }
             #   And, in the case of self.stop, needs to become:
             #      if (__pyx_v_VARNAME == Py_None) { __pyx_t_TMPIDX = PY_SSIZE_T_MAX; } else { __pyx_t_TMPIDX = __Pyx_PyIndex_AsSsize_t(__pyx_v_VARNAME); }
+            c_bool = PyrexTypes.c_bint_type
             c_int = PyrexTypes.c_py_ssize_t_type
             if self.start:
                 self.start = CondExprNode(
@@ -4815,11 +4816,13 @@ class SliceIndexNode(ExprNode):
                     test = PrimaryCmpNode(
                         self.start.pos,
                         operand1 = self.start,
-                        operator = '==',
-                        operand2 = NoneNode(self.start.pos)
-                    )
+                        operator = 'is',
+                        operand2 = NoneNode(self.start.pos),
+                        type = c_bool,  # Why isn't this set automatically?
+                    ),
+                    type = c_int,  # Why isn't this set automatically?
+                    is_temp = 1,  # Set to avoid call to calculate_result_code()
                 )
-                self.start = self.start.coerce_to(c_int, env)
             if self.stop:
                 self.stop = CondExprNode(
                     self.stop.pos,
@@ -4828,11 +4831,13 @@ class SliceIndexNode(ExprNode):
                     test = PrimaryCmpNode(
                         self.stop.pos,
                         operand1 = self.stop,
-                        operator = '==',
-                        operand2 = NoneNode(self.stop.pos)
-                    )
+                        operator = 'is',
+                        operand2 = NoneNode(self.stop.pos),
+                        type = c_bool,  # Why isn't this set automatically?
+                    ),
+                    type = c_int,  # Why isn't this set automatically?
+                    is_temp = 1,  # Set to avoid call to calculate_result_code()
                 )
-                self.stop = self.stop.coerce_to(c_int, env)
         self.is_temp = 1
         return self
 

--- a/tests/run/slice2.pyx
+++ b/tests/run/slice2.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: slicing
+# tag: list, slice, slicing
 
 def test_full(seq):
     """
@@ -18,21 +18,24 @@ def test_full(seq):
 
 def test_start(seq, start):
     """
-    >>> test_start([1,2,3,4], 2)
+    >>> l = [1,2,3,4]
+    >>> test_start(l, 2)
     [3, 4]
-    >>> test_start([1,2,3,4], 3)
+    >>> test_start(l, 3)
     [4]
-    >>> test_start([1,2,3,4], 4)
+    >>> test_start(l, 4)
     []
-    >>> test_start([1,2,3,4], 8)
+    >>> test_start(l, 8)
     []
-    >>> test_start([1,2,3,4], -3)
+    >>> test_start(l, -3)
     [2, 3, 4]
-    >>> test_start([1,2,3,4], -4)
+    >>> test_start(l, -4)
     [1, 2, 3, 4]
-    >>> test_start([1,2,3,4], -8)
+    >>> test_start(l, -8)
     [1, 2, 3, 4]
-    >>> test_start([1,2,3,4], 0)
+    >>> test_start(l, 0)
+    [1, 2, 3, 4]
+    >>> test_start(l, None)
     [1, 2, 3, 4]
     >>> try: test_start(42, 2, 3)
     ... except TypeError: pass
@@ -42,22 +45,50 @@ def test_start(seq, start):
 
 def test_stop(seq, stop):
     """
-    >>> test_stop([1,2,3,4], 3)
+    >>> l = [1,2,3,4]
+    >>> test_stop(l, 3)
     [1, 2, 3]
-    >>> test_stop([1,2,3,4], -1)
+    >>> test_stop(l, -1)
     [1, 2, 3]
-    >>> test_stop([1,2,3,4], -3)
+    >>> test_stop(l, -3)
     [1]
-    >>> test_stop([1,2,3,4], -4)
+    >>> test_stop(l, -4)
     []
-    >>> test_stop([1,2,3,4], -8)
+    >>> test_stop(l, -8)
     []
-    >>> test_stop([1,2,3,4], 0)
+    >>> test_stop(l, 0)
     []
+    >>> test_stop(l, None)
+    [1, 2, 3, 4]
     >>> try: test_stop(42, 3)
     ... except TypeError: pass
     """
     obj = seq[:stop]
+    return obj
+
+def test_step(seq, step):
+    """
+    >>> l = [1,2,3,4]
+    >>> test_step(l, -1)
+    [4, 3, 2, 1]
+    >>> test_step(l, 1)
+    [1, 2, 3, 4]
+    >>> test_step(l, 2)
+    [1, 3]
+    >>> test_step(l, 3)
+    [1, 4]
+    >>> test_step(l, -3)
+    [4, 1]
+    >>> test_step(l, None)
+    [1, 2, 3, 4]
+    >>> try: test_step(l, 0)
+    ... except ValueError: pass
+    ...
+    >>> try: test_step(42, 0)
+    ... except TypeError: pass
+    ...
+    """
+    obj = seq[::step]
     return obj
 
 def test_start_and_stop(seq, start, stop):
@@ -67,10 +98,36 @@ def test_start_and_stop(seq, start, stop):
     [3]
     >>> test_start_and_stop(l, -3, -1)
     [2, 3]
+    >>> test_start_and_stop(l, None, None)
+    [1, 2, 3, 4]
     >>> try: test_start_and_stop(42, 2, 3)
     ... except TypeError: pass
     """
     obj = seq[start:stop]
+    return obj
+
+def test_start_stop_and_step(seq, start, stop, step):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> test_start_stop_and_step(l, 0, 5, 1)
+    [1, 2, 3, 4, 5]
+    >>> test_start_stop_and_step(l, 5, -1, -1)
+    []
+    >>> test_start_stop_and_step(l, 5, None, -1)
+    [5, 4, 3, 2, 1]
+    >>> test_start_stop_and_step(l, 2, 5, 2)
+    [3, 5]
+    >>> test_start_stop_and_step(l, -100, 100, 1)
+    [1, 2, 3, 4, 5]
+    >>> test_start_stop_and_step(l, None, None, None)
+    [1, 2, 3, 4, 5]
+    >>> try: test_start_stop_and_step(l, None, None, 0)
+    ... except ValueError: pass
+    ... 
+    >>> try: test_start_stop_and_step(42, 1, 2, 3)
+    ... except TypeError: pass
+    """
+    obj = seq[start:stop:step]
     return obj
 
 class A(object):

--- a/tests/run/typed_slice.pyx
+++ b/tests/run/typed_slice.pyx
@@ -208,31 +208,35 @@ ctypedef fused slicable:
     list
     tuple
     bytes
+    unicode
 
 def slice_fused_type_start(slicable seq, start):
     """
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
-    ...     for s in (0, 4, 5, -5, None):
-    ...             slice_fused_type_start(o, s)
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
+    ...     for s in (0, 4, 5, -5):
+    ...         print(p(slice_fused_type_start(o, s)))
     ... 
     [1, 2, 3, 4, 5]
     [5]
     []
     [1, 2, 3, 4, 5]
-    [1, 2, 3, 4, 5]
     (1, 2, 3, 4, 5)
     (5,)
     ()
     (1, 2, 3, 4, 5)
-    (1, 2, 3, 4, 5)
-    '12345'
-    '5'
-    ''
-    '12345'
-    '12345'
+    12345
+    5
+    <BLANKLINE>
+    12345
+    12345
+    5
+    <BLANKLINE>
+    12345
     """
     obj = seq[start:]
     return obj
@@ -242,9 +246,11 @@ def slice_fused_type_stop(slicable seq, stop):
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
     ...     for s in (0, 4, 5, -5, None):
-    ...             slice_fused_type_stop(o, s)
+    ...         print(p(slice_fused_type_stop(o, s)))
     ... 
     []
     [1, 2, 3, 4]
@@ -256,11 +262,16 @@ def slice_fused_type_stop(slicable seq, stop):
     (1, 2, 3, 4, 5)
     ()
     (1, 2, 3, 4, 5)
-    ''
-    '1234'
-    '12345'
-    ''
-    '12345'
+    <BLANKLINE>
+    1234
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    1234
+    12345
+    <BLANKLINE>
+    12345
     """
     obj = seq[:stop]
     return obj
@@ -270,10 +281,12 @@ def slice_fused_type_start_and_stop(slicable seq, start, stop):
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
     ...     for start in (0, 1, 4, 5, -5, None):
-    ...             for stop in (0, 4, 5, 10, -10, None):
-    ...                     slice_fused_type_start_and_stop(o, start, stop)
+    ...         for stop in (0, 4, 5, 10, -10, None):
+    ...             print(p(slice_fused_type_start_and_stop(o, start, stop)))
     ... 
     []
     [1, 2, 3, 4]
@@ -347,42 +360,78 @@ def slice_fused_type_start_and_stop(slicable seq, start, stop):
     (1, 2, 3, 4, 5)
     ()
     (1, 2, 3, 4, 5)
-    ''
-    '1234'
-    '12345'
-    '12345'
-    ''
-    '12345'
-    ''
-    '234'
-    '2345'
-    '2345'
-    ''
-    '2345'
-    ''
-    ''
-    '5'
-    '5'
-    ''
-    '5'
-    ''
-    ''
-    ''
-    ''
-    ''
-    ''
-    ''
-    '1234'
-    '12345'
-    '12345'
-    ''
-    '12345'
-    ''
-    '1234'
-    '12345'
-    '12345'
-    ''
-    '12345'
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    234
+    2345
+    2345
+    <BLANKLINE>
+    2345
+    <BLANKLINE>
+    <BLANKLINE>
+    5
+    5
+    <BLANKLINE>
+    5
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    234
+    2345
+    2345
+    <BLANKLINE>
+    2345
+    <BLANKLINE>
+    <BLANKLINE>
+    5
+    5
+    <BLANKLINE>
+    5
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
+    <BLANKLINE>
+    1234
+    12345
+    12345
+    <BLANKLINE>
+    12345
     """
     obj = seq[start:stop]
     return obj
@@ -392,9 +441,11 @@ def slice_fused_type_step(slicable seq, step):
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
     ...     for s in (1, -1, 2, -3, 10, -10, None):
-    ...             slice_fused_type_step(o, s)
+    ...         print(p(slice_fused_type_step(o, s)))
     ... 
     [1, 2, 3, 4, 5]
     [5, 4, 3, 2, 1]
@@ -410,13 +461,20 @@ def slice_fused_type_step(slicable seq, step):
     (1,)
     (5,)
     (1, 2, 3, 4, 5)
-    '12345'
-    '54321'
-    '135'
-    '52'
-    '1'
-    '5'
-    '12345'
+    12345
+    54321
+    135
+    52
+    1
+    5
+    12345
+    12345
+    54321
+    135
+    52
+    1
+    5
+    12345
     >>> for o in (l, t, b):
     ...     try: slice_fused_type_step(o, 0)
     ...     except ValueError: pass
@@ -429,10 +487,12 @@ def slice_fused_type_start_and_step(slicable seq, start, step):
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
     ...     for start in (0, 2, 5, -5, None):
-    ...             for step in (1, -1, 2, -3, None):
-    ...                     slice_fused_type_start_and_step(o, start, step)
+    ...         for step in (1, -1, 2, -3, None):
+    ...             print(p(slice_fused_type_start_and_step(o, start, step)))
     ... 
     [1, 2, 3, 4, 5]
     [1]
@@ -484,31 +544,56 @@ def slice_fused_type_start_and_step(slicable seq, start, step):
     (1, 3, 5)
     (5, 2)
     (1, 2, 3, 4, 5)
-    '12345'
-    '1'
-    '135'
-    '1'
-    '12345'
-    '345'
-    '321'
-    '35'
-    '3'
-    '345'
-    ''
-    '54321'
-    ''
-    '52'
-    ''
-    '12345'
-    '1'
-    '135'
-    '1'
-    '12345'
-    '12345'
-    '54321'
-    '135'
-    '52'
-    '12345'
+    12345
+    1
+    135
+    1
+    12345
+    345
+    321
+    35
+    3
+    345
+    <BLANKLINE>
+    54321
+    <BLANKLINE>
+    52
+    <BLANKLINE>
+    12345
+    1
+    135
+    1
+    12345
+    12345
+    54321
+    135
+    52
+    12345
+    12345
+    1
+    135
+    1
+    12345
+    345
+    321
+    35
+    3
+    345
+    <BLANKLINE>
+    54321
+    <BLANKLINE>
+    52
+    <BLANKLINE>
+    12345
+    1
+    135
+    1
+    12345
+    12345
+    54321
+    135
+    52
+    12345
     >>> for o in (l, t, b):
     ...     try: slice_fused_type_start_and_step(o, 0, 0)
     ...     except ValueError: pass
@@ -521,10 +606,12 @@ def slice_fused_type_stop_and_step(slicable seq, stop, step):
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
     >>> b = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, b):
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
     ...     for stop in (5, 10, 3, -10, None):
-    ...             for step in (1, -1, 2, -3, None):
-    ...                     slice_fused_type_stop_and_step(o, stop, step)
+    ...         for step in (1, -1, 2, -3, None):
+    ...             print(p(slice_fused_type_stop_and_step(o, stop, step)))
     ... 
     [1, 2, 3, 4, 5]
     []
@@ -576,31 +663,56 @@ def slice_fused_type_stop_and_step(slicable seq, stop, step):
     (1, 3, 5)
     (5, 2)
     (1, 2, 3, 4, 5)
-    '12345'
-    ''
-    '135'
-    ''
-    '12345'
-    '12345'
-    ''
-    '135'
-    ''
-    '12345'
-    '123'
-    '5'
-    '13'
-    '5'
-    '123'
-    ''
-    '54321'
-    ''
-    '52'
-    ''
-    '12345'
-    '54321'
-    '135'
-    '52'
-    '12345'
+    12345
+    <BLANKLINE>
+    135
+    <BLANKLINE>
+    12345
+    12345
+    <BLANKLINE>
+    135
+    <BLANKLINE>
+    12345
+    123
+    5
+    13
+    5
+    123
+    <BLANKLINE>
+    54321
+    <BLANKLINE>
+    52
+    <BLANKLINE>
+    12345
+    54321
+    135
+    52
+    12345
+    12345
+    <BLANKLINE>
+    135
+    <BLANKLINE>
+    12345
+    12345
+    <BLANKLINE>
+    135
+    <BLANKLINE>
+    12345
+    123
+    5
+    13
+    5
+    123
+    <BLANKLINE>
+    54321
+    <BLANKLINE>
+    52
+    <BLANKLINE>
+    12345
+    54321
+    135
+    52
+    12345
     >>> for o in (l, t, b):
     ...     try: slice_fused_type_stop_and_step(o, 5, 0)
     ...     except ValueError: pass
@@ -612,55 +724,46 @@ def slice_fused_type_all(slicable seq, start, stop, step):
     """
     >>> l = [1,2,3,4,5]
     >>> t = tuple(l)
-    >>> s = ''.join(map(str, l)).encode('ASCII')
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, 0, 5, 1)
-    ...
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> u = b.decode('ASCII')
+    >>> p = lambda o: o.decode() if isinstance(o, type(b)) else str(o)
+    >>> for o in (l, t, b, u):
+    ...     for args in ((0, 5, 1), (5, 0, -1), (None, 5, 1), (5, None, -1),
+    ...                  (-100, 100, None), (None, None, None), (1, 3, 2), (5, 1, -3)):
+    ...         print(p(slice_fused_type_all(o, *args)))
+    ... 
     [1, 2, 3, 4, 5]
-    (1, 2, 3, 4, 5)
-    '12345'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, 5, 0, -1)
-    ...
     [5, 4, 3, 2]
-    (5, 4, 3, 2)
-    '5432'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, None, 5, 1)
-    ...
     [1, 2, 3, 4, 5]
-    (1, 2, 3, 4, 5)
-    '12345'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, 5, None, -1)
-    ...
     [5, 4, 3, 2, 1]
-    (5, 4, 3, 2, 1)
-    '54321'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, -100, 100, None)
-    ...
     [1, 2, 3, 4, 5]
-    (1, 2, 3, 4, 5)
-    '12345'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, None, None, None)
-    ...
     [1, 2, 3, 4, 5]
-    (1, 2, 3, 4, 5)
-    '12345'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, 1, 3, 2)
-    ...
     [2]
-    (2,)
-    '2'
-    >>> for o in (l, t, s):
-    ...     slice_fused_type_all(o, 5, 1, -3)
-    ...
     [5]
+    (1, 2, 3, 4, 5)
+    (5, 4, 3, 2)
+    (1, 2, 3, 4, 5)
+    (5, 4, 3, 2, 1)
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    (2,)
     (5,)
-    '5'
+    12345
+    5432
+    12345
+    54321
+    12345
+    12345
+    2
+    5
+    12345
+    5432
+    12345
+    54321
+    12345
+    12345
+    2
+    5
     """
     obj = seq[start:stop:step]
     return obj

--- a/tests/run/typed_slice.pyx
+++ b/tests/run/typed_slice.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: list, tuple, slice
+# tag: list, tuple, slice, slicing
 
 def slice_list(list l, int start, int stop):
     """
@@ -203,3 +203,464 @@ def slice_charp_repeat(py_string_arg):
     cdef bytes slice_val = s[1:6]
     s = slice_val
     return s[1:3].decode(u'ASCII')
+
+ctypedef fused slicable:
+    list
+    tuple
+    bytes
+
+def slice_fused_type_start(slicable seq, start):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for s in (0, 4, 5, -5, None):
+    ...             slice_fused_type_start(o, s)
+    ... 
+    [1, 2, 3, 4, 5]
+    [5]
+    []
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    (5,)
+    ()
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    '12345'
+    '5'
+    ''
+    '12345'
+    '12345'
+    """
+    obj = seq[start:]
+    return obj
+
+def slice_fused_type_stop(slicable seq, stop):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for s in (0, 4, 5, -5, None):
+    ...             slice_fused_type_stop(o, s)
+    ... 
+    []
+    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5]
+    []
+    [1, 2, 3, 4, 5]
+    ()
+    (1, 2, 3, 4)
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    ''
+    '1234'
+    '12345'
+    ''
+    '12345'
+    """
+    obj = seq[:stop]
+    return obj
+
+def slice_fused_type_start_and_stop(slicable seq, start, stop):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for start in (0, 1, 4, 5, -5, None):
+    ...             for stop in (0, 4, 5, 10, -10, None):
+    ...                     slice_fused_type_start_and_stop(o, start, stop)
+    ... 
+    []
+    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    []
+    [1, 2, 3, 4, 5]
+    []
+    [2, 3, 4]
+    [2, 3, 4, 5]
+    [2, 3, 4, 5]
+    []
+    [2, 3, 4, 5]
+    []
+    []
+    [5]
+    [5]
+    []
+    [5]
+    []
+    []
+    []
+    []
+    []
+    []
+    []
+    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    []
+    [1, 2, 3, 4, 5]
+    []
+    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    []
+    [1, 2, 3, 4, 5]
+    ()
+    (1, 2, 3, 4)
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    ()
+    (2, 3, 4)
+    (2, 3, 4, 5)
+    (2, 3, 4, 5)
+    ()
+    (2, 3, 4, 5)
+    ()
+    ()
+    (5,)
+    (5,)
+    ()
+    (5,)
+    ()
+    ()
+    ()
+    ()
+    ()
+    ()
+    ()
+    (1, 2, 3, 4)
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 2, 3, 4)
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    ''
+    '1234'
+    '12345'
+    '12345'
+    ''
+    '12345'
+    ''
+    '234'
+    '2345'
+    '2345'
+    ''
+    '2345'
+    ''
+    ''
+    '5'
+    '5'
+    ''
+    '5'
+    ''
+    ''
+    ''
+    ''
+    ''
+    ''
+    ''
+    '1234'
+    '12345'
+    '12345'
+    ''
+    '12345'
+    ''
+    '1234'
+    '12345'
+    '12345'
+    ''
+    '12345'
+    """
+    obj = seq[start:stop]
+    return obj
+
+def slice_fused_type_step(slicable seq, step):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for s in (1, -1, 2, -3, 10, -10, None):
+    ...             slice_fused_type_step(o, s)
+    ... 
+    [1, 2, 3, 4, 5]
+    [5, 4, 3, 2, 1]
+    [1, 3, 5]
+    [5, 2]
+    [1]
+    [5]
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    (5, 4, 3, 2, 1)
+    (1, 3, 5)
+    (5, 2)
+    (1,)
+    (5,)
+    (1, 2, 3, 4, 5)
+    '12345'
+    '54321'
+    '135'
+    '52'
+    '1'
+    '5'
+    '12345'
+    >>> for o in (l, t, b):
+    ...     try: slice_fused_type_step(o, 0)
+    ...     except ValueError: pass
+    """
+    obj = seq[::step]
+    return obj
+
+def slice_fused_type_start_and_step(slicable seq, start, step):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for start in (0, 2, 5, -5, None):
+    ...             for step in (1, -1, 2, -3, None):
+    ...                     slice_fused_type_start_and_step(o, start, step)
+    ... 
+    [1, 2, 3, 4, 5]
+    [1]
+    [1, 3, 5]
+    [1]
+    [1, 2, 3, 4, 5]
+    [3, 4, 5]
+    [3, 2, 1]
+    [3, 5]
+    [3]
+    [3, 4, 5]
+    []
+    [5, 4, 3, 2, 1]
+    []
+    [5, 2]
+    []
+    [1, 2, 3, 4, 5]
+    [1]
+    [1, 3, 5]
+    [1]
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    [5, 4, 3, 2, 1]
+    [1, 3, 5]
+    [5, 2]
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    (1,)
+    (1, 3, 5)
+    (1,)
+    (1, 2, 3, 4, 5)
+    (3, 4, 5)
+    (3, 2, 1)
+    (3, 5)
+    (3,)
+    (3, 4, 5)
+    ()
+    (5, 4, 3, 2, 1)
+    ()
+    (5, 2)
+    ()
+    (1, 2, 3, 4, 5)
+    (1,)
+    (1, 3, 5)
+    (1,)
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    (5, 4, 3, 2, 1)
+    (1, 3, 5)
+    (5, 2)
+    (1, 2, 3, 4, 5)
+    '12345'
+    '1'
+    '135'
+    '1'
+    '12345'
+    '345'
+    '321'
+    '35'
+    '3'
+    '345'
+    ''
+    '54321'
+    ''
+    '52'
+    ''
+    '12345'
+    '1'
+    '135'
+    '1'
+    '12345'
+    '12345'
+    '54321'
+    '135'
+    '52'
+    '12345'
+    >>> for o in (l, t, b):
+    ...     try: slice_fused_type_start_and_step(o, 0, 0)
+    ...     except ValueError: pass
+    """
+    obj = seq[start::step]
+    return obj
+
+def slice_fused_type_stop_and_step(slicable seq, stop, step):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> b = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, b):
+    ...     for stop in (5, 10, 3, -10, None):
+    ...             for step in (1, -1, 2, -3, None):
+    ...                     slice_fused_type_stop_and_step(o, stop, step)
+    ... 
+    [1, 2, 3, 4, 5]
+    []
+    [1, 3, 5]
+    []
+    [1, 2, 3, 4, 5]
+    [1, 2, 3, 4, 5]
+    []
+    [1, 3, 5]
+    []
+    [1, 2, 3, 4, 5]
+    [1, 2, 3]
+    [5]
+    [1, 3]
+    [5]
+    [1, 2, 3]
+    []
+    [5, 4, 3, 2, 1]
+    []
+    [5, 2]
+    []
+    [1, 2, 3, 4, 5]
+    [5, 4, 3, 2, 1]
+    [1, 3, 5]
+    [5, 2]
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 3, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    (1, 2, 3, 4, 5)
+    ()
+    (1, 3, 5)
+    ()
+    (1, 2, 3, 4, 5)
+    (1, 2, 3)
+    (5,)
+    (1, 3)
+    (5,)
+    (1, 2, 3)
+    ()
+    (5, 4, 3, 2, 1)
+    ()
+    (5, 2)
+    ()
+    (1, 2, 3, 4, 5)
+    (5, 4, 3, 2, 1)
+    (1, 3, 5)
+    (5, 2)
+    (1, 2, 3, 4, 5)
+    '12345'
+    ''
+    '135'
+    ''
+    '12345'
+    '12345'
+    ''
+    '135'
+    ''
+    '12345'
+    '123'
+    '5'
+    '13'
+    '5'
+    '123'
+    ''
+    '54321'
+    ''
+    '52'
+    ''
+    '12345'
+    '54321'
+    '135'
+    '52'
+    '12345'
+    >>> for o in (l, t, b):
+    ...     try: slice_fused_type_stop_and_step(o, 5, 0)
+    ...     except ValueError: pass
+    """
+    obj = seq[:stop:step]
+    return obj
+
+def slice_fused_type_all(slicable seq, start, stop, step):
+    """
+    >>> l = [1,2,3,4,5]
+    >>> t = tuple(l)
+    >>> s = ''.join(map(str, l)).encode('ASCII')
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, 0, 5, 1)
+    ...
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    '12345'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, 5, 0, -1)
+    ...
+    [5, 4, 3, 2]
+    (5, 4, 3, 2)
+    '5432'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, None, 5, 1)
+    ...
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    '12345'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, 5, None, -1)
+    ...
+    [5, 4, 3, 2, 1]
+    (5, 4, 3, 2, 1)
+    '54321'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, -100, 100, None)
+    ...
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    '12345'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, None, None, None)
+    ...
+    [1, 2, 3, 4, 5]
+    (1, 2, 3, 4, 5)
+    '12345'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, 1, 3, 2)
+    ...
+    [2]
+    (2,)
+    '2'
+    >>> for o in (l, t, s):
+    ...     slice_fused_type_all(o, 5, 1, -3)
+    ...
+    [5]
+    (5,)
+    '5'
+    """
+    obj = seq[start:stop:step]
+    return obj


### PR DESCRIPTION
Patch and associated unittests for issue #2508.

Apologies for the overly long wait for this PR - I spent entirely too much time attempting to reverse engineer and brute-force the Cython compilation internals instead of taking the time to understand the various hooks. Feedback appreciated.