### PR TITLE
fixes #2764: sensibly normalizes src paths like "../../../src/foo.pyx" when using an out of place build directory

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1000,8 +1000,13 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
 
                 # setup for out of place build directory if enabled
                 if build_dir:
+                    # collapse any dots
+                    c_file = os.path.normpath(c_file)
                     if os.path.isabs(c_file):
-                      warnings.warn("build_dir has no effect for absolute source paths")
+                        warnings.warn("build_dir has no effect for absolute source paths")
+                    else:
+                        # remove any leading dots that remain
+                        c_file = c_file.split('../')[-1]
                     c_file = os.path.join(build_dir, c_file)
                     dir = os.path.dirname(c_file)
                     safe_makedirs_once(dir)

--- a/tests/build/build_above_src.srctree
+++ b/tests/build/build_above_src.srctree
@@ -11,13 +11,10 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
 
-import numpy as np
-
 extensions = [
     Extension(
         'boolFunc',
         ['../../../src/foo.pyx'],
-        include_dirs=[np.get_include()],
     )]
 
 setup(

--- a/tests/build/build_above_src.srctree
+++ b/tests/build/build_above_src.srctree
@@ -1,0 +1,40 @@
+# Tests the out of place (ie with build_dir set) build when a src file is
+# "above" the setup.py (ie it's path begins with dots). 
+# For example, "../../../src/foo.pyx". See #2764 for details.
+
+cd a/b/c/d; PYTHON setup.py build_ext -b ../../pkg -t .
+PYTHON check_paths.py
+
+######## a/b/c/d/setup.py ########
+
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+
+import numpy as np
+
+extensions = [
+    Extension(
+        'boolFunc',
+        ['../../../src/foo.pyx'],
+        include_dirs=[np.get_include()],
+    )]
+
+setup(
+    ext_modules=cythonize(extensions,
+                          build_dir='build_dir'),
+)
+
+######## a/src/foo.pyx ########
+
+def hello():
+    return "hello world"
+
+######## a/b/pkg/__init__.py ########
+
+######## check_paths.py ########
+
+import os
+assert os.path.exists("a/b/c/d/build_dir/src/foo.c")
+assert os.path.exists("a/b/c/d/build_dir/src/foo.o")
+


### PR DESCRIPTION
Here's a fix for #2764, and for the [question on Stackoverflow](https://stackoverflow.com/q/53744729/425458) that inspired it. When using an out place build with a `cythonize`-ed extension, before the path of any source file is used to generate the paths to the corresponding `.c` and `.o` files, the source file path is first cleaned up. This proceeds in two steps:

- `os.path.normpath(pth)` is called, which will resolve any `../` in the middle of the path, or bubble them over to the left side.

- If `pth` is a relative path, all leading `../` elements are then removed. If `pth` is absolute, then we don't need to both checking for any `../`.

This approach should allow for the use of src paths like `"../../../src/foo.pyx"` in `cythonize`-ed extensions, while still preserving enough path to prevent generated files from clobbering one another.