### PR TITLE
DOC: Fixed name of .so file in userguide's numpy_tutorial.

### DIFF
--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -161,8 +161,8 @@ Cython version -- Cython uses ``.pyx`` as its file suffix (but it can also compi
 
 .. literalinclude:: ../../examples/userguide/numpy_tutorial/compute_py.py
 
-This should be compiled to produce :file:`convolve_cy.so` (for Linux systems,
-on Windows systems, this will be a ``.pyd`` file). We
+This should be compiled to produce :file:`compute_cy.so` for Linux systems
+(on Windows systems, this will be a ``.pyd`` file). We
 run a Python session to test both the Python version (imported from
 ``.py``-file) and the compiled Cython module.
 


### PR DESCRIPTION
"convolve_cy.so" -> "compute_cy.so" to match imports used in this tutorial.