### PR TITLE
Utility/CppConvert: fix Cython warning

### DIFF
--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -11,7 +11,7 @@ cdef extern from *:
 
 @cname("{{cname}}")
 cdef string {{cname}}(object o) except *:
-    cdef Py_ssize_t length
+    cdef Py_ssize_t length = 0
     cdef const char* data = __Pyx_PyObject_AsStringAndSize(o, &length)
     return string(data, length)
 


### PR DESCRIPTION
When compiling to C++ code and using automatic conversion from Python
str to C++ string, Cython inserts this function template but generates
the warning:
```
warning: string.from_py:15:63: local variable 'length' might be
referenced before assignment
```
This commit fixes this.