### PR TITLE
 ENH: add check_size option to ctypedef class for external classes 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,10 @@ Features added
 
 * Constants in ``libc.math`` are now declared as ``const`` to simplify their handling.
 
+* An additional ``check_size`` clause was added to the ``ctypedef class`` name
+  specification to allow suppressing warnings when importing modules with
+  backward-compatible `PyTypeObject`` size changes.
+
 Bugs fixed
 ----------
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3061,15 +3061,18 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         # check_size
         if not type.is_external or type.is_subclassed:
-            cs = 0 
-        elif type.check_size == b'min':
-            cs = 1
-        elif type.check_size is True:
+            if type.check_size != 'min':
+                raise AttributeError("unexpected check_size value '%s' when "
+                "compiling %s.%s" % (type.check_size, module_name, type.name))
             cs = 0
-        elif type.check_size is False:
+        elif type.check_size == 'min':
+            cs = 1
+        elif type.check_size == 'True':
+            cs = 0
+        elif type.check_size == 'False':
             cs = 2
         else:
-            raise AttributeError("invalid value for check_size '%r' when compiling "
+            raise AttributeError("invalid value for check_size '%s' when compiling "
                 "%s.%s" % (type.check_size, module_name, type.name))
         code.putln('%d);' % cs)
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3067,9 +3067,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             cs = 0
         elif type.check_size == 'min':
             cs = 1
-        elif type.check_size == 'True':
+        elif type.check_size == True:
             cs = 0
-        elif type.check_size == 'False':
+        elif type.check_size == False:
             cs = 2
         else:
             raise AttributeError("invalid value for check_size '%s' when compiling "

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3061,17 +3061,17 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         # check_size
         if not type.is_external or type.is_subclassed:
-            cs = '__PYX_CHECKSIZE_STRICT'
+            cs = 0 
         elif type.check_size == b'min':
-            cs = '__PYX_CHECKSIZE_MIN'
+            cs = 1
         elif type.check_size is True:
-            cs = '__PYX_CHECKSIZE_STRICT'
+            cs = 0
         elif type.check_size is False:
-            cs = '__PYX_CHECKSIZE_LOOSE'
+            cs = 2
         else:
             raise AttributeError("invalid value for check_size '%r' when compiling "
                 "%s.%s" % (type.check_size, module_name, type.name))
-        code.putln('%s);' % cs)
+        code.putln('%d);' % cs)
 
         code.putln(' if (!%s) %s' % (type.typeptr_cname, error_code))
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -4629,6 +4629,7 @@ class CClassDefNode(ClassDefNode):
     #  bases              TupleNode         Base class(es)
     #  objstruct_name     string or None    Specified C name of object struct
     #  typeobj_name       string or None    Specified C name of type object
+    #  check_size         b'min' or boolean Issue warning if tp_basicsize does not match
     #  in_pxd             boolean           Is in a .pxd file
     #  decorators         [DecoratorNode]   list of decorators or None
     #  doc                string or None
@@ -4645,6 +4646,7 @@ class CClassDefNode(ClassDefNode):
     api = False
     objstruct_name = None
     typeobj_name = None
+    check_size = b'min'
     decorators = None
     shadow = False
 
@@ -4680,6 +4682,7 @@ class CClassDefNode(ClassDefNode):
             typeobj_cname=self.typeobj_name,
             visibility=self.visibility,
             typedef_flag=self.typedef_flag,
+            check_size = self.check_size,
             api=self.api,
             buffer_defaults=self.buffer_defaults(env),
             shadow=self.shadow)
@@ -4765,6 +4768,7 @@ class CClassDefNode(ClassDefNode):
             base_type=self.base_type,
             objstruct_cname=self.objstruct_name,
             typeobj_cname=self.typeobj_name,
+            check_size=self.check_size,
             visibility=self.visibility,
             typedef_flag=self.typedef_flag,
             api=self.api,

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -4629,7 +4629,7 @@ class CClassDefNode(ClassDefNode):
     #  bases              TupleNode         Base class(es)
     #  objstruct_name     string or None    Specified C name of object struct
     #  typeobj_name       string or None    Specified C name of type object
-    #  check_size         b'min' or boolean Issue warning if tp_basicsize does not match
+    #  check_size         'min' or boolean  What to do if tp_basicsize does not match
     #  in_pxd             boolean           Is in a .pxd file
     #  decorators         [DecoratorNode]   list of decorators or None
     #  doc                string or None
@@ -4646,7 +4646,7 @@ class CClassDefNode(ClassDefNode):
     api = False
     objstruct_name = None
     typeobj_name = None
-    check_size = b'min'
+    check_size = 'min'
     decorators = None
     shadow = False
 

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3544,6 +3544,14 @@ def p_c_class_options(s):
         elif s.systring == 'check_size':
             s.next()
             check_size = p_ident(s)
+            if check_size == 'False':
+                check_size = False
+            elif check_size == 'True':
+                check_size = True
+            elif check_size == 'min':
+                pass
+            else:
+                s.error('Expected False, True, or min, not %r' % check_size)
         if s.sy != ',':
             break
         s.next()

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3471,6 +3471,7 @@ def p_c_class_definition(s, pos,  ctx):
     objstruct_name = None
     typeobj_name = None
     bases = None
+    check_size = b'min'
     if s.sy == '(':
         positional_args, keyword_args = p_call_parse_args(s, allow_genexp=False)
         if keyword_args:
@@ -3482,7 +3483,7 @@ def p_c_class_definition(s, pos,  ctx):
     if s.sy == '[':
         if ctx.visibility not in ('public', 'extern') and not ctx.api:
             error(s.position(), "Name options only allowed for 'public', 'api', or 'extern' C class")
-        objstruct_name, typeobj_name = p_c_class_options(s)
+        objstruct_name, typeobj_name, check_size = p_c_class_options(s)
     if s.sy == ':':
         if ctx.level == 'module_pxd':
             body_level = 'c_class_pxd'
@@ -3521,6 +3522,7 @@ def p_c_class_definition(s, pos,  ctx):
         bases = bases,
         objstruct_name = objstruct_name,
         typeobj_name = typeobj_name,
+        check_size = check_size,
         in_pxd = ctx.level == 'module_pxd',
         doc = doc,
         body = body)
@@ -3528,6 +3530,7 @@ def p_c_class_definition(s, pos,  ctx):
 def p_c_class_options(s):
     objstruct_name = None
     typeobj_name = None
+    check_size = b'min'
     s.expect('[')
     while 1:
         if s.sy != 'IDENT':
@@ -3538,11 +3541,14 @@ def p_c_class_options(s):
         elif s.systring == 'type':
             s.next()
             typeobj_name = p_ident(s)
+        elif s.systring == 'check_size':
+            s.next()
+            check_size = p_atom(s).value
         if s.sy != ',':
             break
         s.next()
     s.expect(']', "Expected 'object' or 'type'")
-    return objstruct_name, typeobj_name
+    return objstruct_name, typeobj_name, check_size
 
 
 def p_property_decl(s):

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3471,7 +3471,7 @@ def p_c_class_definition(s, pos,  ctx):
     objstruct_name = None
     typeobj_name = None
     bases = None
-    check_size = b'min'
+    check_size = 'min'
     if s.sy == '(':
         positional_args, keyword_args = p_call_parse_args(s, allow_genexp=False)
         if keyword_args:
@@ -3530,7 +3530,7 @@ def p_c_class_definition(s, pos,  ctx):
 def p_c_class_options(s):
     objstruct_name = None
     typeobj_name = None
-    check_size = b'min'
+    check_size = 'min'
     s.expect('[')
     while 1:
         if s.sy != 'IDENT':
@@ -3543,7 +3543,7 @@ def p_c_class_options(s):
             typeobj_name = p_ident(s)
         elif s.systring == 'check_size':
             s.next()
-            check_size = p_atom(s).value
+            check_size = p_ident(s)
         if s.sy != ',':
             break
         s.next()

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1345,14 +1345,14 @@ class PyExtensionType(PyObjectType):
     #  vtable_cname     string           Name of C method table definition
     #  early_init       boolean          Whether to initialize early (as opposed to during module execution).
     #  defered_declarations [thunk]      Used to declare class hierarchies in order
-
+    #  check_size       b'min' or boolean should tp_basicsize match sizeof(obstruct_cname)
     is_extension_type = 1
     has_attributes = 1
     early_init = 1
 
     objtypedef_cname = None
 
-    def __init__(self, name, typedef_flag, base_type, is_external=0):
+    def __init__(self, name, typedef_flag, base_type, is_external=0, check_size=b'min'):
         self.name = name
         self.scope = None
         self.typedef_flag = typedef_flag
@@ -1368,6 +1368,7 @@ class PyExtensionType(PyObjectType):
         self.vtabptr_cname = None
         self.vtable_cname = None
         self.is_external = is_external
+        self.check_size = check_size
         self.defered_declarations = []
 
     def set_scope(self, scope):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1345,14 +1345,15 @@ class PyExtensionType(PyObjectType):
     #  vtable_cname     string           Name of C method table definition
     #  early_init       boolean          Whether to initialize early (as opposed to during module execution).
     #  defered_declarations [thunk]      Used to declare class hierarchies in order
-    #  check_size       b'min' or boolean should tp_basicsize match sizeof(obstruct_cname)
+    #  check_size       'min' or boolean What to do if tp_basicsize does not match
     is_extension_type = 1
     has_attributes = 1
     early_init = 1
 
     objtypedef_cname = None
 
-    def __init__(self, name, typedef_flag, base_type, is_external=0, check_size=b'min'):
+    def __init__(self, name, typedef_flag, base_type, is_external=0,
+                 check_size='min'):
         self.name = name
         self.scope = None
         self.typedef_flag = typedef_flag

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1476,7 +1476,7 @@ class ModuleScope(Scope):
     def declare_c_class(self, name, pos, defining = 0, implementing = 0,
         module_name = None, base_type = None, objstruct_cname = None,
         typeobj_cname = None, typeptr_cname = None, visibility = 'private',
-        typedef_flag = 0, api = 0, check_size=b'min',
+        typedef_flag = 0, api = 0, check_size='min',
         buffer_defaults = None, shadow = 0):
         # If this is a non-extern typedef class, expose the typedef, but use
         # the non-typedef struct internally to avoid needing forward

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1475,7 +1475,8 @@ class ModuleScope(Scope):
 
     def declare_c_class(self, name, pos, defining = 0, implementing = 0,
         module_name = None, base_type = None, objstruct_cname = None,
-        typeobj_cname = None, typeptr_cname = None, visibility = 'private', typedef_flag = 0, api = 0,
+        typeobj_cname = None, typeptr_cname = None, visibility = 'private',
+        typedef_flag = 0, api = 0, check_size=b'min',
         buffer_defaults = None, shadow = 0):
         # If this is a non-extern typedef class, expose the typedef, but use
         # the non-typedef struct internally to avoid needing forward
@@ -1508,7 +1509,8 @@ class ModuleScope(Scope):
         #  Make a new entry if needed
         #
         if not entry or shadow:
-            type = PyrexTypes.PyExtensionType(name, typedef_flag, base_type, visibility == 'extern')
+            type = PyrexTypes.PyExtensionType(name, typedef_flag, base_type,
+                                              visibility == 'extern', check_size=check_size)
             type.pos = pos
             type.buffer_defaults = buffer_defaults
             if objtypedef_cname is not None:

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -736,6 +736,14 @@ built-in complex object.::
             ...
         } PyComplexObject;
 
+       At runtime, a check will be performed when importing the cython
+       c-extension module that ``__builtin__.complex``'s ``tp_basicsize``
+       matches ``sizeof(`PyComplexObject)``. This check can fail if in the cython
+       c-extension module was compiled with one version of the
+       ``complexobject.h`` header but imported into a python with a changed
+       header. This check can be tweaked by using ``check_size`` in the name
+       specification clause.
+
     2. As well as the name of the extension type, the module in which its type
        object can be found is also specified. See the implicit importing section
        below.
