### PR TITLE
Fix msvc compiler warning C4244

### DIFF
--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -188,13 +188,13 @@ static {{type}} __Pyx_PyComplex_As_{{type_name}}(PyObject* o) {
                 return {{type_name}}_from_parts(a.real / b.real, a.imag / b.imag);
             } else {
                 {{real_type}} r = b.imag / b.real;
-                {{real_type}} s = 1.0 / (b.real + b.imag * r);
+                {{real_type}} s = ({{real_type}})(1.0) / (b.real + b.imag * r);
                 return {{type_name}}_from_parts(
                     (a.real + a.imag * r) * s, (a.imag - a.real * r) * s);
             }
         } else {
             {{real_type}} r = b.real / b.imag;
-            {{real_type}} s = 1.0 / (b.imag + b.real * r);
+            {{real_type}} s = ({{real_type}})(1.0) / (b.imag + b.real * r);
             return {{type_name}}_from_parts(
                 (a.real * r + a.imag) * s, (a.imag * r - a.real) * s);
         }


### PR DESCRIPTION
warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data