### PR TITLE
 Declare PyUnicode_FromStringAndSize and PyUnicode_FromString

### DIFF
--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -96,6 +96,10 @@ cdef extern from *:
     # bytes
     unicode PyUnicode_FromStringAndSize(const char *u, Py_ssize_t size)
 
+    # Similar to PyUnicode_FromUnicode(), but u points to null-terminated
+    # UTF-8 encoded bytes.  The size is determined with strlen().
+    unicode PyUnicode_FromString(const char *u)
+
     # Create a Unicode Object from the given Unicode code point ordinal.
     #
     # The ordinal must be in range(0x10000) on narrow Python builds

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -92,6 +92,10 @@ cdef extern from *:
     # when u is NULL.
     unicode PyUnicode_FromUnicode(Py_UNICODE *u, Py_ssize_t size)
 
+    # Similar to PyUnicode_FromUnicode(), but u points to UTF-8 encoded
+    # bytes
+    unicode PyUnicode_FromStringAndSize(const char *u, Py_ssize_t size)
+
     # Create a Unicode Object from the given Unicode code point ordinal.
     #
     # The ordinal must be in range(0x10000) on narrow Python builds


### PR DESCRIPTION
Fixes #2726 

Example use

```
:~/src/cython [v37] PyUnicode_FromStringAndSize(+4/-0)*± python
Python 3.7.3 (default, Apr  3 2019, 19:16:38)
[GCC 8.0.1 20180414 (experimental) [trunk revision 259383]] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyximport; pyximport.install()
(None, <pyximport.pyximport.PyxImporter object at 0x7f0732f02978>)
>>> import try_PyUnicode_FromStringAndSize
>>> hello(5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'hello' is not defined
>>> try_PyUnicode_FromStringAndSize.hello(5)
'Hello'
>>> try_PyUnicode_FromStringAndSize.hello(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "try_PyUnicode_FromStringAndSize.pyx", line 5, in
try_PyUnicode_FromStringAndSize.hello
    cpdef hello(int i):
  File "try_PyUnicode_FromStringAndSize.pyx", line 7, in
try_PyUnicode_FromStringAndSize.hello
    return PyUnicode_FromStringAndSize(s, i)
SystemError: Negative size passed to PyUnicode_FromStringAndSize
>>>
```

```
:~/src/cython [v37] PyUnicode_FromStringAndSize(+4/-0)*± cat try_PyUnicode_FromStringAndSize.pyx
from cpython.unicode cimport PyUnicode_FromStringAndSize

cpdef hello(int i):
    cdef char* s = b'Hello World'
    return PyUnicode_FromStringAndSize(s, i)
```