@@ -756,11 +764,23 @@ The part of the class declaration in square brackets is a special feature only
 available for extern or public extension types. The full form of this clause
 is::
 
-    [object object_struct_name, type type_object_name ]
+    [object object_struct_name, type type_object_name, check_size cs_option]
 
-where ``object_struct_name`` is the name to assume for the type's C struct,
-and type_object_name is the name to assume for the type's statically declared
-type object. (The object and type clauses can be written in either order.)
+Where:
+
+- ``object_struct_name`` is the name to assume for the type's C struct.
+- ``type_object_name`` is the name to assume for the type's statically
+  declared type object.
+- ``cs_option`` is ``'min'`` (the default), ``True``, or ``False`` and is only
+  used for external extension types. If ``True``, ``sizeof(object_struct)`` must
+  match the type's ``tp_basicsize``. If ``False``, or ``min``, the
+  ``object_struct`` may be smaller than the type's ``tp_basicsize``, which
+  indicates the type allocated at runtime may be part of an updated module, and
+  that the external module's developers extended the object in a
+  backward-compatible fashion (only adding new fields to the end of the
+  object). If ``min``, a warning will be emitted.
+
+The clauses can be written in any order.
 
 If the extension type declaration is inside a :keyword:`cdef` extern from
 block, the object clause is required, because Cython must be able to generate

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -736,11 +736,11 @@ built-in complex object.::
             ...
         } PyComplexObject;
 
