### PR TITLE
Fix 2 minor writing mistakes.

### DIFF
--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -458,9 +458,9 @@ integers as before.
 Using multiple threads
 ======================
 
-Cython have support for OpenMP. It have also some nice wrappers around it,
+Cython have support for OpenMP. It has also some nice wrappers around it,
 like the function :func:`prange`. You can see more information about Cython and
-parralelism in :ref:`parallel`. Since we do elementwise operations, we can easily
+parallelism in :ref:`parallel`. Since we do elementwise operations, we can easily
 distribute the work among multiple threads. It's important not to forget to pass the
 correct arguments to the compiler to enable OpenMP. When using the Jupyter notebook,
 you should use the cell magic like this::


### PR DESCRIPTION
“It have”-> “it has”
“Parralelism” -> “parallelism”