### PR TITLE
Search first for adjacent pxd in compile

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -154,6 +154,11 @@ def search_include_directories(dirs, qualified_name, suffix, pos,
         module_filename = module_name + suffix
         package_filename = "__init__" + suffix
 
+        if pos:
+            path = os.path.join(os.path.dirname(pos[0].filename), module_filename)
+            if path_exists(path):
+                return path
+
     for dir in dirs:
         path = os.path.join(dir, dotted_filename)
         if path_exists(path):


### PR DESCRIPTION
In the function DependencyTree.cimported_files we will find a .pxd file
in the same directory as our .pyx file regardless of the assigned
package name; but when we go on to compile same file this file is not
found; we only look for file matching the assigned package name.

In this change I first find src/bar.pxd matching src/bar.pyx even when
the resulting package would be foo.bar.