### PR TITLE
Argparse for cython

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -120,33 +120,8 @@ def run_distutils(args):
 
 
 def create_args_parser():
-    from argparse import ArgumentParser, Action
-
-    class ParseDirectivesAction(Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            old_directives = dict(getattr(namespace, self.dest,
-                                          Options.get_directive_defaults()))
-            directives = Options.parse_directive_list(
-                values, relaxed_bool=True, current_settings=old_directives)
-            setattr(namespace, self.dest, directives)
-
-    class ParseOptionsAction(Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            options = dict(getattr(namespace, self.dest, {}))
-            for opt in values.split(','):
-                if '=' in opt:
-                    n, v = opt.split('=', 1)
-                    v = v.lower() not in ('false', 'f', '0', 'no')
-                else:
-                    n, v = opt, True
-                options[n] = v
-            setattr(namespace, self.dest, options)
-
-    class ParseCompileTimeEnvAction(Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            old_env = dict(getattr(namespace, self.dest, {}))
-            new_env = Options.parse_compile_time_env(values, current_settings=old_env)
-            setattr(namespace, self.dest, new_env)
+    from argparse import ArgumentParser
+    from ..Compiler.CmdLine import ParseDirectivesAction, ParseOptionsAction, ParseCompileTimeEnvAction
 
     parser = ArgumentParser()
 

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -73,7 +73,7 @@ def create_cython_argparser():
     description = "Cython (https://cython.org/) is a compiler for code written in the "\
                   "Cython language.  Cython is based on Pyrex by Greg Ewing."
 
-    parser = ArgumentParser(description=description)
+    parser = ArgumentParser(description=description, argument_default=SUPPRESS)
 
     parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
                       help='Display version number of cython compiler')
@@ -102,7 +102,7 @@ def create_cython_argparser():
                       help='Output debug information for cygdb')
     parser.add_argument("--gdb-outdir", action=SetGDBDebugOutputAction, type=str,
                       help='Specify gdb debug information output directory. Implies --gdb.')
-    parser.add_argument("-D", "--no-docstrings", dest='docstrings', action='store_false', default=None,
+    parser.add_argument("-D", "--no-docstrings", dest='docstrings', action='store_false',
                       help='Strip docstrings from the compiled module.')
     parser.add_argument('-a', '--annotate', action='store_const', const='default', dest='annotate',
                       help='Produce a colorized HTML version of the source.')
@@ -111,7 +111,7 @@ def create_cython_argparser():
                            'which includes entire generated C/C++-code.')
     parser.add_argument("--annotate-coverage", dest='annotate_coverage_xml', action=SetAnnotateCoverageAction, type=str,
                       help='Annotate and include coverage information from cov.xml.')
-    parser.add_argument("--line-directives", dest='emit_linenums', action='store_true', default=None,
+    parser.add_argument("--line-directives", dest='emit_linenums', action='store_true',
                       help='Produce #line directives pointing to the .pyx source')
     parser.add_argument("-+", "--cplus", dest='cplus', action='store_const', const=1,
                       help='Output a C++ rather than C file.')
@@ -128,38 +128,38 @@ def create_cython_argparser():
     parser.add_argument("--lenient", action=SetLenientAction, nargs=0,
                       help='Change some compile time errors to runtime errors to '
                            'improve Python compatibility')
-    parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true', default=None,
+    parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true',
                       help='Add cincluded headers to any auto-generated header files.')
     parser.add_argument("--fast-fail", dest='fast_fail', action='store_true',
                       help='Abort the compilation on the first error')
-    parser.add_argument("-Werror", "--warning-errors", dest='warning_errors', action='store_true', default=None,
+    parser.add_argument("-Werror", "--warning-errors", dest='warning_errors', action='store_true',
                       help='Make all warnings into errors')
     parser.add_argument("-Wextra", "--warning-extra", action=ActivateAllWarningsAction, nargs=0,
                       help='Enable extra warnings')
 
     parser.add_argument('-X', '--directive', metavar='NAME=VALUE,...',
-                      dest='compiler_directives', default={}, type=str,
+                      dest='compiler_directives', type=str,
                       action=ParseDirectivesAction,
                       help='Overrides a compiler directive')
     parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
-                      dest='compile_time_env', default={}, type=str,
+                      dest='compile_time_env', type=str,
                       action=ParseCompileTimeEnvAction,
                       help='Provides compile time env like DEF would do.')
-    parser.add_argument('sources', nargs='*')
+    parser.add_argument('sources', nargs='*', default=[])
 
     # TODO: add help
     parser.add_argument("-z", "--pre-import", dest='pre_import', action='store', type=str, help=SUPPRESS)
-    parser.add_argument("--convert-range", dest='convert_range', action='store_true', default=None, help=SUPPRESS)
-    parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action='store_false', default=None, help=SUPPRESS)
-    parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action='store_true', default=None, help=SUPPRESS)
-    parser.add_argument("--old-style-globals", dest='old_style_globals', action='store_true', default=None, help=SUPPRESS)
+    parser.add_argument("--convert-range", dest='convert_range', action='store_true', help=SUPPRESS)
+    parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action='store_false', help=SUPPRESS)
+    parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action='store_true', help=SUPPRESS)
+    parser.add_argument("--old-style-globals", dest='old_style_globals', action='store_true', help=SUPPRESS)
 
     # debug stuff:
     from . import DebugFlags
     for name in vars(DebugFlags):
         if name.startswith("debug"):
             option_name = name.replace('_', '-')
