### PR TITLE
Faster absolute reimports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Cython Changelog
 Features added
 --------------
 
+* Reimports of already imported modules are substantially faster.
+  (Github issue #2854)
+
 * The ``volatile`` C modifier is supported in Cython code.
   Patch by Jeroen Demeyer.  (Github issue #1667)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2527,44 +2527,61 @@ class ImportNode(ExprNode):
     #                           relative to the current module.
     #                     None: decide the level according to language level and
     #                           directives
+    #  get_top_level_module   int          true: return top-level module, false: return imported module
+    #  module_names           TupleNode    the separate names of the module and submodules, or None
 
     type = py_object_type
+    module_names = None
+    get_top_level_module = False
+    is_temp = True
 
-    subexprs = ['module_name', 'name_list']
+    subexprs = ['module_name', 'name_list', 'module_names']
 
     def analyse_types(self, env):
         if self.level is None:
-            if (env.directives['py2_import'] or
-                Future.absolute_import not in env.global_scope().context.future_directives):
+            # For modules in packages, and without 'absolute_import' enabled, try relative (Py2) import first.
+            if env.global_scope().parent_module and (
+                    env.directives['py2_import'] or
+                    Future.absolute_import not in env.global_scope().context.future_directives):
                 self.level = -1
             else:
                 self.level = 0
         module_name = self.module_name.analyse_types(env)
         self.module_name = module_name.coerce_to_pyobject(env)
+        assert self.module_name.is_string_literal
         if self.name_list:
             name_list = self.name_list.analyse_types(env)
             self.name_list = name_list.coerce_to_pyobject(env)
-        self.is_temp = 1
+        elif '.' in self.module_name.value:
+            self.module_names = TupleNode(self.module_name.pos, args=[
+                IdentifierStringNode(self.module_name.pos, value=part, constant_result=part)
+                for part in map(StringEncoding.EncodedString, self.module_name.value.split('.'))
+            ]).analyse_types(env)
         return self
 
     gil_message = "Python import"
 
     def generate_result_code(self, code):
-        if self.name_list:
-            name_list_code = self.name_list.py_result()
+        assert self.module_name.is_string_literal
+        module_name = self.module_name.value
+
+        if self.level == 0 and not self.name_list and not self.get_top_level_module:
+            if self.module_names:
+                assert self.module_names.is_literal  # make sure we create the tuple only once
+            code.globalstate.use_utility_code(UtilityCode.load_cached("ImportDottedModule", "ImportExport.c"))
+            import_code = "__Pyx_ImportDottedModule(%s, %s)" % (
+                self.module_name.py_result(),
+                self.module_names.py_result() if self.module_names else 'NULL',
+            )
         else:
-            name_list_code = "0"
+            code.globalstate.use_utility_code(UtilityCode.load_cached("Import", "ImportExport.c"))
+            import_code = "__Pyx_Import(%s, %s, %d)" % (
+                self.module_name.py_result(),
+                self.name_list.py_result() if self.name_list else '0',
+                self.level)
 
-        code.globalstate.use_utility_code(UtilityCode.load_cached("Import", "ImportExport.c"))
-        import_code = "__Pyx_Import(%s, %s, %d)" % (
-            self.module_name.py_result(),
-            name_list_code,
-            self.level)
-
-        if (self.level <= 0 and
-                self.module_name.is_string_literal and
-                self.module_name.value in utility_code_for_imports):
-            helper_func, code_name, code_file = utility_code_for_imports[self.module_name.value]
+        if self.level <= 0 and module_name in utility_code_for_imports:
+            helper_func, code_name, code_file = utility_code_for_imports[module_name]
             code.globalstate.use_utility_code(UtilityCode.load_cached(code_name, code_file))
             import_code = '%s(%s)' % (helper_func, import_code)
 

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1675,11 +1675,6 @@ def p_import_statement(s):
                 as_name=as_name,
                 is_absolute=is_absolute)
         else:
-            if as_name and "." in dotted_name:
-                name_list = ExprNodes.ListNode(pos, args=[
-                    ExprNodes.IdentifierStringNode(pos, value=s.context.intern_ustring("*"))])
-            else:
-                name_list = None
             stat = Nodes.SingleAssignmentNode(
                 pos,
                 lhs=ExprNodes.NameNode(pos, name=as_name or target_name),
@@ -1687,7 +1682,8 @@ def p_import_statement(s):
                     pos,
                     module_name=ExprNodes.IdentifierStringNode(pos, value=dotted_name),
                     level=0 if is_absolute else None,
-                    name_list=name_list))
+                    get_top_level_module='.' in dotted_name and as_name is None,
+                    name_list=None))
         stats.append(stat)
     return Nodes.StatListNode(pos, stats=stats)
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -56,6 +56,7 @@ bad:
 }
 #endif
 
