### PR TITLE
Remove duplicated line from __Pyx_c_pow

### DIFF
--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -253,7 +253,6 @@ static {{type}} __Pyx_PyComplex_As_{{type_name}}(PyObject* o) {
                     case 1:
                         return a;
                     case 2:
-                        z = __Pyx_c_prod{{func_suffix}}(a, a);
                         return __Pyx_c_prod{{func_suffix}}(a, a);
                     case 3:
                         z = __Pyx_c_prod{{func_suffix}}(a, a);


### PR DESCRIPTION
I think this was a copy-paste error. There's no reason to compute the product, throw it away, and then compute it again.