### PR TITLE
Backport of GH-2910 include path reordering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Bugs fixed
 * Support slice handling in newer Pythran versions.
   (Github issue #2989)
 
+* The search order for include files was changed. Previously it was
+  ``include_directories``, ``Cython/Includes``, ``sys.path``. Now it is
+  ``include_directories``, ``sys.path``, ``Cython/Includes``. This was done to
+  allow third-party ``*.pxd`` files to override the ones in Cython.
+  (Github issue #2905)
+
 
 0.29.10 (2019-06-02)
 ====================

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -288,10 +288,11 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        include_dirs = tuple(self.include_directories)
+        include_dirs = self.include_directories
         if sys_path:
-            include_dirs = include_dirs + tuple(sys.path)
-        include_dirs = include_dirs + (standard_include_path,)
+            include_dirs = include_dirs + sys.path
+        # include_dirs must be hashable for caching in @cached_function
+        include_dirs = tuple(include_dirs + [standard_include_path])
         return search_include_directories(include_dirs, qualified_name,
                                           suffix, pos, include)
 

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -38,6 +38,8 @@ module_name_pattern = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_
 
 verbose = 0
 
+standard_include_path = os.path.abspath(os.path.normpath(
+        os.path.join(os.path.dirname(__file__), os.path.pardir, 'Includes')))
 
 class CompilationData(object):
     #  Bundles the information that is passed from transform to transform.
@@ -79,7 +81,7 @@ class Context(object):
         self.modules = {"__builtin__" : Builtin.builtin_scope}
         self.cython_scope = CythonScope.create_cython_scope(self)
         self.modules["cython"] = self.cython_scope
-        self.include_directories = include_directories
+        self.include_directories = tuple(include_directories)
         self.future_directives = set()
         self.compiler_directives = compiler_directives
         self.cpp = cpp
@@ -87,10 +89,6 @@ class Context(object):
 
         self.pxds = {}  # full name -> node tree
         self._interned = {}  # (type(value), value, *key_args) -> interned_value
-
-        standard_include_path = os.path.abspath(os.path.normpath(
-            os.path.join(os.path.dirname(__file__), os.path.pardir, 'Includes')))
-        self.include_directories = include_directories + [standard_include_path]
 
         if language_level is not None:
             self.set_language_level(language_level)
@@ -290,8 +288,13 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        return search_include_directories(
-            tuple(self.include_directories), qualified_name, suffix, pos, include, sys_path)
+        if sys_path:
+            include_dirs = self.include_directories + tuple(sys.path)
+        else:
+            include_dirs = self.include_directories
+        include_dirs = include_dirs + (standard_include_path,)
+        return search_include_directories(include_dirs, qualified_name,
+                                          suffix, pos, include)
 
     def find_root_package_dir(self, file_path):
         return Utils.find_root_package_dir(file_path)
@@ -311,8 +314,10 @@ class Context(object):
             return 1
         for kind, name in self.read_dependency_file(source_path):
             if kind == "cimport":
+                # missing suffix?
                 dep_path = self.find_pxd_file(name, pos)
             elif kind == "include":
+                # missing suffix?
                 dep_path = self.search_include_directories(name, pos)
             else:
                 continue
@@ -779,8 +784,7 @@ def compile(source, options = None, full_module_name = None, **kwds):
 
 
 @Utils.cached_function
-def search_include_directories(dirs, qualified_name, suffix, pos,
-                               include=False, sys_path=False):
+def search_include_directories(dirs, qualified_name, suffix, pos, include=False):
     """
     Search the list of include directories for the given file name.
 
@@ -789,10 +793,7 @@ def search_include_directories(dirs, qualified_name, suffix, pos,
     report an error.
 
     The 'include' option will disable package dereferencing.
-    If 'sys_path' is True, also search sys.path.
     """
-    if sys_path:
-        dirs = dirs + tuple(sys.path)
 
     if pos:
         file_desc = pos[0]
@@ -825,7 +826,18 @@ def search_include_directories(dirs, qualified_name, suffix, pos,
                 path = os.path.join(package_dir, module_filename)
                 if os.path.exists(path):
                     return path
-                path = os.path.join(dirname, package_dir, module_name,
+                # In most cases, dirname and package_dir will be the same.
+                # From the documentation of os.path.join:
+                # " If a component is an absolute path, all previous components
+                # are thrown away and joining continues from the absolute path
+                # component"
+                # So if dirname and package_dir are absolute pathes, one will
+                # be discarded. However what happens when they are relative
+                # single-component paths? They will be concatenated (repeated),
+                # causing rare and hard to debug problems.
+                # path = os.path.join(dirname, package_dir, module_name,
+                #                    package_filename)
+                path = os.path.join(package_dir, module_name,
                                     package_filename)
                 if os.path.exists(path):
                     return path

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -290,7 +290,7 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        return Utils.search_include_directories(
+        return search_include_directories(
             tuple(self.include_directories), qualified_name, suffix, pos, include, sys_path)
 
     def find_root_package_dir(self, file_path):
@@ -776,6 +776,60 @@ def compile(source, options = None, full_module_name = None, **kwds):
         return compile_single(source, options, full_module_name)
     else:
         return compile_multiple(source, options)
+
+
+@Utils.cached_function
+def search_include_directories(dirs, qualified_name, suffix, pos,
+                               include=False, sys_path=False):
+    """
+    Search the list of include directories for the given file name.
+
+    If a source file position is given, first searches the directory
+    containing that file. Returns None if not found, but does not
+    report an error.
+
+    The 'include' option will disable package dereferencing.
+    If 'sys_path' is True, also search sys.path.
+    """
+    if sys_path:
+        dirs = dirs + tuple(sys.path)
+
+    if pos:
+        file_desc = pos[0]
+        if not isinstance(file_desc, FileSourceDescriptor):
+            raise RuntimeError("Only file sources for code supported")
+        if include:
+            dirs = (os.path.dirname(file_desc.filename),) + dirs
+        else:
+            dirs = (Utils.find_root_package_dir(file_desc.filename),) + dirs
+
+    dotted_filename = qualified_name
+    if suffix:
+        dotted_filename += suffix
+
+    if not include:
+        names = qualified_name.split('.')
+        package_names = tuple(names[:-1])
+        module_name = names[-1]
+        module_filename = module_name + suffix
+        package_filename = "__init__" + suffix
+
+    for dirname in dirs:
+        path = os.path.join(dirname, dotted_filename)
+        if os.path.exists(path):
+            return path
+
+        if not include:
+            package_dir = Utils.check_package_dir(dirname, package_names)
+            if package_dir is not None:
+                path = os.path.join(package_dir, module_filename)
+                if os.path.exists(path):
+                    return path
+                path = os.path.join(dirname, package_dir, module_name,
+                                    package_filename)
+                if os.path.exists(path):
+                    return path
+    return None
 
 
 # ------------------------------------------------------------------------

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -38,8 +38,8 @@ module_name_pattern = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_
 
 verbose = 0
 
-standard_include_path = os.path.abspath(os.path.normpath(
-        os.path.join(os.path.dirname(__file__), os.path.pardir, 'Includes')))
+standard_include_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                        os.path.pardir, 'Includes'))
 
 class CompilationData(object):
     #  Bundles the information that is passed from transform to transform.
@@ -81,7 +81,7 @@ class Context(object):
         self.modules = {"__builtin__" : Builtin.builtin_scope}
         self.cython_scope = CythonScope.create_cython_scope(self)
         self.modules["cython"] = self.cython_scope
-        self.include_directories = tuple(include_directories)
+        self.include_directories = include_directories
         self.future_directives = set()
         self.compiler_directives = compiler_directives
         self.cpp = cpp
@@ -288,11 +288,10 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
+        include_dirs = list(self.include_directories)
         if sys_path:
-            include_dirs = self.include_directories + tuple(sys.path)
-        else:
-            include_dirs = self.include_directories
-        include_dirs = include_dirs + (standard_include_path,)
+            include_dirs += list(sys.path)
+        include_dirs += [standard_include_path,]
         return search_include_directories(include_dirs, qualified_name,
                                           suffix, pos, include)
 
@@ -314,10 +313,8 @@ class Context(object):
             return 1
         for kind, name in self.read_dependency_file(source_path):
             if kind == "cimport":
-                # missing suffix?
                 dep_path = self.find_pxd_file(name, pos)
             elif kind == "include":
-                # missing suffix?
                 dep_path = self.search_include_directories(name, pos)
             else:
                 continue
@@ -826,17 +823,6 @@ def search_include_directories(dirs, qualified_name, suffix, pos, include=False)
                 path = os.path.join(package_dir, module_filename)
                 if os.path.exists(path):
                     return path
-                # In most cases, dirname and package_dir will be the same.
-                # From the documentation of os.path.join:
-                # " If a component is an absolute path, all previous components
-                # are thrown away and joining continues from the absolute path
-                # component"
-                # So if dirname and package_dir are absolute pathes, one will
-                # be discarded. However what happens when they are relative
-                # single-component paths? They will be concatenated (repeated),
-                # causing rare and hard to debug problems.
-                # path = os.path.join(dirname, package_dir, module_name,
-                #                    package_filename)
                 path = os.path.join(package_dir, module_name,
                                     package_filename)
                 if os.path.exists(path):

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -288,10 +288,10 @@ class Context(object):
 
     def search_include_directories(self, qualified_name, suffix, pos,
                                    include=False, sys_path=False):
-        include_dirs = list(self.include_directories)
+        include_dirs = tuple(self.include_directories)
         if sys_path:
-            include_dirs += list(sys.path)
-        include_dirs += [standard_include_path,]
+            include_dirs = include_dirs + tuple(sys.path)
+        include_dirs = include_dirs + (standard_include_path,)
         return search_include_directories(include_dirs, qualified_name,
                                           suffix, pos, include)
 

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -124,54 +124,6 @@ def copy_file_to_dir_if_newer(sourcefile, destdir):
 
 
 @cached_function
-def search_include_directories(dirs, qualified_name, suffix, pos,
-                               include=False, sys_path=False):
-    # Search the list of include directories for the given
-    # file name. If a source file position is given, first
-    # searches the directory containing that file. Returns
-    # None if not found, but does not report an error.
-    # The 'include' option will disable package dereferencing.
-    # If 'sys_path' is True, also search sys.path.
-    if sys_path:
-        dirs = dirs + tuple(sys.path)
-    if pos:
-        file_desc = pos[0]
-        from Cython.Compiler.Scanning import FileSourceDescriptor
-        if not isinstance(file_desc, FileSourceDescriptor):
-            raise RuntimeError("Only file sources for code supported")
-        if include:
-            dirs = (os.path.dirname(file_desc.filename),) + dirs
-        else:
-            dirs = (find_root_package_dir(file_desc.filename),) + dirs
-
-    dotted_filename = qualified_name
-    if suffix:
-        dotted_filename += suffix
-    if not include:
-        names = qualified_name.split('.')
-        package_names = tuple(names[:-1])
-        module_name = names[-1]
-        module_filename = module_name + suffix
-        package_filename = "__init__" + suffix
-
-    for dir in dirs:
-        path = os.path.join(dir, dotted_filename)
-        if path_exists(path):
-            return path
-        if not include:
-            package_dir = check_package_dir(dir, package_names)
-            if package_dir is not None:
-                path = os.path.join(package_dir, module_filename)
-                if path_exists(path):
-                    return path
-                path = os.path.join(dir, package_dir, module_name,
-                                    package_filename)
-                if path_exists(path):
-                    return path
-    return None
-
-
-@cached_function
 def find_root_package_dir(file_path):
     dir = os.path.dirname(file_path)
     if file_path == dir:

--- a/tests/compile/find_pxd.srctree
+++ b/tests/compile/find_pxd.srctree
@@ -6,12 +6,13 @@ from Cython.Build import cythonize
 from Cython.Distutils.extension import Extension
 
 import sys
-sys.path.append("path")
+sys.path.insert(0, "path")
 
 ext_modules = [
     Extension("a", ["a.pyx"]),
     Extension("b", ["b.pyx"]),
     Extension("c", ["c.pyx"]),
+    Extension("d", ["d.pyx"]),
 ]
 
 ext_modules = cythonize(ext_modules, include_path=["include"])
@@ -37,3 +38,15 @@ ctypedef int my_type
 
 ######## path/c.pxd ########
 +++syntax error just to show that this file is not actually cimported+++
+
+######## path/numpy/__init__.pxd ########
+
+# gh-2905: This should be found before Cython/Inlude/numpy/__init__.pxd
+
+ctypedef int my_type
+
+######## d.pyx ########
+
+cimport numpy
+
+cdef numpy.my_type foo


### PR DESCRIPTION
Proposed backport of #2910 to allow NumPy to advance with https://github.com/numpy/numpy/pull/12284