### PR TITLE
ENH: allow @property decorator on external ctypedef classes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6976,10 +6976,11 @@ class AttributeNode(ExprNode):
         self.obj = self.obj.analyse_types(env)
         self.analyse_attribute(env)
         if self.entry and self.entry.is_cmethod and not self.is_called:
-            # It must be a property method. This should be done at a different level??
-            self.is_called = 1
-            self.op = ''
-            self.result_ctype = self.type.return_type
+            if getattr(self.entry, 'is_cgetter', False):
+                # This should be done at a different level??
+                self.is_called = 1
+                self.op = ''
+                self.result_ctype = self.type.return_type
             pass
         ## Reference to C array turns into pointer to first element.
         #while self.type.is_array:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7147,7 +7147,7 @@ class AttributeNode(ExprNode):
         #print "...obj_code =", obj_code ###
         if self.entry and self.entry.is_cmethod:
             if self.entry.is_cgetter:
-                return "%s(%s)" %(self.entry.func_cname, obj_code)
+                return "%s(%s)" % (self.entry.func_cname, obj_code)
             if obj.type.is_extension_type and not self.entry.is_builtin_cmethod:
                 if self.entry.final_func_cname:
                     return self.entry.final_func_cname

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6976,11 +6976,7 @@ class AttributeNode(ExprNode):
         self.obj = self.obj.analyse_types(env)
         self.analyse_attribute(env)
         if self.entry and self.entry.is_cmethod and not self.is_called:
-            if getattr(self.entry, 'is_cgetter', False):
-                # This should be done at a different level??
-                self.is_called = 1
-                self.op = ''
-                self.result_ctype = self.type.return_type
+#            error(self.pos, "C method can only be called")
             pass
         ## Reference to C array turns into pointer to first element.
         #while self.type.is_array:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7146,7 +7146,7 @@ class AttributeNode(ExprNode):
         obj_code = obj.result_as(obj.type)
         #print "...obj_code =", obj_code ###
         if self.entry and self.entry.is_cmethod:
-            if getattr(self.entry.type, 'is_cgetter', False):
+            if self.entry.is_cgetter:
                 return "%s(%s)" %(self.entry.func_cname, obj_code)
             if obj.type.is_extension_type and not self.entry.is_builtin_cmethod:
                 if self.entry.final_func_cname:
@@ -11225,9 +11225,9 @@ class NumBinopNode(BinopNode):
             self.operand2 = self.operand2.coerce_to(self.type, env)
 
     def compute_c_result_type(self, type1, type2):
-        if type1.is_cfunction and type1.is_cgetter:
+        if type1.is_cfunction and type1.entry.is_cgetter:
             type1 = type1.return_type
-        if type2.is_cfunction and type2.is_cgetter:
+        if type2.is_cfunction and type2.entry.is_cgetter:
             type2 = type2.return_type
         if self.c_types_okay(type1, type2):
             widest_type = PyrexTypes.widest_numeric_type(type1, type2)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5042,13 +5042,6 @@ class PropertyNode(StatNode):
         self.entry = env.declare_property(self.name, self.doc, self.pos)
         self.entry.scope.directives = env.directives
         self.body.analyse_declarations(self.entry.scope)
-        # XXX DO SOMETHING HERE???
-        if 0 and self.is_wrapper:
-            entry = self.body.stats[0].entry
-            entry.is_property = 1
-            entry.doc = self.doc
-            env.property_entries[-1] = entry
-            env.entries[self.name] = entry
 
     def analyse_expressions(self, env):
         self.body = self.body.analyse_expressions(env)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2422,11 +2422,16 @@ class CFuncDefNode(FuncDefNode):
 
         type.is_const_method = self.is_const_method
         type.is_static_method = self.is_static_method
+        property = False
+        if self.decorators:
+            for _node in self.decorators:
+                if _node.decorator.is_name and _node.decorator.name == 'property':
+                    property = True
         self.entry = env.declare_cfunction(
             name, type, self.pos,
             cname=cname, visibility=self.visibility, api=self.api,
             defining=self.body is not None, modifiers=self.modifiers,
-            overridable=self.overridable)
+            overridable=self.overridable, property=property)
         self.entry.inline_func_in_pxd = self.inline_in_pxd
         self.return_type = type.return_type
         if self.return_type.is_array and self.visibility != 'extern':

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2340,13 +2340,13 @@ class CFuncDefNode(FuncDefNode):
         return self.py_func.code_object if self.py_func else None
 
     def analyse_declarations(self, env):
-        is_property = False
+        is_property = 0
         if self.decorators:
             for decorator in self.decorators:
                 func = decorator.decorator
                 if func.is_name:
                     if func.name == 'property':
-                        is_property = True
+                        is_property = 1
                     elif func.name == 'staticmethod':
                         pass
                     else:
@@ -2429,7 +2429,11 @@ class CFuncDefNode(FuncDefNode):
             name, type, self.pos,
             cname=cname, visibility=self.visibility, api=self.api,
             defining=self.body is not None, modifiers=self.modifiers,
