### PR TITLE
Implement "gen.gi_frame" and "coro.cr_frame" attributes on generators and coroutines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Features added
 * Properties can be defined for external extension types.
   Patch by Matti Picus.  (Github issue #2640)
 
+* The attributes ``gen.gi_frame`` and ``coro.cr_frame`` of Cython compiled
+  generators and coroutines now return an actual frame object for introspection.
+  (Github issue #2306)
+
 * The builtin ``abs()`` function can now be used on C numbers in nogil code.
   Patch by Elliott Sales de Andrade.  (Github issue #2748)
 

--- a/tests/run/coroutines.py
+++ b/tests/run/coroutines.py
@@ -1,0 +1,30 @@
+# cython: language_level=3
+# mode: run
+# tag: pep492, pure3.5
+
+
+async def test_coroutine_frame(awaitable):
+    """
+    >>> class Awaitable(object):
+    ...     def __await__(self):
+    ...         return iter([2])
+
+    >>> coro = test_coroutine_frame(Awaitable())
+    >>> import types
+    >>> isinstance(coro.cr_frame, types.FrameType) or coro.cr_frame
+    True
+    >>> coro.cr_frame is coro.cr_frame  # assert that it's cached
+    True
+    >>> coro.cr_frame.f_code is not None
+    True
+    >>> code_obj = coro.cr_frame.f_code
+    >>> code_obj.co_argcount
+    1
+    >>> code_obj.co_varnames
+    ('awaitable', 'b')
+
+    >>> next(coro.__await__())  # avoid "not awaited" warning
+    2
+    """
+    b = await awaitable
+    return b

--- a/tests/run/generators.pyx
+++ b/tests/run/generators.pyx
@@ -502,3 +502,23 @@ def test_generator_abc():
     True
     """
     yield 1
+
+
+def test_generator_frame(a=1):
+    """
+    >>> gen = test_generator_frame()
+    >>> import types
+    >>> isinstance(gen.gi_frame, types.FrameType) or gen.gi_frame
+    True
+    >>> gen.gi_frame is gen.gi_frame  # assert that it's cached
+    True
+    >>> gen.gi_frame.f_code is not None
+    True
+    >>> code_obj = gen.gi_frame.f_code
+    >>> code_obj.co_argcount
+    1
+    >>> code_obj.co_varnames
+    ('a', 'b')
+    """
+    b = a + 1
+    yield b


### PR DESCRIPTION
Make them return an inspectable (although otherwise dead) frame object.
Closes #2306.