### PR TITLE
include: posix.mman += MAP_FAILED

### DIFF
--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -24,6 +24,8 @@ cdef extern from "<sys/mman.h>" nogil:
     enum: MAP_NOCORE                #  Typically available only on BSD
     enum: MAP_NOSYNC
 
+    void *MAP_FAILED
+
     void *mmap(void *addr, size_t Len, int prot, int flags, int fd, off_t off)
     int   munmap(void *addr, size_t Len)
     int   mprotect(void *addr, size_t Len, int prot)


### PR DESCRIPTION
mmap returns void* and indicates failure via MAP_FAILED that is defined
to be ((void *)-1). Every mmap call has to be checked for failure and
thus posix.mman with mmap, but without MAP_FAILED is not very useful.

We cannot declare MAP_FAILED as enum, because enum assumes int. However
Cython documentation says

	4. If the header file uses macros to define constants, translate
	   them into a normal external variable declaration. ...

(https://cython.readthedocs.io/en/latest/src/userguide/external_C_code.html#referencing-c-header-files)

So add proper declaration for MAP_FAILED to make posix.mman.mmap usable.