### PR TITLE
Fix early binding example

### DIFF
--- a/docs/examples/userguide/early_binding_for_speed/rectangle_cdef.pyx
+++ b/docs/examples/userguide/early_binding_for_speed/rectangle_cdef.pyx
@@ -18,5 +18,5 @@ cdef class Rectangle:
         return self._area()
 
 def rectArea(x0, y0, x1, y1):
-    rect = Rectangle(x0, y0, x1, y1)
-    return rect.area()
+    cdef Rectangle rect = Rectangle(x0, y0, x1, y1)
+    return rect._area()

--- a/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
+++ b/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
@@ -15,5 +15,5 @@ cdef class Rectangle:
         return area
 
 def rectArea(x0, y0, x1, y1):
-    cpdef rect = Rectangle(x0, y0, x1, y1)
+    cdef rect = Rectangle(x0, y0, x1, y1)
     return rect.area()

--- a/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
+++ b/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
@@ -15,5 +15,5 @@ cdef class Rectangle:
         return area
 
 def rectArea(x0, y0, x1, y1):
-    rect = Rectangle(x0, y0, x1, y1)
+    cpdef rect = Rectangle(x0, y0, x1, y1)
     return rect.area()

--- a/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
+++ b/docs/examples/userguide/early_binding_for_speed/rectangle_cpdef.pyx
@@ -15,5 +15,5 @@ cdef class Rectangle:
         return area
 
 def rectArea(x0, y0, x1, y1):
-    cdef rect = Rectangle(x0, y0, x1, y1)
+    cdef Rectangle rect = Rectangle(x0, y0, x1, y1)
     return rect.area()


### PR DESCRIPTION
In the second and third examples of [early binding](https://cython.readthedocs.io/en/latest/src/userguide/early_binding_for_speed.html) the code doesn't match the description: namely, the function
```cython
def rectArea(x0, y0, x1, y1):
    rect = Rectangle(x0, y0, x1, y1)
    return rect.area()
```
doesn't `cdef`fine the local variable `rect`, so it doesn't gain access to the `cdef`/`cpdef` methods `area`/`_area`.

The correct code should be
```cython
def rectArea(x0, y0, x1, y1):
    cdef Rectangle rect = Rectangle(x0, y0, x1, y1)
    return rect._area()
```
for the second example and
```cython
def rectArea(x0, y0, x1, y1):
    cdef Rectangle rect = Rectangle(x0, y0, x1, y1)
    return rect.area()
```
for the third.