### PR TITLE
MemoryView slicing contiguity bugfix

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4722,8 +4722,17 @@ class MemoryCopyScalar(MemoryCopyNode):
             code.putln("%s __pyx_temp_slice = %s;" % (slice_decl, self.dst.result()))
             dst_temp = "__pyx_temp_slice"
 
+        force_strided = False
+        indices = self.dst.original_indices
+        for idx in indices:
+            if isinstance(idx, SliceNode) and not (idx.start.is_none and
+                                                   idx.stop.is_none and
+                                                   idx.step.is_none):
+                force_strided = True
+                
         slice_iter_obj = MemoryView.slice_iter(self.dst.type, dst_temp,
-                                               self.dst.type.ndim, code)
+                                               self.dst.type.ndim, code,
+                                               force_strided=force_strided)
         p = slice_iter_obj.start_loops()
 
         if dtype.is_pyobject:

--- a/Cython/Compiler/MemoryView.py
+++ b/Cython/Compiler/MemoryView.py
@@ -402,8 +402,8 @@ def get_is_contig_utility(contig_type, ndim):
     return utility
 
 
-def slice_iter(slice_type, slice_result, ndim, code):
-    if slice_type.is_c_contig or slice_type.is_f_contig:
+def slice_iter(slice_type, slice_result, ndim, code, force_strided=False):
+    if (slice_type.is_c_contig or slice_type.is_f_contig) and not force_strided:
         return ContigSliceIter(slice_type, slice_result, ndim, code)
     else:
         return StridedSliceIter(slice_type, slice_result, ndim, code)

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2252,7 +2252,9 @@ def test_contig_scalar_to_slice_assignment():
     """
     >>> test_contig_scalar_to_slice_assignment()
     14 14 14 14
+    30 14 30 14
     20 20 20 20
+    30 30 20 20
     """
     cdef int[5][10] a
     cdef int[:, ::1] m = a
@@ -2260,8 +2262,14 @@ def test_contig_scalar_to_slice_assignment():
     m[...] = 14
     print m[0, 0], m[-1, -1], m[3, 2], m[4, 9]
 
+    m[:, :1] = 30
+    print m[0, 0], m[0, 1], m[1, 0], m[1, 1]
+
     m[:, :] = 20
     print m[0, 0], m[-1, -1], m[3, 2], m[4, 9]
+
+    m[:1, :] = 30
+    print m[0, 0], m[0, 1], m[1, 0], m[1, 1]
 
 @testcase
 def test_dtype_object_scalar_assignment():


### PR DESCRIPTION
This addresses #2941.  The MemoryView scalar assignment code currently generates a stride 1 (ie. contiguous) loop whenever the destination of the slice is contiguous, regardless of the slice.  This isn't quite right, since slices of contiguous arrays of course aren't necessarily contiguous.  This patch just adds a check: if any of the indices of the slice is not simply `:`, then do not assume contiguity (these slices are referred to as "ToughSlices" elsewhere in the code).

One can do better than this, ie. if for a C-contiguous array the slice `a[1][:]` is contiguous, so the old generated code is correct and the new generated code is a little slower.  Not ideal, and maybe is worth adding logic to detect these cases, but this seems a reasonable first-pass fix.