### PR TITLE
Add cpp tag to some cpp error tests

### DIFF
--- a/tests/errors/cimport_attributes.pyx
+++ b/tests/errors/cimport_attributes.pyx
@@ -1,4 +1,5 @@
 # mode: error
+# tag: cpp
 
 
 cimport libcpp
@@ -24,8 +25,8 @@ print my_map_with_shadow.python_attribute   # OK (if such a module existed at ru
 
 
 _ERRORS = u"""
-5:12: cimported module has no attribute 'no_such_attribute'
-8:16: cimported module has no attribute 'no_such_attribute'
-11:12: cimported module has no attribute 'no_such_attribute'
-14:15: cimported module has no attribute 'no_such_attribute'
+6:12: cimported module has no attribute 'no_such_attribute'
+9:16: cimported module has no attribute 'no_such_attribute'
+12:12: cimported module has no attribute 'no_such_attribute'
+15:15: cimported module has no attribute 'no_such_attribute'
 """

--- a/tests/errors/cpp_object_template.pyx
+++ b/tests/errors/cpp_object_template.pyx
@@ -1,4 +1,5 @@
 # mode: error
+# tag: cpp
 
 from libcpp.vector cimport vector
 
@@ -12,6 +13,6 @@ def main():
     va.push_back(A())
 
 _ERRORS = u"""
-9:16: Python object type 'Python object' cannot be used as a template argument
-11:16: Python object type 'A' cannot be used as a template argument
+10:16: Python object type 'Python object' cannot be used as a template argument
+12:16: Python object type 'A' cannot be used as a template argument
 """


### PR DESCRIPTION
2 error tests didn't have the `tag: cpp` although they use c++ features.
This was not noticed before because these error tests are not triggering a Node.cpp_check.

This cpp_check function is only called with memory statements `new` and `del`.
So, for example, cython is perfectly happy with compiling a .pyx which is declaring (even defining) a C++ class, as long as you only use stack allocation, **without the `--cplus` flag**.

I think this check may be generalized, just like what is done for gil checking.
If this sounds interesting, I can spare some time to do it.