### PR TITLE
TEST: Fix failing tests

### DIFF
--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2141,8 +2141,8 @@ def test_object_dtype_copying():
     7
     8
     9
+    3 5
     2 5
-    1 5
     """
     cdef int i
 

--- a/tests/run/pstats_profile_test.pyx
+++ b/tests/run/pstats_profile_test.pyx
@@ -12,9 +12,7 @@ __doc__ = u"""
     >>> short_stats['f_cdef']
     100
     >>> short_stats['f_cpdef']
-    200
-    >>> short_stats['f_cpdef (wrapper)']
-    100
+    300
     >>> short_stats['f_inline']
     100
     >>> short_stats['f_inline_prof']
@@ -50,9 +48,7 @@ __doc__ = u"""
     >>> short_stats['m_cdef']
     100
     >>> short_stats['m_cpdef']
-    200
-    >>> short_stats['m_cpdef (wrapper)']
-    100
+    300
 
     >>> try:
     ...    os.unlink(statsfile)
@@ -60,10 +56,10 @@ __doc__ = u"""
     ...    pass
 
     >>> sorted(callees(s, 'test_profile'))  #doctest: +NORMALIZE_WHITESPACE
-    ['f_cdef', 'f_cpdef', 'f_cpdef (wrapper)', 'f_def',
+    ['f_cdef', 'f_cpdef', 'f_def',
      'f_inline', 'f_inline_prof',
      'f_raise',
-     'm_cdef', 'm_cpdef', 'm_cpdef (wrapper)', 'm_def',
+     'm_cdef', 'm_cpdef', 'm_def',
      'withgil_prof']
 
     >>> profile.runctx("test_generators()", locals(), globals(), statsfile)


### PR DESCRIPTION
Fix a couple of failing tests on the hg2564_enable_binding branch. From my analysis of the python3.6 no-cpp test log there are only a few failing tests, I could not replicate the get_refcount failures locally.

<details>

python runtests.py --no-cpp embedsignatures
fails with
```
analyse_types not implemented
Called from: CoerceToComplexNode.not_implemented 459
Called from: CoerceToComplexNode.analyse_types 664
Called from: AddNode.analyse_types 10987
```
python runtests.py --no-cpp memslice.assign_temporary_to_object
python runtests.py --no-cpp memslice.assign_to_object
python runtests.py --no-cpp memslice.printbuf_object
python runtests.py --no-cpp memoryview.assign_temporary_to_object
python runtests.py --no-cpp memoryview.assign_to_object
python runtests.py --no-cpp memoryview.printbuf_object
fails in CI on python3.6, no-cpp. Passes locally
failures are in get_refcount

python runtests.py --no-cpp  memslice.test_object_dtype_copying
fixed reproducable refcount failure here

python runtests.py --no-cpp  pstats_profile_test
fixed reproducable refcount failure here

python runtests.py --no-cpp  bufaccess
fails in CI on python3.6, no-cpp. Passes locally.
Fails with "Compiler crash in AnalyseExpressionsTransform"

