### PR TITLE
Cppclass defining improvements

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6949,6 +6949,8 @@ class AttributeNode(ExprNode):
                         ubcm_entry.func_cname = entry.func_cname
                         ubcm_entry.is_unbound_cmethod = 1
                         ubcm_entry.scope = entry.scope
+                        if type.is_cpp_class:
+                            ubcm_entry.overloaded_alternatives = [Symtab.Entry(entry.name, entry.func_cname, entry.type) for entry in entry.overloaded_alternatives]
                     return self.as_name_node(env, ubcm_entry, target=False)
             elif type.is_enum:
                 if self.attribute in type.values:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -831,7 +831,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_typedef(self, entry, code):
         base_type = entry.type.typedef_base_type
-        if base_type.is_numeric:
+        enclosing_scope = entry.scope
+        if base_type.is_numeric and not enclosing_scope.is_cpp_class_scope:
             try:
                 writer = code.globalstate['numeric_typedefs']
             except KeyError:
@@ -909,6 +910,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     [base_class.empty_declaration_code() for base_class in type.base_classes])
                 code.put(" : public %s" % base_class_decl)
             code.putln(" {")
+            self.generate_type_header_code(scope.type_entries, code)
             py_attrs = [e for e in scope.entries.values()
                         if e.type.is_pyobject and not e.is_inherited]
             has_virtual_methods = False

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5775,7 +5775,7 @@ class InPlaceAssignmentNode(AssignmentNode):
 
     def create_binop_node(self):
         from . import ExprNodes
-        return ExprNodes.binop_node(self.pos, self.operator, self.lhs, self.rhs)
+        return ExprNodes.binop_node(self.pos, self.operator, self.lhs, self.rhs, inplace=True)
 
 
 class PrintStatNode(StatNode):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1509,6 +1509,9 @@ class CppClassNode(CStructOrUnionDefNode, BlockNode):
                 elif isinstance(attr, CompilerDirectivesNode):
                     for sub_attr in func_attributes(attr.body.stats):
                         yield sub_attr
+                elif isinstance(attr, CppClassNode):
+                    for sub_attr in func_attributes(attr.attributes):
+                        yield sub_attr
         if self.attributes is not None:
             if self.in_pxd and not env.in_cinclude:
                 self.entry.defined_in_pxd = 1

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3782,6 +3782,7 @@ def p_cpp_class_definition(s, pos,  ctx):
         s.next()
         s.expect('NEWLINE')
         s.expect_indent()
+        doc = p_doc_string(s)
         attributes = []
         body_ctx = Ctx(visibility = ctx.visibility, level='cpp_class', nogil=nogil or ctx.nogil)
         body_ctx.templates = template_names

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3795,9 +3795,10 @@ class CppClassType(CType):
     def is_subclass(self, other_type):
         if self.same_as_resolved_type(other_type):
             return 1
-        for base_class in self.base_classes:
-            if base_class.is_subclass(other_type):
-                return 1
+        if self.base_classes:
+            for base_class in self.base_classes:
+                if base_class.is_subclass(other_type):
+                    return 1
         return 0
 
     def set_scope(self, scope):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3800,6 +3800,11 @@ class CppClassType(CType):
                 return 1
         return 0
 
+    def set_scope(self, scope):
+        self.scope = scope
+        if scope:
+            scope.parent_type = self
+
     def subclass_dist(self, super_type):
         if self.same_as_resolved_type(super_type):
             return 0

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -613,7 +613,7 @@ class Scope(object):
                 warning(pos, "'%s' already defined  (ignoring second definition)" % name, 0)
             else:
                 if scope:
-                    entry.type.scope = scope
+                    entry.type.set_scope(scope)
                     self.type_entries.append(entry)
             if base_classes:
                 if entry.type.base_classes and entry.type.base_classes != base_classes:
@@ -636,6 +636,7 @@ class Scope(object):
                     declare_inherited_attributes(entry, base_class.base_classes)
                     entry.type.scope.declare_inherited_cpp_attributes(base_class)
         if scope:
+            entry.type.set_scope(scope)
             declare_inherited_attributes(entry, base_classes)
             scope.declare_var(name="this", cname="this", type=PyrexTypes.CPtrType(entry.type), pos=entry.pos)
         if self.is_cpp_class_scope:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2419,6 +2419,7 @@ class CppClassScope(Scope):
         else:
             entry = self.declare(name, cname, type, pos, visibility)
         entry.is_variable = 1
