### PR TITLE
Fix stop generating code that compiler skips

### DIFF
--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -852,28 +852,40 @@ if (unlikely(__pyx_memoryview_slice_memviewslice(
 
 {
     Py_ssize_t __pyx_tmp_idx = {{idx}};
-    Py_ssize_t __pyx_tmp_shape = {{src}}.shape[{{dim}}];
+
+    {{if wraparound or boundscheck}}
+        Py_ssize_t __pyx_tmp_shape = {{src}}.shape[{{dim}}];
+    {{endif}}
+
     Py_ssize_t __pyx_tmp_stride = {{src}}.strides[{{dim}}];
-    if ({{wraparound}} && (__pyx_tmp_idx < 0))
-        __pyx_tmp_idx += __pyx_tmp_shape;
+    {{if wraparound}}
+        if (__pyx_tmp_idx < 0)
+            __pyx_tmp_idx += __pyx_tmp_shape;
+    {{endif}}
 
-    if ({{boundscheck}} && !__Pyx_is_valid_index(__pyx_tmp_idx, __pyx_tmp_shape)) {
-        {{if not have_gil}}
-            #ifdef WITH_THREAD
-            PyGILState_STATE __pyx_gilstate_save = PyGILState_Ensure();
-            #endif
-        {{endif}}
+    {{if boundscheck}}
+        if (!__Pyx_is_valid_index(__pyx_tmp_idx, __pyx_tmp_shape)) {
+            {{if not have_gil}}
+                #ifdef WITH_THREAD
+                PyGILState_STATE __pyx_gilstate_save = PyGILState_Ensure();
+                #endif
+            {{endif}}
 
-        PyErr_SetString(PyExc_IndexError, "Index out of bounds (axis {{dim}})");
+            PyErr_SetString(PyExc_IndexError,
+                            "Index out of bounds (axis {{dim}})");
 
-        {{if not have_gil}}
-            #ifdef WITH_THREAD
-            PyGILState_Release(__pyx_gilstate_save);
-            #endif
-        {{endif}}
+            {{if not have_gil}}
+                #ifdef WITH_THREAD
+                PyGILState_Release(__pyx_gilstate_save);
+                #endif
+            {{endif}}
 
-        {{error_goto}}
-    }
+            {{error_goto}}
+        }
+    {{else}}
+        // make sure label is not un-used
+        if ((0)) {{error_goto}}
+    {{endif}}
 
     {{if all_dimensions_direct}}
         {{dst}}.data += __pyx_tmp_idx * __pyx_tmp_stride;

--- a/tests/memoryview/gh2588.pyx
+++ b/tests/memoryview/gh2588.pyx
@@ -1,0 +1,18 @@
+# mode: run
+
+cimport cython
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def testing_memoryview(double[:, :] x):
+    """ Function testing boundscheck and wraparound in memoryview
+    >>> import numpy as np
+    >>> array = np.ones((2,2)) * 3.5
+    >>> testing_memoryview(array)
+    """
+    cdef Py_ssize_t numrow = x.shape[0]
+    cdef Py_ssize_t i
+    for i in range(numrow):
+        x[i, 0]
+        x[i]
+        x[i, ...]
+        x[i, :]


### PR DESCRIPTION
Closes #2588 

Issues working on at PyConDE sprint.

Stop generate codes that will be skipped by the compiler (for example `if (0 && …`)