### PR TITLE
Fix #3057: Implement `include_once` statement.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Features added
 
 * The ``@cython.binding`` decorator is available in Python code.
 
+* Add ``include_once`` statement (Github issue #3057).
+
 Bugs fixed
 ----------
 

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -403,7 +403,7 @@ def strip_string_literals(code, prefix='__Pyx_L'):
 dependency_regex = re.compile(r"(?:^\s*from +([0-9a-zA-Z_.]+) +cimport)|"
                               r"(?:^\s*cimport +([0-9a-zA-Z_.]+(?: *, *[0-9a-zA-Z_.]+)*))|"
                               r"(?:^\s*cdef +extern +from +['\"]([^'\"]+)['\"])|"
-                              r"(?:^\s*include +['\"]([^'\"]+)['\"])", re.M)
+                              r"(?:^\s*include(?:_once)? +['\"]([^'\"]+)['\"])", re.M)
 dependency_after_from_regex = re.compile(
     r"(?:^\s+\(([0-9a-zA-Z_., ]*)\)[#\n])|"
     r"(?:^\s+([0-9a-zA-Z_., ]*)[#\n])",

--- a/Cython/Build/Tests/TestStripLiterals.py
+++ b/Cython/Build/Tests/TestStripLiterals.py
@@ -51,6 +51,10 @@ class TestStripLiterals(CythonTest):
         self.t("include 'a.pxi' # something here",
                "include '_L1_' #_L2_")
 
+    def test_include_once(self):
+        self.t("include_once 'a.pxi' # something here",
+               "include_once '_L1_' #_L2_")
+
     def test_extern(self):
         self.t("cdef extern from 'a.h': # comment",
                "cdef extern from '_L1_': #_L2_")

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -274,7 +274,7 @@ class Context(object):
         for kind, name in self.read_dependency_file(source_path):
             if kind == "cimport":
                 dep_path = self.find_pxd_file(name, pos)
-            elif kind == "include":
+            elif kind == "include" or kind == "include_once":
                 dep_path = self.search_include_directories(name, pos)
             else:
                 continue

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -96,6 +96,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     L1.append(x)
 
         extend_if_not_in(self.scope.included_files, scope.included_files)
+        self.scope.included_file_paths.update(scope.included_file_paths)
 
         if merge_scope:
             # Ensure that we don't generate import code for these entries!

--- a/Cython/Compiler/Scanning.pxd
+++ b/Cython/Compiler/Scanning.pxd
@@ -23,6 +23,7 @@ cdef class CompileTimeScope:
 cdef class PyrexScanner(Scanner):
     cdef public context
     cdef public list included_files
+    cdef public set included_file_paths
     cdef public CompileTimeScope compile_time_env
     cdef public bint compile_time_eval
     cdef public bint compile_time_expr

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -46,7 +46,7 @@ py_reserved_words = [
 ]
 
 pyx_reserved_words = py_reserved_words + [
-    "include", "ctypedef", "cdef", "cpdef",
+    "include", "include_once", "ctypedef", "cdef", "cpdef",
     "cimport", "DEF", "IF", "ELIF", "ELSE"
 ]
 
@@ -294,11 +294,12 @@ class StringSourceDescriptor(SourceDescriptor):
 #------------------------------------------------------------------
 
 class PyrexScanner(Scanner):
-    #  context            Context  Compilation context
-    #  included_files     [string] Files included with 'include' statement
-    #  compile_time_env   dict     Environment for conditional compilation
-    #  compile_time_eval  boolean  In a true conditional compilation context
-    #  compile_time_expr  boolean  In a compile-time expression context
+    #  context             Context  Compilation context
+    #  included_files      [string] Name of files included with 'include' statement
+    #  included_file_paths {string} Absolute path of files included with 'include' statement
+    #  compile_time_env    dict     Environment for conditional compilation
+    #  compile_time_eval   boolean  In a true conditional compilation context
+    #  compile_time_expr   boolean  In a compile-time expression context
 
     def __init__(self, file, filename, parent_scanner=None,
                  scope=None, context=None, source_encoding=None, parse_comments=True, initial_pos=None):
@@ -306,12 +307,14 @@ class PyrexScanner(Scanner):
         if parent_scanner:
             self.context = parent_scanner.context
             self.included_files = parent_scanner.included_files
+            self.included_file_paths = parent_scanner.included_file_paths
             self.compile_time_env = parent_scanner.compile_time_env
             self.compile_time_eval = parent_scanner.compile_time_eval
             self.compile_time_expr = parent_scanner.compile_time_expr
         else:
             self.context = context
             self.included_files = scope.included_files
+            self.included_file_paths = scope.included_file_paths
             self.compile_time_env = initial_compile_time_env()
             self.compile_time_eval = 1
             self.compile_time_expr = 0

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1122,7 +1122,8 @@ class ModuleScope(Scope):
     # parent_module        Scope              Parent in the import namespace
     # module_entries       {string : Entry}   For cimport statements
     # type_names           {string : 1}       Set of type names (used during parsing)
-    # included_files       [string]           Cython sources included with 'include'
+    # included_files       [string]           Name of cython source files included with 'include' or 'include_once'
+    # included_file_paths  {string}           Path of cython source files included with 'include' or 'include_once'
     # pxd_file_loaded      boolean            Corresponding .pxd file has been processed
     # cimported_modules    [ModuleScope]      Modules imported with cimport
     # types_imported       {PyrexType}        Set of types for which import code generated
@@ -1164,6 +1165,7 @@ class ModuleScope(Scope):
         self.cimported_modules = []
         self.types_imported = set()
         self.included_files = []
+        self.included_file_paths = set()
         self.has_extern_class = 0
         self.cached_builtins = []
         self.undeclared_cached_builtins = []

--- a/Cython/Parser/ConcreteSyntaxTree.pyx
+++ b/Cython/Parser/ConcreteSyntaxTree.pyx
@@ -63,7 +63,7 @@ def handle_includes(source, path):
             return include_line.group(0) + ' # no such path: ' + included
         return handle_includes(open(included).read(), path)
     # TODO: Proper string tokenizing.
-    return re.sub(r'^include\s+([^\n]+[\'"])\s*(#.*)?$', include_here, source, flags=re.M)
+    return re.sub(r'^include(?:_once)?\s+([^\n]+[\'"])\s*(#.*)?$', include_here, source, flags=re.M)
 
 def p_module(path):
     cdef perrdetail err

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -846,19 +846,27 @@ The include statement and include files
     Historically the ``include`` statement was used for sharing declarations.
     Use :ref:`sharing-declarations` instead.
 
-A Cython source file can include material from other files using the include
+A Cython source file can include material from other files using the ``include``
 statement, for example,::
 
     include "spamstuff.pxi"
 
 The contents of the named file are textually included at that point.  The
 included file can contain any complete statements or declarations that are
-valid in the context where the include statement appears, including other
-include statements.  The contents of the included file should begin at an
+valid in the context where the ``include`` statement appears, including other
+``include`` statements.  The contents of the included file should begin at an
 indentation level of zero, and will be treated as though they were indented to
-the level of the include statement that is including the file.  The include
-statement cannot, however, be used outside of the module scope, such as inside
-of functions or class bodies.
+the level of the ``include`` statement that is including the file.  The
+``include`` statement cannot, however, be used outside of the module scope,
+such as inside of functions or class bodies.
+
+It is also possible to use the ``include_once`` statement. It behaves like the
+``include`` statement, with the only difference being that if the file has
+already been included in the module, it will not be included again.
+
+For example::
+
+    include_once "spamstuff.pxi"
 
 .. note::
 

--- a/tests/compile/include_once.srctree
+++ b/tests/compile/include_once.srctree
@@ -1,0 +1,38 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import test"
+
+######## setup.py ########
+
+from distutils.core import setup
+from Cython.Build.Dependencies import cythonize
+
+setup(name="test", ext_modules=cythonize("test.pyx"))
+
+######## test.pyx ########
+include_once "include/a.pxi"
+include "include/b/b.pxi"
+include_once "include/recursive.pxi"
+
+assert (A)
+assert (B)
+assert (RECURSIVE)
+assert (GLOBAL_COUNTER == 1)
+
+######## include/inc.pxi ########
+try:
+    GLOBAL_COUNTER += 1
+except NameError:
+    GLOBAL_COUNTER = 1
+
+######## include/a.pxi ########
+include_once "inc.pxi"
+A = True
+
+######## include/b/b.pxi ########
+include_once "../inc.pxi"
+B = True
+
+######## include/recursive.pxi ########
+include_once "inc.pxi"
+include_once "recursive.pxi"
+RECURSIVE = True


### PR DESCRIPTION
Implement ``include_once`` statement. (#3057)

The ``include_once`` statement behaves like the ``include`` statement, with the only difference being that if the file has already been included in the module, it will not be included again.
