### PR TITLE
Handle normalization of unicode identifiers

### DIFF
--- a/Cython/Compiler/Lexicon.py
+++ b/Cython/Compiler/Lexicon.py
@@ -85,7 +85,7 @@ def make_lexicon():
     comment = Str("#") + Rep(AnyBut("\n"))
 
     return Lexicon([
-        (name, IDENT),
+        (name, Method('normalize_ident')),
         (intliteral, Method('strip_underscores', symbol='INT')),
         (fltconst, Method('strip_underscores', symbol='FLOAT')),
         (imagconst, Method('strip_underscores', symbol='IMAG')),

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -12,6 +12,7 @@ cython.declare(make_lexicon=object, lexicon=object,
 
 import os
 import platform
+from unicodedata import normalize
 
 from .. import Utils
 from ..Plex.Scanners import Scanner
@@ -340,6 +341,13 @@ class PyrexScanner(Scanner):
         self.begin('INDENT')
         self.sy = ''
         self.next()
+
+    def normalize_ident(self, text):
+        try:
+            text.encode('ascii') # really just name.isascii but supports Python 2 and 3
+        except UnicodeEncodeError:
+            text = normalize('NFKC', text)
+        self.produce(IDENT, text)
 
     def commentline(self, text):
         if self.parse_comments:

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -216,7 +216,7 @@ def decode_filename(filename):
 _match_file_encoding = re.compile(br"(\w*coding)[:=]\s*([-\w.]+)").search
 
 
-def detect_opened_file_encoding(f):
+def detect_opened_file_encoding(f, default='UTF-8'):
     # PEPs 263 and 3120
     # Most of the time the first two lines fall in the first couple of hundred chars,
     # and this bulk read/split is much faster.
@@ -236,7 +236,7 @@ def detect_opened_file_encoding(f):
         m = _match_file_encoding(lines[1])
         if m:
             return m.group(2).decode('iso8859-1')
-    return "UTF-8"
+    return default
 
 
 def skip_bom(f):

--- a/runtests.py
+++ b/runtests.py
@@ -545,9 +545,14 @@ class build_ext(_build_ext):
 class ErrorWriter(object):
     match_error = re.compile(r'(warning:)?(?:.*:)?\s*([-0-9]+)\s*:\s*([-0-9]+)\s*:\s*(.*)').match
 
-    def __init__(self):
+    def __init__(self, encoding=None):
         self.output = []
-        self.write = self.output.append
+        self.encoding = encoding
+
+    def write(self, value):
+        if self.encoding:
+            value = value.encode('ISO-8859-1').decode(self.encoding)
+        self.output.append(value)
 
     def _collect(self):
         s = ''.join(self.output)
@@ -1005,23 +1010,22 @@ class CythonCompileTestCase(unittest.TestCase):
 
         from Cython.Utils import detect_opened_file_encoding
         with io_open(source_file, 'rb') as f:
-            encoding = detect_opened_file_encoding(f, default='ISO-8859-1')
-        if encoding.lower() == 'ascii':
-            encoding = 'ISO-8859-1' # at least one test is based around a file tagged with ascii
-            # but with a character that can't be read with ascii. Therefore use different default
+            # encoding is passed to ErrorWriter but not used on the source
+            # since it is sometimes deliberately wrong
+            encoding = detect_opened_file_encoding(f, default=None)
 
-        with io_open(source_file, 'r', encoding=encoding) as source_and_output:
+        with io_open(source_file, 'r', encoding='ISO-8859-1') as source_and_output:
             error_writer = warnings_writer = None
             out = io_open(os.path.join(workdir, module + os.path.splitext(source_file)[1]),
-                          'w', encoding=encoding)
+                          'w', encoding='ISO-8859-1')
             try:
                 for line in source_and_output:
                     if line.startswith("_ERRORS"):
                         out.close()
-                        out = error_writer = ErrorWriter()
+                        out = error_writer = ErrorWriter(encoding=encoding)
                     elif line.startswith("_WARNINGS"):
                         out.close()
-                        out = warnings_writer = ErrorWriter()
+                        out = warnings_writer = ErrorWriter(encoding=encoding)
                     else:
                         out.write(line)
             finally:

--- a/runtests.py
+++ b/runtests.py
@@ -1002,10 +1002,18 @@ class CythonCompileTestCase(unittest.TestCase):
 
     def split_source_and_output(self, test_directory, module, workdir):
         source_file = self.find_module_source_file(os.path.join(test_directory, module) + '.pyx')
-        with io_open(source_file, 'r', encoding='ISO-8859-1') as source_and_output:
+
+        from Cython.Utils import detect_opened_file_encoding
+        with io_open(source_file, 'rb') as f:
+            encoding = detect_opened_file_encoding(f, default='ISO-8859-1')
+        if encoding.lower() == 'ascii':
+            encoding = 'ISO-8859-1' # at least one test is based around a file tagged with ascii
+            # but with a character that can't be read with ascii. Therefore use different default
+
+        with io_open(source_file, 'r', encoding=encoding) as source_and_output:
             error_writer = warnings_writer = None
             out = io_open(os.path.join(workdir, module + os.path.splitext(source_file)[1]),
-                          'w', encoding='ISO-8859-1')
+                          'w', encoding=encoding)
             try:
                 for line in source_and_output:
                     if line.startswith("_ERRORS"):

--- a/tests/errors/unicode_identifiers_e1.pyx
+++ b/tests/errors/unicode_identifiers_e1.pyx
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# mode: error
+
+★1 = 5 # invalid start symbol
+
+_ERRORS = u"""
+4:0: Unrecognized character
+"""

--- a/tests/errors/unicode_identifiers_e2.pyx
+++ b/tests/errors/unicode_identifiers_e2.pyx
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# mode: error
+
+class MyClass₡: # invalid continue symbol
+    pass
+
+_ERRORS = u"""
+4:13: Unrecognized character
+"""

--- a/tests/errors/unicode_identifiers_e3.pyx
+++ b/tests/errors/unicode_identifiers_e3.pyx
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# mode: error
+
+def f():
+    a = 1
+    ́b = 2 # looks like an identation error but is actually a combining accent as the first letter of column 4
+    c = 3
+
+_ERRORS = u"""
+6:4: Unrecognized character
+"""

--- a/tests/errors/unicode_identifiers_e4.pyx
+++ b/tests/errors/unicode_identifiers_e4.pyx
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# mode: error
+
+cdef class C:
+    # these two symbols "\u1e69" and "\u1e9b\u0323" normalize to the same thing
+    # so the two attributes can't coexist
+    cdef int ṩomething
+    cdef double ẛ̣omething
+
+_ERRORS = u"""
+7:13: Previous declaration is here
+8:16: 'ṩomething' redeclared
+"""

--- a/tests/run/unicode_identifiers.pyx
+++ b/tests/run/unicode_identifiers.pyx
@@ -49,6 +49,17 @@ if sys.version_info[0]>2:
     10
     >>> NormalClassΓΓ().εxciting_function(None).__qualname__
     'NormalClassΓΓ.εxciting_function.<locals>.nestεd'
+
+    Do kwargs work?
+    >>> unicode_kwarg(αrg=5)
+    5
+    >>> unicode_kwarg_from_cy()
+    1
+
+    Normalization of attributes
+    (The cdef class version is testable in Python 2 too)
+    >>> NormalizeAttrPy().get()
+    5
     """
 else:
     __doc__ = ""
@@ -183,6 +194,32 @@ class NormalClassΓΓ(Γναμε2):
         def nestεd():
             pass
         return nestεd
+
+def unicode_kwarg(*,αrg):
+    return αrg
+
+def unicode_kwarg_from_cy():
+    return unicode_kwarg(αrg=1)
+
+class NormalizeAttrPy:
+    """Python normalizes identifier names before they are used;
+    therefore ﬁ and fi should access the same attribute"""
+    def __init__(self):
+        self.ﬁ = 5 # note unicode ligature symbol
+    def get(self):
+        return self.fi
+
+cdef class NormalizeAttrCdef:
+    """Python normalizes identifier names before they are used;
+    therefore ﬁ and fi should access the same attribute
+    >>> NormalizeAttrCdef().get()
+    5
+    """
+    cdef int ﬁ # note unicode ligature symbol
+    def __init__(self):
+        self.fi = 5
+    def get(self):
+        return self.ﬁ
 
 if sys.version_info[0]<=2:
     # These symbols are causing problems for doctest

--- a/tests/run/unicode_identifiers.pyx
+++ b/tests/run/unicode_identifiers.pyx
@@ -55,11 +55,6 @@ if sys.version_info[0]>2:
     5
     >>> unicode_kwarg_from_cy()
     1
-
-    Normalization of attributes
-    (The cdef class version is testable in Python 2 too)
-    >>> NormalizeAttrPy().get()
-    5
     """
 else:
     __doc__ = ""
@@ -201,17 +196,13 @@ def unicode_kwarg(*,αrg):
 def unicode_kwarg_from_cy():
     return unicode_kwarg(αrg=1)
 
-class NormalizeAttrPy:
-    """Python normalizes identifier names before they are used;
-    therefore ﬁ and fi should access the same attribute"""
-    def __init__(self):
-        self.ﬁ = 5 # note unicode ligature symbol
-    def get(self):
-        return self.fi
-
 cdef class NormalizeAttrCdef:
     """Python normalizes identifier names before they are used;
-    therefore ﬁ and fi should access the same attribute
+    therefore ﬁ and fi should access the same attribute.
+    A more comprehensive version of this is in "unicode_identifiers_normalize.py"
+    comparing the behaviour to Python. The version here shows it
+    behaves the same in a cdef class and is tested with Python 2
+
     >>> NormalizeAttrCdef().get()
     5
     """

--- a/tests/run/unicode_identifiers_normalization.srctree
+++ b/tests/run/unicode_identifiers_normalization.srctree
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# mode: run
+# tag: pure3.0, pep3131
+
+PYTHON build_tests.py
+# show behaviour in Python mode
+PYTHON -m doctest test0.py
+PYTHON -m doctest test1.py
+#PYTHON -m doctest test2.py
+
+PYTHON setup.py build_ext --inplace
+# test in Cython mode
+PYTHON -c "import doctest; import test0 as m; exit(doctest.testmod(m)[0])"
+PYTHON -c "import doctest; import test1 as m; exit(doctest.testmod(m)[0])"
+PYTHON -c "import doctest; import test2 as m; exit(doctest.testmod(m)[0])"
+
+########## setup.py #########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(
+  ext_modules = cythonize("test*.py"),
+)
+
+######### build_tests.py ########
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import sys
+import unicodedata
+
+# a few pairs of unicode strings that should be equivalent after normalization
+string_pairs = [("ﬁ", "fi"), # ligature and two letters
+                ("a\u0301", '\u00e1'), # a with acute accent with combining character or as 1 character
+                ("α\u0334\u0362", "α\u0362\u0334") # alpha with a pair of combining characters
+                    # in a different order. No single character to normalize to
+                ]
+
+# Show that the pairs genuinely aren't equal before normalization
+for sp in string_pairs:
+    assert sp[0] != sp[1]
+    assert unicodedata.normalize('NFKC', sp[0]) == unicodedata.normalize('NFKC', sp[1])
+    
+# some code that accesses the identifiers through the two different names
+#  contains doctests
+example_code = [
+"""
+class C:
+    '''
+    >>> C().get()
+    True
+    '''
+    def __init__(self):
+        self.{0} = True
+    def get(self):
+        return self.{1}
+""", """
+def pass_through({0}):
+    '''
+    >>> pass_through(True)
+    True
+    '''
+    return {1}
+""", """
+import cython
+{0} = True
+def test():
+    '''
+    >>> test()
+    True
+    '''
+    return {1}
+"""]
+
+for idx in range(len(example_code)):
+    with open("test{0}.py".format(idx),"w") as f:
+        if sys.version_info[0] > 2:
+            f.write("# -*- coding: utf-8 -*-\n")
+            f.write(example_code[idx].format(*string_pairs[idx]))
+        else:
+            f.write("\n") # code isn't Python 2 compatible - write a dummy file

