### PR TITLE
include: cpython.pystate: Fix PyGILState_STATE definition

### DIFF
--- a/Cython/Includes/cpython/pystate.pxd
+++ b/Cython/Includes/cpython/pystate.pxd
@@ -20,7 +20,8 @@ cdef extern from "Python.h":
 
     # This is not actually a struct, but make sure it can never be coerced to
     # an int or used in arithmetic expressions
-    ctypedef struct PyGILState_STATE
+    ctypedef struct PyGILState_STATE:
+        pass
 
     # The type of the trace function registered using PyEval_SetProfile() and
     # PyEval_SetTrace().

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -2,6 +2,7 @@
 # tag: c-api
 
 from cpython cimport mem
+from cpython.pystate cimport PyGILState_Ensure, PyGILState_Release, PyGILState_STATE
 
 
 def test_pymalloc():
@@ -47,3 +48,17 @@ def test_pymalloc_raw():
             mem.PyMem_RawFree(m)
     assert m2
     return retval
+
+
+def test_gilstate():
+    """
+    >>> test_gilstate()
+    'ok'
+    """
+
+    # cython used to have invalid definition for PyGILState_STATE, which was
+    # making the following code fail to compile
+    cdef PyGILState_STATE gstate = PyGILState_Ensure()
+    # TODO assert that GIL is taken
+    PyGILState_Release(gstate)
+    return 'ok'


### PR DESCRIPTION
PyGILState_STATE was added in commit 3fd6fdce66 (Gilnanny + pystate.pxd)
with struct type on-purpose different from what CPython actually uses
with the idea so that PyGILState_STATE cannot be coerced into int.

However as it is, it prevents PyGILState_STATE usage:

	cdef PyGILState_STATE gstate = PyGILState_Ensure()

gives

	Variable type 'PyGILState_STATE' is incomplete

Fix it by making PyGILState_STATE a defined structure.