### PR TITLE
[DOC] Add doc for memory views with custom numpy dtype

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ highlight_language = 'cython'
 extensions = [
     'ipython_console_highlighting',
     'cython_highlighting',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.todo',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autodoc'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ highlight_language = 'cython'
 extensions = [
     'ipython_console_highlighting',
     'cython_highlighting',
-    'sphinx.ext.imgmath',
+    'sphinx.ext.pngmath',
     'sphinx.ext.todo',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autodoc'

--- a/docs/examples/userguide/memoryviews/custom_dtype.pyx
+++ b/docs/examples/userguide/memoryviews/custom_dtype.pyx
@@ -1,0 +1,26 @@
+import numpy as np
+
+CUSTOM_DTYPE = np.dtype([
+    ('x', np.uint8),
+    ('y', np.float32),
+])
+
+a = np.zeros(100, dtype=CUSTOM_DTYPE)
+
+cdef packed struct custom_dtype_struct:
+    # The struct needs to be packed since by default numpy dtypes aren't
+    # aligned
+    unsigned char x
+    float y
+
+def sum(custom_dtype_struct [:] a):
+
+    cdef:
+        unsigned char sum_x = 0
+        float sum_y = 0.
+
+    for i in range(a.shape[0]):
+        sum_x += a[i].x
+        sum_y += a[i].y
+
+    return sum_x, sum_y

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -75,6 +75,13 @@ three dimensional buffer into a function that requires a two
 dimensional buffer will raise a ``ValueError``.
 
 
+To use a memory view on a numpy array with a custom dtype, you'll need to
+declare an equivalent packed struct that mimics the dtype:
+
+.. literalinclude:: ../../examples/userguide/memoryviews/custom_dtype.pyx
+
+
+
 Indexing
 --------
 

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -81,7 +81,6 @@ declare an equivalent packed struct that mimics the dtype:
 .. literalinclude:: ../../examples/userguide/memoryviews/custom_dtype.pyx
 
 
-
 Indexing
 --------
 


### PR DESCRIPTION
Closes #2760 

I have added a section in the memory view doc that indicates how to use memory views on numpy array that have a custom dtype.

I really think this is something that should be in the docs somewhere. I needed this and the only source was one of the scipy paper from 2008.