### PR TITLE
Mark regex as raw string to avoid syntax warnings

### DIFF
--- a/Cython/Debugger/Tests/TestLibCython.py
+++ b/Cython/Debugger/Tests/TestLibCython.py
@@ -40,7 +40,7 @@ def test_gdb():
     else:
         stdout, _ = p.communicate()
         # Based on Lib/test/test_gdb.py
-        regex = "GNU gdb [^\d]*(\d+)\.(\d+)"
+        regex = r"GNU gdb [^\d]*(\d+)\.(\d+)"
         gdb_version = re.match(regex, stdout.decode('ascii', 'ignore'))
 
     if gdb_version:


### PR DESCRIPTION
The regex to match the gdb version is not intended to be interpreted as a regular string, it is designed to be used as-is as a regex.  This tells python about that minor detail.