### PR TITLE
BUG: prefer sys.path before Cython/Include when searching for pxd files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,6 +115,10 @@ Other changes
 
 * Support for Python 2.6 was removed.
 
+* The search order for include files was changed. Previously it was
+  ``include_directories``, ``Cython/Includes``, ``sys.path``. Now it is
+  ``include_directories``, ``sys.path``, ``Cython/Includes``. (Github issue
+  #2905)
 
 0.29.7 (2019-0?-??)
 ===================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,8 +117,10 @@ Other changes
 
 * The search order for include files was changed. Previously it was
   ``include_directories``, ``Cython/Includes``, ``sys.path``. Now it is
-  ``include_directories``, ``sys.path``, ``Cython/Includes``. (Github issue
-  #2905)
+  ``include_directories``, ``sys.path``, ``Cython/Includes``. This was done to
+  allow third-party ``*.pxd`` files to override the ones in Cython.
+  (Github issue #2905)
+
 
 0.29.7 (2019-0?-??)
 ===================

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -251,10 +251,11 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        include_dirs = tuple(self.include_directories)
+        include_dirs = self.include_directories
         if sys_path:
-            include_dirs = include_dirs + tuple(sys.path)
-        include_dirs = include_dirs + (standard_include_path,)
+            include_dirs = include_dirs + sys.path
+        # include_dirs must be hashable for caching in @cached_function
+        include_dirs = tuple(include_dirs + [standard_include_path])
         return search_include_directories(include_dirs, qualified_name,
                                           suffix, pos, include)
 

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -251,10 +251,10 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        include_dirs = list(self.include_directories)
+        include_dirs = tuple(self.include_directories)
         if sys_path:
-            include_dirs += list(sys.path)
-        include_dirs += [standard_include_path,]
+            include_dirs = include_dirs + tuple(sys.path)
+        include_dirs = include_dirs + (standard_include_path,)
         return search_include_directories(include_dirs, qualified_name,
                                           suffix, pos, include)
 

--- a/tests/compile/find_pxd.srctree
+++ b/tests/compile/find_pxd.srctree
@@ -6,12 +6,13 @@ from Cython.Build import cythonize
 from Cython.Distutils.extension import Extension
 
 import sys
-sys.path.append("path")
+sys.path.insert(0, "path")
 
 ext_modules = [
     Extension("a", ["a.pyx"]),
     Extension("b", ["b.pyx"]),
     Extension("c", ["c.pyx"]),
+    Extension("d", ["d.pyx"]),
 ]
 
 ext_modules = cythonize(ext_modules, include_path=["include"])
@@ -37,3 +38,15 @@ ctypedef int my_type
 
 ######## path/c.pxd ########
 +++syntax error just to show that this file is not actually cimported+++
+
+######## path/numpy/__init__.pxd ########
+
+# gh-2905: This should be found before Cython/Inlude/numpy/__init__.pxd
+
+ctypedef int my_type
+
+######## d.pyx ########
+
+cimport numpy
+
+cdef numpy.my_type foo


### PR DESCRIPTION
Fixes #2905 by raising the sys_path resolution into Context.search_include_directories

Also fix a bug in calling `os.path.join` with identical paths which merges them when they are absolute paths but concatenates them when they are relative paths, causing the test which adds a relative path to `sys.path` to fail. This would only occur when searching for `__init__.pxd`.

