### PR TITLE
Add support of const fused type memory views

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1573,6 +1573,8 @@ class PythranExpr(CType):
 class CConstOrVolatileType(BaseType):
     "A C const or volatile type"
 
+    subtypes = ['cv_base_type']
+
     is_cv_qualified = 1
 
     def __init__(self, base_type, is_const=0, is_volatile=0):

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -1,4 +1,5 @@
 # mode: error
+# ticket: 1772
 
 cimport cython
 from cython import fused_type
@@ -64,17 +65,30 @@ ctypedef fused fused2:
 func(x, y)
 
 
+cdef fused mix_const_t:
+    int
+    const int
+
+cdef cdef_func_with_mix_const_type(mix_const_t val):
+    print(val)
+
+# Mixing const and non-const type makes fused type ambiguous
+cdef_func_with_mix_const_type(1)
+
+
 _ERRORS = u"""
-10:15: fused_type does not take keyword arguments
-15:33: Type specified multiple times
-26:0: Invalid use of fused types, type cannot be specialized
-26:4: Not enough types specified to specialize the function, int2_t is still fused
+11:15: fused_type does not take keyword arguments
+16:33: Type specified multiple times
 27:0: Invalid use of fused types, type cannot be specialized
 27:4: Not enough types specified to specialize the function, int2_t is still fused
-28:16: Call with wrong number of arguments (expected 2, got 1)
-29:16: Call with wrong number of arguments (expected 2, got 3)
-36:6: Invalid base type for memoryview slice: int *
-39:0: Fused lambdas not allowed
-42:5: Fused types not allowed here
-45:9: Fused types not allowed here
+28:0: Invalid use of fused types, type cannot be specialized
+28:4: Not enough types specified to specialize the function, int2_t is still fused
+29:16: Call with wrong number of arguments (expected 2, got 1)
+30:16: Call with wrong number of arguments (expected 2, got 3)
+37:6: Invalid base type for memoryview slice: int *
+40:0: Fused lambdas not allowed
+43:5: Fused types not allowed here
+46:9: Fused types not allowed here
+76:0: Invalid use of fused types, type cannot be specialized
+76:29: ambiguous overloaded method
 """

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -403,6 +403,18 @@ def test_index_fused_args(cython.floating f, ints_t i):
     """
     _test_index_fused_args[cython.floating, ints_t](f, i)
 
+cdef _test_index_const_fused_args(const cython.floating f, const ints_t i):
+    print(cython.typeof(f), cython.typeof(i))
+
+def test_index_const_fused_args(const cython.floating f, const ints_t i):
+    """Test indexing function implementation with const fused type args
+
+    >>> import cython
+    >>> test_index_const_fused_args[cython.double, cython.int](2.0, 3)
+    ('const double', 'const int')
+    """
+    _test_index_const_fused_args[cython.floating, ints_t](f, i)
+
 
 def test_composite(fused_composite x):
     """

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -366,7 +366,7 @@ def test_fused_const_memslice_dtype_repeated(const cython.floating[:] array1, cy
     """Test fused types memory view with one being const
 
     >>> sorted(test_fused_const_memslice_dtype_repeated.__signatures__)
-    ['const double|double', 'const float|float']
+    ['double', 'float']
 
     >>> test_fused_const_memslice_dtype_repeated(get_array(8, 'd'), get_array(8, 'd'))
     const double[:] double[:]
@@ -374,7 +374,7 @@ def test_fused_const_memslice_dtype_repeated(const cython.floating[:] array1, cy
     const float[:] float[:]
     >>> test_fused_const_memslice_dtype_repeated(get_array(8, 'd'), get_array(4, 'f'))
     Traceback (most recent call last):
-    TypeError: No matching signature found
+    ValueError: Buffer dtype mismatch, expected 'double' but got 'float'
     """
     print cython.typeof(array1), cython.typeof(array2)
 

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -417,3 +417,27 @@ def test_composite(fused_composite x):
         return x
     else:
         return 2 * x
+
+
+cdef cdef_func_const_fused_arg(const cython.floating val,
+                               const fused_type1 * ptr_to_const,
+                               const (cython.floating *) const_ptr):
+    print(val, cython.typeof(val))
+    print(ptr_to_const[0], cython.typeof(ptr_to_const[0]))
+    print(const_ptr[0], cython.typeof(const_ptr[0]))
+
+    ptr_to_const = NULL  # pointer is not const, value is const
+    const_ptr[0] = 0.0  # pointer is const, value is not const
+
+def test_cdef_func_with_const_fused_arg():
+    """Test cdef function with const fused type argument
+
+    >>> test_cdef_func_with_const_fused_arg()
+    (0.0, 'const float')
+    (1, 'const int')
+    (2.0, 'float')
+    """
+    cdef float arg0 = 0.0
+    cdef int arg1 = 1
+    cdef float arg2 = 2.0
+    cdef_func_const_fused_arg(arg0, &arg1, &arg2)

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -1,4 +1,5 @@
 # mode: run
+# ticket: 1772
 
 cimport cython
 from cython.view cimport array
@@ -360,6 +361,22 @@ def test_fused_memslice_dtype_repeated_2(cython.floating[:] array1, cython.float
     float[:] float[:] int[:]
     """
     print cython.typeof(array1), cython.typeof(array2), cython.typeof(array3)
+
+def test_fused_const_memslice_dtype_repeated(const cython.floating[:] array1, cython.floating[:] array2):
+    """Test fused types memory view with one being const
+
+    >>> sorted(test_fused_const_memslice_dtype_repeated.__signatures__)
+    ['const double|double', 'const float|float']
+
+    >>> test_fused_const_memslice_dtype_repeated(get_array(8, 'd'), get_array(8, 'd'))
+    const double[:] double[:]
+    >>> test_fused_const_memslice_dtype_repeated(get_array(4, 'f'), get_array(4, 'f'))
+    const float[:] float[:]
+    >>> test_fused_const_memslice_dtype_repeated(get_array(8, 'd'), get_array(4, 'f'))
+    Traceback (most recent call last):
+    TypeError: No matching signature found
+    """
+    print cython.typeof(array1), cython.typeof(array2)
 
 def test_cython_numeric(cython.numeric arg):
     """


### PR DESCRIPTION
This PR is related to #1772 and is an attempt at supporting `const` fused type memory views such as:

```
cimport cython
def sum(const cython.floating[:] array):
    cdef cython.floating sum = 0
    for v in array:
        sum += v
    return sum
```

Cython internals are new to me, so I don't know how far this is from a proper solution, but it's working fine from what I tested.
Let me know if it is worth spending more time on it and what can be improved.

One remark: In case of function signature like `def test(const cython.floating[:] a, cython.foating[:] b)` and mismatching input floating types, the exception is:
`TypeError: No matching signature found`
while without `const` it is: `ValueError: Buffer dtype mismatch, expected 'float' but got 'double'`

Closes #1772.