### PR TITLE
Fix #3047: Add PyMem_(Raw)Calloc to cpython.mem

### DIFF
--- a/Cython/Includes/cpython/mem.pxd
+++ b/Cython/Includes/cpython/mem.pxd
@@ -35,6 +35,15 @@ cdef extern from "Python.h":
     # PyMem_Malloc(1) had been called instead. The memory will not
     # have been initialized in any way.
 
+    void* PyMem_RawCalloc(size_t nelem, size_t elsize) nogil
+    void* PyMem_Calloc(size_t nelem, size_t elsize)
+    # Allocates nelem elements each whose size in bytes is elsize and
+    # returns a pointer of type void* to the allocated memory, or NULL if
+    # the request fails. The memory is initialized to zeros. Requesting
+    # zero elements or elements of size zero bytes returns a distinct
+    # non-NULL pointer if possible, as if PyMem_Calloc(1, 1) had been
+    # called instead.
+
     void* PyMem_RawRealloc(void *p, size_t n) nogil
     void* PyMem_Realloc(void *p, size_t n)
     # Resizes the memory block pointed to by p to n bytes. The
@@ -43,13 +52,13 @@ cdef extern from "Python.h":
     # else if n is equal to zero, the memory block is resized but is
     # not freed, and the returned pointer is non-NULL. Unless p is
     # NULL, it must have been returned by a previous call to
-    # PyMem_Malloc() or PyMem_Realloc().
+    # PyMem_Malloc(), PyMem_Realloc(), or PyMem_Calloc().
 
     void PyMem_RawFree(void *p) nogil
     void PyMem_Free(void *p)
     # Frees the memory block pointed to by p, which must have been
-    # returned by a previous call to PyMem_Malloc() or
-    # PyMem_Realloc(). Otherwise, or if PyMem_Free(p) has been called
+    # returned by a previous call to PyMem_Malloc(), PyMem_Realloc(), or
+    # PyMem_Calloc(). Otherwise, or if PyMem_Free(p) has been called
     # before, undefined behavior occurs. If p is NULL, no operation is
     # performed.
 

--- a/runtests.py
+++ b/runtests.py
@@ -443,6 +443,7 @@ VER_DEP_MODULES = {
                                          'run.mod__spec__',
                                          'run.pep526_variable_annotations',  # typing module
                                          'run.test_exceptions',  # copied from Py3.7+
+                                         'run.cpython_capi',
                                          ]),
 }
 

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -5,7 +5,7 @@ from cpython cimport mem
 from cpython.pystate cimport PyGILState_Ensure, PyGILState_Release, PyGILState_STATE
 
 
-cdef short _assert_calloc(short * s, int n):
+cdef short _assert_calloc(short* s, int n) except -1 with gil:
     """Assert array ``s`` of length ``n`` is zero and return 3."""
     s[0] += 1
     s[n - 1] += 3

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -5,18 +5,36 @@ from cpython cimport mem
 from cpython.pystate cimport PyGILState_Ensure, PyGILState_Release, PyGILState_STATE
 
 
+cdef short _assert_calloc(short * s, int n):
+    """Assert array ``s`` of length ``n`` is zero and return 3."""
+    s[0] += 1
+    s[n - 1] += 3
+    assert not s[0] and not s[n - 1]
+    for i in range(1, n - 1):
+        assert not s[i]
+    return s[n - 1]
+
+
 def test_pymalloc():
     """
     >>> test_pymalloc()
     3
     """
+    cdef short i
+    cdef short* s = <short*> mem.PyMem_Calloc(10, sizeof(*s))
+    if not s:
+        raise MemoryError()
+    try:
+        i = _assert_calloc(s, 10)
+    finally:
+        mem.PyMem_Free(m)
     cdef char* m2
     cdef char* m = <char*> mem.PyMem_Malloc(20)
     assert m
     try:
         m[0] = 1
         m[1] = 2
-        m[2] = 3
+        m[2] = i
         m2 = <char*> mem.PyMem_Realloc(m, 10)
         assert m2
         m = m2
