### PR TITLE
Fixing the handling of --annotate-fullc in cythonize.py

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -209,7 +209,7 @@ def parse_args(args):
         Options.error_on_uninitialized = False
 
     if options.annotate:
-        Options.annotate = True
+        Options.annotate = options.annotate
 
     if options.no_docstrings:
         Options.docstrings = False

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -192,6 +192,7 @@ def parse_args_raw(parser, args):
 def parse_args(args):
     parser = create_args_parser()
     options, args = parse_args_raw(parser, args)
+
     if not args:
         parser.error("no source files provided")
     if options.build_inplace:
@@ -201,11 +202,6 @@ def parse_args(args):
     if options.language_level:
         assert options.language_level in (2, 3, '3str')
         options.options['language_level'] = options.language_level
-    return options, args
-
-
-def main(args=None):
-    options, paths = parse_args(args)
 
     if options.lenient:
         # increase Python compatibility by ignoring compile time errors
@@ -217,6 +213,12 @@ def main(args=None):
 
     if options.no_docstrings:
         Options.docstrings = False
+
+    return options, args
+
+
+def main(args=None):
+    options, paths = parse_args(args)
 
     for path in paths:
         cython_compile(path, options)

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -2,6 +2,10 @@ from Cython.Build.Cythonize import (
     create_args_parser, parse_args_raw, parse_args,
     parallel_compiles
 )
+
+from Cython.Compiler import Options
+from Cython.Compiler.Tests.Utils import backup_Options, restore_Options, check_global_options
+
 from unittest import TestCase
 
 import sys
@@ -438,7 +442,41 @@ class TestCythonizeArgsParser(TestCase):
 
 
 class TestParseArgs(TestCase):
+    def setUp(self):
+        self._options_backup = backup_Options()
+
+    def tearDown(self):
+        restore_Options(self._options_backup)
+
+    def check_default_global_options(self, white_list=[]):
+        self.assertEqual(check_global_options(self._options_backup, white_list), "")
 
     def test_build_set_for_inplace(self):
         options, args = parse_args(['foo.pyx', '-i'])
         self.assertEqual(options.build, True)
