### PR TITLE
Fix interspersed positional arguments in cythonize.py

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -203,10 +203,10 @@ def create_args_parser():
 def parse_args_raw(parser, args):
     options, unknown = parser.parse_known_args(args)
     sources = options.sources
-    # if positional arguments were interspersed 
+    # if positional arguments were interspersed
     # some of them are in unknown
     for option in unknown:
-        if option.startswith('-'):           
+        if option.startswith('-'):
             parser.error("unknown option "+option)
         else:
             sources.append(option)

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -201,8 +201,17 @@ def create_args_parser():
 
 
 def parse_args_raw(parser, args):
-    options = parser.parse_args(args)
-    return (options, options.sources)
+    options, unknown = parser.parse_known_args(args)
+    sources = options.sources
+    # if positional arguments were interspersed 
+    # some of them are in unknown
+    for option in unknown:
+        if option.startswith('-'):           
+            parser.error("unknown option "+option)
+        else:
+            sources.append(option)
+    delattr(options, 'sources')
+    return (options, sources)
 
 
 def parse_args(args):

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -5,11 +5,11 @@ from Cython.Build.Cythonize import (
 from unittest import TestCase
 
 import sys
-import argparse
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO  # doesn't accept 'str' in Py2
+
 
 class TestCythonizeArgsParser(TestCase):
 
@@ -399,7 +399,7 @@ class TestCythonizeArgsParser(TestCase):
 
     def test_interspersed_positional(self):
         options, sources = self.parse_args([
-             'file1.pyx', '-a', 
+             'file1.pyx', '-a',
              'file2.pyx'
         ])
         self.assertEqual(sources, ['file1.pyx', 'file2.pyx'])
@@ -408,7 +408,7 @@ class TestCythonizeArgsParser(TestCase):
 
     def test_interspersed_positional2(self):
         options, sources = self.parse_args([
-             'file1.pyx', '-a', 
+             'file1.pyx', '-a',
              'file2.pyx', '-a', 'file3.pyx'
         ])
         self.assertEqual(sources, ['file1.pyx', 'file2.pyx', 'file3.pyx'])
@@ -417,7 +417,7 @@ class TestCythonizeArgsParser(TestCase):
 
     def test_interspersed_positional3(self):
         options, sources = self.parse_args([
-             '-f', 'f1', 'f2', '-a', 
+             '-f', 'f1', 'f2', '-a',
              'f3', 'f4', '-a', 'f5'
         ])
         self.assertEqual(sources, ['f1', 'f2', 'f3', 'f4', 'f5'])
@@ -429,7 +429,9 @@ class TestCythonizeArgsParser(TestCase):
         old_stderr = sys.stderr
         stderr = sys.stderr = StringIO()
         try:
-            self.assertRaises(SystemExit, self.parse_args, ['--unknown-option'])
+            self.assertRaises(SystemExit, self.parse_args,
+                              ['--unknown-option']
+                              )
         finally:
             sys.stderr = old_stderr
         self.assertTrue(stderr.getvalue())

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -392,6 +392,15 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(options.build_inplace, True)
         self.assertTrue(self.are_default(options, ['build_inplace']))
 
+    def test_interspersed_positional(self):
+        options, sources = self.parse_args([
+             'file1.pyx', '-a', 
+             'file2.pyx'
+        ])
+        self.assertEqual(sources, ['file1.pyx', 'file2.pyx'])
+        self.assertEqual(options.annotate, 'default')
+        self.assertTrue(self.are_default(options, ['annotate']))
+
 class TestParseArgs(TestCase):
 
     def test_build_set_for_inplace(self):

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -406,6 +406,25 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(options.annotate, 'default')
         self.assertTrue(self.are_default(options, ['annotate']))
 
+    def test_interspersed_positional2(self):
+        options, sources = self.parse_args([
+             'file1.pyx', '-a', 
+             'file2.pyx', '-a', 'file3.pyx'
+        ])
+        self.assertEqual(sources, ['file1.pyx', 'file2.pyx', 'file3.pyx'])
+        self.assertEqual(options.annotate, 'default')
+        self.assertTrue(self.are_default(options, ['annotate']))
+
+    def test_interspersed_positional3(self):
+        options, sources = self.parse_args([
+             '-f', 'f1', 'f2', '-a', 
+             'f3', 'f4', '-a', 'f5'
+        ])
+        self.assertEqual(sources, ['f1', 'f2', 'f3', 'f4', 'f5'])
+        self.assertEqual(options.annotate, 'default')
+        self.assertEqual(options.force, True)
+        self.assertTrue(self.are_default(options, ['annotate', 'force']))
+
     def test_wrong_option(self):
         old_stderr = sys.stderr
         stderr = sys.stderr = StringIO()

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -4,7 +4,12 @@ from Cython.Build.Cythonize import (
 )
 from unittest import TestCase
 
+import sys
 import argparse
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO  # doesn't accept 'str' in Py2
 
 class TestCythonizeArgsParser(TestCase):
 
@@ -400,6 +405,16 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(sources, ['file1.pyx', 'file2.pyx'])
         self.assertEqual(options.annotate, 'default')
         self.assertTrue(self.are_default(options, ['annotate']))
+
+    def test_wrong_option(self):
+        old_stderr = sys.stderr
+        stderr = sys.stderr = StringIO()
+        try:
+            self.assertRaises(SystemExit, self.parse_args, ['--unknown-option'])
+        finally:
+            sys.stderr = old_stderr
+        self.assertTrue(stderr.getvalue())
+
 
 class TestParseArgs(TestCase):
 


### PR DESCRIPTION
This is fix for a regression in #2952: in optparse interspersed arguments are on per default, but not in argparse (I was not able to parse this information from https://docs.python.org/3.7/library/argparse.html#upgrading-optparse-code), thus the following

 cythonize.py   file1 -a file2

works with optparse but not argparse.

As the native-argparse support for interspersed/intermixed arguments is only available since Python3.7 (https://bugs.python.org/issue14191) we need to emulate it.