### PR TITLE
Support Py_TPFLAGS_METHOD_DESCRIPTOR

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -696,6 +696,9 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     0,                                  /*tp_getattro*/
     0,                                  /*tp_setattro*/
     0,                                  /*tp_as_buffer*/
+#ifdef Py_TPFLAGS_METHOD_DESCRIPTOR
+    Py_TPFLAGS_METHOD_DESCRIPTOR |
+#endif
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                  /*tp_doc*/
     (traverseproc) __Pyx_CyFunction_traverse,   /*tp_traverse*/

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1486,7 +1486,9 @@ static int __Pyx_PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **me
     if (likely(descr != NULL)) {
         Py_INCREF(descr);
         // Repeating the condition below accommodates for MSVC's inability to test macros inside of macro expansions.
-#if PY_MAJOR_VERSION >= 3
+#ifdef Py_TPFLAGS_METHOD_DESCRIPTOR
+        if (PyType_HasFeature(Py_TYPE(descr), Py_TPFLAGS_METHOD_DESCRIPTOR))
+#elif PY_MAJOR_VERSION >= 3
         #ifdef __Pyx_CyFunction_USED
         if (likely(PyFunction_Check(descr) || (Py_TYPE(descr) == &PyMethodDescr_Type) || __Pyx_CyFunction_Check(descr)))
         #else


### PR DESCRIPTION
Support `Py_TPFLAGS_METHOD_DESCRIPTOR` in `__Pyx_PyObject_GetMethod` and set that flag for the class `cython_function_or_method`.

I don't know whether `fused_cython_function` should also get that flag or not, so I didn't add it.