### PR TITLE
TEST: add cpp attribute example from docs, add CYTHON_PROJECT_DIR for tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2013,8 +2013,7 @@ def main():
     global DISTDIR, WITH_CYTHON
 
     # Set an environment variable to the top directory
-    CYTHON_PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
-    os.environ['CYTHON_PROJECT_DIR'] = CYTHON_PROJECT_DIR
+    os.environ['CYTHON_PROJECT_DIR'] = os.path.abspath(os.path.dirname(__file__))
 
     DISTDIR = os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]))
 

--- a/runtests.py
+++ b/runtests.py
@@ -2011,6 +2011,11 @@ def flush_and_terminate(status):
 def main():
 
     global DISTDIR, WITH_CYTHON
+
+    # Set an environment variable to the top directory
+    CYTHON_PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
+    os.environ['CYTHON_PROJECT_DIR'] = CYTHON_PROJECT_DIR
+
     DISTDIR = os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]))
 
     from Cython.Compiler import DebugFlags

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -8,14 +8,11 @@ PYTHON -c "import runner"
 from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 import os
-import pprint
 
-CYTHON_PROJECT_DIR = os.environ['CYTHON_PROJECT_DIR']
-example_dir = os.path.abspath(os.path.join(CYTHON_PROJECT_DIR,
+example_dir = os.path.abspath(os.path.join(os.environ['CYTHON_PROJECT_DIR'],
                               'docs/examples/userguide/wrapping_CPlusPlus'))
 
 ext_modules= cythonize("rect.pyx", include_path=[example_dir])
-ext_modules[0].include_dirs.append(example_dir)
 setup(ext_modules=ext_modules)
 
 ######## rect.pyx ########

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -1,0 +1,78 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import runner"
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+import os
+
+examples = '../../../docs/examples/userguide/wrapping_CPlusPlus'
+
+ext_modules= cythonize("rect.pyx", include_path=[examples]) 
+ext_modules[0].include_dirs.append(examples)
+setup(ext_modules=ext_modules)
+
+######## rect.pyx ########
+
+# distutils: language = c++
+
+cimport Rectangle
+
+cdef class PyRectangle:
+    cdef Rectangle.Rectangle c_rect
+
+    def __cinit__(self, int x0, int y0, int x1, int y1):
+        self.c_rect = Rectangle.Rectangle(x0, y0, x1, y1)
+
+    def get_area(self):
+        return self.c_rect.getArea()
+
+    def get_size(self):
+        cdef int width, height
+        self.c_rect.getSize(&width, &height)
+        return width, height
+
+    def move(self, dx, dy):
+        self.c_rect.move(dx, dy)
+
+    # Attribute access
+    @property
+    def x0(self):
+        return self.c_rect.x0
+    @x0.setter
+    def x0(self, x0):
+        self.c_rect.x0 = x0
+
+    # Attribute access
+    @property
+    def x1(self):
+        return self.c_rect.x1
+    @x1.setter
+    def x1(self, x1):
+        self.c_rect.x1 = x1
+
+    # Attribute access
+    @property
+    def y0(self):
+        return self.c_rect.y0
+    @y0.setter
+    def y0(self, y0):
+        self.c_rect.y0 = y0
+
+    # Attribute access
+    @property
+    def y1(self):
+        return self.c_rect.y1
+    @y1.setter
+    def y1(self, y1):
+        self.c_rect.y1 = y1
+
+######## runner.py ########
+
+import rect
+
+x0, y0, x1, y1 = 1, 2, 3, 4
+rect_obj = rect.PyRectangle(x0, y0, x1, y1)
+
+assert rect_obj.x0 == x0

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -6,8 +6,11 @@ PYTHON -c "import runner"
 from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 import os
+import pprint
 
 CYTHON_PROJECT_DIR = os.environ['CYTHON_PROJECT_DIR']
+print('CYTHON_PROJECT_DIR', CYTHON_PROJECT_DIR)
+print(pprint.pprint(os.listdir(CYTHON_PROJECT_DIR)))
 example_dir = os.path.abspath(os.path.join(CYTHON_PROJECT_DIR,
                               'docs/examples/userguide/wrapping_CPlusPlus'))
 

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -7,7 +7,8 @@ from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 import os
 
-examples = '../../../docs/examples/userguide/wrapping_CPlusPlus'
+examples = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                 '../../../docs/examples/userguide/wrapping_CPlusPlus'))
 
 ext_modules= cythonize("rect.pyx", include_path=[examples]) 
 ext_modules[0].include_dirs.append(examples)

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -12,69 +12,15 @@ import os
 example_dir = os.path.abspath(os.path.join(os.environ['CYTHON_PROJECT_DIR'],
                               'docs/examples/userguide/wrapping_CPlusPlus'))
 
