### PR TITLE
Always enable C line in traceback for tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1114,6 +1114,11 @@ class CythonCompileTestCase(unittest.TestCase):
                 from Cython.Build.Dependencies import update_pythran_extension
                 update_pythran_extension(extension)
 
+            # Compile with -DCYTHON_CLINE_IN_TRACEBACK=1 unless we have
+            # the "traceback" tag
+            if 'traceback' not in self.tags['tag']:
+                extension.define_macros.append(("CYTHON_CLINE_IN_TRACEBACK", 1))
+
             for matcher, fixer in list(EXT_EXTRAS.items()):
                 if isinstance(matcher, str):
                     # lazy init

--- a/tests/run/tracebacks.pyx
+++ b/tests/run/tracebacks.pyx
@@ -1,4 +1,4 @@
-import traceback
+# tag: traceback
 
 def foo1():
   foo2()
@@ -21,6 +21,7 @@ def test_traceback(cline_in_traceback=None):
   try:
     foo1()
   except:
+    import traceback
     tb_string = traceback.format_exc()
     expected = (
       'tracebacks.pyx',

--- a/tests/run/unicode_identifiers.pyx
+++ b/tests/run/unicode_identifiers.pyx
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # cython: language_level=3
 # mode: run
-# tag: pep3131
+# tag: pep3131, traceback
 
 # Code with unicode identifiers can be compiled with Cython running either Python 2 or 3.
 # However Python access to unicode identifiers is only possible in Python 3. In Python 2


### PR DESCRIPTION
This compiles all tests with `-DCYTHON_CLINE_IN_TRACEBACK=1` which is useful for debugging test failures. As an exception, this is not done for `# tag: traceback` which specifically tests the `cline_in_traceback` feature.