-            overridable=self.overridable, is_property=is_property)
+            overridable=self.overridable)
+        if is_property:
+            self.entry.is_property = 1
+            env.property_entries.append(self.entry)
+            env.cfunc_entries.remove(self.entry)
         self.entry.inline_func_in_pxd = self.inline_in_pxd
         self.return_type = type.return_type
         if self.return_type.is_array and self.visibility != 'extern':

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2340,11 +2340,14 @@ class CFuncDefNode(FuncDefNode):
         return self.py_func.code_object if self.py_func else None
 
     def analyse_declarations(self, env):
+        is_property = False
         if self.decorators:
             for decorator in self.decorators:
                 func = decorator.decorator
                 if func.is_name:
-                    if func.name in ('property', 'staticmethod'):
+                    if func.name == 'property':
+                        is_property = True
+                    elif func.name == 'staticmethod':
                         pass
                     else:
                         error(self.pos, "Cannot handle %s decorators yet" % func.name)
@@ -2421,16 +2424,12 @@ class CFuncDefNode(FuncDefNode):
 
         type.is_const_method = self.is_const_method
         type.is_static_method = self.is_static_method
-        property = False
-        if self.decorators:
-            for _node in self.decorators:
-                if _node.decorator.is_name and _node.decorator.name == 'property':
-                    property = True
+
         self.entry = env.declare_cfunction(
             name, type, self.pos,
             cname=cname, visibility=self.visibility, api=self.api,
             defining=self.body is not None, modifiers=self.modifiers,
-            overridable=self.overridable, property=property)
+            overridable=self.overridable, is_property=is_property)
         self.entry.inline_func_in_pxd = self.inline_in_pxd
         self.return_type = type.return_type
         if self.return_type.is_array and self.visibility != 'extern':

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2344,11 +2344,10 @@ class CFuncDefNode(FuncDefNode):
             for decorator in self.decorators:
                 func = decorator.decorator
                 if func.is_name:
-                    if func.name == 'classmethod' or func.name == 'staticmethod':
-                        error(self.pos, "Cannot handle these decorators yet")
-                    if func.name == 'property':
-                        # XXX DO SOMETHING HERE???
+                    if func.name in ('property', 'staticmethod'):
                         pass
+                    else:
+                        error(self.pos, "Cannot handle %s decorators yet" % func.name)
 
         self.is_c_class_method = env.is_c_class_scope
         if self.directive_locals is None:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2243,21 +2243,20 @@ class ReplacePropertyNode(CythonTransform):
     def visit_CFuncDefNode(self, node):
         if not node.decorators:
             return node
-
-        # transform @property decorators
+        # transform @property decorators on ctypedef class functions
         for decorator_node in node.decorators[::-1]:
             decorator = decorator_node.decorator
             if decorator.is_name and decorator.name == 'property':
                 if len(node.decorators) > 1:
                     return self._reject_decorated_property(node, decorator_node)
-                name = node.declarator.base.name
-                node.name = name #EncodedString('__get__')
-                newstats = node.body.analyse_expressions(node.local_scope)
-                newnode = newstats.stats[0].value
-                newnode.name = name
+                # Mark the node as a cgetter
+                node.type.is_cgetter = True
+                # Add a func_cname to be output instead of the attribute
+                node.entry.func_cname = node.body.stats[0].value.function.name
+                # done - remove the decorator node
                 node.decorators.remove(decorator_node)
-                return [newnode]
-        # XXX still need to update everywhere that used the old node
+                return [node]
+
 
 class FindInvalidUseOfFusedTypes(CythonTransform):
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2243,23 +2243,24 @@ class ReplacePropertyNode(CythonTransform):
     def visit_CFuncDefNode(self, node):
         if not node.decorators:
             return node
-        # transform @property decorators on ctypedef class functions
-        for decorator_node in node.decorators[::-1]:
-            if self.find_decorator(decorator_node.decorator, 'property'):
-                if len(node.decorators) > 1:
-                    # raises
-                    self._reject_decorated_property(node, decorator_node)
-                node.entry.is_cgetter = True
-                # Add a func_cname to be output instead of the attribute
-                node.entry.func_cname = node.body.stats[0].value.function.name
-                node.decorators.remove(decorator_node)
-                break
+        decorator = self.find_first_decorator(node, 'property')
+        if decorator:
+            # transform class functions into c-getters
+            if len(node.decorators) > 1:
+                # raises
+                self._reject_decorated_property(node, decorator_node)
+            node.entry.is_cgetter = True
+            # Add a func_cname to be output instead of the attribute
+            node.entry.func_cname = node.body.stats[0].value.function.name
+            node.decorators.remove(decorator)
         return node
 
-    def find_decorator(self, decorator, name):
-        if decorator.is_name and decorator.name == name:
-            return True
-        return False
+    def find_first_decorator(self, node, name):
+        for decorator_node in node.decorators[::-1]:
+            decorator = decorator_node.decorator
+            if decorator.is_name and decorator.name == name:
+                return decorator_node
+        return None
 
 
 class FindInvalidUseOfFusedTypes(CythonTransform):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1398,67 +1398,6 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
         node.decorators = None
         return self.chain_decorators(node, decs, node.name)
 
