### PR TITLE
Make sure not to emit duplicate typedefs for fused nodes

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -511,18 +511,18 @@ class FusedCFuncDefNode(StatListNode):
         seen_int_dtypes = set()
         for buffer_type in all_buffer_types:
             dtype = buffer_type.dtype
+            dtype_name = self._dtype_name(dtype)
             if dtype.is_typedef:
-                if self._dtype_name(dtype) not in seen_typedefs:
-                    seen_typedefs.add(self._dtype_name(dtype))
+                if dtype_name not in seen_typedefs:
+                    seen_typedefs.add(dtype_name)
                     decl_code.putln(
-                        'ctypedef %s %s "%s"' % (dtype.resolve(),
-                                                 self._dtype_name(dtype),
+                        'ctypedef %s %s "%s"' % (dtype.resolve(), dtype_name,
                                                  dtype.empty_declaration_code()))
 
             if buffer_type.dtype.is_int:
                 if str(dtype) not in seen_int_dtypes:
                     seen_int_dtypes.add(str(dtype))
-                    pyx_code.context.update(dtype_name=self._dtype_name(dtype),
+                    pyx_code.context.update(dtype_name=dtype_name,
                                             dtype_type=self._dtype_type(dtype))
                     pyx_code.local_variable_declarations.put_chunk(
                         u"""

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -507,15 +507,17 @@ class FusedCFuncDefNode(StatListNode):
                 ndarray = __Pyx_ImportNumPyArrayTypeIfAvailable()
             """)
 
+        seen_typedefs = set()
         seen_int_dtypes = set()
         for buffer_type in all_buffer_types:
             dtype = buffer_type.dtype
             if dtype.is_typedef:
-                 #decl_code.putln("ctypedef %s %s" % (dtype.resolve(),
-                 #                                    self._dtype_name(dtype)))
-                decl_code.putln('ctypedef %s %s "%s"' % (dtype.resolve(),
-                                                         self._dtype_name(dtype),
-                                                         dtype.empty_declaration_code()))
+                if self._dtype_name(dtype) not in seen_typedefs:
+                    seen_typedefs.add(self._dtype_name(dtype))
+                    decl_code.putln(
+                        'ctypedef %s %s "%s"' % (dtype.resolve(),
+                                                 self._dtype_name(dtype),
+                                                 dtype.empty_declaration_code()))
 
             if buffer_type.dtype.is_int:
                 if str(dtype) not in seen_int_dtypes:

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -1,0 +1,21 @@
+# ticket: 3111
+# mode: compile
+# tag: warnings
+
+ctypedef unsigned char npy_uint8
+ctypedef unsigned short npy_uint16
+
+
+ctypedef fused dtype_t:
+    npy_uint8
+
+ctypedef fused dtype_t_out:
+    npy_uint8
+    npy_uint16
+
+
+def foo(dtype_t[:] a, dtype_t_out[:, :] b):
+    pass
+
+
+_WARNINGS = ""

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -18,4 +18,22 @@ def foo(dtype_t[:] a, dtype_t_out[:, :] b):
     pass
 
 
-_WARNINGS = ""
+# The primary thing we're trying to test here is the _absence_ of the warning
+# "__pyxutil:16:4: '___pyx_npy_uint8' redeclared".  The remaining warnings are
+# unrelated to this test.
+_WARNINGS = """
+22:10: 'cpdef_method' redeclared
+33:10: 'cpdef_cname_method' redeclared
+446:72: Argument evaluation order in C function call is undefined and may not be as expected
+446:72: Argument evaluation order in C function call is undefined and may not be as expected
+749:34: Argument evaluation order in C function call is undefined and may not be as expected
+749:34: Argument evaluation order in C function call is undefined and may not be as expected
+943:27: Ambiguous exception value, same as default return value: 0
+943:27: Ambiguous exception value, same as default return value: 0
+974:29: Ambiguous exception value, same as default return value: 0
+974:29: Ambiguous exception value, same as default return value: 0
+1002:46: Ambiguous exception value, same as default return value: 0
+1002:46: Ambiguous exception value, same as default return value: 0
+1092:29: Ambiguous exception value, same as default return value: 0
+1092:29: Ambiguous exception value, same as default return value: 0
+"""


### PR DESCRIPTION
Fixes #3111.

The test currently doesn't work because, while with the changes to `FusedNode`, the file itself no longer generates any warnings, for some reason it appears to be pulling in `Cython/Utility/TestCythonScope.pyx` which *does* produce warnings.  This doesn't happen when running `cython` from the command line.  I would appreciate some help figuring out how this test is supposed to work, since I wasn't sure where to look for examples of writing a test for "does not produce a warning".