### PR TITLE
Travis CI: make CPython 3.8 tests mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,13 @@ matrix:
     - python: 3.6
       env: BACKEND=cpp
     - python: 3.8-dev
-      dist: xenial    # Required for Python 3.7
+      dist: xenial    # Required for Python 3.8
       sudo: required  # travis-ci/travis-ci#9069
+      env: BACKEND=c
+    - python: 3.8-dev
+      dist: xenial    # Required for Python 3.8
+      sudo: required  # travis-ci/travis-ci#9069
+      env: BACKEND=cpp
     - os: osx
       osx_image: xcode6.4
       env: PY=2
@@ -91,9 +96,6 @@ matrix:
   allow_failures:
     - python: pypy
     - python: pypy3
-    - python: 3.8-dev
-    #- env: STACKLESS=true BACKEND=c PY=2
-    #- env: STACKLESS=true BACKEND=c PY=3
 
 branches:
   only:


### PR DESCRIPTION
Now that the CPython 3.8 release is getting nearer, we should make it mandatory on Travis CI, no longer allowing failures. We also test both C and C++ like the other Python versions.