-    def visit_CFuncDefNode(self, node):
-        scope_type = self.scope_type
-        if scope_type != 'cclass' or not node.decorators:
-            return node
-
-        # XXX currently only handle getter property
-        # transform @property decorators
-        properties = self._properties[-1]
-        for decorator_node in node.decorators[::-1]:
-            decorator = decorator_node.decorator
-            if decorator.is_name and decorator.name == 'property':
-                if len(node.decorators) > 1:
-                    return self._reject_decorated_property(node, decorator_node)
-                name = node.declarator.base.name
-                # XXX Disables handling property decorator
-                # return [node]
-                node.name = name #EncodedString('__get__')
-                node.decorators.remove(decorator_node)
-                stat_list = [node]
-                if name in properties:
-                    prop = properties[name]
-                    prop.pos = node.pos
-                    prop.doc = node.doc
-                    prop.body.stats = stat_list
-                    return []
-                prop = Nodes.PropertyNode(node.pos, name=name)
-                prop.doc = node.doc
-                prop.body = Nodes.StatListNode(node.pos, stats=stat_list)
-                prop.is_wrapper = True
-                properties[name] = prop
-                return [prop]
-            elif decorator.is_attribute and decorator.obj.name in properties:
-                # TODO fix this
-                raise error(decorator_node.pos, "Not handled yet")
-                handler_name = self._map_property_attribute(decorator.attribute)
-                if handler_name:
-                    if decorator.obj.name != node.name:
-                        # CPython generates neither an error nor warning, but nothing useful either.
-                        error(decorator_node.pos,
-                              "Mismatching property names, expected '%s', got '%s'" % (
-                                  decorator.obj.name, node.name))
-                    elif len(node.decorators) > 1:
-                        return self._reject_decorated_property(node, decorator_node)
-                    else:
-                        return self._add_to_property(properties, node, handler_name, decorator_node)
-
-        # we clear node.decorators, so we need to set the
-        # is_staticmethod/is_classmethod attributes now
-        for decorator in node.decorators:
-            # TODO fix this
-            raise error(decorator.pos, "Not handled yet")
-            func = decorator.decorator
-            if func.is_name:
-                node.is_classmethod |= func.name == 'classmethod'
-                node.is_staticmethod |= func.name == 'staticmethod'
-
-        # transform normal decorators
-        decs = node.decorators
-        node.decorators = None
-        return self.chain_decorators(node, decs, None)
-
     @staticmethod
     def _reject_decorated_property(node, decorator_node):
         # restrict transformation to outermost decorator as wrapped properties will probably not work
@@ -2300,6 +2239,25 @@ class AnalyseExpressionsTransform(CythonTransform):
             node = node.base
         return node
 
+class ReplacePropertyNode(CythonTransform):
+    def visit_CFuncDefNode(self, node):
+        if not node.decorators:
+            return node
+
+        # transform @property decorators
+        for decorator_node in node.decorators[::-1]:
+            decorator = decorator_node.decorator
+            if decorator.is_name and decorator.name == 'property':
+                if len(node.decorators) > 1:
+                    return self._reject_decorated_property(node, decorator_node)
+                name = node.declarator.base.name
+                node.name = name #EncodedString('__get__')
+                newstats = node.body.analyse_expressions(node.local_scope)
+                newnode = newstats.stats[0].value
+                newnode.name = name
+                node.decorators.remove(decorator_node)
+                return [newnode]
+        # XXX still need to update everywhere that used the old node
 
 class FindInvalidUseOfFusedTypes(CythonTransform):
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2256,6 +2256,7 @@ class ReplacePropertyNode(CythonTransform):
                 # done - remove the decorator node
                 node.decorators.remove(decorator_node)
                 return [node]
+        return [node]
 
 
 class FindInvalidUseOfFusedTypes(CythonTransform):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2245,23 +2245,21 @@ class ReplacePropertyNode(CythonTransform):
             return node
         # transform @property decorators on ctypedef class functions
         for decorator_node in node.decorators[::-1]:
-            _node = self.analyse_decorator(node, decorator_node.decorator)
-            if _node:
+            if self.find_decorator(decorator_node.decorator, 'property'):
+                if len(node.decorators) > 1:
+                    # raises
+                    self._reject_decorated_property(node, decorator_node)
+                node.entry.is_cgetter = True
+                # Add a func_cname to be output instead of the attribute
+                node.entry.func_cname = node.body.stats[0].value.function.name
                 node.decorators.remove(decorator_node)
-                node = _node
                 break
         return node
 
-    def analyse_decorator(self, node, decorator):
-        if decorator.is_name and decorator.name == 'property':
-            if len(node.decorators) > 1:
-                return self._reject_decorated_property(node, decorator_node)
-            # Mark the node as a cgetter
-            node.type.is_cgetter = True
-            # Add a func_cname to be output instead of the attribute
-            node.entry.func_cname = node.body.stats[0].value.function.name
-            return node
-        return None
+    def find_decorator(self, decorator, name):
+        if decorator.is_name and decorator.name == name:
+            return True
+        return False
 
 
 class FindInvalidUseOfFusedTypes(CythonTransform):

--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -146,7 +146,7 @@ def create_pipeline(context, mode, exclude_classes=()):
     from .ParseTreeTransforms import CreateClosureClasses, MarkClosureVisitor, DecoratorTransform
     from .ParseTreeTransforms import TrackNumpyAttributes, InterpretCompilerDirectives, TransformBuiltinMethods
     from .ParseTreeTransforms import ExpandInplaceOperators, ParallelRangeTransform
