### PR TITLE
Fixing regression from #2858

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,7 @@ Features added
 * PEP-479 (``generator_stop``) is now enabled by default with language level 3.
   (Github issue #2580)
 
-* Code annotation accepts a new debugging argument ``--annotate=fullc`` that
+* Code annotation accepts a new debugging argument ``--annotate-fullc`` that
   will include the complete syntax highlighted C file in the HTML output.
   (Github issue #2855)
 

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -168,10 +168,11 @@ def create_args_parser():
                       help='use Python 3 syntax mode by default')
     parser.add_argument('--3str', dest='language_level', action='store_const', const='3str',
                       help='use Python 3 syntax mode by default')
-    parser.add_argument('-a', '--annotate', nargs='?', const='default', type=str, choices={'default','fullc'},
-                      help='Produce a colorized HTML version of the source. '
-                           'Use --annotate=fullc to include entire '
-                           'generated C/C++-code.')
+    parser.add_argument('-a', '--annotate', action='store_const', const='default', dest='annotate',
+                      help='Produce a colorized HTML version of the source.')
+    parser.add_argument('--annotate-fullc', action='store_const', const='fullc', dest='annotate',
+                      help='Produce a colorized HTML version of the source '
+                           'which includes entire generated C/C++-code.')
     parser.add_argument('-x', '--exclude', metavar='PATTERN', dest='excludes',
                       action='append', default=[],
                       help='exclude certain file patterns from the compilation')

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -179,11 +179,13 @@ class CythonMagics(Magics):
 
     @magic_arguments.magic_arguments()
     @magic_arguments.argument(
-        '-a', '--annotate', nargs='?', const="default", type=str,
-        choices={"default","fullc"},
-        help="Produce a colorized HTML version of the source. "
-             "Use --annotate=fullc to include entire "
-             "generated C/C++-code."
+        '-a', '--annotate', action='store_const', const='default', dest='annotate',
+        help="Produce a colorized HTML version of the source."
+    )
+    @magic_arguments.argument(
+        '--annotate-fullc', action='store_const', const='fullc', dest='annotate',
+        help="Produce a colorized HTML version of the source "
+             "which includes entire generated C/C++-code."
     )
     @magic_arguments.argument(
         '-+', '--cplus', action='store_true', default=False,

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -243,16 +243,10 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(options.annotate, 'default')
 
     def test_annotate_fullc(self):
-        options, args =  self.parse_args(['--annotate=fullc'])
+        options, args =  self.parse_args(['--annotate-fullc'])
         self.assertFalse(args)
         self.assertTrue(self.are_default(options, ['annotate']))
         self.assertEqual(options.annotate, 'fullc')
-
-    def test_annotate_fullc(self):
-        options, args =  self.parse_args(['-a=default'])
-        self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['annotate']))
-        self.assertEqual(options.annotate, 'default')
 
     def test_annotate_and_positional(self):
         options, args =  self.parse_args(['-a', 'foo.pyx'])

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -16,11 +16,11 @@ class TestCythonizeArgsParser(TestCase):
         are_none = ['language_level', 'annotate', 'build', 'build_inplace', 'force', 'quiet', 'lenient', 'keep_going', 'no_docstrings']
         for opt_name in empty_containers:
             if len(getattr(options, opt_name))!=0 and (not opt_name in skip):
-                self.assertEqual(opt_name,"")
+                self.assertEqual(opt_name,"", msg="For option "+opt_name)
                 return False
         for opt_name in are_none:
             if (getattr(options, opt_name) is not None) and (not opt_name in skip):
-                self.assertEqual(opt_name,"")
+                self.assertEqual(opt_name,"", msg="For option "+opt_name)
                 return False
         if options.parallel!=3 and (not 'parallel' in skip):
             return False
@@ -253,6 +253,19 @@ class TestCythonizeArgsParser(TestCase):
         self.assertFalse(args)
         self.assertTrue(self.are_default(options, ['annotate']))
         self.assertEqual(options.annotate, 'default')
