### PR TITLE
Fix support for C++ enum classes

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -731,7 +731,14 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t wid
     Py_ssize_t length, ulength;
     int prepend_sign, last_one_off;
     {{TYPE}} remaining;
-    const {{TYPE}} neg_one = ({{TYPE}}) (({{TYPE}}) 0 - ({{TYPE}}) 1), const_zero = ({{TYPE}}) 0;
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+    const {{TYPE}} neg_one = ({{TYPE}}) -1, const_zero = ({{TYPE}}) 0;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     const int is_unsigned = neg_one > const_zero;
 
     if (format_char == 'X') {


### PR DESCRIPTION
The current code fails to compile with:

```
<source>:3:54: error: invalid operands to binary expression ('enum E' and 'enum E')
const enum E neg_one_class_29 = (enum E) ((enum E) 0 - (enum E) 1);
                                          ~~~~~~~~~~ ^ ~~~~~~~~~~
```

This change reverts to the code that was before #2186 but silences erroneous GCC warning enabled by `-Wconversion` (which is not a part of `-Wall`).

Fixes #2749

---

Alternatively Cython can revert to the state before #2186 without adding GCC pragmas because the warning is a GCC bug with `-Wconversion`, which is not enabled even by `-Wall`.