### PR TITLE
Only error out for non-ASCII literals on actual bytes literals

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -960,7 +960,7 @@ def p_string_literal(s, kind_override=None):
         bytes_value, unicode_value = chars.getstrings()
         if is_python3_source and has_non_ascii_literal_characters:
             # Python 3 forbids literal non-ASCII characters in byte strings
-            if kind not in ('u', 'f'):
+            if kind == 'b':
                 s.error("bytes can only contain ASCII literal characters.", pos=pos)
             bytes_value = None
     if kind == 'f':

--- a/tests/run/cython3_no_unicode_literals.pyx
+++ b/tests/run/cython3_no_unicode_literals.pyx
@@ -57,6 +57,8 @@ def no_unicode_literals():
     >>> print( no_unicode_literals() )
     True
     abcdefg
+
+    Testing non-ASCII docstrings: Πυθαγόρας
     """
     print(isinstance(str_string, str) or type(str_string))
     return str_string


### PR DESCRIPTION
Allow non-ASCII string literals like `"μ"` when language_level=3str.