### PR TITLE
Simplify and optimize calls, using vectorcall on Python 3.8

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6115,75 +6115,27 @@ class PyMethodCallNode(SimpleCallNode):
             code.put_gotref(self.py_result())
         else:
             code.globalstate.use_utility_code(
-                UtilityCode.load_cached("PyFunctionFastCall", "ObjectHandling.c"))
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("PyCFunctionFastCall", "ObjectHandling.c"))
-            for test_func, call_prefix in [('PyFunction_Check', 'Py'), ('__Pyx_PyFastCFunction_Check', 'PyC')]:
-                code.putln("#if CYTHON_FAST_%sCALL" % call_prefix.upper())
-                code.putln("if (%s(%s)) {" % (test_func, function))
-                code.putln("PyObject *%s[%d] = {%s, %s};" % (
-                    Naming.quick_temp_cname,
-                    len(args)+1,
-                    self_arg,
-                    ', '.join(arg.py_result() for arg in args)))
-                code.putln("%s = __Pyx_%sFunction_FastCall(%s, %s+1-%s, %d+%s); %s" % (
-                    self.result(),
-                    call_prefix,
-                    function,
-                    Naming.quick_temp_cname,
-                    arg_offset_cname,
-                    len(args),
-                    arg_offset_cname,
-                    code.error_goto_if_null(self.result(), self.pos)))
-                code.put_xdecref_clear(self_arg, py_object_type)
-                code.put_gotref(self.py_result())
-                for arg in args:
-                    arg.generate_disposal_code(code)
-                code.putln("} else")
-                code.putln("#endif")
+                UtilityCode.load_cached("PyObjectFastCall", "ObjectHandling.c"))
 
             code.putln("{")
-            args_tuple = code.funcstate.allocate_temp(py_object_type, manage_ref=True)
-            code.putln("%s = PyTuple_New(%d+%s); %s" % (
-                args_tuple, len(args), arg_offset_cname,
-                code.error_goto_if_null(args_tuple, self.pos)))
-            code.put_gotref(args_tuple)
-
-            if len(args) > 1:
-                code.putln("if (%s) {" % self_arg)
-            code.putln("__Pyx_GIVEREF(%s); PyTuple_SET_ITEM(%s, 0, %s); %s = NULL;" % (
-                self_arg, args_tuple, self_arg, self_arg))  # stealing owned ref in this case
-            code.funcstate.release_temp(self_arg)
-            if len(args) > 1:
-                code.putln("}")
-
-            for i, arg in enumerate(args):
-                arg.make_owned_reference(code)
-                code.put_giveref(arg.py_result())
-                code.putln("PyTuple_SET_ITEM(%s, %d+%s, %s);" % (
-                    args_tuple, i, arg_offset_cname, arg.py_result()))
-            if len(args) > 1:
-                code.funcstate.release_temp(arg_offset_cname)
-
-            for arg in args:
-                arg.generate_post_assignment_code(code)
-                arg.free_temps(code)
-
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("PyObjectCall", "ObjectHandling.c"))
-            code.putln(
-                "%s = __Pyx_PyObject_Call(%s, %s, NULL); %s" % (
-                    self.result(),
-                    function, args_tuple,
-                    code.error_goto_if_null(self.result(), self.pos)))
+            code.putln("PyObject *%s[%d] = {%s, %s};" % (
+                Naming.quick_temp_cname,
+                len(args)+1,
+                self_arg,
+                ', '.join(arg.py_result() for arg in args)))
+            code.putln("%s = __Pyx_PyObject_FastCall(%s, %s+1-%s, %d+%s); %s" % (
+                self.result(),
+                function,
+                Naming.quick_temp_cname,
+                arg_offset_cname,
+                len(args),
+                arg_offset_cname,
+                code.error_goto_if_null(self.result(), self.pos)))
+            code.put_xdecref_clear(self_arg, py_object_type)
             code.put_gotref(self.py_result())
