### PR TITLE
include: posix.mman += MADV_* (MADV_NORMAL, MADV_DONTNEED, etc ...)

### DIFF
--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -57,12 +57,25 @@ cdef extern from "<sys/mman.h>" nogil:
     int shm_unlink(const char *name)
 
     # often available
-    enum: MADV_REMOVE               # pre-POSIX advice flags; often available
+    enum: MADV_NORMAL               # pre-POSIX advice flags; should translate 1-1 to POSIX_*
+    enum: MADV_RANDOM               # but in practice it is not always the same.
+    enum: MADV_SEQUENTIAL
+    enum: MADV_WILLNEED
+    enum: MADV_DONTNEED
+    enum: MADV_REMOVE               # other pre-POSIX advice flags; often available
     enum: MADV_DONTFORK
     enum: MADV_DOFORK
     enum: MADV_HWPOISON
     enum: MADV_MERGEABLE,
     enum: MADV_UNMERGEABLE
+    enum: MADV_SOFT_OFFLINE
+    enum: MADV_HUGEPAGE
+    enum: MADV_NOHUGEPAGE
+    enum: MADV_DONTDUMP
+    enum: MADV_DODUMP
+    enum: MADV_FREE
+    enum: MADV_WIPEONFORK
+    enum: MADV_KEEPONFORK
     int   madvise(void *addr, size_t Len, int advice)
 
     # sometimes available


### PR DESCRIPTION
I was going to use posix_madvise(POSIX_MADV_DONTNEED) in my tests to
make sure a memory page should be evicted from kernel cache, but found
out that this operation is hardcoded to be NOOP on Glibc/Linux systems:

https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/posix_madvise.c;h=c89fa64f0749;hb=HEAD#l25
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=8889e7aa461a

On the other hand, as also verified by strace, `madvise(MADV_DONTNEED)`
is not a NOOP as it actually goes to kernel by making syscall.

Since it is not possible to use posix_madvise for what should be
POSIX_MADV_DONTNEED behaviour, let's add all raw madvise behaviour flags
as documented on http://man7.org/linux/man-pages/man2/madvise.2.html

Presumably MADV_NORMAL and other behaviours that should translate 1-1 to
POSIX ones were omitted in 59ac999110b7 (Add pxd for mmap & friends
from "sys/mman.h" covering POSIX/Linux/BSD) to make people use the
standardised POSIX interface. However given that it turned out to be not
possible to use posix_madvise for all standard behaviours,
system-specific madvise behaviours have to be used.