+#if PY_MAJOR_VERSION >= 3
 static PyObject *__Pyx__ImportDottedModule_Lookup(PyObject *name) {
     PyObject *imported_module;
 #if PY_VERSION_HEX < 0x030700A1
@@ -69,6 +70,7 @@ static PyObject *__Pyx__ImportDottedModule_Lookup(PyObject *name) {
 #endif
     return imported_module;
 }
+#endif
 
 static PyObject *__Pyx__ImportDottedModule(PyObject *name, CYTHON_UNUSED PyObject *parts_tuple) {
 #if PY_MAJOR_VERSION < 3

--- a/runtests.py
+++ b/runtests.py
@@ -1125,6 +1125,8 @@ class CythonCompileTestCase(unittest.TestCase):
                     extension = newext or extension
             if self.language == 'cpp':
                 extension.language = 'c++'
+            if IS_PY2:
+                workdir = str(workdir)  # work around type check in distutils that disallows unicode strings
             build_extension.extensions = [extension]
             build_extension.build_temp = workdir
             build_extension.build_lib  = workdir

--- a/runtests.py
+++ b/runtests.py
@@ -29,6 +29,7 @@ try:
 except (ImportError, AttributeError):
     IS_CPYTHON = True
     IS_PYPY = False
+IS_PY2 = sys.version_info[0] < 3
 
 from io import open as io_open
 try:
@@ -1911,7 +1912,7 @@ class ShardExcludeSelector(object):
         self.shard_num = shard_num
         self.shard_count = shard_count
 
-    def __call__(self, testname, tags=None, _hash=zlib.crc32, _is_py2=sys.version_info[0] < 3):
+    def __call__(self, testname, tags=None, _hash=zlib.crc32, _is_py2=IS_PY2):
         # Cannot use simple hash() here as shard processes might use different hash seeds.
         # CRC32 is fast and simple, but might return negative values in Py2.
         hashval = _hash(testname) & 0x7fffffff if _is_py2 else _hash(testname.encode())
@@ -2493,10 +2494,7 @@ def runtests(options, cmd_args, coverage=None):
     else:
         text_runner_options = {}
         if options.failfast:
-            if sys.version_info < (2, 7):
-                sys.stderr.write("--failfast not supported with Python < 2.7\n")
-            else:
-                text_runner_options['failfast'] = True
+            text_runner_options['failfast'] = True
         test_runner = unittest.TextTestRunner(verbosity=options.verbosity, **text_runner_options)
 
     if options.pyximport_py:

--- a/tests/run/importas.pyx
+++ b/tests/run/importas.pyx
@@ -1,4 +1,14 @@
+# mode: run
+# tag: all_language_levels
+
 __doc__ = u"""
+>>> try: sys
+... except NameError: pass
+... else: print("sys was defined!")
+>>> try: distutils
+... except NameError: pass
+... else: print("distutils was defined!")
+
 >>> import sys as sous
 >>> import distutils.core as corey
 >>> from copy import deepcopy as copey

--- a/tests/run/reimport_from_package.srctree
+++ b/tests/run/reimport_from_package.srctree
@@ -17,8 +17,8 @@ setup(
 
 import sys
 import a
-assert a in sys.modules.values(), list(sys.modules)
-assert sys.modules['a'] is a, list(sys.modules)
+assert a in sys.modules.values(), sorted(sys.modules)
+assert sys.modules['a'] is a, sorted(sys.modules)
 
 from atest.package import module
 
@@ -33,8 +33,8 @@ assert 'atest.package.module' in sys.modules
 
 import a
 import atest.package.module as module
-assert module in sys.modules.values(), list(sys.modules)
-assert sys.modules['atest.package.module'] is module, list(sys.modules)
+assert module in sys.modules.values(), sorted(sys.modules)
+assert sys.modules['atest.package.module'] is module, sorted(sys.modules)
 
 if sys.version_info >= (3, 5):
     from . import pymodule

--- a/tests/run/relativeimport_T542.srctree
+++ b/tests/run/relativeimport_T542.srctree
@@ -26,7 +26,8 @@ try:
 except ImportError:
     pass
 else:
-    assert False, "absolute import succeeded"
+    import sys
+    assert False, "absolute import succeeded: %s" % sorted(sys.modules)
 
 import relimport.a
 import relimport.bmod


### PR DESCRIPTION
Closes #2854.

```
CPython:
$ python3.7 -m timeit 'import pyarrow.pandas_compat as pdcompat'
1 loop, best of 5: 592 nsec per loop
$ python3.6 -m timeit 'import pyarrow.pandas_compat as pdcompat'
10 loops, best of 3: 0.302 usec per loop
$ python3.5 -m timeit 'import pyarrow.pandas_compat as pdcompat'
10 loops, best of 3: 0.946 usec per loop

Cython before:
$ python3.7 -m timeit -s 'from importbench import _import_bench' '_import_bench()'
1 loop, best of 5: 1.37 usec per loop

After change, without initialisation check:
$ python3.7 -m timeit -n 100000 -r 50 -s 'from importbench import _import_bench' '_import_bench()'
100000 loops, best of 50: 51.5 nsec per loop
$ python3.6 -m timeit -n 100000 -r 50 -s 'from importbench import _import_bench' '_import_bench()'
100000 loops, best of 50: 0.0424 usec per loop
$ python3.5 -m timeit -n 100000 -r 50 -s 'from importbench import _import_bench' '_import_bench()'
100000 loops, best of 50: 0.0454 usec per loop

After change, with initialisation check:
$ python3.7 -m timeit -r 20 -n 200000 -s 'from importbench import _import_bench' '_import_bench()'
200000 loops, best of 20: 119 nsec per loop
$ python3.6 -m timeit -r 20 -n 200000 -s 'from importbench import _import_bench' '_import_bench()'
200000 loops, best of 20: 0.0882 usec per loop
$ python3.5 -m timeit -r 20 -n 200000 -s 'from importbench import _import_bench' '_import_bench()'
200000 loops, best of 20: 0.107 usec per loop
```
Not sure what to do about Py2.7. It's not too bad in comparison, but I guess there are also some cases where calling `__import__()` (because that's what Cython does in Py2) isn't exactly the fastest.
```
$ python2.7 -m timeit -r 50 -n 200000 'import pyarrow.pandas_compat as pdcompat'
200000 loops, best of 50: 0.44 usec per loop
$ python2.7 -m timeit -r 50 -n 200000 -s 'from importbench import _import_bench' '_import_bench()'
200000 loops, best of 50: 0.691 usec per loop
```
Then again, its time is running up, so why bother…