-       At runtime, a check will be performed when importing the cython
+       At runtime, a check will be performed when importing the Cython
        c-extension module that ``__builtin__.complex``'s ``tp_basicsize``
-       matches ``sizeof(`PyComplexObject)``. This check can fail if in the cython
+       matches ``sizeof(`PyComplexObject)``. This check can fail if the Cython
        c-extension module was compiled with one version of the
-       ``complexobject.h`` header but imported into a python with a changed
+       ``complexobject.h`` header but imported into a Python with a changed
        header. This check can be tweaked by using ``check_size`` in the name
        specification clause.
 
@@ -771,7 +771,7 @@ Where:
 - ``object_struct_name`` is the name to assume for the type's C struct.
 - ``type_object_name`` is the name to assume for the type's statically
   declared type object.
-- ``cs_option`` is ``'min'`` (the default), ``True``, or ``False`` and is only
+- ``cs_option`` is ``min`` (the default), ``True``, or ``False`` and is only
   used for external extension types. If ``True``, ``sizeof(object_struct)`` must
   match the type's ``tp_basicsize``. If ``False``, or ``min``, the
   ``object_struct`` may be smaller than the type's ``tp_basicsize``, which

--- a/runtests.py
+++ b/runtests.py
@@ -1735,9 +1735,6 @@ class EndToEndTest(unittest.TestCase):
         old_path = os.environ.get('PYTHONPATH')
         env = dict(os.environ)
         env['PYTHONPATH'] = self.cython_syspath + os.pathsep + (old_path or '')