-            parser.add_argument("--" + option_name, action='store_true', default=None, help=SUPPRESS)
+            parser.add_argument("--" + option_name, action='store_true', help=SUPPRESS)
 
     return parser
 
@@ -206,8 +206,6 @@ def parse_command_line(args):
 
     options = Options.CompilationOptions(Options.default_options)
     for name, value in vars(arguments).items():
-        if value is None or value == {}:
-            continue
         if name.startswith('debug'):
             from . import DebugFlags
             if name in dir(DebugFlags):

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -153,6 +153,14 @@ def create_cython_argparser():
     parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action='store_false', default=None, help=SUPPRESS)
     parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action='store_true', default=None, help=SUPPRESS)
     parser.add_argument("--old-style-globals", dest='old_style_globals', action='store_true', default=None, help=SUPPRESS)
+
+    # debug stuff:
+    from . import DebugFlags
+    for name in vars(DebugFlags):
+        if name.startswith("debug"):
+            option_name = name.replace('_', '-')
+            parser.add_argument("--" + option_name, action='store_true', default=None, help=SUPPRESS)
+
     return parser
 
 
@@ -176,10 +184,7 @@ def parse_command_line_raw(parser, args):
 
     # unknown can be either debug, embed or input files or really unknown
     for option in unknown:
-        if option.startswith('--debug'):
-            option = option[2:].replace('-', '_')
-            setattr(arguments, option, True)
-        elif option.startswith('-'):
+        if option.startswith('-'):
             parser.error("unknown option " + option)
         else:
             sources.append(option)

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -42,31 +42,31 @@ class ActivateAllWarningsAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         directives = getattr(namespace, 'compiler_directives', {})
         directives.update(Options.extra_warnings)
-        setattr(namespace, 'compiler_directives', directives)
+        namespace.compiler_directives = directives
 
 
 class SetLenientAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, 'error_on_unknown_names', False)
-        setattr(namespace, 'error_on_uninitialized', False)
+        namespace.error_on_unknown_names = False
+        namespace.error_on_uninitialized = False
 
 
 class SetGDBDebugAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, 'gdb_debug', True)
-        setattr(namespace, 'output_dir', os.curdir)
+        namespace.gdb_debug = True
+        namespace.output_dir = os.curdir
 
 
 class SetGDBDebugOutputAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, 'gdb_debug', True)
-        setattr(namespace, 'output_dir', values)
+        namespace.gdb_debug = True
+        namespace.output_dir = values
 
 
 class SetAnnotateCoverageAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, 'annotate', True)
-        setattr(namespace, 'annotate_coverage_xml', values)
+        namespace.annotate = True
+        namespace.annotate_coverage_xml = values
 
 
 def create_cython_argparser():

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -6,7 +6,38 @@ from __future__ import absolute_import
 
 import os
 import sys