+
+    def test_annotate_and_positional(self):
+        options, args =  self.parse_args(['-a', 'foo.pyx'])
+        self.assertEqual(args, ['foo.pyx'])
+        self.assertTrue(self.are_default(options, ['annotate']))
+        self.assertEqual(options.annotate, 'default')
+
+    def test_annotate_and_optional(self):
+        options, args =  self.parse_args(['-a', '--3str'])
+        self.assertFalse(args)
+        self.assertTrue(self.are_default(options, ['annotate', 'language_level']))
+        self.assertEqual(options.annotate, 'default')
+        self.assertEqual(options.language_level, '3str')
 
     def test_exclude_short(self):
         options, args =  self.parse_args(['-x', '*.pyx'])

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -226,14 +226,14 @@ x = sin(0.0)
 
     def test_cython_annotate_default(self):
         ip = self._ip
-        html = ip.run_cell_magic('cython', '--a=default', code)
+        html = ip.run_cell_magic('cython', '-a', code)
         # somewhat brittle way to differentiate between annotated htmls
         # with/without complete source code:
         self.assertTrue(AnnotationCCodeWriter.COMPLETE_CODE_TITLE not in html.data)
 
     def test_cython_annotate_complete_c_code(self):
         ip = self._ip
-        html = ip.run_cell_magic('cython', '--a=fullc', code)
+        html = ip.run_cell_magic('cython', '--annotate-fullc', code)
         # somewhat brittle way to differentiate between annotated htmls
         # with/without complete source code:
         self.assertTrue(AnnotationCCodeWriter.COMPLETE_CODE_TITLE in html.data)

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -34,7 +34,8 @@ Options:
 
   -D, --no-docstrings            Strip docstrings from the compiled module.
   -a, --annotate                 Produce a colorized HTML version of the source.
-                                 Use --annotate=fullc to include entire generated C/C++-code.
+  --annotate-fullc               Produce a colorized HTML version of the source which
+                                 includes entire generated C/C++-code.
   --annotate-coverage <cov.xml>  Annotate and include coverage information from cov.xml.
   --line-directives              Produce #line directives pointing to the .pyx source
   --cplus                        Output a C++ rather than C file.
@@ -129,7 +130,9 @@ def parse_command_line(args):
             elif option in ("-D", "--no-docstrings"):
                 Options.docstrings = False
             elif option in ("-a", "--annotate"):
-                Options.annotate = pop_value('default')
+                Options.annotate = "default"
+            elif option == "--annotate-fullc":
+                Options.annotate = "fullc"
             elif option == "--annotate-coverage":
                 Options.annotate = True
                 Options.annotate_coverage_xml = pop_value()

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -104,23 +104,23 @@ class CmdLineParserTest(TestCase):
         ])
         self.assertFalse(Options.annotate)
 
-    def test_annotate_simple(self):
+    def test_annotate_short(self):
         options, sources = parse_command_line([
             '-a',
             'source.pyx',
         ])
         self.assertEqual(Options.annotate, 'default')
 
-    def test_annotate_default(self):
+    def test_annotate_long(self):
         options, sources = parse_command_line([
-            '--annotate=default',
+            '--annotate',
             'source.pyx',
         ])
         self.assertEqual(Options.annotate, 'default')
 
     def test_annotate_fullc(self):
         options, sources = parse_command_line([
-            '--annotate=fullc',
+            '--annotate-fullc',
             'source.pyx',
         ])
         self.assertEqual(Options.annotate, 'fullc')

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -621,7 +621,9 @@ You can see them also by typing ```%%cython?`` in IPython or a Jupyter notebook.
 
 ============================================  =======================================================================================================================================
 
--a, --annotate                                Produce a colorized HTML version of the source. Use ``--annotate=fullc`` to include the complete generated C/C++-code as well.
+-a, --annotate                                Produce a colorized HTML version of the source.
+
+--annotate-fullc                              Produce a colorized HTML version of the source which includes entire generated C/C++-code.
 
 -+, --cplus                                   Output a C++ rather than C file.
 


### PR DESCRIPTION
Unluckily my #2858 has introduced a regression for cythonize.py: in

  cythonize -a foo.pyx

`foo.pyx` is interpreted as a value for option -a and not as source-file. The problem `nargs='?'` doesn't work well with positional arguments.

It would be possible to save the syntax `--annotate fullc` but at cost of adding more complexity, so I think it is easier to introduce new option `--annotate-fullc` instead, which corresponds to the old `--annotate=fullc`, as done in this PR.