### PR TITLE
Fix incompatibility with C89

### DIFF
--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -915,8 +915,8 @@ static PyObject* __Pyx_PyUnicode_BuildFromAscii(Py_ssize_t ulength, char* chars,
 #else
     // non-CPython
     {
-        uval = NULL;
         PyObject *sign = NULL, *padding = NULL;
+        uval = NULL;
         if (uoffset > 0) {
             prepend_sign = !!prepend_sign;
             if (uoffset > prepend_sign) {


### PR DESCRIPTION
It fixes error 
```
src\lxml\etree.c(241210) : error C2275: 'PyObject' : illegal use of this type as an expression
```
when installing lxml 4.3.0 to pypy2 v6.0.0 on Windows.