### PR TITLE
Show cythonized code in ipython

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -242,7 +242,7 @@ class CythonMagics(Magics):
         '--verbose', dest='quiet', action='store_false', default=True,
         help=("Print debug information like generated .c/.cpp file location "
               "and exact gcc/g++ command invoked.")
-    )    
+    )
     @magic_arguments.argument(
         '--show-cythonized-code', action='store_true', default=False,
         help="Show cythonized c/cpp file (ignored if in combination with -a/--annotate)."
@@ -365,9 +365,8 @@ class CythonMagics(Magics):
                       'source could not be read.', file=sys.stderr)
                 print(e, file=sys.stderr)
             else:
-                code_as_html = self.code_to_html(cythonized_code)  
+                code_as_html = self.code_to_html(cythonized_code)
                 return display.HTML(code_as_html)
-
 
     def _profile_pgo_wrapper(self, extension, lib_dir):
         """
@@ -561,8 +560,8 @@ class CythonMagics(Magics):
     def code_to_html(code):
         """Convert source code to a html-file, so tabs and new lines are properly shown
         """
-        return '<!DOCTYPE html><html><body><span style="white-space: pre">\n'+\
-               code+\
+        return '<!DOCTYPE html><html><body><span style="white-space: pre">\n' + \
+               code + \
                '</span></body></html>'
 
 

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -210,3 +210,25 @@ x = sin(0.0)
             ip.ex('g = f(10)')
         self.assertEqual(ip.user_ns['g'], 20.0)
         self.assertEquals([normal_log.INFO], normal_log.thresholds)
+
+
+    def test_cython_show_cythonized_c(self):
+        ip = self._ip
+        html = ip.run_cell_magic('cython', '--show-cythonized-code', code)
+        # somewhat brittle way to differentiate between annotated html and source code:
+        self.assertTrue('#include "Python.h"' in html.data)
+
+
+    def test_cython_show_cythonized_cpp(self):
+        ip = self._ip
+        html = ip.run_cell_magic('cython', '--show-cythonized-code --cplus', code)
+        # somewhat brittle way to differentiate between annotated html and source code:
+        self.assertTrue('#include "Python.h"' in html.data)
+
+
+    def test_cython_show_cythonized_with_anotate(self):
+        ip = self._ip
+        html = ip.run_cell_magic('cython', '--show-cythonized-code --a', code)
+        # somewhat brittle way to differentiate between annotated html and source code:
+        self.assertFalse('#include "Python.h"' in html.data)  # it is annotated html
+

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -211,13 +211,11 @@ x = sin(0.0)
         self.assertEqual(ip.user_ns['g'], 20.0)
         self.assertEquals([normal_log.INFO], normal_log.thresholds)
 
-
     def test_cython_show_cythonized_c(self):
         ip = self._ip
         html = ip.run_cell_magic('cython', '--show-cythonized-code', code)
         # somewhat brittle way to differentiate between annotated html and source code:
         self.assertTrue('#include "Python.h"' in html.data)
-
 
     def test_cython_show_cythonized_cpp(self):
         ip = self._ip
@@ -225,10 +223,8 @@ x = sin(0.0)
         # somewhat brittle way to differentiate between annotated html and source code:
         self.assertTrue('#include "Python.h"' in html.data)
 
-
     def test_cython_show_cythonized_with_anotate(self):
         ip = self._ip
         html = ip.run_cell_magic('cython', '--show-cythonized-code --a', code)
         # somewhat brittle way to differentiate between annotated html and source code:
         self.assertFalse('#include "Python.h"' in html.data)  # it is annotated html
-

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -648,6 +648,8 @@ You can see them also by typing ```%%cython?`` in IPython or a Jupyter notebook.
 --pgo                                         Enable profile guided optimisation in the C compiler. Compiles the cell twice and executes it in between to generate a runtime profile.
 
 --verbose                                     Print debug information like generated .c/.cpp file location and exact gcc/g++ command invoked.
+
+--show-cythonized-code                        Show cythonized c/cpp file (ignored if in combination with -a/--annotate).
 ============================================  =======================================================================================================================================
 
 


### PR DESCRIPTION
Closes #2855

This PR introduces `--show-cythonized-code` option for IPython-%%cython-magic, so the whole resulting c/cpp file is displayed (and not only some parts, as this is the case with --annotate.

`--show-cythonized-code` is a second class citizen, because it is overruled by `--annotate` (to fix it and to show both, the easiest would be to use `display.display_html(display.HTML(...))` instead of `return display.HTML(...)` for --annotate and  --show-cythonized-code, but I was unwilling to change behavior for --annotate).

The is alo no highlighting in the shown code, but I didn't really missed it so far.