-    from .ParseTreeTransforms import CalculateQualifiedNamesTransform
+    from .ParseTreeTransforms import CalculateQualifiedNamesTransform, ReplacePropertyNode
     from .TypeInference import MarkParallelAssignments, MarkOverflowingArithmetic
     from .ParseTreeTransforms import AdjustDefByDirectives, AlignFunctionDefinitions
     from .ParseTreeTransforms import RemoveUnreachableCode, GilCheck
@@ -198,6 +198,7 @@ def create_pipeline(context, mode, exclude_classes=()):
         AnalyseDeclarationsTransform(context),
         AutoTestDictTransform(context),
         EmbedSignature(context),
+        ReplacePropertyNode(context),
         EarlyReplaceBuiltinCalls(context),  ## Necessary?
         TransformBuiltinMethods(context),
         MarkParallelAssignments(context),

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -753,7 +753,7 @@ class Scope(object):
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='private', api=0, in_pxd=0,
                           defining=0, modifiers=(), utility_code=None,
-                          overridable=False, property=False):
+                          overridable=False, is_property=False):
         # Add an entry for a C function.
         if not cname:
             if visibility != 'private' or api:
@@ -831,7 +831,7 @@ class Scope(object):
         return entry
 
     def add_cfunction(self, name, type, pos, cname, visibility, modifiers,
-                      inherited=False, property=False):
+                      inherited=False, is_property=False):
         # Add a C function entry without giving it a func_cname.
         entry = self.declare(name, cname, type, pos, visibility)
         entry.is_cfunction = 1
@@ -839,7 +839,7 @@ class Scope(object):
             entry.func_modifiers = modifiers
         if inherited or type.is_fused:
             self.cfunc_entries.append(entry)
-        elif property:
+        elif is_property:
             self.property_entries.append(entry)
         else:
             # For backwards compatibility reasons, we must keep all non-fused methods
@@ -1440,7 +1440,7 @@ class ModuleScope(Scope):
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='private', api=0, in_pxd=0,
                           defining=0, modifiers=(), utility_code=None,
-                          overridable=False, property=False):
+                          overridable=False, is_property=False):
         if not defining and 'inline' in modifiers:
             # TODO(github/1736): Make this an error.
             warning(pos, "Declarations should not be declared inline.", 1)
@@ -1464,7 +1464,7 @@ class ModuleScope(Scope):
             self, name, type, pos,
             cname=cname, visibility=visibility, api=api, in_pxd=in_pxd,
             defining=defining, modifiers=modifiers, utility_code=utility_code,
-            overridable=overridable, property=property)
+            overridable=overridable, is_property=is_property)
         return entry
 
     def declare_global(self, name, pos):
@@ -2220,7 +2220,7 @@ class CClassScope(ClassScope):
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='private', api=0, in_pxd=0,
                           defining=0, modifiers=(), utility_code=None,
-                          overridable=False, property=False):
+                          overridable=False, is_property=False):
         if get_special_method_signature(name) and not self.parent_type.is_builtin_type:
             error(pos, "Special methods must be declared with 'def', not 'cdef'")
         args = type.args
@@ -2265,7 +2265,7 @@ class CClassScope(ClassScope):
                     "C method '%s' not previously declared in definition part of"
                     " extension type '%s'" % (name, self.class_name))
             entry = self.add_cfunction(name, type, pos, cname, visibility,
-                                                 modifiers, property=property)
+                                                 modifiers, is_property=is_property)
         if defining:
             entry.func_cname = self.mangle(Naming.func_prefix, name)
         entry.utility_code = utility_code
@@ -2282,12 +2282,12 @@ class CClassScope(ClassScope):
         return entry
 
     def add_cfunction(self, name, type, pos, cname, visibility, modifiers,
-                                             inherited=False, property=False):
+                                             inherited=False, is_property=False):
         # Add a cfunction entry without giving it a func_cname.
         prev_entry = self.lookup_here(name)
         entry = ClassScope.add_cfunction(self, name, type, pos, cname,
                                     visibility, modifiers,
-                                    inherited=inherited, property=property)
+                                    inherited=inherited, is_property=is_property)
         entry.is_cmethod = 1
         entry.prev_entry = prev_entry
         return entry

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -754,8 +754,7 @@ class Scope(object):
 
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='private', api=0, in_pxd=0,
-                          defining=0, modifiers=(), utility_code=None,
-                          overridable=False):
+                          defining=0, modifiers=(), utility_code=None, overridable=False):
         # Add an entry for a C function.
         if not cname:
             if visibility != 'private' or api:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2408,7 +2408,8 @@ class CppClassScope(Scope):
 
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='extern', api=0, in_pxd=0,
-                          defining=0, modifiers=(), utility_code=None, overridable=False):
+                          defining=0, modifiers=(), utility_code=None, overridable=False,
+                          property=False):
         class_name = self.name.split('::')[-1]
         if name in (class_name, '__init__') and cname is None:
             cname = "%s__init__%s" % (Naming.func_prefix, class_name)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -134,6 +134,7 @@ class Entry(object):
     # cf_used          boolean    Entry is used
     # is_fused_specialized boolean Whether this entry of a cdef or def function
     #                              is a specialization
+    # is_cgetter       boolean    Is a c-level getter function
 
     # TODO: utility_code and utility_code_definition serves the same purpose...
 
