### PR TITLE
0.29.x: posix.mman and cpython.pystate include backports

### DIFF
--- a/Cython/Includes/cpython/pystate.pxd
+++ b/Cython/Includes/cpython/pystate.pxd
@@ -20,7 +20,8 @@ cdef extern from "Python.h":
 
     # This is not actually a struct, but make sure it can never be coerced to
     # an int or used in arithmetic expressions
-    ctypedef struct PyGILState_STATE
+    ctypedef struct PyGILState_STATE:
+        pass
 
     # The type of the trace function registered using PyEval_SetProfile() and
     # PyEval_SetTrace().

--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -57,12 +57,25 @@ cdef extern from "<sys/mman.h>" nogil:
     int shm_unlink(const char *name)
 
     # often available
-    enum: MADV_REMOVE               # pre-POSIX advice flags; often available
+    enum: MADV_NORMAL               # pre-POSIX advice flags; should translate 1-1 to POSIX_*
+    enum: MADV_RANDOM               # but in practice it is not always the same.
+    enum: MADV_SEQUENTIAL
+    enum: MADV_WILLNEED
+    enum: MADV_DONTNEED
+    enum: MADV_REMOVE               # other pre-POSIX advice flags; often available
     enum: MADV_DONTFORK
     enum: MADV_DOFORK
     enum: MADV_HWPOISON
     enum: MADV_MERGEABLE,
     enum: MADV_UNMERGEABLE
+    enum: MADV_SOFT_OFFLINE
+    enum: MADV_HUGEPAGE
+    enum: MADV_NOHUGEPAGE
+    enum: MADV_DONTDUMP
+    enum: MADV_DODUMP
+    enum: MADV_FREE
+    enum: MADV_WIPEONFORK
+    enum: MADV_KEEPONFORK
     int   madvise(void *addr, size_t Len, int advice)
 
     # sometimes available

--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -46,6 +46,10 @@ cdef extern from "<sys/mman.h>" nogil:
     int   munlock(const void *addr, size_t Len)
     int   mlockall(int flags)
     int   munlockall()
+    # Linux-specific
+    enum: MLOCK_ONFAULT
+    enum: MCL_ONFAULT
+    int   mlock2(const void *addr, size_t len, int flags)
 
     int shm_open(const char *name, int oflag, mode_t mode)
     int shm_unlink(const char *name)

--- a/Cython/Includes/posix/mman.pxd
+++ b/Cython/Includes/posix/mman.pxd
@@ -24,6 +24,8 @@ cdef extern from "<sys/mman.h>" nogil:
     enum: MAP_NOCORE                #  Typically available only on BSD
     enum: MAP_NOSYNC
 
+    void *MAP_FAILED
+
     void *mmap(void *addr, size_t Len, int prot, int flags, int fd, off_t off)
     int   munmap(void *addr, size_t Len)
     int   mprotect(void *addr, size_t Len, int prot)

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -2,6 +2,7 @@
 # tag: c-api
 
 from cpython cimport mem
+from cpython.pystate cimport PyGILState_Ensure, PyGILState_Release, PyGILState_STATE
 
 
 def test_pymalloc():
@@ -47,3 +48,17 @@ def test_pymalloc_raw():
             mem.PyMem_RawFree(m)
     assert m2
     return retval
+
+
+def test_gilstate():
+    """
+    >>> test_gilstate()
+    'ok'
+    """
+
+    # cython used to have invalid definition for PyGILState_STATE, which was
+    # making the following code fail to compile
+    cdef PyGILState_STATE gstate = PyGILState_Ensure()
+    # TODO assert that GIL is taken
+    PyGILState_Release(gstate)
+    return 'ok'


### PR DESCRIPTION
Backport from master to 0.29.x branch my fixes to mman and pystate includes. The following changes are backported:

- https://github.com/cython/cython/pull/2893
- https://github.com/cython/cython/pull/2894
- https://github.com/cython/cython/pull/2997
- https://github.com/cython/cython/pull/3012

Reason for backport is that not everyone is using unrelased Cython 3 while Cython 0.29.x usage is common.
