### PR TITLE
Consistently name "closure" argument for Cython functions

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -49,12 +49,12 @@ static PyTypeObject *__pyx_CyFunctionType = 0;
 
 #define __Pyx_CyFunction_Check(obj)  (__Pyx_TypeCheck(obj, __pyx_CyFunctionType))
 
-#define __Pyx_CyFunction_NewEx(ml, flags, qualname, self, module, globals, code) \
-    __Pyx_CyFunction_New(__pyx_CyFunctionType, ml, flags, qualname, self, module, globals, code)
+#define __Pyx_CyFunction_NewEx(ml, flags, qualname, closure, module, globals, code) \
+    __Pyx_CyFunction_New(__pyx_CyFunctionType, ml, flags, qualname, closure, module, globals, code)
 
-static PyObject *__Pyx_CyFunction_New(PyTypeObject *, PyMethodDef *ml,
+static PyObject *__Pyx_CyFunction_New(PyTypeObject *type, PyMethodDef *ml,
                                       int flags, PyObject* qualname,
-                                      PyObject *self,
+                                      PyObject *closure,
                                       PyObject *module, PyObject *globals,
                                       PyObject* code);
 
@@ -812,11 +812,11 @@ typedef struct {
     PyObject *self;
 } __pyx_FusedFunctionObject;
 
-#define __pyx_FusedFunction_NewEx(ml, flags, qualname, self, module, globals, code)         \
-        __pyx_FusedFunction_New(__pyx_FusedFunctionType, ml, flags, qualname, self, module, globals, code)
+#define __pyx_FusedFunction_NewEx(ml, flags, qualname, closure, module, globals, code)         \
+        __pyx_FusedFunction_New(__pyx_FusedFunctionType, ml, flags, qualname, closure, module, globals, code)
 static PyObject *__pyx_FusedFunction_New(PyTypeObject *type,
                                          PyMethodDef *ml, int flags,
-                                         PyObject *qualname, PyObject *self,
+                                         PyObject *qualname, PyObject *closure,
                                          PyObject *module, PyObject *globals,
                                          PyObject *code);
 
@@ -831,13 +831,13 @@ static int __pyx_FusedFunction_init(void);
 
 static PyObject *
 __pyx_FusedFunction_New(PyTypeObject *type, PyMethodDef *ml, int flags,
-                        PyObject *qualname, PyObject *self,
+                        PyObject *qualname, PyObject *closure,
                         PyObject *module, PyObject *globals,
                         PyObject *code)
 {
     __pyx_FusedFunctionObject *fusedfunc =
         (__pyx_FusedFunctionObject *) __Pyx_CyFunction_New(type, ml, flags, qualname,
-                                                           self, module, globals, code);
+                                                           closure, module, globals, code);
     if (!fusedfunc)
         return NULL;
 


### PR DESCRIPTION
There is some inconsistency in the naming of the fourth argument of `__Pyx_CyFunction_NewEx` and `__pyx_FusedFunction_NewEx`: in some places `self` is used and in other places `closure` is used. I think that `closure` is the right name since
1. This has nothing to do with the `self` of methods, nor with the `self` argument to the C function (in case the function is not defined in a cdef class).
2. The value is stored in the `func_closure` field of `__pyx_CyFunctionObject`.

This is a purely cosmetic fix in the source code, it doesn't affect any external behaviour.