### PR TITLE
BUG: revert numpy.pxd to 0.29.13

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -244,26 +244,13 @@ cdef extern from "numpy/arrayobject.h":
 
         cdef:
             # Only taking a few of the most commonly used and stable fields.
+            # One should use PyArray_* macros instead to access the C fields.
             char *data
-            dtype descr
+            int ndim "nd"
+            npy_intp *shape "dimensions"
+            npy_intp *strides
+            dtype descr  # deprecated since NumPy 1.7 !
             PyObject* base
-
-            @property
-            cdef int ndim(self):
-                return PyArray_NDIM(self)
-
-            @property
-            cdef npy_intp *shape(self):
-                return PyArray_DIMS(self)
-
-            @property
-            cdef npy_intp *strides(self):
-                return PyArray_STRIDES(self)
-
-            @property
-            cdef npy_intp size(self):
-                return PyArray_SIZE(ndarray)
-
 
         # Note: This syntax (function definition in pxd files) is an
         # experimental exception made for __getbuffer__ and __releasebuffer__


### PR DESCRIPTION
#3095 changed `Cython/Includes/numpy/__init.pxd` to use the new `@property` attributes. It seems that decorator is not quite finished yet, so I propose to back out the changed pxd file to unbreak downstream packages.

related to #3113