### PR TITLE
Allow empty struct or union definition.

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -877,12 +877,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("  #pragma pack(push, 1)")
                 code.putln("#endif")
             code.putln(header)
-            var_entries = scope.var_entries
-            if not var_entries:
-                error(entry.pos, "Empty struct or union definition not allowed outside a 'cdef extern from' block")
-            for attr in var_entries:
-                code.putln(
-                    "%s;" % attr.type.declaration_code(attr.cname))
+            for attr in scope.var_entries:
+                code.putln("%s;" % attr.type.declaration_code(attr.cname))
             code.putln(footer)
             if packed:
                 code.putln("#if defined(__SUNPRO_C)")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -877,6 +877,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("  #pragma pack(push, 1)")
                 code.putln("#endif")
             code.putln(header)
+            if not scope.var_entries:
+                warning(entry.pos, "Empty %s definition: %s" % (type.kind, type.cname))
             for attr in scope.var_entries:
                 code.putln("%s;" % attr.type.declaration_code(attr.cname))
             code.putln(footer)


### PR DESCRIPTION
#2802

Minimum test code:

```python
# test.pyx
cdef struct Foo:
    pass


def main():
    cdef Foo foo = []
    print("test:", sizeof(foo))
```

Result:

```python
>>> import test
>>> test.main()
test: 0
```

But a grammar error still here:

```bash
cdef struct Foo: pass
                ^
------------------------------------------------------------

test.pyx:1:17: Expected 'NEWLINE', found 'pass'
```