@@ -203,6 +204,7 @@ class Entry(object):
     error_on_uninitialized = False
     cf_used = True
     outer_entry = None
+    is_cgetter = False
 
     def __init__(self, name, cname, type, pos = None, init = None):
         self.name = name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1938,7 +1938,8 @@ class StructOrUnionScope(Scope):
 
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='private', api=0, in_pxd=0,
-                          defining=0, modifiers=(), overridable=False):  # currently no utility code ...
+                          defining=0, modifiers=(), overridable=False,
+                          is_property=False):  # currently no utility code ...
         if overridable:
             error(pos, "C struct/union member cannot be declared 'cpdef'")
         return self.declare_var(name, type, pos,
@@ -2409,7 +2410,7 @@ class CppClassScope(Scope):
     def declare_cfunction(self, name, type, pos,
                           cname=None, visibility='extern', api=0, in_pxd=0,
                           defining=0, modifiers=(), utility_code=None, overridable=False,
-                          property=False):
+                          is_property=False):
         class_name = self.name.split('::')[-1]
         if name in (class_name, '__init__') and cname is None:
             cname = "%s__init__%s" % (Naming.func_prefix, class_name)

--- a/runtests.py
+++ b/runtests.py
@@ -428,6 +428,7 @@ VER_DEP_MODULES = {
     (3,3) : (operator.lt, lambda x: x in ['build.package_compilation',
                                           'run.yield_from_py33',
                                           'pyximport.pyximport_namespace',
+                                          'run.qualname',
                                           ]),
     (3,4): (operator.lt, lambda x: x in ['run.py34_signature',
                                          'run.test_unicode',  # taken from Py3.7, difficult to backport
@@ -640,6 +641,7 @@ class TestBuilder(object):
         self.default_mode = default_mode
         self.stats = stats
         self.add_embedded_test = add_embedded_test
+        self.capture = options.capture
 
     def build_suite(self):
         suite = unittest.TestSuite()
@@ -697,7 +699,9 @@ class TestBuilder(object):
 
             if ext == '.srctree':
                 if 'cpp' not in tags['tag'] or 'cpp' in self.languages:
-                    suite.addTest(EndToEndTest(filepath, workdir, self.cleanup_workdir, stats=self.stats))
+                    suite.addTest(EndToEndTest(filepath, workdir,
+                             self.cleanup_workdir, stats=self.stats,
+                             capture=self.capture))
                 continue
 
             # Choose the test suite.
@@ -1570,6 +1574,8 @@ class TestCodeFormat(unittest.TestCase):
     def runTest(self):
         import pycodestyle
         config_file = os.path.join(self.cython_dir, "tox.ini")
+        if not os.path.exists(config_file):
+            config_file=os.path.join(os.path.dirname(__file__), "tox.ini")
         paths = glob.glob(os.path.join(self.cython_dir, "**/*.py"), recursive=True)
         style = pycodestyle.StyleGuide(config_file=config_file)
         print("")  # Fix the first line of the report.
@@ -1670,12 +1676,14 @@ class EndToEndTest(unittest.TestCase):
     """
     cython_root = os.path.dirname(os.path.abspath(__file__))
 
-    def __init__(self, treefile, workdir, cleanup_workdir=True, stats=None):
+    def __init__(self, treefile, workdir, cleanup_workdir=True, stats=None,
+                 capture=True):
         self.name = os.path.splitext(os.path.basename(treefile))[0]
         self.treefile = treefile
         self.workdir = os.path.join(workdir, self.name)
         self.cleanup_workdir = cleanup_workdir
         self.stats = stats
+        self.capture = capture
         cython_syspath = [self.cython_root]
         for path in sys.path:
             if path.startswith(self.cython_root) and path not in cython_syspath:
@@ -1731,16 +1739,23 @@ class EndToEndTest(unittest.TestCase):
         for command_no, command in enumerate(filter(None, commands.splitlines()), 1):
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c',
                                  'etoe-build' if ' setup.py ' in command else 'etoe-run'):
-                p = subprocess.Popen(command,
+                if self.capture:
+                    p = subprocess.Popen(command,
                                      stderr=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      shell=True,
                                      env=env)
-                _out, _err = p.communicate()
+                    _out, _err = p.communicate()
+                    res = p.returncode
+                else:
+                    p = subprocess.call(command,
+                                     shell=True,
+                                     env=env)
+                    _out, _err = b'', b''
+                    res = p
                 cmd.append(command)
                 out.append(_out)
                 err.append(_err)
-            res = p.returncode
             if res != 0:
                 for c, o, e in zip(cmd, out, err):
                     sys.stderr.write("%s\n%s\n%s\n\n" % (
@@ -2092,6 +2107,8 @@ def main():
                       help="test whether Cython's output is deterministic")
     parser.add_option("--pythran-dir", dest="pythran_dir", default=None,
                       help="specify Pythran include directory. This will run the C++ tests using Pythran backend for Numpy")
+    parser.add_option("--no-capture", dest="capture", default=True, action="store_false",
+                      help="do not capture stdout, stderr in srctree tests. Makes pdb.set_trace interactive")
 
     options, cmd_args = parser.parse_args(args)
 
@@ -2118,6 +2135,10 @@ def main():
     if options.xml_output_dir:
         shutil.rmtree(options.xml_output_dir, ignore_errors=True)
 
+    if options.capture:
+        keep_alive_interval = 10
+    else:
+        keep_alive_interval = None
     if options.shard_count > 1 and options.shard_num == -1:
         import multiprocessing
         pool = multiprocessing.Pool(options.shard_count)
@@ -2126,7 +2147,7 @@ def main():
         # NOTE: create process pool before time stamper thread to avoid forking issues.
         total_time = time.time()
         stats = Stats()
-        with time_stamper_thread():
+        with time_stamper_thread(interval=keep_alive_interval):
             for shard_num, shard_stats, return_code in pool.imap_unordered(runtests_callback, tasks):
                 if return_code != 0:
                     errors.append(shard_num)
@@ -2143,7 +2164,7 @@ def main():
         else:
             return_code = 0
     else:
-        with time_stamper_thread():
+        with time_stamper_thread(interval=keep_alive_interval):
             _, stats, return_code = runtests(options, cmd_args, coverage)
 
     if coverage:
@@ -2182,27 +2203,31 @@ def time_stamper_thread(interval=10):
     from datetime import datetime
     from time import sleep
 
-    interval = _xrange(interval * 4)
-    now = datetime.now
-    write = sys.__stderr__.write
-    stop = False
-
-    def time_stamper():
-        while True:
-            for _ in interval:
-                if stop:
-                    return
-                sleep(1./4)
-            write('\n#### %s\n' % now())
-
-    thread = threading.Thread(target=time_stamper, name='time_stamper')
-    thread.setDaemon(True)  # Py2 ...
-    thread.start()
-    try:
+    if not interval or interval < 0:
+        # Do nothing
         yield
-    finally:
-        stop = True
-        thread.join()
+    else:
+        interval = _xrange(interval * 4)
+        now = datetime.now
+        write = sys.__stderr__.write
+        stop = False
+
+        def time_stamper():
+            while True:
+                for _ in interval:
+                    if stop:
+                        return
+                    sleep(1./4)
+                write('\n#### %s\n' % now())
+
+        thread = threading.Thread(target=time_stamper, name='time_stamper')
+        thread.setDaemon(True)  # Py2 ...
+        thread.start()
+        try:
+            yield
+        finally:
+            stop = True
+            thread.join()
 
 
 def configure_cython(options):

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -150,7 +150,7 @@ def sum(Foo f):
 
 cdef extern from "foo.h":
     ctypedef class foo_extension.Foo [object FooStructOpaque]:
-        @staticmethod
+        @classmethod
         cdef void field0():
             print('in staticmethod of Foo')
 

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -38,23 +38,23 @@ typedef struct {
 } FooStructOpaque;
 
 
-#define PyFoo_GET0(a) a.f0
-#define PyFoo_GET1(a) a.f1
-#define PyFoo_GET2(a) a.f2
+#define PyFoo_GET0M(a) ((FooStructNominal*)a)->f0
+#define PyFoo_GET1M(a) ((FooStructNominal*)a)->f1
+#define PyFoo_GET2M(a) ((FooStructNominal*)a)->f2
 
-int PyFoo_Get0(FooStructNominal f)
+int PyFoo_Get0F(FooStructOpaque *f)
 {
-    return f.f0;
+    return ((FooStructNominal*)f)->f0;
 }
 
-int PyFoo_Get1(FooStructNominal f)
+int PyFoo_Get1F(FooStructOpaque *f)
 {
-    return f.f1;
+    return ((FooStructNominal*)f)->f1;
 }
 
-int PyFoo_Get2(FooStructNominal f)
+int PyFoo_Get2F(FooStructOpaque *f)
 {
-    return f.f2;
+    return ((FooStructNominal*)f)->f2;
 }
 
 #ifdef __cplusplus
@@ -124,19 +124,19 @@ cdef extern from "foo.h":
     ctypedef class foo_extension.Foo [object FooStructOpaque, check_size ignore]:
         @property
         cdef int field0(self):
-            return PyFoo_GET0(self)
+            return PyFoo_GET0M(self)
 
         @property
         cdef int field1(self):
-            return PyFoo_Get1(self)
+            return PyFoo_Get1F(self)
 
         @property
         cdef int field2(self):
-            return PyFoo_GET2(self)
+            return PyFoo_GET2M(self)
 
-    int PyFoo_GET0(Foo);  # this is actually a macro !
-    int PyFoo_Get1(Foo);
-    int PyFoo_GET2(Foo);  # this is actually a macro !
+    int PyFoo_GET0M(Foo);  # this is actually a macro !
+    int PyFoo_Get1F(Foo);
+    int PyFoo_GET2M(Foo);  # this is actually a macro !
 
 def sum(Foo f):
     # Note - not a cdef function but compiling the f.__getattr__('field0')

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -123,15 +123,15 @@ def sum(Foo f):
 cdef extern from "foo.h":
     ctypedef class foo_extension.Foo [object FooStructOpaque, check_size ignore]:
         @property
-        cdef int field0(self):
+        cdef int fieldM0(self):
             return PyFoo_GET0M(self)
 
         @property
-        cdef int field1(self):
+        cdef int fieldF1(self):
             return PyFoo_Get1F(self)
 
         @property
-        cdef int field2(self):
+        cdef int fieldM2(self):
             return PyFoo_GET2M(self)
 
     int PyFoo_GET0M(Foo);  # this is actually a macro !
@@ -141,7 +141,7 @@ cdef extern from "foo.h":
 def sum(Foo f):
     # Note - not a cdef function but compiling the f.__getattr__('field0')
     # notices the getter and replaces the __getattr__ in c by PyFoo_GET anyway
-    return f.field0 + f.field1 + f.field2
+    return f.fieldM0 + f.fieldF1 + f.fieldM2
 
 
 ######## getter_fail0.pyx ########

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -4,14 +4,21 @@ PYTHON -c "import runner"
 ######## setup.py ########
 
 from Cython.Build.Dependencies import cythonize
+from Cython.Compiler.Errors import CompileError
 from distutils.core import setup
 
 # force the build order
-setup(ext_modules= cythonize("foo_extension.pyx"))
+setup(ext_modules= cythonize("foo_extension.pyx", language_level=3))
 
-setup(ext_modules = cythonize("getter*.pyx"))
+setup(ext_modules = cythonize("getter[0-9].pyx", language_level=3))
 
-######## foo_nominal.h ########
+try:
+    cythonize("getter_fail0.pyx", language_level=3)
+    assert False
+except CompileError:
+    print("\nGot expected exception, continuing\n")
+
+######## foo.h ########
 
 #include <Python.h>
 
@@ -26,6 +33,30 @@ typedef struct {
     int f2;
 } FooStructNominal;
 
+typedef struct {
+    PyObject_HEAD
+} FooStructOpaque;
+
+
+#define PyFoo_GET0(a) a.f0
+#define PyFoo_GET1(a) a.f1
+#define PyFoo_GET2(a) a.f2
+
+int PyFoo_Get0(FooStructNominal f)
+{
+    return f.f0;
+}
+
+int PyFoo_Get1(FooStructNominal f)
+{
+    return f.f1;
+}
+
+int PyFoo_Get2(FooStructNominal f)
+{
+    return f.f2;
+}
+
 #ifdef __cplusplus
 }
 #endif
@@ -33,21 +64,24 @@ typedef struct {
 ######## foo_extension.pyx ########
 
 cdef class Foo:
-    cdef public int field0, field1, field2;
+    cdef public int _field0, _field1, _field2;
+
+    @property
+    def field0(self):
+        return self._field0
+
+    @property
+    def field1(self):
+        return self._field1
+
+    @property
+    def field2(self):
+        return self._field2
 
     def __init__(self, f0, f1, f2):
-        self.field0 = f0
-        self.field1 = f1
-        self.field2 = f2
-
-cdef get_field0(Foo f):
-    return f.field0
-
-cdef get_field1(Foo f):
-    return f.field1
-
-cdef get_field2(Foo f):
-    return f.field2
+        self._field0 = f0
+        self._field1 = f1
+        self._field2 = f2
 
 # A pure-python class that disallows direct access to fields
 class OpaqueFoo(Foo):
@@ -64,12 +98,11 @@ class OpaqueFoo(Foo):
     def field2(self):
         raise AttributeError('no direct access to field2')
 
-
 ######## getter0.pyx ########
 
 # Access base Foo fields from C via aliased field names
 
-cdef extern from "foo_nominal.h":
+cdef extern from "foo.h":
 
     ctypedef class foo_extension.Foo [object FooStructNominal]:
         cdef:
@@ -78,13 +111,62 @@ cdef extern from "foo_nominal.h":
             int field2 "f2"
 
 def sum(Foo f):
-    # the f.__getattr__('field0') is replaced in c by f->f0
+    # Note - not a cdef function but compiling the f.__getattr__('field0')
+    # notices the alias and replaces the __getattr__ in c by f->f0 anyway
     return f.field0 + f.field1 + f.field2
+
+######## getter1.pyx ########
+
+# Access base Foo fields from C via getter functions
+
+
+cdef extern from "foo.h":
+    ctypedef class foo_extension.Foo [object FooStructOpaque]:
+    # Importing will warn until we can use this syntax
+    # ctypedef class foo_extension.Foo [object FooStructOpaque, check_size]:
+        @property
+        cdef int field0(self):
+            return PyFoo_GET0(self)
+
+        @property
+        cdef int field1(self):
+            return PyFoo_Get1(self)
+
+        @property
+        cdef int field2(self):
+            return PyFoo_GET2(self)
+
+    int PyFoo_GET0(Foo);  # this is actually a macro !
+    int PyFoo_Get1(Foo);
+    int PyFoo_GET2(Foo);  # this is actually a macro !
+
+def sum(Foo f):
+    # Note - not a cdef function but compiling the f.__getattr__('field0')
+    # notices the getter and replaces the __getattr__ in c by PyFoo_GET anyway
+    return f.field0 + f.field1 + f.field2
+
+
+######## getter_fail0.pyx ########
+
+# Make sure not all decorators are accepted
+
+cdef extern from "foo.h":
+    ctypedef class foo_extension.Foo [object FooStructOpaque]:
+        @staticmethod
+        cdef void field0():
+            print('in staticmethod of Foo')
+
 
 ######## runner.py ########
 
-import foo_extension, getter0
+import warnings
+import foo_extension, getter0, getter1
 
+def sum(f):
+    # pure python field access, but code is identical to cython cdef sum
+    return f.field0 + f.field1 + f.field2
+
+# Baseline test: if this fails something else is wrong
 foo = foo_extension.Foo(23, 123, 1023)
 
 assert foo.field0 == 23
@@ -92,18 +174,31 @@ assert foo.field1 == 123
 assert foo.field2 == 1023
 
 ret =  getter0.sum(foo)
-assert ret == foo.field0 + foo.field1 + foo.field2
+assert ret == sum(foo)
+
+# Aliasing test. Check 'cdef int field0 "f0" works as advertised:
+# - C can access the fields through the aliases
+# - Python cannot access the fields at all
 
 opaque_foo = foo_extension.OpaqueFoo(23, 123, 1023)
 
-# C can access the fields through the aliases
 opaque_ret = getter0.sum(opaque_foo)
 assert opaque_ret == ret
 try:
-    # Python cannot access the fields
     f0 = opaque_ret.field0
     assert False
 except AttributeError as e:
     pass
 
+# Getter test. Check C-level getter works as advertised:
+# - C accesses the fields through getter calls (maybe macros)
+# - Python accesses the fields through attribute lookup
+
+opaque_foo = foo_extension.OpaqueFoo(23, 123, 1023)
+
+# Remove warnings filter once we can use check_size=False
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    opaque_ret = getter1.sum(opaque_foo)
+assert opaque_ret == ret
 

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -44,17 +44,17 @@ typedef struct {
 
 int PyFoo_Get0F(FooStructOpaque *f)
 {
-    return ((FooStructNominal*)f)->f0;
+    return PyFoo_GET0M(f);
 }
 
 int PyFoo_Get1F(FooStructOpaque *f)
 {
-    return ((FooStructNominal*)f)->f1;
+    return PyFoo_GET1M(f);
 }
 
 int PyFoo_Get2F(FooStructOpaque *f)
 {
-    return ((FooStructNominal*)f)->f2;
+    return PyFoo_GET2M(f);
 }
 
 #ifdef __cplusplus

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -121,9 +121,7 @@ def sum(Foo f):
 
 
 cdef extern from "foo.h":
-    ctypedef class foo_extension.Foo [object FooStructOpaque]:
-    # Importing will warn until we can use this syntax
-    # ctypedef class foo_extension.Foo [object FooStructOpaque, check_size]:
+    ctypedef class foo_extension.Foo [object FooStructOpaque, check_size ignore]:
         @property
         cdef int field0(self):
             return PyFoo_GET0(self)
@@ -196,9 +194,6 @@ except AttributeError as e:
 
 opaque_foo = foo_extension.OpaqueFoo(23, 123, 1023)
 
-# Remove warnings filter once we can use check_size=False
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    opaque_ret = getter1.sum(opaque_foo)
+opaque_ret = getter1.sum(opaque_foo)
 assert opaque_ret == ret
 

--- a/tests/run/ext_attr_getter.srctree
+++ b/tests/run/ext_attr_getter.srctree
@@ -12,11 +12,12 @@ setup(ext_modules= cythonize("foo_extension.pyx", language_level=3))
 
 setup(ext_modules = cythonize("getter[0-9].pyx", language_level=3))
 
-try:
-    cythonize("getter_fail0.pyx", language_level=3)
-    assert False
-except CompileError:
-    print("\nGot expected exception, continuing\n")
+for name in ("getter_fail0.pyx", "getter_fail1.pyx"):
+    try:
+        cythonize(name, language_level=3)
+        assert False
+    except CompileError as e:
+        print("\nGot expected exception, continuing\n")
 
 ######## foo.h ########
 
@@ -154,6 +155,16 @@ cdef extern from "foo.h":
         cdef void field0():
             print('in staticmethod of Foo')
 
+######## getter_fail1.pyx ########
+
+# Make sure not all decorators are accepted
+cimport cython
+
+cdef extern from "foo.h":
+    ctypedef class foo_extension.Foo [object FooStructOpaque]:
+        @prop.getter
+        cdef void field0(self):
+            pass
 
 ######## runner.py ########
 


### PR DESCRIPTION
Following up the discussion on the mailing list. I got to the point where I can use the new syntax:

- [X] Write a srctree test that creates various types of external ctypedef classes, add one that overrides a python-level @property with a cython one. This is a continuation of the test added in #2629 
- [X] Add `decorator` child and outer attributes to `CFuncDefNode`. ~I simply copied this from `DefNode`, is it required?~ - yes, seems to be required
- [X] ~Add a `DecoratorTransform.visit_CFuncDefNode` function based on `DecoratorTransform.visit_DefNode` and verify it is reached while parsing the `ctypedef class`.~
- [x] ~Found the point at which the attribute lookup should become a property function call (I think) is in `AttributeNode.analyse_attribute`. But it seems the entry is wrong, I need to either~ 

- ~fix the entry in `PropertyNode.analyse_declarations` and somehow make sure it is used instead of the old entry~
- ~change the code in `CFuncDefNode.analyse_declarations` and remove the `DecoratorTransform.visit_CFuncDefNode` function~

Any hints would be welcome.

Edit: added a new pass, ~still not working~