### PR TITLE
Make pythran version checks more resilient

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -39,10 +39,8 @@ except ImportError:
 
 try:
     import pythran
-    import pythran.config
-    pythran_version = pythran.__version__
 except:
-    pythran_version = None
+    pythran = None
 
 from .. import Utils
 from ..Utils import (cached_function, cached_method, path_exists,
@@ -131,13 +129,13 @@ def file_hash(filename):
 
 
 def update_pythran_extension(ext):
-    if not pythran_version:
+    if pythran is None:
         raise RuntimeError("You first need to install Pythran to use the np_pythran directive.")
-    pythran_ext = (
-        pythran.config.make_extension(python=True)
-        if pythran_version >= '0.9' or pythran_version >= '0.8.7'
-        else pythran.config.make_extension()
-    )
+    try:
+        pythran_ext = pythran.config.make_extension(python=True)
+    except TypeError:  # older pythran version only
+        pythran_ext = pythran.config.make_extension()
+
     ext.include_dirs.extend(pythran_ext['include_dirs'])
     ext.extra_compile_args.extend(pythran_ext['extra_compile_args'])
     ext.extra_link_args.extend(pythran_ext['extra_link_args'])
@@ -953,8 +951,9 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
     if 'common_utility_include_dir' in options:
         safe_makedirs(options['common_utility_include_dir'])
 
-    pythran_options = None
-    if pythran_version:
+    if pythran is None:
+        pythran_options = None
+    else:
         pythran_options = CompilationOptions(**options)
         pythran_options.cplus = True
         pythran_options.np_pythran = True

--- a/runtests.py
+++ b/runtests.py
@@ -760,12 +760,10 @@ class TestBuilder(object):
         pythran_dir = self.pythran_dir
         if 'pythran' in tags['tag'] and not pythran_dir and 'cpp' in languages:
             import pythran.config
-            from pythran import __version__ as pythran_version
-            pythran_ext = (
-                pythran.config.make_extension(python=True)
-                if pythran_version >= '0.9' or pythran_version >= '0.8.7'
-                else pythran.config.make_extension()
-            )
+            try:
+                pythran_ext = pythran.config.make_extension(python=True)
+            except TypeError:  # old pythran version syntax
+                pythran_ext = pythran.config.make_extension()
             pythran_dir = pythran_ext['include_dirs'][0]
 
         preparse_list = tags.get('preparse', ['id'])


### PR DESCRIPTION
Current checks breaks when setting 0.10.0 as a Pythran version :-/