### PR TITLE
Fix support for functions with ndarray parameters of type npy_bool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ TAGS
 MANIFEST
 
 .tox
+
+# Jetbrains IDE project files
+/.idea
+/*.iml
+

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -298,6 +298,7 @@ static void __Pyx_BufFmt_RaiseUnexpectedChar(char ch) {
 
 static const char* __Pyx_BufFmt_DescribeTypeChar(char ch, int is_complex) {
   switch (ch) {
+    case '?': return "'bool'";
     case 'c': return "'char'";
     case 'b': return "'signed char'";
     case 'B': return "'unsigned char'";
@@ -342,7 +343,7 @@ static size_t __Pyx_BufFmt_TypeCharToStandardSize(char ch, int is_complex) {
 
 static size_t __Pyx_BufFmt_TypeCharToNativeSize(char ch, int is_complex) {
   switch (ch) {
-    case 'c': case 'b': case 'B': case 's': case 'p': return 1;
+    case '?': case 'c': case 'b': case 'B': case 's': case 'p': return 1;
     case 'h': case 'H': return sizeof(short);
     case 'i': case 'I': return sizeof(int);
     case 'l': case 'L': return sizeof(long);
@@ -431,7 +432,7 @@ static char __Pyx_BufFmt_TypeCharToGroup(char ch, int is_complex) {
     case 'b': case 'h': case 'i':
     case 'l': case 'q': case 's': case 'p':
         return 'I';
-    case 'B': case 'H': case 'I': case 'L': case 'Q':
+    case '?': case 'B': case 'H': case 'I': case 'L': case 'Q':
         return 'U';
     case 'f': case 'd': case 'g':
         return (is_complex ? 'C' : 'R');
@@ -752,7 +753,7 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
           return NULL;
         }
         CYTHON_FALLTHROUGH;
-      case 'c': case 'b': case 'B': case 'h': case 'H': case 'i': case 'I':
+      case '?': case 'c': case 'b': case 'B': case 'h': case 'H': case 'i': case 'I':
       case 'l': case 'L': case 'q': case 'Q':
       case 'f': case 'd': case 'g':
       case 'O': case 'p':

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -134,6 +134,7 @@ try:
        ...
     ValueError: ndarray is not C...contiguous
 
+    >>> test_dtype('?', inc1_bool)
     >>> test_dtype('b', inc1_byte)
     >>> test_dtype('B', inc1_ubyte)
     >>> test_dtype('h', inc1_short)
@@ -340,6 +341,7 @@ def test_f_contig(np.ndarray[int, ndim=2, mode='fortran'] arr):
         print u" ".join([unicode(arr[i, j]) for j in range(arr.shape[1])])
 
 # Exhaustive dtype tests -- increments element [1] by 1 (or 1+1j) for all dtypes
+def inc1_bool(np.ndarray[unsigned char] arr):           arr[1] += 1
 def inc1_byte(np.ndarray[char] arr):                    arr[1] += 1
 def inc1_ubyte(np.ndarray[unsigned char] arr):          arr[1] += 1
 def inc1_short(np.ndarray[short] arr):                  arr[1] += 1
@@ -402,6 +404,13 @@ def test_dtype(dtype, inc1):
         a = np.array([0, 10+10j], dtype=dtype)
         inc1(a)
         if a[1] != (11 + 11j): print u"failed!", a[1]
+    elif dtype == '?':
+        # bool ndarrays coerce all values to 0 or 1
+        a = np.array([0, 0], dtype=dtype)
+        inc1(a)
+        if a[1] != 1: print u"failed!"
+        inc1(a)
+        if a[1] != 1: print u"failed!"
     else:
         a = np.array([0, 10], dtype=dtype)
         inc1(a)


### PR DESCRIPTION
Fixes #2675.

Currently, the `cast=True` argument is needed when writing functions with `ndarray` parameters of type `npy_bool`, like so:
```
def foo(np.ndarray[np.npy_bool, ndim=1, cast=True] npdata):
    return npdata
```
Without `cast`, any such function will always raise a `ValueError`:

    ValueError: Does not understand character buffer dtype format string ('?')

The code in this PR removes the need for the `cast` keyword.

This fix puts support for `ndarray` parameters of type `npy_bool` at the same level as support for parameters of the other `npy_` types (eg `npy_long`, `npy_float`, etc). The fix was accomplished by adding a `'?'` case to a few case/swtich statements in `Buffer.c` from which it was missing.