-ext_modules= cythonize("rect.pyx", include_path=[example_dir])
+ext_modules= cythonize(os.path.join(example_dir, "rect_with_attributes.pyx"),
+                       include_path=[example_dir])
 setup(ext_modules=ext_modules)
-
-######## rect.pyx ########
-
-# distutils: language = c++
-
-cimport Rectangle
-
-cdef class PyRectangle:
-    cdef Rectangle.Rectangle c_rect
-
-    def __cinit__(self, int x0, int y0, int x1, int y1):
-        self.c_rect = Rectangle.Rectangle(x0, y0, x1, y1)
-
-    def get_area(self):
-        return self.c_rect.getArea()
-
-    def get_size(self):
-        cdef int width, height
-        self.c_rect.getSize(&width, &height)
-        return width, height
-
-    def move(self, dx, dy):
-        self.c_rect.move(dx, dy)
-
-    # Attribute access
-    @property
-    def x0(self):
-        return self.c_rect.x0
-    @x0.setter
-    def x0(self, x0):
-        self.c_rect.x0 = x0
-
-    # Attribute access
-    @property
-    def x1(self):
-        return self.c_rect.x1
-    @x1.setter
-    def x1(self, x1):
-        self.c_rect.x1 = x1
-
-    # Attribute access
-    @property
-    def y0(self):
-        return self.c_rect.y0
-    @y0.setter
-    def y0(self, y0):
-        self.c_rect.y0 = y0
-
-    # Attribute access
-    @property
-    def y1(self):
-        return self.c_rect.y1
-    @y1.setter
-    def y1(self, y1):
-        self.c_rect.y1 = y1
 
 ######## runner.py ########
 
-import rect
+import rect_with_attributes
 
 x0, y0, x1, y1 = 1, 2, 3, 4
-rect_obj = rect.PyRectangle(x0, y0, x1, y1)
+rect_obj = rect_with_attributes.PyRectangle(x0, y0, x1, y1)
 
 assert rect_obj.x0 == x0

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -7,11 +7,12 @@ from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 import os
 
-examples = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                 '../../../docs/examples/userguide/wrapping_CPlusPlus'))
+CYTHON_PROJECT_DIR = os.environ['CYTHON_PROJECT_DIR']
+example_dir = os.path.abspath(os.path.join(CYTHON_PROJECT_DIR,
+                              'docs/examples/userguide/wrapping_CPlusPlus'))
 
-ext_modules= cythonize("rect.pyx", include_path=[examples]) 
-ext_modules[0].include_dirs.append(examples)
+ext_modules= cythonize("rect.pyx", include_path=[example_dir])
+ext_modules[0].include_dirs.append(example_dir)
 setup(ext_modules=ext_modules)
 
 ######## rect.pyx ########

--- a/tests/run/cpp_class_attrib.srctree
+++ b/tests/run/cpp_class_attrib.srctree
@@ -1,3 +1,5 @@
+# tag: cpp
+
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import runner"
 
@@ -9,8 +11,6 @@ import os
 import pprint
 
 CYTHON_PROJECT_DIR = os.environ['CYTHON_PROJECT_DIR']
-print('CYTHON_PROJECT_DIR', CYTHON_PROJECT_DIR)
-print(pprint.pprint(os.listdir(CYTHON_PROJECT_DIR)))
 example_dir = os.path.abspath(os.path.join(CYTHON_PROJECT_DIR,
                               'docs/examples/userguide/wrapping_CPlusPlus'))
 


### PR DESCRIPTION
Add a test of attribute decorators from the [docs](http://docs.cython.org/en/latest/src/userguide/wrapping_CPlusPlus.html) to exercise the attribute getter/setter decorators