### PR TITLE
Change type name for cyfunctions and use it in __repr__

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -574,10 +574,10 @@ static PyObject*
 __Pyx_CyFunction_repr(__pyx_CyFunctionObject *op)
 {
 #if PY_MAJOR_VERSION >= 3
-    return PyUnicode_FromFormat("<cyfunction %U at %p>",
+    return PyUnicode_FromFormat("<%s %U at %p>", Py_TYPE(op)->tp_name,
                                 op->func_qualname, (void *)op);
 #else
-    return PyString_FromFormat("<cyfunction %s at %p>",
+    return PyString_FromFormat("<%s %s at %p>", Py_TYPE(op)->tp_name,
                                PyString_AsString(op->func_qualname), (void *)op);
 #endif
 }
@@ -674,7 +674,7 @@ static PyObject *__Pyx_CyFunction_CallAsMethod(PyObject *func, PyObject *args, P
 
 static PyTypeObject __pyx_CyFunctionType_type = {
     PyVarObject_HEAD_INIT(0, 0)
-    "cython_function_or_method",      /*tp_name*/
+    "cyfunction",                     /*tp_name*/
     sizeof(__pyx_CyFunctionObject),   /*tp_basicsize*/
     0,                                  /*tp_itemsize*/
     (destructor) __Pyx_CyFunction_dealloc, /*tp_dealloc*/
@@ -1155,7 +1155,7 @@ static PyMappingMethods __pyx_FusedFunction_mapping_methods = {
 
 static PyTypeObject __pyx_FusedFunctionType_type = {
     PyVarObject_HEAD_INIT(0, 0)
-    "fused_cython_function",           /*tp_name*/
+    "fused_cyfunction",                /*tp_name*/
     sizeof(__pyx_FusedFunctionObject), /*tp_basicsize*/
     0,                                  /*tp_itemsize*/
     (destructor) __pyx_FusedFunction_dealloc, /*tp_dealloc*/

--- a/runtests.py
+++ b/runtests.py
@@ -154,7 +154,7 @@ def patch_inspect_isfunction():
     import inspect
     orig_isfunction = inspect.isfunction
     def isfunction(obj):
-        return orig_isfunction(obj) or type(obj).__name__ == 'cython_function_or_method'
+        return orig_isfunction(obj) or type(obj).__name__ == 'cyfunction'
     isfunction._orig_isfunction = orig_isfunction
     inspect.isfunction = isfunction
 

--- a/tests/run/common_utility_types.srctree
+++ b/tests/run/common_utility_types.srctree
@@ -31,7 +31,7 @@ print("importing...")
 import a, b
 print(type(a.funcA))
 
-assert type(a.funcA).__name__ == 'cython_function_or_method'
+assert type(a.funcA).__name__ == 'cyfunction'
 assert type(a.funcA) is type(b.funcB)
 
 assert a.funcA.func_globals is a.__dict__

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -109,6 +109,13 @@ def test_doc():
     'docstring'
     """
 
+class TestRepr:
+    """
+    >>> TestRepr.__dict__["meth"]  #doctest:+ELLIPSIS
+    <cyfunction TestRepr.meth at 0x...>
+    """
+    def meth(self): pass
+
 
 def test_hash():
     """

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -214,6 +214,14 @@ def args_kwargs(fused_t obj, cython.floating myf = 1.2, *args, **kwargs):
     print obj, "%.2f" % myf, "%.2f" % f, args, kwargs
 
 
+class TestRepr:
+    """
+    >>> TestRepr.__dict__["meth"]  #doctest:+ELLIPSIS
+    <fused_cyfunction TestRepr.meth at 0x...>
+    """
+    def meth(self, cython.integral foo): pass
+
+
 class BaseClass(object):
     """
     Test fused class/static/normal methods and super() without args


### PR DESCRIPTION
Shorten the type names:
- `cython_function_or_method` -> `cyfunction`
- `fused_cython_function` -> `fused_cyfunction`

And use these type names in the `__repr__`.