### PR TITLE
Use ClassCellNode for __class__ so that it's available in methods

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9967,7 +9967,6 @@ class LocalsDictItemNode(DictItemNode):
             self.value = None
         return self
 
-
 class FuncLocalsExprNode(DictNode):
     def __init__(self, pos, env):
         local_vars = sorted([key for key, entry in env.entries.items() if entry.name])

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9970,8 +9970,7 @@ class LocalsDictItemNode(DictItemNode):
 
 class FuncLocalsExprNode(DictNode):
     def __init__(self, pos, env):
-        local_vars = sorted([
-            entry.name for entry in env.entries.values() if entry.name])
+        local_vars = sorted([key for key, entry in env.entries.items() if entry.name])
         items = [LocalsDictItemNode(
             pos, key=IdentifierStringNode(pos, value=var),
             value=NameNode(pos, name=var, allow_null=True))

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2787,6 +2787,7 @@ class DefNode(FuncDefNode):
 
     is_staticmethod = False
     is_classmethod = False
+    has_class_reference = False
 
     lambda_name = None
     reqd_kw_flags_cname = "0"

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3118,7 +3118,6 @@ class TransformBuiltinMethods(EnvTransform):
 
     def _check_inside_class(self, def_node):
         return isinstance(def_node, Nodes.DefNode) and def_node.args and len(self.env_stack) >= 2
-        
 
     def _get_current_class_and_scope(self):
         return self.env_stack[-2]

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3061,9 +3061,10 @@ class TransformBuiltinMethods(EnvTransform):
             # not the builtin
             return node
 
+        def_node = self.current_scope_node()
+
         class_entry = lenv.lookup_here('__class__')
         if not class_entry:
-            def_node = self.current_scope_node()
             if def_node.has_class_reference:
                 local_class_node, _ = self._get_current_class_and_scope()
                 lenv.entries[EncodedString(u'__class__')] = local_class_node.target.entry
@@ -3133,8 +3134,7 @@ class TransformBuiltinMethods(EnvTransform):
     def _get_current_class_and_scope(self):
         return next(
             (node, scope)
-            for node, scope
-            in self.env_stack[::-1]
+            for node, scope in self.env_stack[::-1]
             if isinstance(node, Nodes.ClassDefNode)
         )
     

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3055,6 +3055,7 @@ class TransformBuiltinMethods(EnvTransform):
 
     def _inject_locals(self, node, func_name):
         # locals()/dir()/vars() builtins
+
         lenv = self.current_env()
         entry = lenv.lookup_here(func_name)
         if entry:
@@ -3063,9 +3064,10 @@ class TransformBuiltinMethods(EnvTransform):
 
         def_node = self.current_scope_node()
 
-        class_entry = lenv.lookup_here('__class__')
-        if not class_entry:
-            if def_node.has_class_reference:
+        if lenv.is_py_class_scope and def_node.has_class_reference:
+            class_entry = lenv.lookup_here('__class__')
+
+            if not class_entry:
                 local_class_node, _ = self._get_current_class_and_scope()
                 lenv.entries[EncodedString(u'__class__')] = local_class_node.target.entry
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3062,9 +3062,11 @@ class TransformBuiltinMethods(EnvTransform):
             # not the builtin
             return node
 
+        # Handle __class__ injection
         def_node = self.current_scope_node()
 
-        if lenv.is_py_class_scope and def_node.has_class_reference:
+        if self._check_inside_class(def_node) and def_node.has_class_reference:
+
             class_entry = lenv.lookup_here('__class__')
 
             if not class_entry:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3141,7 +3141,7 @@ class TransformBuiltinMethods(EnvTransform):
             for node, scope in self.env_stack[::-1]
             if isinstance(node, Nodes.ClassDefNode)
         )
-    
+
     def _inject_class(self, node):
         # bare __class__ reference inside function
         def_node = self.current_scope_node()
@@ -3153,7 +3153,8 @@ class TransformBuiltinMethods(EnvTransform):
 
         if class_scope.is_py_class_scope:
             def_node.has_class_reference = True
-            return ExprNodes.NameNode(node.pos, name=class_node.target.name)
+            self_node = ExprNodes.NameNode(pos=node.pos, name=u'self')
+            return ExprNodes.AttributeNode(pos=node.pos, obj=self_node, attribute=EncodedString(u'__class__'))
 
         return node
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3133,11 +3133,10 @@ class TransformBuiltinMethods(EnvTransform):
         def_node = self.current_scope_node()
         if not self._check_inside_class(def_node):
             return
-        
+    
         class_node, class_scope = self._get_current_class_and_scope()
+        
         if class_scope.is_py_class_scope:
