### PR TITLE
Minor typo of the word "declare" in user guide

### DIFF
--- a/docs/examples/userguide/wrapping_CPlusPlus/Rectangle.pxd
+++ b/docs/examples/userguide/wrapping_CPlusPlus/Rectangle.pxd
@@ -1,7 +1,7 @@
 cdef extern from "Rectangle.cpp":
     pass
 
-# Decalre the class with cdef
+# Declare the class with cdef
 cdef extern from "Rectangle.h" namespace "shapes":
     cdef cppclass Rectangle:
         Rectangle() except +


### PR DESCRIPTION
Well looking through the user guide noticed this very minor typo