### PR TITLE
Misc. typo fixes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2110,7 +2110,7 @@ class NameNode(AtomicExprNode):
     def may_be_none(self):
         if self.cf_state and self.type and (self.type.is_pyobject or
                                             self.type.is_memoryviewslice):
-            # gard against infinite recursion on self-dependencies
+            # guard against infinite recursion on self-dependencies
             if getattr(self, '_none_checking', False):
                 # self-dependency - either this node receives a None
                 # value from *another* node, or it can not reference

--- a/docs/src/tutorial/readings.rst
+++ b/docs/src/tutorial/readings.rst
@@ -16,7 +16,7 @@ features for managing it.
 Finally, don't hesitate to ask questions (or post reports on
 successes!) on the Cython users mailing list [UserList]_.  The Cython
 developer mailing list, [DevList]_, is also open to everybody, but
-focusses on core development issues.  Feel free to use it to report a
+focuses on core development issues.  Feel free to use it to report a
 clear bug, to ask for guidance if you have time to spare to develop
 Cython, or if you have suggestions for future development.
 

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -504,7 +504,7 @@ It is quite common to want to instantiate an extension class from an existing
 (pointer to a) data structure, often as returned by external C/C++ functions.
 
 As extension classes can only accept Python objects as arguments in their
-contructors, this necessitates the use of factory functions. For example, ::
+constructors, this necessitates the use of factory functions. For example, ::
 
     from libc.stdlib cimport malloc, free
 


### PR DESCRIPTION
Found via `codespell -q 3 -L uint,sinc,nd,byteorder,delimeter,delimeters,te,iff,splitted,highlightning,tripple,varius,includee,ist,ue,ba,defin,amin,ith,creat,minimise,crasher`