### PR TITLE
BUG: Fix reference count issues

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -432,11 +432,9 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
         PyMappingMethods *mm = Py_TYPE(o)->tp_as_mapping;
         PySequenceMethods *sm = Py_TYPE(o)->tp_as_sequence;
         if (mm && mm->mp_subscript) {
-            PyObject *key = PyInt_FromSsize_t(i);
-            if (unlikely(!key)) {
-                return NULL;
-            }
-            PyObject *r = mm->mp_subscript(o, key);
+            PyObject *r, *key = PyInt_FromSsize_t(i);
+            if (unlikely(!key)) return NULL;
+            r = mm->mp_subscript(o, key);
             Py_DECREF(key);
             return r;
         }
@@ -502,11 +500,10 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
         PyMappingMethods *mm = Py_TYPE(o)->tp_as_mapping;
         PySequenceMethods *sm = Py_TYPE(o)->tp_as_sequence;
         if (mm && mm->mp_ass_subscript) {
+            int r;
             PyObject *key = PyInt_FromSsize_t(i);
-            if (unlikely(!key)) {
-                return -1;
-            }
-            int r = mm->mp_ass_subscript(o, key, v);
+            if (unlikely(!key)) return -1;
+            mm->mp_ass_subscript(o, key, v);
             Py_DECREF(key);
             return r;
         }

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -433,7 +433,12 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
         PySequenceMethods *sm = Py_TYPE(o)->tp_as_sequence;
         if (mm && mm->mp_subscript) {
             PyObject *key = PyInt_FromSsize_t(i);
-            return likely(key) ? mm->mp_subscript(o, key) : NULL;
+            if (unlikely(!key)) {
+                return NULL;
+            }
+            PyObject *r = mm->mp_subscript(o, key);
+            Py_DECREF(key);
+            return r;
         }
         if (likely(sm && sm->sq_item)) {
             if (wraparound && unlikely(i < 0) && likely(sm->sq_length)) {
@@ -498,7 +503,12 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
         PySequenceMethods *sm = Py_TYPE(o)->tp_as_sequence;
         if (mm && mm->mp_ass_subscript) {
             PyObject *key = PyInt_FromSsize_t(i);
-            return likely(key) ? mm->mp_ass_subscript(o, key, v) : -1;
+            if (unlikely(!key)) {
+                return -1;
+            }
+            int r = mm->mp_ass_subscript(o, key, v);
+            Py_DECREF(key);
+            return r;
         }
         if (likely(sm && sm->sq_ass_item)) {
             if (wraparound && unlikely(i < 0) && likely(sm->sq_length)) {

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -685,9 +685,11 @@ static PyObject* __Pyx__PyNumber_PowerOf2(PyObject *two, PyObject *exp, PyObject
             return PyLong_FromUnsignedLongLong(value);
 #endif
         } else {
-            PyObject *one = PyInt_FromLong(1L);
+            PyObject *result, *one = PyInt_FromLong(1L);
             if (unlikely(!one)) return NULL;
-            return PyNumber_Lshift(one, exp);
+            result = PyNumber_Lshift(one, exp);
+            Py_DECREF(one);
+            return result;
         }
     } else if (shiftby == -1 && PyErr_Occurred()) {
         PyErr_Clear();


### PR DESCRIPTION
The new PyInt_FromSsize_t reference was not decref'ed in general.

---

I was hacking on numpy using `pytest-leaks` and ran into a reference issues within cython (numpy.random). This is the on that I managed to track down for now. There is another coming up (although most likely I will only open an issue).

I suppose these should get tests? Just ping me, and I will look into it.