### PR TITLE
__Pyx_GetNameInClass() should get raw attribute from __dict__

### DIFF
--- a/tests/run/cclass_assign_attr_GH3100.pyx
+++ b/tests/run/cclass_assign_attr_GH3100.pyx
@@ -1,0 +1,19 @@
+cdef class Foo:
+    """
+    >>> D = Foo.__dict__
+    >>> D["meth"] is D["meth2"]
+    True
+    >>> D["classmeth"] is D["classmeth2"]
+    True
+    >>> D["staticmeth"] is D["staticmeth2"]
+    True
+    """
+    def meth(self): pass
+    @classmethod
+    def classmeth(cls): pass
+    @staticmethod
+    def staticmeth(): pass
+
+    meth2 = meth
+    classmeth2 = classmeth
+    staticmeth2 = staticmeth


### PR DESCRIPTION
This fixes various bugs of the form
```
In [22]: %%cython
    ...: cdef class Foo:
    ...:     @classmethod
    ...:     def meth(cls): return cls
    ...:     meth2 = meth

In [23]: Foo.__dict__["meth"]
Out[23]: <method 'meth' of '_cython_magic_47326ec5db9a0810fa14f024478f1a5d.Foo' objects>

In [24]: Foo.__dict__["meth2"]
Out[24]: <built-in method meth of type object at 0x7fe8b9b61700>
```
One would expect `Foo.__dict__["meth"]` and `Foo.__dict__["meth2"]` to be the same. However, the logic that implements the line `meth2 = meth` uses `Foo.meth` (which calls `__get__` to bind the classmethod) instead of `Foo.__dict__["meth"]`.