### PR TITLE
Fix list set item functions to "steal" reference

### DIFF
--- a/Cython/Includes/cpython/list.pxd
+++ b/Cython/Includes/cpython/list.pxd
@@ -40,13 +40,13 @@ cdef extern from "Python.h":
     # Return value: Borrowed reference.
     # Macro form of PyList_GetItem() without error checking.
 
-    int PyList_SetItem(object list, Py_ssize_t index, object item) except -1
+    int PyList_SetItem(object list, Py_ssize_t index, PyObject* item) except -1
     # Set the item at index index in list to item. Return 0 on success
     # or -1 on failure. Note: This function ``steals'' a reference to
     # item and discards a reference to an item already in the list at
     # the affected position.
 
-    void PyList_SET_ITEM(object list, Py_ssize_t i, object o)
+    void PyList_SET_ITEM(object list, Py_ssize_t i, PyObject* o)
     # Macro form of PyList_SetItem() without error checking. This is
     # normally only used to fill in new lists where there is no
     # previous content. Note: This function ``steals'' a reference to


### PR DESCRIPTION
The `PyList_SetItem` and `PyList_SET_ITEM` function and macro steal a reference to the item according to the docs. So it shouldn't be refcounted. Should fix some segfaults and other errors caused by using these definitions as they were.

ref: https://docs.python.org/3/c-api/list.html
ref: https://stackoverflow.com/q/41925500