-            def_node.requires_classobj = True
-            class_node.class_cell.is_active = True
             lenv.entries[EncodedString(u"__class__")] = class_node.target.entry
 
     def _inject_super(self, node, func_name):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3160,7 +3160,7 @@ class TransformBuiltinMethods(EnvTransform):
             return node
         # Inject no-args super
         def_node = self.current_scope_node()
-        if not self._check_inside_class(def_node):
+        if not self._check_inside_class(def_node) or not def_node.args:
             return node
         class_node, class_scope = self._get_current_class_and_scope()
         if class_scope.is_py_class_scope:

--- a/tests/run/pep3135_class_cell.py
+++ b/tests/run/pep3135_class_cell.py
@@ -117,3 +117,31 @@ __test__ = {
     'K'
     """
 }
+
+class L:
+    """
+    >>> OldL().method().__name__
+    'L'
+    """
+    def method(self): return self.__class__
+
+OldL = L
+L = None
+
+class M:
+    """
+    >>> M().method()
+    u'overwritten'
+    """
+    def method(self):
+        __class__ = 'overwritten'
+        return __class__
+
+class N:
+    """
+    >>> N().method().__name__
+    'N'
+    """
+    __class__ = 'N'
+    def method(self):
+        return __class__

--- a/tests/run/pep3135_class_cell.py
+++ b/tests/run/pep3135_class_cell.py
@@ -12,6 +12,8 @@ class C(object):
     3
     >>> obj.method_3()
     ['__class__', 'self']
+    >>> obj.method_4()
+    ['self']
     """
 
     @classmethod
@@ -31,3 +33,84 @@ class C(object):
     def method_3(self):
         __class__
         return sorted(list(locals().keys()))
+
+    def method_4(self):
+        return sorted(list(locals().keys()))
+
+
+class D:
+    """
+    >>> obj = D()
+    >>> obj.method(1)
+    1
+    >>> obj.method(0)
+    Traceback (most recent call last):
+    ...
+    UnboundLocalError: local variable '__class__' referenced before assignment
+    """
+    def method(self, x):
+        if x: __class__ = x
+        print(__class__)
+
+
+class E:
+    """
+    >>> obj = E()
+    >>> obj.method()().__name__
+    'E'
+    """
+    def method(self):
+        def inner(): return __class__
+        return inner
+
+
+class F:
+    """
+    >>> obj = F()
+    >>> obj.method()()().__name__
+    'F'
+    """
+    def method(self):
+        def inner():
+            def inner_inner():
+                return __class__
+            return inner_inner
+        return inner
+
+
+class G:
+    """
+    >>> obj = G()
+    >>> obj.method().__name__
+    'H'
+    """
+    def method(self):
+        class H:
+            def inner(self):
+                return __class__
+        return H().inner()
+
+
+class I:
+    """
+    >>> obj = I()
+    >>> obj.method()()().__name__
+    'J'
+    """
+    def method(self):
+        def inner():
+            class J:
+                def inner(self):
+                    return __class__
+            return J().inner
+        return inner
+
+
+class K:
+    """
+    >>> OldK = K
+    >>> K = None
+    >>> OldK().method().__name__
+    'K'
+    """
+    def method(self): return __class__

--- a/tests/run/pep3135_class_cell.py
+++ b/tests/run/pep3135_class_cell.py
@@ -10,6 +10,8 @@ class C(object):
     2
     >>> obj.method_2()
     3
+    >>> obj.method_3()
+    ['__class__', 'self']
     """
 
     @classmethod
@@ -25,3 +27,7 @@ class C(object):
 
     def method_2(self):
         return __class__.static_method()
+
+    def method_3(self):
+        __class__
+        return sorted(list(locals().keys()))

--- a/tests/run/pep3135_class_cell.py
+++ b/tests/run/pep3135_class_cell.py
@@ -1,0 +1,27 @@
+# cython: language_level=3
+# mode: run
+# tag: pep3135, pure3.0
+
+
+class C(object):
+    """
+    >>> obj = C()
+    >>> obj.method_1()
+    2
+    >>> obj.method_2()
+    3
+    """
+
+    @classmethod
+    def class_method(cls):
+        return 2
+
+    @staticmethod
+    def static_method():
+        return 3
+
+    def method_1(self):
+        return __class__.class_method()
+
+    def method_2(self):
+        return __class__.static_method()

--- a/tests/run/pep3135_class_cell.py
+++ b/tests/run/pep3135_class_cell.py
@@ -107,10 +107,13 @@ class I:
 
 
 class K:
-    """
+    def method(self): return __class__
+
+__test__ = {
+    "k": """
     >>> OldK = K
     >>> K = None
     >>> OldK().method().__name__
     'K'
     """
-    def method(self): return __class__
+}

--- a/tests/run/py3k_super.pyx
+++ b/tests/run/py3k_super.pyx
@@ -52,13 +52,19 @@ class C(A):
     2
     >>> obj.method_2()
     3
+    >>> obj.method_3()
+    ['__class__', 'self']
     """
-
+    
     def method_1(self):
         return __class__.class_method()
 
     def method_2(self):
         return __class__.static_method()
+
+    def method_3(self):
+        __class__
+        return sorted(list(locals().keys()))
 
 
 def test_class_cell_empty():

--- a/tests/run/py3k_super.pyx
+++ b/tests/run/py3k_super.pyx
@@ -54,6 +54,8 @@ class C(A):
     3
     >>> obj.method_3()
     ['__class__', 'self']
+    >>> obj.method_4()
+    ['self']
     """
     
     def method_1(self):
@@ -65,6 +67,87 @@ class C(A):
     def method_3(self):
         __class__
         return sorted(list(locals().keys()))
+
+    def method_4(self):
+        return sorted(list(locals().keys()))
+
+
+class D:
+    """
+    >>> obj = D()
+    >>> obj.method(1)
+    1
+    >>> obj.method(0)
+    Traceback (most recent call last):
+    ...
+    UnboundLocalError: local variable '__class__' referenced before assignment
+    """
+    def method(self, x):
+        if x: __class__ = x
+        print(__class__)
+
+
+class E:
+    """
+    >>> obj = E()
+    >>> obj.method()()
+    <class 'py3k_super.E'>
+    """
+    def method(self):
+        def inner(): return __class__
+        return inner
+
+
+class F:
+    """
+    >>> obj = F()
+    >>> obj.method()()()
+    <class 'py3k_super.F'>
+    """
+    def method(self):
+        def inner():
+            def inner_inner():
+                return __class__
+            return inner_inner
+        return inner
+
+
+class G:
+    """
+    >>> obj = G()
+    >>> obj.method()
+    <class 'py3k_super.G.method.<locals>.H'>
+    """
+    def method(self):
+        class H:
+            def inner(self):
+                return __class__
+        return H().inner()
+
+
+class I:
+    """
+    >>> obj = I()
+    >>> obj.method()()()
+    <class 'py3k_super.I.method.<locals>.inner.<locals>.J'>
+    """
+    def method(self):
+        def inner():
+            class J:
+                def inner(self):
+                    return __class__
+            return J().inner
+        return inner
+
+
+class K:
+    """
+    >>> OldK = K
+    >>> K = None
+    >>> OldK().method().__name__
+    'K'
+    """
+    def method(self): return __class__
 
 
 def test_class_cell_empty():

--- a/tests/run/py3k_super.pyx
+++ b/tests/run/py3k_super.pyx
@@ -16,6 +16,8 @@ class A(object):
     def generator_test(self):
         return [1, 2, 3]
 
+    def super_class(self):
+        return __class__
 
 class B(A):
     """
@@ -28,6 +30,24 @@ class B(A):
     3
     >>> list(obj.generator_test())
     [1, 2, 3]
+    >>> obj.star_method()
+    1
+    >>> obj.starstar_method()
+    1
+    >>> obj.starstarstar_method()
+    1
+    >>> obj.star_class_method()
+    2
+    >>> obj.starstar_class_method()
+    2
+    >>> obj.starstarstar_class_method()
+    2
+    >>> obj.star_static_method(obj)
+    3
+    >>> obj.starstar_static_method(obj)
+    3
+    >>> obj.starstarstar_static_method(obj)
+    3
     """
     def method(self):
         return super().method()
@@ -44,6 +64,39 @@ class B(A):
         for i in super().generator_test():
             yield i
 
+    def star_method(self, *args):
+        return super().method()
+
+    def starstar_method(self, **kwargs):
+        return super().method()
+
+    def starstarstar_method(cls, *args, **kwargs):
+        return super().method()
+
+    @classmethod
+    def star_class_method(cls, *args):
+        return super().class_method()
+
+    @classmethod
+    def starstar_class_method(cls, **kwargs):
+        return super().class_method()
+
+    @classmethod
+    def starstarstar_class_method(cls, *args, **kwargs):
+        return super().class_method()
+
+    @staticmethod
+    def star_static_method(instance, *args):
+        return super().static_method()
+
+    @staticmethod
+    def starstar_static_method(instance, **kwargs):
+        return super().static_method()
+
+    @staticmethod
+    def starstarstar_static_method(instance, *args, **kwargs):
+        return super().static_method()
+
 
 class C(A):
     """
@@ -56,6 +109,10 @@ class C(A):
     ['__class__', 'self']
     >>> obj.method_4()
     ['self']
+    >>> obj.method_5()
+    <class 'py3k_super.C'>
+    >>> obj.super_class()
+    <class 'py3k_super.A'>
     """
     
     def method_1(self):
@@ -70,6 +127,9 @@ class C(A):
 
     def method_4(self):
         return sorted(list(locals().keys()))
+
+    def method_5(self):
+        return __class__
 
 
 class D:
@@ -90,8 +150,8 @@ class D:
 class E:
     """
     >>> obj = E()
-    >>> obj.method()()
-    <class 'py3k_super.E'>
+    >>> obj.method()().__name__
+    'E'
     """
     def method(self):
         def inner(): return __class__
@@ -101,8 +161,8 @@ class E:
 class F:
     """
     >>> obj = F()
-    >>> obj.method()()()
-    <class 'py3k_super.F'>
+    >>> obj.method()()().__name__
+    'F'
     """
     def method(self):
         def inner():
@@ -115,8 +175,8 @@ class F:
 class G:
     """
     >>> obj = G()
-    >>> obj.method()
-    <class 'py3k_super.G.method.<locals>.H'>
+    >>> obj.method().__name__
+    'H'
     """
     def method(self):
         class H:
@@ -128,8 +188,8 @@ class G:
 class I:
     """
     >>> obj = I()
-    >>> obj.method()()()
-    <class 'py3k_super.I.method.<locals>.inner.<locals>.J'>
+    >>> obj.method()()().__name__
+    'J'
     """
     def method(self):
         def inner():
@@ -141,14 +201,16 @@ class I:
 
 
 class K:
-    """
+    def method(self): return __class__
+
+__test__ = {
+    "k": """
     >>> OldK = K
     >>> K = None
     >>> OldK().method().__name__
     'K'
     """
-    def method(self): return __class__
-
+}
 
 def test_class_cell_empty():
     """

--- a/tests/run/py3k_super.pyx
+++ b/tests/run/py3k_super.pyx
@@ -45,6 +45,22 @@ class B(A):
             yield i
 
 
+class C(A):
+    """
+    >>> obj = C()
+    >>> obj.method_1()
+    2
+    >>> obj.method_2()
+    3
+    """
+
+    def method_1(self):
+        return __class__.class_method()
+
+    def method_2(self):
+        return __class__.static_method()
+
+
 def test_class_cell_empty():
     """
     >>> test_class_cell_empty()


### PR DESCRIPTION
Closes #2912 

Per the comment on the issue, this turns `NameNodes` for `__class__` into `ClassCellNodes`, so that you can call `__class__` inside methods without qualifying with `self`. I believe that this fix is effectively just replacing `__class__` with `<name of class>` in these expressions, EG, no `__class__` local ends up created. 

This is quite a minimal fix. There are a few remaining differences in `__class__` behaviour but I wasn't sure how to proceed with them, so I thought I'd raise a PR for comment. 

Basically, in non-Cythonized Python it appears that `__class__` is a bit of a "magic" local. If it appears anywhere in a method body, then `locals()` will contain `__class__` pointing to the containing class, anywhere in the function, but if it doesn't, then it won't. So:

```
class A:
    def b(self):
        print(locals())
        __class__
```
`A().b()` will print `['self', '__class__']`. As would 

```
class A:
    def b(self):
        __class__
        print(locals())
```

But:

```
class A:
    def b(self):
        print(locals())
```
would print only `['self']`

This behaviour is hard to achieve with the current PR, because instead of creating a local called `__class__` we are just replacing the `NameNode` with a `ClassCellNode`. As a result, when cythonized, in all the above examples `locals()` just prints `['self']`. 

Off the top of my head, some approaches that might be better: 

- Instead of replacing the `NameNode`, inject an `entry` into the current scope called `__class__` pointing to the containing `__class__` object. This requires rewriting `FuncLocalsExprNode` so that it iterates over the keys in `entries` rather than calling `.name` on each one. I tried this and it sort of worked but it was a bit messy manually updating the entries dictionary, maybe there's a better way?

- From a higher level in the tree (the `DefNode`?) iterating through all of the statements in the body checking to see if any of them contain `__class__` and, if so, injecting it as a local.  

- Without bothering to see if it's in the body or not, just always injecting `__class__` into the method scope (it's harmless if unused and I don't think it's unreasonable to interpret PEP3135 as implying it should always be in the `locals()` symbol table. However, I am far from an expert and there is potentially a good reason why Python doesn't put it into `locals()` for methods not containing `__class__`.)

Eager to get any and all feedback on the above! This is my first time touching the Cython codebase so I might have missed some things, but it's been really fun to dig into.
