### PR TITLE
Add nargs variable in args-parsing code

### DIFF
--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -67,6 +67,7 @@ interned_prefixes = {
 
 ctuple_type_prefix = pyrex_prefix + "ctuple_"
 args_cname       = pyrex_prefix + "args"
+nargs_cname      = pyrex_prefix + "nargs"
 generator_cname  = pyrex_prefix + "generator"
 sent_value_cname = pyrex_prefix + "sent_value"
 pykwdlist_cname  = pyrex_prefix + "pyargnames"


### PR DESCRIPTION
Simplify args-parsing code by replacing all occurrences of `PyTuple_GET_SIZE(__pyx_args)` by `__pyx_nargs` and setting `__pyx_nargs = PyTuple_GET_SIZE(__pyx_args)` just once.

This will be needed also for `METH_FASTCALL`, where `nargs` is passed as a function parameter.