-
-            code.put_decref_clear(args_tuple, py_object_type)
-            code.funcstate.release_temp(args_tuple)
-
-            if len(args) == 1:
-                code.putln("}")
-            code.putln("}")  # !CYTHON_FAST_PYCALL
+            for arg in args:
+                arg.generate_disposal_code(code)
+            code.putln("}")
 
         if reuse_function_temp:
             self.function.generate_disposal_code(code)

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -194,14 +194,6 @@ static PyObject *__Pyx__Coroutine_GetAwaitableIter(PyObject *obj) {
         PyObject *method = NULL;
         int is_method = __Pyx_PyObject_GetMethod(obj, PYIDENT("__await__"), &method);
         if (likely(is_method)) {
-#if PY_VERSION_HEX >= 0x030700A1 && CYTHON_UNPACK_METHODS && CYTHON_FAST_PYCCALL
-            if (Py_TYPE(method) == &PyMethodDescr_Type) {
-                PyMethodDescrObject *descr = (PyMethodDescrObject *)method;
-                res = _PyMethodDef_RawFastCallKeywords(descr->d_method, obj, NULL, 0, NULL);
-                if (unlikely(!res))
-                    res = _Py_CheckFunctionResult(obj, res, NULL);
-            } else
-#endif
             res = __Pyx_PyObject_CallOneArg(method, obj);
         } else if (likely(method)) {
             res = __Pyx_PyObject_CallNoArg(method);

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -198,6 +198,10 @@
 #define CYTHON_FAST_PYCCALL  (CYTHON_FAST_PYCALL && PY_VERSION_HEX >= 0x030600B1)
 #endif
 
+#if !defined(CYTHON_VECTORCALL)
+#define CYTHON_VECTORCALL  (CYTHON_FAST_PYCCALL && PY_VERSION_HEX >= 0x030800B1)
+#endif
+
 #if CYTHON_USE_PYLONG_INTERNALS
   #include "longintrepr.h"
   /* These short defines can easily conflict with other code */
@@ -440,12 +444,6 @@ class __Pyx_FakeReference {
 #else
   #define __Pyx_PyCFunctionFast _PyCFunctionFast
   #define __Pyx_PyCFunctionFastWithKeywords _PyCFunctionFastWithKeywords
-#endif
-#if CYTHON_FAST_PYCCALL
-#define __Pyx_PyFastCFunction_Check(func) \
-    ((PyCFunction_Check(func) && (METH_FASTCALL == (PyCFunction_GET_FLAGS(func) & ~(METH_CLASS | METH_STATIC | METH_COEXIST | METH_KEYWORDS | METH_STACKLESS)))))
-#else
-#define __Pyx_PyFastCFunction_Check(func) 0
 #endif
 
 #if CYTHON_COMPILING_IN_PYPY && !defined(PyObject_Malloc)

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1809,14 +1809,6 @@ static PyObject* __Pyx_PyObject_CallMethod0(PyObject* obj, PyObject* method_name
     PyObject *method = NULL, *result = NULL;
     int is_method = __Pyx_PyObject_GetMethod(obj, method_name, &method);
     if (likely(is_method)) {
-#if PY_VERSION_HEX >= 0x030700A1 && CYTHON_UNPACK_METHODS && CYTHON_FAST_PYCCALL
-        if (Py_TYPE(method) == &PyMethodDescr_Type) {
-            PyMethodDescrObject *descr = (PyMethodDescrObject *)method;
-            result = _PyMethodDef_RawFastCallKeywords(descr->d_method, obj, NULL, 0, NULL);
-            if (unlikely(!result))
-                result = _Py_CheckFunctionResult(obj, result, NULL);
-        } else
-#endif
         result = __Pyx_PyObject_CallOneArg(method, obj);
         Py_DECREF(method);
         return result;
@@ -1849,14 +1841,6 @@ static PyObject* __Pyx_PyObject_CallMethod1(PyObject* obj, PyObject* method_name
     PyObject *method = NULL, *result;
     int is_method = __Pyx_PyObject_GetMethod(obj, method_name, &method);
     if (likely(is_method)) {
-#if PY_VERSION_HEX >= 0x030700A1 && CYTHON_UNPACK_METHODS && CYTHON_FAST_PYCCALL
-        if (Py_TYPE(method) == &PyMethodDescr_Type) {
-            PyMethodDescrObject *descr = (PyMethodDescrObject *)method;
-            result = _PyMethodDef_RawFastCallKeywords(descr->d_method, obj, &arg, 1, NULL);
-            if (unlikely(!result))
-                result = _Py_CheckFunctionResult(obj, result, NULL);
-        } else
-#endif
         result = __Pyx_PyObject_Call2Args(method, obj, arg);
         Py_DECREF(method);
         return result;
@@ -1908,15 +1892,6 @@ static PyObject* __Pyx_PyObject_CallMethod2(PyObject* obj, PyObject* method_name
     PyObject *args, *method = NULL, *result = NULL;
     int is_method = __Pyx_PyObject_GetMethod(obj, method_name, &method);
     if (likely(is_method)) {
-#if PY_VERSION_HEX >= 0x030700A1 && CYTHON_UNPACK_METHODS && CYTHON_FAST_PYCCALL
-        if (Py_TYPE(method) == &PyMethodDescr_Type) {
-            PyMethodDescrObject *descr = (PyMethodDescrObject *)method;
-            PyObject *args[2] = {arg1, arg2};
-            result = _PyMethodDef_RawFastCallKeywords(descr->d_method, obj, args, 2, NULL);
-            if (unlikely(!result))
-                result = _Py_CheckFunctionResult(obj, result, NULL);
-        } else
-#endif
         result = __Pyx_PyObject_Call3Args(method, obj, arg1, arg2);
         Py_DECREF(method);
         return result;

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1850,59 +1850,6 @@ static PyObject* __Pyx_PyObject_CallMethod1(PyObject* obj, PyObject* method_name
 }
 
 
-/////////////// PyObjectCallMethod2.proto ///////////////
-
-static PyObject* __Pyx_PyObject_CallMethod2(PyObject* obj, PyObject* method_name, PyObject* arg1, PyObject* arg2); /*proto*/
-
-/////////////// PyObjectCallMethod2 ///////////////
-//@requires: PyObjectCall
-//@requires: PyFunctionFastCall
-//@requires: PyCFunctionFastCall
-//@requires: PyObjectCall2Args
-
-static PyObject* __Pyx_PyObject_Call3Args(PyObject* function, PyObject* arg1, PyObject* arg2, PyObject* arg3) {
-    #if CYTHON_FAST_PYCALL
-    if (PyFunction_Check(function)) {
-        PyObject *args[3] = {arg1, arg2, arg3};
-        return __Pyx_PyFunction_FastCall(function, args, 3);
-    }
-    #endif
-    #if CYTHON_FAST_PYCCALL
-    if (__Pyx_PyFastCFunction_Check(function)) {
-        PyObject *args[3] = {arg1, arg2, arg3};
-        return __Pyx_PyFunction_FastCall(function, args, 3);
-    }
-    #endif
-
-    args = PyTuple_New(3);
-    if (unlikely(!args)) goto done;
-    Py_INCREF(arg1);
-    PyTuple_SET_ITEM(args, 0, arg1);
-    Py_INCREF(arg2);
-    PyTuple_SET_ITEM(args, 1, arg2);
-    Py_INCREF(arg3);
-    PyTuple_SET_ITEM(args, 2, arg3);
-
-    result = __Pyx_PyObject_Call(function, args, NULL);
-    Py_DECREF(args);
-    return result;
-}
-
-static PyObject* __Pyx_PyObject_CallMethod2(PyObject* obj, PyObject* method_name, PyObject* arg1, PyObject* arg2) {
-    PyObject *args, *method = NULL, *result = NULL;
-    int is_method = __Pyx_PyObject_GetMethod(obj, method_name, &method);
-    if (likely(is_method)) {
-        result = __Pyx_PyObject_Call3Args(method, obj, arg1, arg2);
-        Py_DECREF(method);
-        return result;
-    }
-    if (unlikely(!method)) return NULL;
-    result = __Pyx_PyObject_Call2Args(method, arg1, arg2);
-    Py_DECREF(method);
-    return result;
-}
-
-
 /////////////// tp_new.proto ///////////////
 
 #define __Pyx_tp_new(type_obj, args) __Pyx_tp_new_kwargs(type_obj, args, NULL)

--- a/tests/run/iterdict.pyx
+++ b/tests/run/iterdict.pyx
@@ -555,3 +555,19 @@ def for_in_iteritems_of_expression(*args, **kwargs):
     for k, v in dict(*args, **kwargs).iteritems():
         result.append((k, v))
     return result
+
+
+cdef class NotADict:
+    """
+    >>> NotADict().listvalues()  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    TypeError: descriptor 'values' for 'mappingproxy' objects doesn't apply to a 'iterdict.NotADict' object
+    """
+    cdef long v
+    def __cinit__(self):
+        self.v = 1
+    itervalues = type(object.__dict__).values
+
+    def listvalues(self):
+        return [v for v in self.itervalues()]


### PR DESCRIPTION
- Replace the `_PyMethodDef_RawFastCallKeywords` calls by `_PyMethodDescr_FastCallKeywords` to fix #2996 and add a test for it.
- Replace the manually-written code to call functions with a known number of arguments by calls to a new function `__Pyx_PyObject_FastCall`. The compiler should be able to optimize this if the number of arguments is a compile-time constant. Some special code for 0 and 1 arguments is still kept.
- In `__Pyx_PyObject_FastCall`, use code optimized for each CPython version. This includes vectorcall on Python 3.8 (enabled by a new feature test macro `CYTHON_VECTORCALL`)
- Remove `__Pyx_PyCFunction_FastCall` and `__Pyx_PyFastCFunction_Check` which seems no longer needed.
- In `__Pyx_PyObject_CallMatrixMethod`, call `__Pyx_PyObject_Call2Args` instead of essentially putting an inline copy of that function.