### PR TITLE
Only generate __qualname__ in Python versions supporting it

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -913,8 +913,10 @@ static PyObject *__Pyx_CreateClass(PyObject *bases, PyObject *dict, PyObject *na
 
     if (PyDict_SetItem(dict, PYIDENT("__module__"), modname) < 0)
         return NULL;
+#if PY_VERSION_HEX >= 0x03030000
     if (PyDict_SetItem(dict, PYIDENT("__qualname__"), qualname) < 0)
         return NULL;
+#endif
 
     /* Python2 __metaclass__ */
     metaclass = __Pyx_PyDict_GetItemStr(dict, PYIDENT("__metaclass__"));
@@ -974,7 +976,9 @@ static PyObject *__Pyx_Py3MetaclassPrepare(PyObject *metaclass, PyObject *bases,
 
     /* Required here to emulate assignment order */
     if (unlikely(PyObject_SetItem(ns, PYIDENT("__module__"), modname) < 0)) goto bad;
+#if PY_VERSION_HEX >= 0x03030000
     if (unlikely(PyObject_SetItem(ns, PYIDENT("__qualname__"), qualname) < 0)) goto bad;
+#endif
     if (unlikely(doc && PyObject_SetItem(ns, PYIDENT("__doc__"), doc) < 0)) goto bad;
     return ns;
 bad:

--- a/runtests.py
+++ b/runtests.py
@@ -428,6 +428,7 @@ VER_DEP_MODULES = {
     (3,3) : (operator.lt, lambda x: x in ['build.package_compilation',
                                           'run.yield_from_py33',
                                           'pyximport.pyximport_namespace',
+                                          'run.qualname',
                                           ]),
     (3,4): (operator.lt, lambda x: x in ['run.py34_signature',
                                          'run.test_unicode',  # taken from Py3.7, difficult to backport

--- a/tests/run/decorators_T593.pyx
+++ b/tests/run/decorators_T593.pyx
@@ -110,8 +110,8 @@ class Base(type):
 
 class Bar(metaclass=Base):
    """
-   >>> Bar._order
-   ['__module__', '__qualname__', '__doc__', 'bar']
+   >>> [n for n in Bar._order if n != "__qualname__"]
+   ['__module__', '__doc__', 'bar']
    """
    @property
    def bar(self):

--- a/tests/run/locals_T732.pyx
+++ b/tests/run/locals_T732.pyx
@@ -23,8 +23,8 @@ def test_class_locals_and_dir():
     >>> klass = test_class_locals_and_dir()
     >>> 'visible' in klass.locs and 'not_visible' not in klass.locs
     True
-    >>> klass.names
-    ['__module__', '__qualname__', 'visible']
+    >>> [n for n in klass.names if n != "__qualname__"]
+    ['__module__', 'visible']
     """
     not_visible = 1234
     class Foo:

--- a/tests/run/metaclass.pyx
+++ b/tests/run/metaclass.pyx
@@ -69,8 +69,8 @@ class Py3ClassMCOnly(object, metaclass=Py3MetaclassPlusAttr):
     321
     >>> obj.metaclass_was_here
     True
-    >>> obj._order
-    ['__module__', '__qualname__', '__doc__', 'bar', 'metaclass_was_here']
+    >>> [n for n in obj._order if n != "__qualname__"]
+    ['__module__', '__doc__', 'bar', 'metaclass_was_here']
     """
     bar = 321
 
@@ -81,8 +81,8 @@ class Py3InheritedMetaclass(Py3ClassMCOnly):
     345
     >>> obj.metaclass_was_here
     True
-    >>> obj._order
-    ['__module__', '__qualname__', '__doc__', 'bar', 'metaclass_was_here']
+    >>> [n for n in obj._order if n != "__qualname__"]
+    ['__module__', '__doc__', 'bar', 'metaclass_was_here']
     """
     bar = 345
 
@@ -109,8 +109,8 @@ class Py3Foo(object, metaclass=Py3Base, foo=123):
     123
     >>> obj.bar
     321
-    >>> obj._order
-    ['__module__', '__qualname__', '__doc__', 'bar', 'foo']
+    >>> [n for n in obj._order if n != "__qualname__"]
+    ['__module__', '__doc__', 'bar', 'foo']
     """
     bar = 321
 
@@ -122,8 +122,8 @@ class Py3FooInherited(Py3Foo, foo=567):
     567
     >>> obj.bar
     321
-    >>> obj._order
-    ['__module__', '__qualname__', '__doc__', 'bar', 'foo']
+    >>> [n for n in obj._order if n != "__qualname__"]
+    ['__module__', '__doc__', 'bar', 'foo']
     """
     bar = 321
 


### PR DESCRIPTION
Fix #2772

Needs a bit of work in the testsuite to fix test failures on Python 2.