### PR TITLE
BUG: Fix(up) incorrect return in SetItemFast

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -503,7 +503,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
             int r;
             PyObject *key = PyInt_FromSsize_t(i);
             if (unlikely(!key)) return -1;
-            mm->mp_ass_subscript(o, key, v);
+            r = mm->mp_ass_subscript(o, key, v);
             Py_DECREF(key);
             return r;
         }


### PR DESCRIPTION
Sorry, my previous fix was cursed (not running the tests), now I
saw the compiler warning, and I suppose it would be good for the
tests to run error paths.