### PR TITLE
Setting language level 3str for ipython

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -424,7 +424,7 @@ class CythonMagics(Magics):
                 quiet=quiet,
                 annotate=args.annotate,
                 force=True,
-                language_level=min(3, sys.version_info[0]),
+                language_level='3str',
             )
             if args.language_level is not None:
                 assert args.language_level in (2, 3)

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -193,11 +193,11 @@ class CythonMagics(Magics):
     )
     @magic_arguments.argument(
         '-3', dest='language_level', action='store_const', const=3, default=None,
-        help="Select Python 3 syntax."
+        help="Select Python 3 syntax. Default is language_level=3str."
     )
     @magic_arguments.argument(
         '-2', dest='language_level', action='store_const', const=2, default=None,
-        help="Select Python 2 syntax."
+        help="Select Python 2 syntax. Default is language_level=3str."
     )
     @magic_arguments.argument(
         '-f', '--force', action='store_true', default=False,

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -49,6 +49,14 @@ def call(x):
     return f(*(x,))
 """)
 
+cython3str_code = py3compat.str_to_unicode("""\
+def div():
+    return 5/2
+
+def literal():
+    return "aaa"
+""")
+
 pgo_cython3_code = cython3_code + py3compat.str_to_unicode("""\
 def main():
     for _ in range(100): call(5)
@@ -123,16 +131,14 @@ class TestIPythonMagic(CythonTest):
         self.assertEqual(ip.user_ns['g'], 20.0)
 
     def test_cython_language_level(self):
-        # The Cython cell defines the functions f() and call().
+        # The Cython cell defines the functions div() and literal().
         ip = self._ip
-        ip.run_cell_magic('cython', '', cython3_code)
-        ip.ex('g = f(10); h = call(10)')
-        if sys.version_info[0] < 3:
-            self.assertEqual(ip.user_ns['g'], 2 // 10)
-            self.assertEqual(ip.user_ns['h'], 2 // 10)
-        else:
-            self.assertEqual(ip.user_ns['g'], 2.0 / 10.0)
-            self.assertEqual(ip.user_ns['h'], 2.0 / 10.0)
+        ip.run_cell_magic('cython', '', cython3str_code)
+        ip.ex('d = div(); s = literal()')
+        # differentiate between 2 and (3 or 3str):
+        self.assertEqual(type(ip.user_ns['d']), float)
+        # differentiate between 3 and 3str (for Py2):
+        self.assertEqual(type(ip.user_ns['s']), str)
 
     def test_cython3(self):
         # The Cython cell defines the functions f() and call().

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -629,9 +629,9 @@ You can see them also by typing ```%%cython?`` in IPython or a Jupyter notebook.
 
 -f, --force                                   Force the compilation of a new module, even if the source has been previously compiled.
 
--3                                            Select Python 3 syntax
+-3                                            Select Python 3 syntax. Default language_level is 3str.
 
--2                                            Select Python 2 syntax
+-2                                            Select Python 2 syntax. Default language_level is 3str.
 
 -c=COMPILE_ARGS, --compile-args=COMPILE_ARGS  Extra flags to pass to compiler via the extra_compile_args.
 


### PR DESCRIPTION
Sets the default language_level for Ipython-cells to 3str, as communicated here: https://github.com/cython/cython/pull/3001#issuecomment-518936786

This is however a breaking change for a lot of Python2-Notebooks, so probably some additional note somewhere is needed.