### PR TITLE
GH-2934: improve error reporting for non-constant exception value expressions

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -734,8 +734,8 @@ class CFuncDeclaratorNode(CDeclaratorNode):
                         self.exception_value = ConstNode(
                             self.pos, value=return_type.exception_value, type=return_type)
             if self.exception_value:
-                self.exception_value = self.exception_value.analyse_const_expression(env)
                 if self.exception_check == '+':
+                    self.exception_value = self.exception_value.analyse_const_expression(env)
                     exc_val_type = self.exception_value.type
                     if (not exc_val_type.is_error
                             and not exc_val_type.is_pyobject
@@ -748,13 +748,11 @@ class CFuncDeclaratorNode(CDeclaratorNode):
                               "Exception value must be a Python exception or cdef function with no arguments or *.")
                     exc_val = self.exception_value
                 else:
-                    self.exception_value = self.exception_value.coerce_to(
+                    self.exception_value = self.exception_value.analyse_types(env).coerce_to(
                         return_type, env).analyse_const_expression(env)
                     exc_val = self.exception_value.get_constant_c_result_code()
                     if exc_val is None:
-                        raise InternalError(
-                            "get_constant_c_result_code not implemented for %s" %
-                            self.exception_value.__class__.__name__)
+                        error(self.exception_value.pos, "Exception value must be constant")
                     if not return_type.assignable_from(self.exception_value.type):
                         error(self.exception_value.pos,
                               "Exception value incompatible with function return type")

--- a/tests/errors/nonconst_excval.pyx
+++ b/tests/errors/nonconst_excval.pyx
@@ -1,0 +1,12 @@
+# mode: error
+
+import math
+
+cdef double cfunc(double x) except math.nan:
+    return x
+
+
+_ERRORS = """
+5:39: Exception value must be constant
+5:39: Not allowed in a constant expression
+"""


### PR DESCRIPTION
Instead of two errors and a crash, just report it once and explicitly.
Closes #2934.