### PR TITLE
Fill shape when PyBUF_ND is in the flags

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -64,6 +64,7 @@ cdef extern from *:
         PyBUF_WRITABLE
         PyBUF_STRIDES
         PyBUF_INDIRECT
+        PyBUF_ND
         PyBUF_RECORDS
         PyBUF_RECORDS_RO
 


### PR DESCRIPTION
Based off of [this table]( https://docs.python.org/3/c-api/buffer.html#shape-strides-suboffsets ).