### PR TITLE
Fix crash in lvalue_refs test.

### DIFF
--- a/tests/run/lvalue_refs.pyx
+++ b/tests/run/lvalue_refs.pyx
@@ -15,7 +15,7 @@ cdef void foo(vector[dpp] &bar, vector[vector[dp]] &baz) nogil:
 def test_lvalue_ref_assignment():
     cdef vector[dpp]        bar
     cdef vector[vector[dp]] baz
-    cdef vector[double]     data
+    cdef vector[double]     data = [0.0]
     cdef dp                 bongle = &data[0]
 
     bar.resize(1)


### PR DESCRIPTION
Accessing the first element of a `std::vector` that is empty results in a crash.

In C++11, one could use [`std::vector.data()`](https://en.cppreference.com/w/cpp/container/vector/data) for the pointer, but I think this test is not C++11.