### PR TITLE
Positional-only code generation optimization

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3734,10 +3734,10 @@ class DefNodeWrapper(FuncDefNode):
         else:
             # Here we do not accept kw-args but we are passed a non-empty kw-dict.
             # We call ParseOptionalKeywords which will raise an appropriate error if
-            # the kw-args dict passed is non-empty.
+            # the kw-args dict passed is non-empty (which it will be, since kw_unpacking_condition is true)
             code.globalstate.use_utility_code(
                 UtilityCode.load_cached("ParseKeywords", "FunctionArguments.c"))
-            code.putln('if (unlikely(__Pyx_ParseOptionalKeywords(%s, %s, %s, %s, %s, "%s") < 0)) %s' % (
+            code.putln('if (likely(__Pyx_ParseOptionalKeywords(%s, %s, %s, %s, %s, "%s") < 0)) %s' % (
                 Naming.kwds_cname,
                 Naming.pykwdlist_cname,
                 self.starstar_arg and self.starstar_arg.entry.cname or '0',

--- a/tests/run/posonly.pyx
+++ b/tests/run/posonly.pyx
@@ -2,8 +2,6 @@
 # mode: run
 # tag: posonly
 
-# TODO: remove posonly tag before merge
-
 import cython
 import sys
 import pickle
@@ -126,7 +124,7 @@ def test_use_positional_as_keyword3(a, b, /):
     >>> test_use_positional_as_keyword3(1, 2)
     >>> test_use_positional_as_keyword3(a=1, b=2)
     Traceback (most recent call last):
-    TypeError: test_use_positional_as_keyword3() takes no keyword arguments
+    TypeError: test_use_positional_as_keyword3() got an unexpected keyword argument 'a'
     """
 
 def test_positional_only_and_arg_invalid_calls(a, b, /, c):
@@ -266,7 +264,7 @@ class TestPosonlyMethods(object):
     Got type error
     >>> TestPosonlyMethods().f(1, b=2)
     Traceback (most recent call last):
-    TypeError: f() takes no keyword arguments
+    TypeError: f() got an unexpected keyword argument 'b'
     """
     def f(self, a, b, /):
         return a, b
@@ -367,7 +365,7 @@ def test_serialization1(a, b, /):
     (1, 2)
     >>> unpickled_posonly(a=1, b=2)
     Traceback (most recent call last):
-    TypeError: test_serialization1() takes no keyword arguments
+    TypeError: test_serialization1() got an unexpected keyword argument 'a'
     """
     return (a, b)
 
@@ -510,7 +508,8 @@ def f_call_posonly_kwarg(a,/,**kw):
     """
     >>> f_call_posonly_kwarg(1)
     (1, {})
-    >>> f_call_posonly_kwarg(1, b=2, c=3, d=4)==(1, {'b': 2, 'c': 3, 'd': 4})
+    >>> all_args = f_call_posonly_kwarg(1, b=2, c=3, d=4)
+    >>> all_args == (1, {'b': 2, 'c': 3, 'd': 4}) or all_args
     True
     """
     return (a,kw)
@@ -521,9 +520,23 @@ def f_call_posonly_stararg_kwarg(a,/,*args,**kw):
     (1, (), {})
     >>> f_call_posonly_stararg_kwarg(1, 2)
     (1, (2,), {})
-    >>> f_call_posonly_stararg_kwarg(1, b=3, c=4)==(1, (), {'b': 3, 'c': 4})
+    >>> all_args = f_call_posonly_stararg_kwarg(1, b=3, c=4)
+    >>> all_args == (1, (), {'b': 3, 'c': 4}) or all_args
     True
-    >>> f_call_posonly_stararg_kwarg(1, 2, b=3, c=4)==(1, (2,), {'b': 3, 'c': 4})
+    >>> all_args = f_call_posonly_stararg_kwarg(1, 2, b=3, c=4)
+    >>> all_args == (1, (2,), {'b': 3, 'c': 4}) or all_args
     True
     """
     return (a,args,kw)
+
+def test_empty_kwargs(a, b, /):
+    """
+    >>> test_empty_kwargs(1, 2)
+    (1, 2)
+    >>> test_empty_kwargs(1, 2, **{})
+    (1, 2)
+    >>> test_empty_kwargs(1, 2, **{'c': 3})
+    Traceback (most recent call last):
+    TypeError: test_empty_kwargs() got an unexpected keyword argument 'c'
+    """
+    return (a,b)

--- a/tests/run/posonly.pyx
+++ b/tests/run/posonly.pyx
@@ -122,9 +122,9 @@ def test_use_positional_as_keyword2(a, /, b):
 def test_use_positional_as_keyword3(a, b, /):
     """
     >>> test_use_positional_as_keyword3(1, 2)
-    >>> test_use_positional_as_keyword3(a=1, b=2)
+    >>> test_use_positional_as_keyword3(a=1, b=2) # doctest:+ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_use_positional_as_keyword3() got an unexpected keyword argument 'a'
+    TypeError: test_use_positional_as_keyword3() got an unexpected keyword argument '...'
     """
 
 def test_positional_only_and_arg_invalid_calls(a, b, /, c):
@@ -363,9 +363,9 @@ def test_serialization1(a, b, /):
     >>> unpickled_posonly = pickle.loads(pickled_posonly)
     >>> unpickled_posonly(1, 2)
     (1, 2)
-    >>> unpickled_posonly(a=1, b=2)
+    >>> unpickled_posonly(a=1, b=2) # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_serialization1() got an unexpected keyword argument 'a'
+    TypeError: test_serialization1() got an unexpected keyword argument '...'
     """
     return (a, b)
 

--- a/tests/run/posonly.pyx
+++ b/tests/run/posonly.pyx
@@ -540,3 +540,19 @@ def test_empty_kwargs(a, b, /):
     TypeError: test_empty_kwargs() got an unexpected keyword argument 'c'
     """
     return (a,b)
+
+cdef class TestExtensionClass:
+    """
+    >>> t = TestExtensionClass()
+    >>> t.f(1,2)
+    (1, 2, 3)
+    >>> t.f(1,2,4)
+    (1, 2, 4)
+    >>> t.f(1, 2, c=4)
+    (1, 2, 4)
+    >>> t.f(1, 2, 5, c=6)
+    Traceback (most recent call last):
+    TypeError: f() got multiple values for keyword argument 'c'
+    """
+    def f(self, a, b, /, c=3):
+        return (a,b,c)

--- a/tests/run/posonly.pyx
+++ b/tests/run/posonly.pyx
@@ -126,7 +126,7 @@ def test_use_positional_as_keyword3(a, b, /):
     >>> test_use_positional_as_keyword3(1, 2)
     >>> test_use_positional_as_keyword3(a=1, b=2)
     Traceback (most recent call last):
-    TypeError: test_use_positional_as_keyword3() takes exactly 2 positional arguments (0 given)
+    TypeError: test_use_positional_as_keyword3() takes no keyword arguments
     """
 
 def test_positional_only_and_arg_invalid_calls(a, b, /, c):
@@ -266,7 +266,7 @@ class TestPosonlyMethods(object):
     Got type error
     >>> TestPosonlyMethods().f(1, b=2)
     Traceback (most recent call last):
-    TypeError: f() takes exactly 3 positional arguments (2 given)
+    TypeError: f() takes no keyword arguments
     """
     def f(self, a, b, /):
         return a, b
@@ -367,7 +367,7 @@ def test_serialization1(a, b, /):
     (1, 2)
     >>> unpickled_posonly(a=1, b=2)
     Traceback (most recent call last):
-    TypeError: test_serialization1() takes exactly 2 positional arguments (0 given)
+    TypeError: test_serialization1() takes no keyword arguments
     """
     return (a, b)
 
@@ -496,3 +496,34 @@ def f_call_one_optional_kwd(a,/,*,b=2):
     (1, 3)
     """
     return (a,b)
+
+def f_call_posonly_stararg(a,/,*args):
+    """
+    >>> f_call_posonly_stararg(1)
+    (1, ())
+    >>> f_call_posonly_stararg(1, 2, 3, 4)
+    (1, (2, 3, 4))
+    """
+    return (a,args)
+
+def f_call_posonly_kwarg(a,/,**kw):
+    """
+    >>> f_call_posonly_kwarg(1)
+    (1, {})
+    >>> f_call_posonly_kwarg(1, b=2, c=3, d=4)==(1, {'b': 2, 'c': 3, 'd': 4})
+    True
+    """
+    return (a,kw)
+
+def f_call_posonly_stararg_kwarg(a,/,*args,**kw):
+    """
+    >>> f_call_posonly_stararg_kwarg(1)
+    (1, (), {})
+    >>> f_call_posonly_stararg_kwarg(1, 2)
+    (1, (2,), {})
+    >>> f_call_posonly_stararg_kwarg(1, b=3, c=4)==(1, (), {'b': 3, 'c': 4})
+    True
+    >>> f_call_posonly_stararg_kwarg(1, 2, b=3, c=4)==(1, (2,), {'b': 3, 'c': 4})
+    True
+    """
+    return (a,args,kw)


### PR DESCRIPTION
This addresses the suggestions from the comments in #2927.  There are two changes:
1. whenever a function has only positional-only arguments and no **arg, no keyword unpacking code is generated, and instead an error is raised,
2. if a function takes `n` positional-only args and `m` not-positional-only args, then the check that at least `n` positional args have been passed occurs in the very first switch statement.  The subsequent switch statements then exclude the cases `<n`,

As a concrete example of (1), here is the code generated for a signature like `test1(a, b, /)`:
```
    PyObject* values[2] = {0,0};
    if (unlikely(__pyx_kwds)) {
      PyErr_Format(PyExc_TypeError, "test1() takes no keyword arguments");
      __PYX_ERR(0, 2, __pyx_L3_error)
    } else if (PyTuple_GET_SIZE(__pyx_args) != 2) {
      goto __pyx_L5_argtuple_error;
    } else {
      values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
      values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
    }
    __pyx_v_a = values[0];
    __pyx_v_b = values[1];
```

For (2), here is the start of the code generated for `test2(a, b, /, c, d)`:

```
    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_c,&__pyx_n_s_d,0};
    PyObject* values[4] = {0,0,0,0};
    if (unlikely(__pyx_kwds)) {
      Py_ssize_t kw_args;
      const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
      switch (pos_args) {
        case  4: values[3] = PyTuple_GET_ITEM(__pyx_args, 3);
        CYTHON_FALLTHROUGH;
        case  3: values[2] = PyTuple_GET_ITEM(__pyx_args, 2);
        CYTHON_FALLTHROUGH;
        case  2: values[1] = PyTuple_GET_ITEM(__pyx_args, 1);
        values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
        break;
        case  1: CYTHON_FALLTHROUGH;
        case  0:
        goto __pyx_L5_argtuple_error;
        default: goto __pyx_L5_argtuple_error;
      }
      kw_args = PyDict_Size(__pyx_kwds);
      switch (pos_args) {
        case  2:
        ...
        CYTHON_FALLTHROUGH;
        case  3:
        ...
      }
      if (unlikely(kw_args > 0)) {
      ...

```

Note that the error message raised in (1) is `test1() takes no keyword arguments`.  This is copied from the error raised when keyword arguments are passed to a non-`METH_KWARGS` function.  CPython's error messages are different: `test1() got an unexpected keyword argument 'c'`.  If we want to match this, I can also generate code to extract the name of one of the passed keywords.  

Another difference to the CPython behaviour:  say we have `def f(a,b,/):`.  If we call `f(a=1)` in the Cython implementation we get `f() takes no keyword arguments`.  In CPython we get ` f() got some positional-only arguments passed as keyword arguments: 'a'`.  This error is thrown before even checking that the correct number of positional arguments is passed.  So to replicate this behaviour we'd need to check the names of the passed keyword arguments against the names of positional-only arguments at the very beginning of argument parsing.  Seems like too big a performance hit, but I'm not sure how important it is to try to exactly replicate the CPython errors.

