### PR TITLE
Fix compile error with 3.8

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -381,8 +381,13 @@ class __Pyx_FakeReference {
   #define __Pyx_DefaultClassType PyClass_Type
 #else
   #define __Pyx_BUILTIN_MODULE_NAME "builtins"
+#if PY_VERSION_HEX < 0x030800A4
   #define __Pyx_PyCode_New(a, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos) \
           PyCode_New(a, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)
+#else
+  #define __Pyx_PyCode_New(a, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos) \
+          PyCode_New(a, 0, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)
+#endif
   #define __Pyx_DefaultClassType PyType_Type
 #endif
 

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -293,20 +293,18 @@ static PyCodeObject *__Pyx_createFrameCodeObject(const char *funcname, const cha
     PyObject *py_funcname = 0;
     PyCodeObject *py_code = 0;
 
-    #if PY_MAJOR_VERSION < 3
+#if PY_MAJOR_VERSION >= 3
+    py_code = PyCode_NewEmpty(srcfile, funcname, firstlineno);
+    // make CPython use a fresh dict for "f_locals" at need (see GH #1836)
+    py_code->co_flags |= CO_OPTIMIZED | CO_NEWLOCALS;
+#else
+
+
     py_funcname = PyString_FromString(funcname);
     py_srcfile = PyString_FromString(srcfile);
-    #else
-    py_funcname = PyUnicode_FromString(funcname);
-    py_srcfile = PyUnicode_FromString(srcfile);
-    #endif
-    if (!py_funcname | !py_srcfile) goto bad;
 
     py_code = PyCode_New(
         0,                /*int argcount,*/
-        #if PY_MAJOR_VERSION >= 3
-        0,                /*int kwonlyargcount,*/
-        #endif
         0,                /*int nlocals,*/
         0,                /*int stacksize,*/
         // make CPython use a fresh dict for "f_locals" at need (see GH #1836)
@@ -326,6 +324,7 @@ static PyCodeObject *__Pyx_createFrameCodeObject(const char *funcname, const cha
 bad:
     Py_XDECREF(py_srcfile);
     Py_XDECREF(py_funcname);
+#endif
 
     return py_code;
 }


### PR DESCRIPTION
This resolves compile errors with Python 3.8 on the 0.29.x branch.