### PR TITLE
Use METH_FASTCALL on Python >= 3.7

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9614,8 +9614,8 @@ class LambdaNode(InnerFunctionNode):
         self.lambda_name = self.def_node.lambda_name = env.next_id('lambda')
         self.def_node.no_assignment_synthesis = True
         self.def_node.pymethdef_required = True
-        self.def_node.analyse_declarations(env)
         self.def_node.is_cyfunction = True
+        self.def_node.analyse_declarations(env)
         self.pymethdef_cname = self.def_node.entry.pymethdef_cname
         env.add_lambda_def(self.def_node)
 

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -827,6 +827,10 @@ class FusedCFuncDefNode(StatListNode):
         else:
             nodes = self.nodes
 
+        # For the moment, fused functions do not support METH_FASTCALL
+        for node in nodes:
+            node.entry.signature.use_fastcall = False
+
         signatures = [StringEncoding.EncodedString(node.specialized_signature_string)
                       for node in nodes]
         keys = [ExprNodes.StringNode(node.pos, value=sig)

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -77,6 +77,7 @@ interned_prefixes = {
 ctuple_type_prefix = pyrex_prefix + "ctuple_"
 args_cname       = pyrex_prefix + "args"
 nargs_cname      = pyrex_prefix + "nargs"
+kwvalues_cname   = pyrex_prefix + "kwvalues"
 generator_cname  = pyrex_prefix + "generator"
 sent_value_cname = pyrex_prefix + "sent_value"
 pykwdlist_cname  = pyrex_prefix + "pyargnames"

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1798,6 +1798,8 @@ if VALUE is not None:
         node.stats.insert(0, node.py_func)
         node.py_func = self.visit(node.py_func)
         node.update_fused_defnode_entry(env)
+        # For the moment, fused functions do not support METH_FASTCALL
+        node.py_func.entry.signature.use_fastcall = False
         pycfunc = ExprNodes.PyCFunctionNode.from_defnode(node.py_func, binding=True)
         pycfunc = ExprNodes.ProxyNode(pycfunc.coerce_to_temp(env))
         node.resulting_fused_function = pycfunc
@@ -1935,6 +1937,9 @@ if VALUE is not None:
             rhs.binding = True
 
         node.is_cyfunction = rhs.binding
+        if rhs.binding:
+            # For the moment, CyFunctions do not support METH_FASTCALL
+            node.entry.signature.use_fastcall = False
         return self._create_assignment(node, rhs, env)
 
     def _create_assignment(self, def_node, rhs, env):

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -738,8 +738,8 @@ bad:
 /////////////// TupleAndListFromArray.proto ///////////////
 
 #if CYTHON_COMPILING_IN_CPYTHON
-static CYTHON_INLINE PyObject* __Pyx_PyTuple_FromArray(PyObject *const *src, Py_ssize_t n);
 static CYTHON_INLINE PyObject* __Pyx_PyList_FromArray(PyObject *const *src, Py_ssize_t n);
+static CYTHON_INLINE PyObject* __Pyx_PyTuple_FromArray(PyObject *const *src, Py_ssize_t n);
 #endif
 
 /////////////// TupleAndListFromArray ///////////////

--- a/tests/run/str_subclass_kwargs.pyx
+++ b/tests/run/str_subclass_kwargs.pyx
@@ -1,0 +1,21 @@
+def test_str_subclass_kwargs(k=None):
+    """
+    Test passing keywords with names that are not of type ``str``
+    but a subclass:
+
+    >>> class StrSubclass(str):
+    ...     pass
+    >>> class StrNoCompare(str):
+    ...     def __eq__(self, other):
+    ...         raise RuntimeError("do not compare me")
+    ...     def __hash__(self):
+    ...         return hash(str(self))
+    >>> kwargs = {StrSubclass('k'): 'value'}
+    >>> test_str_subclass_kwargs(**kwargs)
+    'value'
+    >>> kwargs = {StrNoCompare('k'): 'value'}
+    >>> test_str_subclass_kwargs(**kwargs)
+    Traceback (most recent call last):
+    RuntimeError: do not compare me
+    """
+    return k


### PR DESCRIPTION
Support `METH_FASTCALL` for builtin functions (not yet CyFunctions) on CPython 3.7