### PR TITLE
MAINT: if subtree test fails, print out all stdout, stderr not just last

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1735,6 +1735,9 @@ class EndToEndTest(unittest.TestCase):
         old_path = os.environ.get('PYTHONPATH')
         env = dict(os.environ)
         env['PYTHONPATH'] = self.cython_syspath + os.pathsep + (old_path or '')
+        cmd = []
+        out = []
+        err = []
         for command_no, command in enumerate(filter(None, commands.splitlines()), 1):
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c',
                                  'etoe-build' if ' setup.py ' in command else 'etoe-run'):
@@ -1743,11 +1746,15 @@ class EndToEndTest(unittest.TestCase):
                                      stdout=subprocess.PIPE,
                                      shell=True,
                                      env=env)
-                out, err = p.communicate()
+                _out, _err = p.communicate()
+                cmd.append(command)
+                out.append(_out)
+                err.append(_err)
             res = p.returncode
             if res != 0:
-                sys.stderr.write("%s\n%s\n%s\n" % (
-                    command, self._try_decode(out), self._try_decode(err)))
+                for c, o, e in zip(cmd, out, err):
+                    sys.stderr.write("%s\n%s\n%s\n\n" % (
+                        c, self._try_decode(o), self._try_decode(e)))
             self.assertEqual(0, res, "non-zero exit status")
         self.success = True
 


### PR DESCRIPTION
srctree tests may invoke multiple commands. If one fails, print out all the commands, stdout, and stderr. This is helpful when debugging. Print statements can be used to reveal state during the successful first steps that cause later steps to fail.