### PR TITLE
cython_inline compiler directives support

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -136,8 +136,10 @@ def _populate_unbound(kwds, unbound_symbols, locals=None, globals=None):
             else:
                 print("Couldn't find %r" % symbol)
 
-def cython_inline(code, get_type=unsafe_type, lib_dir=os.path.join(get_cython_cache_dir(), 'inline'),
-                  cython_include_dirs=None, force=False, quiet=False, locals=None, globals=None, **kwds):
+def cython_inline(code, get_type=unsafe_type,
+                  lib_dir=os.path.join(get_cython_cache_dir(), 'inline'),
+                  cython_include_dirs=None, cython_compiler_directives=None,
+                  force=False, quiet=False, locals=None, globals=None, **kwds):
 
     if get_type is None:
         get_type = lambda x: 'object'
@@ -233,7 +235,11 @@ def __invoke(%(params)s):
                 extra_compile_args = cflags)
             if build_extension is None:
                 build_extension = _get_build_extension()
-            build_extension.extensions = cythonize([extension], include_path=cython_include_dirs or ['.'], quiet=quiet)
+            build_extension.extensions = cythonize(
+                [extension],
+                include_path=cython_include_dirs or ['.'],
+                compiler_directives=cython_compiler_directives or {},
+                quiet=quiet)
             build_extension.build_temp = os.path.dirname(pyx_file)
             build_extension.build_lib  = lib_dir
             build_extension.run()

--- a/Cython/Build/Tests/TestInline.py
+++ b/Cython/Build/Tests/TestInline.py
@@ -60,6 +60,14 @@ class TestInline(CythonTest):
         """, a=3, **self.test_kwds)
         self.assertEquals(type(b), float)
 
+    def test_compiler_directives(self):
+        self.assertEqual(
+            inline('return sum(x)',
+                   x=[1, 2, 3],
+                   cython_compiler_directives={'boundscheck': False}),
+            6
+        )
+
     if has_numpy:
 
         def test_numpy(self):

--- a/tests/run/test_fstring.pyx
+++ b/tests/run/test_fstring.pyx
@@ -849,6 +849,14 @@ f'{a * x()}'"""
         self.assertEqual(f'{d["foo"]}', 'bar')
         self.assertEqual(f"{d['foo']}", 'bar')
 
+    def test_inline_compiler_directives(self):
+        self.assertEqual(
+            cy_eval('sum(x)',
+                    x=[1,2,3],
+                    cython_compiler_directives={'boundscheck': False}),
+            6
+        )
+
     def __test_backslash_char(self):
         # Check eval of a backslash followed by a control char.
         # See bpo-30682: this used to raise an assert in pydebug mode.

--- a/tests/run/test_fstring.pyx
+++ b/tests/run/test_fstring.pyx
@@ -849,14 +849,6 @@ f'{a * x()}'"""
         self.assertEqual(f'{d["foo"]}', 'bar')
         self.assertEqual(f"{d['foo']}", 'bar')
 
-    def test_inline_compiler_directives(self):
-        self.assertEqual(
-            cy_eval('sum(x)',
-                    x=[1,2,3],
-                    cython_compiler_directives={'boundscheck': False}),
-            6
-        )
-
     def __test_backslash_char(self):
         # Check eval of a backslash followed by a control char.
         # See bpo-30682: this used to raise an assert in pydebug mode.


### PR DESCRIPTION
Support for user-supplied compiler directives to `cython_inline()` via a new `cython_compiler_directives` argument.