--- a/tests/run/unicode_identifiers_normalization.srctree
+++ b/tests/run/unicode_identifiers_normalization.srctree
@@ -6,7 +6,7 @@ PYTHON build_tests.py
 # show behaviour in Python mode
 PYTHON -m doctest test0.py
 PYTHON -m doctest test1.py
-#PYTHON -m doctest test2.py
+PYTHON -m doctest test2.py
 
 PYTHON setup.py build_ext --inplace
 # test in Cython mode


### PR DESCRIPTION
Also add a test-case. (Also add a test case for passing keyword
arguments, which already worked, but is good to have as a test
case).

PEP3131 implies that normalization of identifiers should be done before tokenization (i.e. the moment any unicode character is found the surrounding area of code should be normalized then checked to see if it's an identifier). Practically, I don't think this is what Python does. Instead it finds a bit of string that might be an identifier and validates that it is (https://github.com/python/cpython/blob/69f37bcb28d7cd78255828029f895958b5baf6ff/Parser/tokenizer.c#L1062). Normalization is done when the AST is generated (https://github.com/python/cpython/blob/51aac15f6d525595e200e3580409c4b8656e8a96/Python/ast.c#L610).

I've followed (what I believe is) Python's approach. This might make a different if some unicode characters that aren't valid start or continuation characters can get normalized to something that is. I don't think this happens though. And this patch should certainly take care of the majority of the cases.