-        cmd = []
-        out = []
-        err = []
         for command_no, command in enumerate(filter(None, commands.splitlines()), 1):
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c',
                                  'etoe-build' if ' setup.py ' in command else 'etoe-run'):
@@ -1746,15 +1743,11 @@ class EndToEndTest(unittest.TestCase):
                                      stdout=subprocess.PIPE,
                                      shell=True,
                                      env=env)
-                _out, _err = p.communicate()
-                cmd.append(command)
-                out.append(_out)
-                err.append(_err)
+                out, err = p.communicate()
             res = p.returncode
             if res != 0:
-                for c, o, e in zip(cmd, out, err):
-                    sys.stderr.write("%s\n%s\n%s\n\n" % (
-                        c, self._try_decode(o), self._try_decode(e)))
+                sys.stderr.write("%s\n%s\n%s\n" % (
+                    command, self._try_decode(out), self._try_decode(err)))
             self.assertEqual(0, res, "non-zero exit status")
         self.success = True
 

--- a/runtests.py
+++ b/runtests.py
@@ -1735,6 +1735,9 @@ class EndToEndTest(unittest.TestCase):
         old_path = os.environ.get('PYTHONPATH')
         env = dict(os.environ)
         env['PYTHONPATH'] = self.cython_syspath + os.pathsep + (old_path or '')