@@ -30,16 +48,25 @@ def test_pymalloc_raw():
     >>> test_pymalloc_raw()
     3
     """
+    cdef short i
+    cdef short* s
     cdef char* m
     cdef char* m2 = NULL
     with nogil:
+        s = <short*> mem.PyMem_RawCalloc(10, sizeof(*s))
+        if not s:
+            raise MemoryError()
+        try:
+            i = _assert_calloc(s, 10)
+        finally:
+            mem.PyMem_Free(m)
         m = <char*> mem.PyMem_RawMalloc(20)
         if not m:
             raise MemoryError()
         try:
             m[0] = 1
             m[1] = 2
-            m[2] = 3
+            m[2] = i
             m2 = <char*> mem.PyMem_RawRealloc(m, 10)
             if m2:
                 m = m2

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -7,9 +7,9 @@ from cpython.pystate cimport PyGILState_Ensure, PyGILState_Release, PyGILState_S
 
 cdef short _assert_calloc(short* s, int n) except -1 with gil:
     """Assert array ``s`` of length ``n`` is zero and return 3."""
+    assert not s[0] and not s[n - 1]
     s[0] += 1
     s[n - 1] += 3
-    assert not s[0] and not s[n - 1]
     for i in range(1, n - 1):
         assert not s[i]
     return s[n - 1]

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -59,7 +59,7 @@ def test_pymalloc_raw():
         try:
             i = _assert_calloc(s, 10)
         finally:
-            mem.PyMem_Free(s)
+            mem.PyMem_RawFree(s)
         m = <char*> mem.PyMem_RawMalloc(20)
         if not m:
             raise MemoryError()

--- a/tests/run/cpython_capi.pyx
+++ b/tests/run/cpython_capi.pyx
@@ -21,13 +21,13 @@ def test_pymalloc():
     3
     """
     cdef short i
-    cdef short* s = <short*> mem.PyMem_Calloc(10, sizeof(*s))
+    cdef short* s = <short*> mem.PyMem_Calloc(10, sizeof(short))
     if not s:
         raise MemoryError()
     try:
         i = _assert_calloc(s, 10)
     finally:
-        mem.PyMem_Free(m)
+        mem.PyMem_Free(s)
     cdef char* m2
     cdef char* m = <char*> mem.PyMem_Malloc(20)
     assert m
@@ -53,13 +53,13 @@ def test_pymalloc_raw():
     cdef char* m
     cdef char* m2 = NULL
     with nogil:
-        s = <short*> mem.PyMem_RawCalloc(10, sizeof(*s))
+        s = <short*> mem.PyMem_RawCalloc(10, sizeof(short))
         if not s:
             raise MemoryError()
         try:
             i = _assert_calloc(s, 10)
         finally:
-            mem.PyMem_Free(m)
+            mem.PyMem_Free(s)
         m = <char*> mem.PyMem_RawMalloc(20)
         if not m:
             raise MemoryError()


### PR DESCRIPTION
Fix #3047. CPython added PyMem_RawCalloc and PyMem_Calloc in version 3.5. I did not
in include a version guard for 3.4 because PyObject_Calloc was also
added in 3.5 but it's already in this file without a version guard.

I updated comments for other functions to reflect PyMem_Calloc but not
PyMem_RawCalloc to match comments' currently only referencing
PyMem_Malloc and friends.

I did not modify Cython/Utility/ModuleSetupCode.c, where
PyMem_RawMalloc, PyMem_RawRealloc, and PyMem_RawFree are #defined for
Python 3.3 because (a) I couldn't figure out where these were being used
and (b) they're defined to their non-raw versions, which strikes me as
dangerous since the Raw versions allow use without the GIL but the
non-Raw versions do not.

Finally, I updated the tests in cpython_capi.pyx. I'm never sure when
compilers decide code is dead and just ignore it, so I tried actually to
write to the memory and return data from it. I can't figure out how to
run Cython's tests, so... fingers crossed.