### PR TITLE
Avoid generating a tp_new() function for extension types that do not need their own one.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,11 @@ Bugs fixed
   semantics.  It now passes through the Mapping protocol first when supported.
   (Github issue #1807)
 
+* Extension types that do not need their own ``tp_new`` implementation (because
+  they have no object attributes etc.) directly inherit the implementation of
+  their parent type if that is available in the same module.
+  (Github issue #1555)
+
 * The ``Py_hash_t`` type failed to accept arbitrary "index" values.
   (Github issue #2752)
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1270,8 +1270,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 type.empty_declaration_code()))
 
     def generate_new_function(self, scope, code, cclass_entry):
-        tp_slot = TypeSlots.ConstructorSlot("tp_new", '__new__')
+        tp_slot = TypeSlots.ConstructorSlot("tp_new", "__cinit__")
         slot_func = scope.mangle_internal("tp_new")
+        if tp_slot.slot_code(scope) != slot_func:
+            return  # never used
+
         type = scope.parent_type
         base_type = type.base_type
 
@@ -1554,7 +1557,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_usr_dealloc_call(self, scope, code):
         entry = scope.lookup_here("__dealloc__")
-        if not entry:
+        if not entry or not entry.is_special:
             return
 
         code.putln("{")

--- a/tests/run/exttype.pyx
+++ b/tests/run/exttype.pyx
@@ -1,6 +1,52 @@
+# mode: run
+# tag: exttype, tpnew
+
+from __future__ import print_function
+
+from cpython.object cimport PyTypeObject
+
 
 cdef gobble(a, b):
-    print a, b
+    print(a, b)
+
+
+def tp_new_ptr(exttype):
+    assert isinstance(exttype, type)
+    tp = <PyTypeObject*> exttype
+    return <unsigned long long><void*>tp.tp_new
+
+
+cdef class Empty:
+    """
+    >>> n = Empty()
+    >>> isinstance(n, Empty)
+    True
+    >>> tp_new_ptr(Empty) != 0
+    True
+    """
+
+
+cdef class EmptySubclass(Empty):
+    """
+    >>> n = EmptySubclass()
+    >>> isinstance(n, EmptySubclass)
+    True
+    >>> tp_new_ptr(EmptySubclass) != 0
+    True
+    >>> tp_new_ptr(EmptySubclass) == tp_new_ptr(Empty)
+    True
+    """
+
+
+cdef class CInit:
+    """
+    >>> c = CInit()
+    >>> isinstance(c, CInit)
+    True
+    """
+    def __cinit__(self):
+        assert self is not None
+
 
 cdef class Spam:
     """
@@ -20,6 +66,7 @@ cdef class Spam:
 
     def eat(self):
         gobble(self.eggs, self.ham)
+
 
 def f(Spam spam):
     """

--- a/tests/run/tp_new.pyx
+++ b/tests/run/tp_new.pyx
@@ -1,3 +1,5 @@
+# mode: run
+# tag: exttype, tpnew
 # ticket: 808
 
 cimport cython


### PR DESCRIPTION
See #1555.