+        cmd = []
+        out = []
+        err = []
         for command_no, command in enumerate(filter(None, commands.splitlines()), 1):
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c',
                                  'etoe-build' if ' setup.py ' in command else 'etoe-run'):
@@ -1743,11 +1746,15 @@ class EndToEndTest(unittest.TestCase):
                                      stdout=subprocess.PIPE,
                                      shell=True,
                                      env=env)
-                out, err = p.communicate()
+                _out, _err = p.communicate()
+                cmd.append(command)
+                out.append(_out)
+                err.append(_err)
             res = p.returncode
             if res != 0:
-                sys.stderr.write("%s\n%s\n%s\n" % (
-                    command, self._try_decode(out), self._try_decode(err)))
+                for c, o, e in zip(cmd, out, err):
+                    sys.stderr.write("%s\n%s\n%s\n\n" % (
+                        c, self._try_decode(o), self._try_decode(e)))
             self.assertEqual(0, res, "non-zero exit status")
         self.success = True
 

--- a/tests/run/check_size.srctree
+++ b/tests/run/check_size.srctree
@@ -129,8 +129,8 @@ cpdef public int testme(Foo f) except -1:
 
 cdef extern from "check_size_smaller.h":
 
-    # make sure missing check_size is equivalent to 'min'
-    ctypedef class check_size.Foo [object FooStructSmall, check_size 'min']:
+    # make sure missing check_size is equivalent to min
+    ctypedef class check_size.Foo [object FooStructSmall, check_size min]:
         cdef:
             int f9
 
@@ -169,7 +169,7 @@ cpdef public int testme(Foo f) except -1:
 cdef extern from "check_size_smaller.h":
 
     # Raise AttributeError when using bad value
-    ctypedef class check_size.Foo [object FooStructSmall, check_size 'max']:
+    ctypedef class check_size.Foo [object FooStructSmall, check_size max]:
         cdef:
             int f9
 

--- a/tests/run/check_size.srctree
+++ b/tests/run/check_size.srctree
@@ -11,6 +11,12 @@ setup(ext_modules= cythonize("check_size.pyx"))
 
 setup(ext_modules = cythonize("_check_size*.pyx"))
 
+try:
+    setup(ext_modules= cythonize("check_size6.pyx"))
+    assert False
+except AttributeError as e:
+    assert 'max' in str(e)
+
 ######## check_size_nominal.h ########
 
 #include <Python.h>
@@ -119,6 +125,58 @@ cdef extern from "check_size_smaller.h":
 cpdef public int testme(Foo f) except -1:
     return f.f9
 
