### PR TITLE
Fix source of non-deterministic cython output for try/finally statements

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -900,9 +900,9 @@ class FunctionState(object):
         try-except and try-finally blocks to clean up temps in the
         error case.
         """
-        return [(cname, type)
-                for (type, manage_ref), freelist in self.temps_free.items() if manage_ref
-                for cname in freelist[0]]
+        return sorted([(cname, type)
+                      for (type, manage_ref), freelist in self.temps_free.items() if manage_ref
+                      for cname in freelist[0]])
 
     def start_collecting_temps(self):
         """


### PR DESCRIPTION
Hi,

I'm trying to get reproducible builds for my project and found a source of indeterminism in cython.
The __PYX_XDEC_MEMVIEW statements generated for try/finally statements varied per build if there were multiple types of variables to be cleaned up.

This patch sorts the list of free variables before returning it, making this bit of the codegen deterministic.