+        self.check_default_global_options()
+
+    def test_lenient(self):
+        options, sources = parse_args(['foo.pyx', '--lenient'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(Options.error_on_unknown_names, False)
+        self.assertEqual(Options.error_on_uninitialized, False)
+        self.check_default_global_options(['error_on_unknown_names', 'error_on_uninitialized'])
+
+    def test_annotate(self):
+        options, sources = parse_args(['foo.pyx', '--annotate'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(Options.annotate, 'default')
+        self.check_default_global_options(['annotate'])
+
+    def test_annotate_fullc(self):
+        options, sources = parse_args(['foo.pyx', '--annotate-fullc'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(Options.annotate, 'fullc')
+        self.check_default_global_options(['annotate'])
+
+    def test_no_docstrings(self):
+        options, sources = parse_args(['foo.pyx', '--no-docstrings'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(Options.docstrings, False)
+        self.check_default_global_options(['docstrings'])

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import copy
 from unittest import TestCase
 try:
     from StringIO import StringIO
@@ -10,32 +9,18 @@ except ImportError:
 from .. import Options
 from ..CmdLine import parse_command_line
 
+from .Utils import backup_Options, restore_Options, check_global_options
+
 
 class CmdLineParserTest(TestCase):
     def setUp(self):
-        backup = {}
-        for name, value in vars(Options).items():
-            # we need a deep copy of _directive_defaults, because they can be changed
-            if name == '_directive_defaults':
-               value = copy.deepcopy(value)
-            backup[name] = value
-        self._options_backup = backup
+        self._options_backup = backup_Options()
 
     def tearDown(self):
-        no_value = object()
-        for name, orig_value in self._options_backup.items():
-            if getattr(Options, name, no_value) != orig_value:
-                setattr(Options, name, orig_value)
-        # strip Options from new keys that might have been added:
-        for name in vars(Options).keys():
-            if name not in self._options_backup:
-                delattr(Options, name)
+        restore_Options(self._options_backup)
 
     def check_default_global_options(self, white_list=[]):
-        no_value = object()
-        for name, orig_value in self._options_backup.items():
-            if name not in white_list:
-               self.assertEqual(getattr(Options, name, no_value), orig_value, msg="error in option " + name)
+        self.assertEqual(check_global_options(self._options_backup, white_list), "")
 
     def check_default_options(self, options, white_list=[]):
         default_options = Options.CompilationOptions(Options.default_options)

--- a/Cython/Compiler/Tests/Utils.py
+++ b/Cython/Compiler/Tests/Utils.py
@@ -1,0 +1,36 @@
+import copy
+
+from .. import Options
+
+
+def backup_Options():
+    backup = {}
+    for name, value in vars(Options).items():
+        # we need a deep copy of _directive_defaults, because they can be changed
+        if name == '_directive_defaults':
+           value = copy.deepcopy(value)
+        backup[name] = value
+    return backup
+
+
+def restore_Options(backup):
+    no_value = object()
+    for name, orig_value in backup.items():
+        if getattr(Options, name, no_value) != orig_value:
+            setattr(Options, name, orig_value)
+    # strip Options from new keys that might have been added:
+    for name in vars(Options).keys():
+        if name not in backup:
+            delattr(Options, name)
+
+
+def check_global_options(expected_options, white_list=[]):
+    """
+    returns error message of "" if check Ok
+    """
+    no_value = object()
+    for name, orig_value in expected_options.items():
+        if name not in white_list:
+            if getattr(Options, name, no_value) != orig_value:
+                return "error in option " + name
+    return ""

--- a/runtests.py
+++ b/runtests.py
@@ -1748,6 +1748,7 @@ class EndToEndTest(unittest.TestCase):
     def runTest(self):
         self.success = False
         commands = (self.commands
+            .replace("CYTHONIZE", "PYTHON %s" % os.path.join(self.cython_root, 'cythonize.py'))
             .replace("CYTHON", "PYTHON %s" % os.path.join(self.cython_root, 'cython.py'))
             .replace("PYTHON", sys.executable))
         old_path = os.environ.get('PYTHONPATH')

--- a/tests/build/cythonize_with_annotate_via_cli.srctree
+++ b/tests/build/cythonize_with_annotate_via_cli.srctree
@@ -1,0 +1,36 @@
+CYTHONIZE -i -3 not_annotated.pyx
+PYTHON -c "import not_annotated; not_annotated.check()"
+CYTHONIZE -i -3 --annotate default_annotated.pyx
+PYTHON -c "import default_annotated; default_annotated.check()"
+CYTHONIZE -i -3 --annotate-fullc fullc_annotated.pyx
+PYTHON -c "import fullc_annotated; fullc_annotated.check()"
+
+######## not_annotated.pyx ########
+# check that html-file doesn't exist:
+def check():
+    import os.path as os_path
+    assert not os_path.isfile(__name__+'.html')
+
+
+
+######## default_annotated.pyx ########
+# load html-site and check that the marker isn't there:
+def check():
+    from codecs import open
+    with open(__name__+'.html', 'r', 'utf8') as html_file:
+        html = html_file.read()
+
+    from Cython.Compiler.Annotate import AnnotationCCodeWriter
+    assert (AnnotationCCodeWriter.COMPLETE_CODE_TITLE not in html) # per default no complete c code
+
+
+
+######## fullc_annotated.pyx ########
+# load html-site and check that the marker is there:
+def check():
+    from codecs import open
+    with open(__name__+'.html', 'r', 'utf8') as html_file:
+        html = html_file.read()
+
+    from Cython.Compiler.Annotate import AnnotationCCodeWriter
+    assert (AnnotationCCodeWriter.COMPLETE_CODE_TITLE in html)


### PR DESCRIPTION
cythonize.py doesn't take `--annotate-fullc` correctly into account  (https://github.com/cython/cython/commit/8e5f944607da002f918cd4c270ad0e4ad48bc4c8 - a test case showing the problem): when called via cli, there is no difference to calling with `--annotate`.

Also improved unit tests, so they also test changes in global Options.

Fixed [here](https://github.com/cython/cython/commit/841ec5e715f9575f2a5c7642f83fb35a40e6de85).