+        entry.is_cfunction = type.is_cfunction
         if type.is_cfunction and self.type:
             if not self.type.get_fused_types():
                 entry.func_cname = "%s::%s" % (self.type.empty_declaration_code(), cname)
@@ -2488,6 +2489,7 @@ class CppClassScope(Scope):
                     base_entry.type, None, 'extern')
                 entry.is_variable = 1
                 entry.is_inherited = 1
+                entry.is_cfunction = base_entry.is_cfunction
                 self.inherited_var_entries.append(entry)
         for base_entry in base_scope.cfunc_entries:
             entry = self.declare_cfunction(base_entry.name, base_entry.type,

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2490,6 +2490,8 @@ class CppClassScope(Scope):
                 entry.is_variable = 1
                 entry.is_inherited = 1
                 entry.is_cfunction = base_entry.is_cfunction
+                if entry.is_cfunction:
+                    entry.func_cname = base_entry.func_cname
                 self.inherited_var_entries.append(entry)
         for base_entry in base_scope.cfunc_entries:
             entry = self.declare_cfunction(base_entry.name, base_entry.type,

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2528,6 +2528,13 @@ class CppClassScope(Scope):
 
         return scope
 
+    def lookup_here(self, name):
+        if name == "__init__":
+            name = "<init>"
+        elif name == "__dealloc__":
+            name = "<del>"
+        return super(CppClassScope, self).lookup_here(name)
+
 
 class PropertyScope(Scope):
     #  Scope holding the __get__, __set__ and __del__ methods for

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2406,6 +2406,7 @@ class CppClassScope(Scope):
         Scope.__init__(self, name, outer_scope, None)
         self.directives = outer_scope.directives
         self.inherited_var_entries = []
+        self.inherited_type_entries = []
         if templates is not None:
             for T in templates:
                 template_entry = self.declare(
@@ -2514,12 +2515,13 @@ class CppClassScope(Scope):
                                            modifiers=base_entry.func_modifiers,
                                            utility_code=base_entry.utility_code)
             entry.is_inherited = 1
-        for base_entry in base_scope.type_entries:
+        for base_entry in base_scope.type_entries + base_scope.inherited_type_entries:
             if base_entry.name not in base_templates:
                 entry = self.declare_type(base_entry.name, base_entry.type,
                                           base_entry.pos, base_entry.cname,
-                                          base_entry.visibility)
+                                          base_entry.visibility, defining=0)
                 entry.is_inherited = 1
+                self.inherited_type_entries.append(entry)
 
     def specialize(self, values, type_entry):
         scope = CppClassScope(self.name, self.outer_scope)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2433,7 +2433,7 @@ class CppClassScope(Scope):
         if name in (class_name, '__init__') and cname is None:
             cname = "%s__init__%s" % (Naming.func_prefix, class_name)
             name = '<init>'
-            type.return_type = PyrexTypes.CVoidType()
+            type.return_type = PyrexTypes.c_void_type
             # This is called by the actual constructor, but need to support
             # arguments that cannot by called by value.
             type.original_args = type.args
@@ -2447,7 +2447,7 @@ class CppClassScope(Scope):
         elif name == '__dealloc__' and cname is None:
             cname = "%s__dealloc__%s" % (Naming.func_prefix, class_name)
             name = '<del>'
-            type.return_type = PyrexTypes.CVoidType()
+            type.return_type = PyrexTypes.c_void_type
         if name in ('<init>', '<del>') and type.nogil:
             for base in self.type.base_classes:
                 base_entry = base.scope.lookup(name)

--- a/tests/errors/cpp_no_constructor.pyx
+++ b/tests/errors/cpp_no_constructor.pyx
@@ -9,5 +9,5 @@ cdef extern from *:
 new Foo(1, 2)
 
 _ERRORS = u"""
-9:7: Call with wrong number of arguments (expected 1, got 2)
+9:7: Call with wrong number of arguments (expected 0, got 2)
 """

--- a/tests/run/cpp_classes_def.pyx
+++ b/tests/run/cpp_classes_def.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror, cpp11
+# tag: cpp, cpp11
 # cython: experimental_cpp_class_def=True
 
 cdef double pi
@@ -249,3 +249,7 @@ def test_uncopyable_constructor_argument():
     cdef UncopyableConstructorArgument *c = new UncopyableConstructorArgument(
         unique_ptr[vector[int]](new vector[int]()))
     del c
+
+_WARNINGS="""
+23:4: Unraisable exception in function 'RegularPolygon.area'.
+"""

--- a/tests/run/cpp_method_overloading.pyx
+++ b/tests/run/cpp_method_overloading.pyx
@@ -1,0 +1,77 @@
+# mode: run
+# tag: cpp
+
+cdef extern from "cpp_method_overloading_support.h":
+    cdef cppclass Base:
+        __init__()
+        __init__(int a)
+        int foo(double)
+        int foo(double*)
+
+cdef cppclass Derived(Base):
+    pass
+
+cdef cppclass DefinedBase:
+    int state
+
+    __init__():
+        # If we skip this one, inheritance won't work because of the
+        # derived class constructor implicitely calling default constructor
+        this.__init__(0)
+
+    __init__(int a):
+        this.state = a
+
+    int getter():
+        return this.state
+
+    void setter(int a):
+        this.state = a
+
+    void setter(int* a):
+        if a != NULL:
+            this.state = a[0]
+
+cdef cppclass DefinedDerived(DefinedBase):
+    __init__(int a):
+        DefinedBase.__init__(a)
+
+def testDeclared():
+    """
+    >>> testDeclared()
+    4 3
+    """
+    #pass
+    cdef double a = 4.2
+    cdef double *b = &a
+    cdef Derived d
+    rst_a = d.foo(a)
+    rst_b = d.foo(b)
+    print rst_a, rst_b
+
+def testDefined():
+    """
+    >>> testDefined()
+    24 42 42
+    """
+
+    dd = new DefinedDerived(24)
+
+    dorig = dd.getter()
+
+    cdef int val = 42
+
+    dd.setter(val)
+
+    dstate = dd.getter()
+    # dstate should be 42
+
+    da_addr = &dstate
+
+    dd.setter(da_addr)
+
+    # dstate2 should be 42
+    dstate2 = dd.getter()
+
+    print dorig, dstate, dstate2
+    del dd

--- a/tests/run/cpp_method_overloading_support.h
+++ b/tests/run/cpp_method_overloading_support.h
@@ -1,0 +1,9 @@
+class Base {
+public:
+    int foo(double a) {
+        return (int) (a+0.5);
+    }
+    int foo(double* a) {
+      return (int) (*a+0.5) - 1;
+    }
+};

--- a/tests/run/cpp_nested_classes.pyx
+++ b/tests/run/cpp_nested_classes.pyx
@@ -25,6 +25,20 @@ cdef extern from "cpp_nested_classes_support.h":
     cdef cppclass SpecializedTypedClass(TypedClass[double]):
         pass
 
+cdef cppclass AA:
+    cppclass BB:
+        int square(int x):
+            return x * x
+        cppclass CC:
+            int cube(int x):
+                return x * x * x
+    BB* createB():
+        return new BB()
+    ctypedef int my_int
+    @staticmethod
+    my_int negate(my_int x):
+        return -x
+
 
 def test_nested_classes():
     """
@@ -40,7 +54,28 @@ def test_nested_classes():
     assert b_ptr.square(4) == 16
     del b_ptr
 
+def test_nested_defined_classes():
+    """
+    >>> test_nested_defined_classes()
+    """
+    cdef AA a
+    cdef AA.BB b
+    assert b.square(3) == 9
+    cdef AA.BB.CC c
+    assert c.cube(3) == 27
+
+    cdef AA.BB *b_ptr = a.createB()
+    assert b_ptr.square(4) == 16
+    del b_ptr
+
 def test_nested_typedef(py_x):
+    """
+    >>> test_nested_typedef(5)
+    """
+    cdef A.my_int x = py_x
+    assert A.negate(x) == -py_x
+
+def test_nested_defined_typedef(py_x):
     """
     >>> test_nested_typedef(5)
     """


### PR DESCRIPTION
# What it this about

This patch is about fixing and extending some stuff in the C++ support of Cython.
Basically the goal is to improve code definition within a C++ class, to be able to write C++ classes entirely in Cython, not only wrap them.

This patch comes from my current internship at Nexedi, where my goal is to extend Cython to have the possibility to do OOP in a efficient multithreaded context with memory management.
As we can't rely on Python class for that purpose (because of the GIL in CPython), we've choosen the path of C++ class to do the current implementation.
The memory management of this new type of class is done by an atomic refcount, so it's really basic, but, still, it frees the user from manual memory (de)allocation.

This patch is not about this memory managed class. It's a collection of changes I have made while wandering in the C++ class Cython code, trying to make my new type of class work.
So this patch is only about the cppclass system that exists within Cython.
I expect the only blocker would be technical misunderstanding from my part, which lead me to write things that shouldn't have been written.

I will release (hopefully) soon another patch (based on this one), which is the extension of Cython with the above-mentioned memory managed class.
You may reject it for technical reasons, as well as for some sort of "we just don't want to maintain/integrate this into mainline Cython", which would be perfectly acceptable.

This patch contains four parts sorted like the description order below.

The first batch is quite messy as it contains a mix between "perceived non-controversial changes" (because it's not feature but pure bugfix, and small ones) and small features necessary for the rest above to work.

1.a is the most "perceived controversial" commit among them for me, that's why it's the first one: to make you shout if you're unhappy with it.

## 1 - Various small fixes (a useful and crystal-clear name right ?)
a) Be able to call `__init__` and `__dealloc__` in user code
b) Allow docstrings for cppclass (syntactic sugar, it is discarded like comments during code generation)
c) Make CppClassScope holds parent_type like CClassScope
d) Fix is_subclass in the case of an empty base_class attribute
e) Fix void return types for `__init__` and `__dealloc__`
f) Fix some entry attributes: `is_cfunction` and `func_cname`
g) Make `InPlaceAssignmentNode` effectively produce a `BinopNode` with the inplace flag set

## 2 - Overloaded methods
The goal here is to be able to define (and not just declare) methods in CppClass that can be overloaded.
I will now take some time to explain why the current implementation cannot do this, and why I think the approach proposed in my commits is a not-so-bad one.

TL;DR: The current code doesn't allow clean method inheritance.

In the current implementation of `CClassScope`, when we declare a cfunction, we check for the presence
of an entry with the same name, and if this is the case, we shout if the function signature is different or if the entry is already defined.
So we cannot have declaration and/or definition of different function types with the same name.
You can declare then define a function, as it's the same function signature, so everything is fine.

In the current implementation of `CppClassScope`, when we declare a cfunction, we check for the presence of an entry with the same name and if we try to define, not just declare, the new entry.
If this is the case, we update the type if the signatures (function types) are compatible, else we shout.
In any other cases (no previous entry or new entry is just declared, not defined), override the entry.
This checks are performed in `CppClassScope.declare_var`. This also explains why the cpp methods are in the `var_entries` array.
Polymorphism is usable because in `CppClassScope.declare_cfunction` (which calls the above-mentioned `declare_var`), we link the previously declared entries to the new one if we're just declaring the entry, not defining it.
Moreover, in this `declare_cfunction`, we never touch `cfunc_entries`. This explains why this array is always empty in a `CppClassScope`.
For a classic (non-special) method, the flow is:
CppClassScope.declare_cfunction (will link the alternatives to have polymorphism)
----> calls CppClassScope.declare_var (make the checks, if we create a new entry, add it to var_entries)
-----------> calls Scope.declare (blindly create and override the entry in the entries dict)

Wrapping C++ class is possible, because we fall into the "override the entry" clause (we never define an entry).

A real issue is method inheritance.
When inheriting methods with the same name, only one is kept because of the continuous override in `Scope.declare`.
The kept method will be, in my current understanding of the code, the last (in the base) upper (not deep in the inheritance chain: the "parenthesied" bases, not base of base) right-most (in the parenthesis) base method with this name:
```
cdef cppclass Base1:
    int method(int a)

cdef cppclass Base2:
    int method(double a)

cdef cppclass HiddenBase:
    int method(double b, double b)

cdef cppclass Base3(HiddenBase):
    int method(double b, int a)
    int method(int a, double b) # <=== This one will be the only method kept in Derived by inheritance

cdef cppclass Derived(Base1, Base2, Base3):
    pass
    # The only method Derived is aware of is Base3.method(int, double), the other ones were (sadly) lost in the process
```
So we may have lost a lot of alternatives.
This is exactly what is described in issue #1357.

The proposed approach deals with the alternative management directly in `Scope.declare`.
The behaviour is quite simple: we scan the previous alternatives for a compatible function signature.
If there is a match and the previous method is marked as inherited (or the default init), we override it.
If there is a match and it's not an inherited method, shout.
If there is no match, add the new entry to the alternatives.

This involves six changes:
a) Change `Symtab.declare` logic for cppclass methods: the `overloaded_entry` array is properly managed in this code (the switch from is_cpp to is_cpp_class_scope is intentional: it restricts this overloading to cppclass, otherwise it is available to everything when cython produces c++ code)
b) Change the `declare_var` and `declare_cfunction` in CppClassScope to use the previous changes
c) Add the `overloaded_alternative` array to ubcm_entry created with a Type.method() statement
d) Amend a test case (cpp_no_constructor) because the error message is not the same:
Below is a long text explaining why this is not a stupid idea to modify this test.
Beware, there is e) and f) change sets under it.

TL;DR: Method alternatives order in the entries corresponds to the declaration order. Before the patch, the alternatives order corresponded to reversed declaration order.

`PyrexTypes.best_match` shouts when it does not find a suitable alternative.
When doing so, it uses the "principal alternative" as a reference.
Principal alternative here refers to the entry which is in `entries[name]` in the type scope.
The other ones are held in the `overloaded_alternatives` array of this principal alternative.

Before the a) change set, alternatives in a `CppClassScope` are always overridden, and it is the duty
of `CppClassScope.declare_cfunction` to fill the `overloaded_alternative` array of the newly created alternative.
So the principal alternative is always changing, and the last alternative declared will effectively be the principal one.
Consequently, when `PyrexTypes.best_match` shouts, it uses the last declared alternative as a reference (for argument number and such).

After the a and b change set, `Scope.declare` takes care of the alternatives, and overrides an alternative in a `CppClassScope` only if it is an inherited one with the same signature as the new one. As the signature is the same, each info used by `PyrexTypes.best_match` when shouting doesn't change between old overridden alternative and new one.
Consequently, a signature represented by an alternative never change position: if it is carried by the principal alternative, it will always be carried by the principal one, therefore `PyrexTypes.best_match`, when taking the principal alternative as a reference, is effectively taking the first defined alternative as reference.

As `cpp_no_constructor` is an error test about failing to find the correct alternative, it expects `PyrexTypes.best_match` to shout.
The expected string refers to the last (2nd / 2 defined alternatives) alternative, whereas with a & b changes, it should refer to the first alternative, because that's what is expected.

This commit does this.

e) Amend a test case (cpp_classes_def) because one warning must stand:
It is, again, a long text explaining why I'm not mad.

TL;DR: The test module lacked a _WARNINGS variable to catch the RegularPolygon.area warning since the beginning. It's just that it wasn't noticeable before.

In `cpp_classes_def` (in the tests/run directory), we have some defined method (area) in a class (RegularPolygon) which has no exception indication, but is performing a division.
Consequently, a divide-by-zero check is performed, and we should, theorically, raise an exception if the check is true.
As there is no except indication on this method, we have a compile-time warning : Unraisable exception in function 'RegularPolygon.area'.
This is not a bug, it's a feature.

So we should have a warning from cython when compiling this test module. A warning that should be reported when running the test suite.
With the a) & b) changes in Symtab, this is what's happening.
This wasn't before, and the reason is quite tricky.

`RegularPolygon` has a base class, `Shape`, which is declared as 'extern'. Shape has the `area` method.
So, RegularPolygon inherits area from Shape before overloading it.
`Shape.area` and `RegularPolygon.area` have exactly the same signature.
In `CppClassScope.declare_var`, we are in the following situation: previous entry and defining.
This leads to:
*We update the type if the signatures (function types) are compatible, else we shout*
As types are compatible, we just modify the entry type, keeping the inherited entry for all other attributes.
The side effect is that we didn't change `entry.pos`. An inherited entry has a pos equal to None, because the corresponding attribute is declared nowhere in the subclass body.

Consequently, when making the warning, the entry has no pos therefore it is discarded by the test suite when trying to match actual warnings from expected ones.

This commit adds the warning from RegularPolygon.area to the expected warnings. It also removes werror to the tags, since this warning is not a runtime blocker.

f) Provide test for the feature (which is failing on the current master as it is related to issue #1357)

## 3 - Cppclass generation fixes
a) Allow defined (not wrapped) cppclass to have multiple constructors
This fixes cppclass generation. With the above code everything is there to handle overloaded constructors.
This is about generating the correct C++ code when we're not wrapping an external cppclass, but defining it in cython.

## 4 - Nested classes
This is not about wrapping nested C++ classes, because it is already present and functional (and there's a test which can prove it).
This is about being able to generate C++ classes definitions with nested classes. So it is exactly like the batch about method overloading: being able to define and not just declare.
If I have understood it properly, this addresses issue #1218

a) Make cppclass generate code for nested definitions (for example nested cppclass)
b) Fix Symtab for the inherited nested types: this is basically the same thing than for other attributes, have a separate "inherited types" array, to be able to have them in scope but ignore them during code generation.
c) Amend the nested classes test