### PR TITLE
Fix inconsistency between traced files and reported files

### DIFF
--- a/Cython/Coverage.py
+++ b/Cython/Coverage.py
@@ -74,7 +74,7 @@ class Plugin(CoveragePlugin):
         if c_file is None:
             c_file, py_file = self._find_source_files(filename)
             if not c_file:
-                return None
+                return None  # unknown file
 
             # parse all source file paths and lines from C file
             # to learn about all relevant source files right away (pyx/pxi/pxd)
@@ -82,7 +82,9 @@ class Plugin(CoveragePlugin):
             #        is not from the main .pyx file but a file with a different
             #        name than the .c file (which prevents us from finding the
             #        .c file)
-            self._parse_lines(c_file, filename)
+            _, code = self._parse_lines(c_file, filename)
+            if code is None:
+                return None  # no source found
 
         if self._file_path_map is None:
             self._file_path_map = {}

--- a/tests/run/coverage_installed_pkg.srctree
+++ b/tests/run/coverage_installed_pkg.srctree
@@ -1,0 +1,71 @@
+# mode: run
+# tag: coverage,trace
+
+"""
+PYTHON setup.py build_ext -i
+PYTHON -c "import shutil; shutil.move('ext_src/ext_pkg', 'ext_pkg')"
+PYTHON -m coverage run coverage_test.py
+PYTHON -m coverage report
+"""
+
+######## setup.py ########
+from distutils.core import setup, Extension
+from Cython.Build import cythonize
+
+setup(ext_modules = cythonize([
+    'pkg/*.pyx',
+]))
+
+setup(
+    name='ext_pkg',
+    package_dir={'': 'ext_src'},
+    ext_modules = cythonize([
+        Extension('ext_pkg._mul', ['ext_src/ext_pkg/mul.py'])
+    ]),
+)
+
+
+######## .coveragerc ########
+[run]
+plugins = Cython.Coverage
+
+
+######## pkg/__init__.py ########
+from .test_ext_import import test_add
+
+
+######## pkg/test_ext_import.pyx ########
+# cython: linetrace=True
+# distutils: define_macros=CYTHON_TRACE=1
+
+import ext_pkg
+
+
+cpdef test_add(int a, int b):
+    return a + ext_pkg.test_mul(b, 2)
+
+
+######## ext_src/ext_pkg/__init__.py ########
+from .mul import test_mul
+
+
+######## ext_src/ext_pkg/mul.py ########
+from __future__ import absolute_import
+
+
+def test_mul(a, b):
+     return a * b
+
+
+try:
+    from ._mul import *
+except ImportError:
+    pass
+
+
+######## coverage_test.py ########
+
+from pkg import test_add
+
+
+assert 5 == test_add(1, 2)


### PR DESCRIPTION
When solving #2776 which reported ``Plugin 'Cython.Coverage.Plugin' did not provide a file reporter for '/Users/wenjun.swj/miniconda3/lib/python3.7/site-packages/gevent/_hub_local.py'`` when executing ``coverage report``, I find the cause is that some tracers built in Cython.Coverage do not have corresponding reporters.
In Cython.Coverage, when ``Plugin._parse_lines(c_file, filename)`` returns (None, None), ``Plugin.file_tracer(filename)`` returns a tracer, while ``Plugin.file_reporter(filename)`` returns None, and then coverage.py reports the error. This happens when shared packages have both *.py and *.c sharing the same base name. For instance, in the wheel package of gevent, both _hub_local.c and _hub_local.py exist, which mislead Cython.Coverage to produce a tracer as it does not ignore shared libraries. However, file_reporter() ignores shared libraries, and the report error is raised. 
The simple solution is to ignore shared libraries in file_tracer like it does in file_reporter, and ``coverage report`` does not raise errors, thus fixes #2776 .