### PR TITLE
include: posix.mman += mlock2, MLOCK_ONFAULT, MCL_ONFAULT

### DIFF
--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -46,6 +46,10 @@ cdef extern from "<sys/mman.h>" nogil:
     int   munlock(const void *addr, size_t Len)
     int   mlockall(int flags)
     int   munlockall()
+    # Linux-specific
+    enum: MLOCK_ONFAULT
+    enum: MCL_ONFAULT
+    int   mlock2(const void *addr, size_t len, int flags)
 
     int shm_open(const char *name, int oflag, mode_t mode)
     int shm_unlink(const char *name)


### PR DESCRIPTION
mlock2 is Linux-specific version of mlock that accepts flags. The only
flag available so far is MLOCK_ONFAULT which asks to lock pages only at
the time when they are faulted in, not in the beginning. MCL_ONFAULT is
Linux-specific flag to mlockall which requests similar behaviour.

http://man7.org/linux/man-pages/man2/mlock2.2.html