+######## _check_size3.pyx ########
+
+cdef extern from "check_size_smaller.h":
+
+    # make sure missing check_size is equivalent to 'min'
+    ctypedef class check_size.Foo [object FooStructSmall, check_size 'min']:
+        cdef:
+            int f9
+
+
+cpdef public int testme(Foo f) except -1:
+    return f.f9
+
+######## _check_size4.pyx ########
+
+cdef extern from "check_size_smaller.h":
+
+    # Disable size check
+    ctypedef class check_size.Foo [object FooStructSmall, check_size False]:
+        cdef:
+            int f9
+
+
+cpdef public int testme(Foo f) except -1:
+    return f.f9
+
+######## _check_size5.pyx ########
+
+cdef extern from "check_size_smaller.h":
+
+    # Strict checking, will raise an error
+    ctypedef class check_size.Foo [object FooStructSmall, check_size True]:
+        cdef:
+            int f9
+
+
+cpdef public int testme(Foo f) except -1:
+    return f.f9
+
+######## check_size6.pyx ########
+
+cdef extern from "check_size_smaller.h":
+
+    # Raise AttributeError when using bad value
+    ctypedef class check_size.Foo [object FooStructSmall, check_size 'max']:
+        cdef:
+            int f9
+
+
+cpdef public int testme(Foo f) except -1:
+    return f.f9
+
 ######## runner.py ########
 
 import check_size, _check_size0, warnings
@@ -137,19 +195,36 @@ try:
     import _check_size1
     assert False
 except ValueError as e:
-    assert str(e).startswith('check_size.Foo has the wrong size, try recompiling')
+    assert str(e).startswith('check_size.Foo size changed')
 
 # Warining since check_size.Foo's tp_basicsize is larger than what is needed
 # for FooStructSmall. There is "spare", accessing FooStructSmall's fields will
 # never access invalid memory. This can happen, for instance, when using old
-# headers with a newer runtime, or when using an old _check_size2 with a newer
+# headers with a newer runtime, or when using an old _check_size{2,3} with a newer
 # check_size, where the developers of check_size are careful to be backward
 # compatible.
 
 with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
     import _check_size2
-    assert len(w) == 1, 'expected one warning, got %d' % len(w)
-    assert str(w[-1].message).startswith('check_size.Foo size changed')
+    import _check_size3
+    assert len(w) == 2, 'expected two warnings, got %d' % len(w)
+    assert str(w[0].message).startswith('check_size.Foo size changed')
+    assert str(w[1].message).startswith('check_size.Foo size changed')
 
 ret = _check_size2.testme(foo)
 assert ret == 23
+ret = _check_size3.testme(foo)
+assert ret == 23
+
+with warnings.catch_warnings(record=True) as w:
+    # No warning, runtime vendor must provide backward compatibility
+    import _check_size4
+    assert len(w) == 0
+
+try:
+    # Enforce strict checking
+    import _check_size5
+    assert False
+except ValueError as e:
+    assert str(e).startswith('check_size.Foo size changed')

--- a/tests/run/check_size.srctree
+++ b/tests/run/check_size.srctree
@@ -4,6 +4,7 @@ PYTHON -c "import runner"
 ######## setup.py ########
 
 from Cython.Build.Dependencies import cythonize
+from Cython.Compiler.Errors import CompileError
 from distutils.core import setup
 
 # force the build order
@@ -14,8 +15,8 @@ setup(ext_modules = cythonize("_check_size*.pyx"))
 try:
     setup(ext_modules= cythonize("check_size6.pyx"))
     assert False
-except AttributeError as e:
-    assert 'max' in str(e)
+except CompileError as e:
+    pass
 
 ######## check_size_nominal.h ########
 
@@ -168,7 +169,7 @@ cpdef public int testme(Foo f) except -1:
 
 cdef extern from "check_size_smaller.h":
 
-    # Raise AttributeError when using bad value
+    # Raise Compilerror when using bad value
     ctypedef class check_size.Foo [object FooStructSmall, check_size max]:
         cdef:
             int f9


### PR DESCRIPTION
Address #2221 by adding a new `check_size` clause to `ctypedef class` definitions. This will allow suppressing the warning.

The srctree test actually comprises a few tests, but they are reported as one pass/fail. I am not sure how to break them into separate tests.

I think 'min', True, and False were the proposed values, but maybe I misunderstood.