+from argparse import Action
 from . import Options
+
+
+class ParseDirectivesAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        old_directives = dict(getattr(namespace, self.dest,
+                                      Options.get_directive_defaults()))
+        directives = Options.parse_directive_list(
+            values, relaxed_bool=True, current_settings=old_directives)
+        setattr(namespace, self.dest, directives)
+
+
+class ParseOptionsAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        options = dict(getattr(namespace, self.dest, {}))
+        for opt in values.split(','):
+            if '=' in opt:
+                n, v = opt.split('=', 1)
+                v = v.lower() not in ('false', 'f', '0', 'no')
+            else:
+                n, v = opt, True
+            options[n] = v
+        setattr(namespace, self.dest, options)
+
+
+class ParseCompileTimeEnvAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        old_env = dict(getattr(namespace, self.dest, {}))
+        new_env = Options.parse_compile_time_env(values, current_settings=old_env)
+        setattr(namespace, self.dest, new_env)
+
 
 usage = """\
 Cython (https://cython.org/) is a compiler for code written in the

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -66,7 +66,7 @@ def bad_usage():
     sys.exit(1)
 
 
-def parse_command_line(args):
+def parse_command_line_raw(args):
     pending_arg = []
 
     def pop_arg():
@@ -216,6 +216,12 @@ def parse_command_line(args):
 
     if pending_arg:
         bad_usage()
+
+    return arguments, sources
+
+
+def parse_command_line(args):
+    arguments, sources = parse_command_line_raw(args)
 
     options = Options.CompilationOptions(Options.default_options)
     for name, value in arguments.items():

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -204,12 +204,7 @@ def parse_command_line(args):
                     sys.exit(1)
             elif option.startswith('--debug'):
                 option = option[2:].replace('-', '_')
-                from . import DebugFlags
-                if option in dir(DebugFlags):
-                    setattr(DebugFlags, option, True)
-                else:
-                    sys.stderr.write("Unknown debug flag: %s\n" % option)
-                    bad_usage()
+                arguments[option] = True
             elif option in ('-h', '--help'):
                 sys.stdout.write(usage)
                 sys.exit(0)
@@ -224,7 +219,14 @@ def parse_command_line(args):
 
     options = Options.CompilationOptions(Options.default_options)
     for name, value in arguments.items():
-        if hasattr(Options, name):
+        if name.startswith('debug'):
+            from . import DebugFlags
+            if name in dir(DebugFlags):
+                setattr(DebugFlags, name, value)
+            else:
+                sys.stderr.write("Unknown debug flag: %s\n" % name)
+                bad_usage()
+        elif hasattr(Options, name):
             setattr(Options, name, value)
         else:
             setattr(options, name, value)

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -355,27 +355,23 @@ class CmdLineParserTest(TestCase):
         self.check_default_global_options()
         self.check_default_options(options, ['compiler_directives'])
 
-    # ToDo: activate
-    # def test_directive_value_invalid(self):
-    #    with self.assertRaises(ValueError) as context:
-    #        options, source = parse_command_line([
-    #           '-X', 'cdivision=sadfasd',
-    #           'source.pyx'
-    #        ])
+    def test_directive_value_invalid(self):
+        self.assertRaises(ValueError, parse_command_line, [
+               '-X', 'cdivision=sadfasd',
+               'source.pyx'
+        ])
 
-    # def test_directive_key_invalid(self):
-    #    with self.assertRaises(ValueError) as context:
-    #        options, source = parse_command_line([
-    #           '-X', 'abracadabra',
-    #           'source.pyx'
-    #        ])
+    def test_directive_key_invalid(self):
+        self.assertRaises(ValueError, parse_command_line, [
+               '-X', 'abracadabra',
+               'source.pyx'
+        ])
 
-    # def test_directive_no_value(self):
-    #    with self.assertRaises(ValueError) as context:
-    #        options, source = parse_command_line([
-    #           '-X', 'cdivision',
-    #           'source.pyx'
-    #        ])
+    def test_directive_no_value(self):
+        self.assertRaises(ValueError, parse_command_line, [
+               '-X', 'cdivision',
+               'source.pyx'
+        ])
 
     def test_compile_time_env_short(self):
         options, source = parse_command_line([

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -120,6 +120,30 @@ class CmdLineParserTest(TestCase):
         self.assertEqual(options.output_dir, '/gdb/outdir')
         self.assertEqual(options.compiler_directives['wraparound'], False)
 
+    def test_embed_before_positional(self):
+        options, sources = parse_command_line([
+            '--embed',
+            'source.pyx',
+        ])
+        self.assertEqual(sources, ['source.pyx'])
+        self.assertEqual(Options.embed, 'main')
+
+    def test_two_embeds(self):
+        options, sources = parse_command_line([
+            '--embed', '--embed=huhu',
+            'source.pyx',
+        ])
+        self.assertEqual(sources, ['source.pyx'])
+        self.assertEqual(Options.embed, 'huhu')
+
+    def test_two_embeds2(self):
+        options, sources = parse_command_line([
+            '--embed=huhu', '--embed',
+            'source.pyx',
+        ])
+        self.assertEqual(sources, ['source.pyx'])
+        self.assertEqual(Options.embed, 'main')
+
     def test_no_annotate(self):
         options, sources = parse_command_line([
             '--embed=huhu', 'source.pyx'

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -411,6 +411,16 @@ class CmdLineParserTest(TestCase):
         ])
         self.assertEqual(sources, ['file1.pyx', 'file2.pyx', 'file3.pyx'])
 
+    def test_debug_flags(self):
+        options, sources = parse_command_line([
+             '--debug-disposal-code', '--debug-coercion',
+             'file3.pyx'
+        ])
+        from Cython.Compiler import DebugFlags
+        for name in ['debug_disposal_code', 'debug_temp_alloc', 'debug_coercion']:
+            self.assertEqual(getattr(DebugFlags, name), name in ['debug_disposal_code', 'debug_coercion'])
+            setattr(DebugFlags, name, 0)  # restore original value
+
     def test_errors(self):
         def error(*args):
             old_stderr = sys.stderr
@@ -429,3 +439,4 @@ class CmdLineParserTest(TestCase):
         error('--verbose=1')
         error('--verbose=1')
         error('--cleanup')
+        error('--debug-disposal-code-wrong-name', 'file3.pyx')

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -1,5 +1,6 @@
 
 import sys
+import copy
 from unittest import TestCase
 try:
     from StringIO import StringIO
@@ -14,6 +15,9 @@ class CmdLineParserTest(TestCase):
     def setUp(self):
         backup = {}
         for name, value in vars(Options).items():
+            # we need a deep copy of _directive_defaults, because they can be changed
+            if name == '_directive_defaults':
+               value = copy.deepcopy(value)
             backup[name] = value
         self._options_backup = backup
 
@@ -22,6 +26,10 @@ class CmdLineParserTest(TestCase):
         for name, orig_value in self._options_backup.items():
             if getattr(Options, name, no_value) != orig_value:
                 setattr(Options, name, orig_value)
+        # strip Options from new keys that might have been added:
+        for name in vars(Options).keys():
+            if name not in self._options_backup:
+                delattr(Options, name)
 
     def test_short_options(self):
         options, sources = parse_command_line([

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -105,6 +105,7 @@ class CmdLineParserTest(TestCase):
         self.assertEqual(Options.annotate_coverage_xml, 'cov.xml')
         self.assertTrue(options.gdb_debug)
         self.assertEqual(options.output_dir, '/gdb/outdir')
+        self.assertEqual(options.compiler_directives['wraparound'], False)
 
     def test_no_annotate(self):
         options, sources = parse_command_line([


### PR DESCRIPTION
This is a continuation to  #2952: replacing a self-made command line parser for cython.py with argparse, which is already used by cythonize and (kind of) by IPython-magic.

Using only one library for argument parsing will make it easier to add new options to cython/cythonize/IPython-magic and/or syncronize/consolidate them all.

Apart of a slightly different help message there should be no behavioral changes.