### PR TITLE
Workaround for long internals misconfiguration on 64-bit MinGW.

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -246,6 +246,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.put_generated_by()
             api_guard = Naming.api_guard_prefix + self.api_name(env)
             h_code.put_h_guard(api_guard)
+            # Work around https://bugs.python.org/issue4709
+            h_code.putln('#ifdef __MINGW64__')
+            h_code.putln('#define MS_WIN64')
+            h_code.putln('#endif')
+
             h_code.putln('#include "Python.h"')
             if result.h_file:
                 h_code.putln('#include "%s"' % os.path.basename(result.h_file))

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -205,6 +205,10 @@
   #undef SHIFT
   #undef BASE
   #undef MASK
+  /* Compile-time sanity check that these are indeed equal.  Github issue #2670. */
+  #ifdef SIZEOF_VOID_P
+    enum { __pyx_check_sizeof_voidp = 1/(SIZEOF_VOID_P == sizeof(void*)) };
+  #endif
 #endif
 
 #ifndef __has_attribute


### PR DESCRIPTION
Also add a compile time check for SIZEOF_VOID_P.

This fixes #2670.

See also
https://bugs.python.org/issue35037
https://bugs.python.org/issue4709