### PR TITLE
add cython.inline_module() - refactored

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -113,6 +113,60 @@ def _get_build_extension():
 def _create_context(cython_include_dirs):
     return Context(list(cython_include_dirs), default_options)
 
+def cython_inline_module(code, lib_dir=os.path.join(get_cython_cache_dir(), 'inline'),
+                  cython_include_dirs=None, c_include_dirs=[], cflags = None, force=False, include_numpy = True, **kwds):
+    if cython_include_dirs is None:
+        cython_include_dirs = ['.']
+    code = to_unicode(code)
+    orig_code = code
+    code, literals = strip_string_literals(code)
+    code = strip_common_indent(code)
+    ctx = _create_context(tuple(cython_include_dirs))
+    key = orig_code, cflags, sys.version_info, sys.executable, Cython.__version__
+    module_name = "_cython_inline_module_" + hashlib.md5(_unicode(key).encode('utf-8')).hexdigest()
+
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        build_extension = None
+        #little weird to access/set so_ext from here, but nothing technically wrong with it
+        if cython_inline.so_ext is None:
+            # Figure out and cache current extension suffix
+            build_extension = _get_build_extension()
+            cython_inline.so_ext = build_extension.get_ext_filename('')
+
+        module_path = os.path.join(lib_dir, module_name + cython_inline.so_ext)
+
+        if not os.path.exists(lib_dir):
+            os.makedirs(lib_dir)
+        if force or not os.path.isfile(module_path):
+            qualified = re.compile(r'([.\w]+)[.]')
+            #assume everybody wants numpy
+            if include_numpy:
+                try:
+                    import numpy as np
+                    c_include_dirs = c_include_dirs + [np.get_include()]
+                except ImportError:
+                    pass
+            pyx_file = os.path.join(lib_dir, module_name + '.pyx')
+            fh = open(pyx_file, 'w')
+            try:
+                fh.write(code)
+            finally:
+                fh.close()
+            extension = Extension(
+                name = module_name,
+                sources = [pyx_file],
+                include_dirs = c_include_dirs,
+                extra_compile_args = cflags)
+            if build_extension is None:
+                build_extension = _get_build_extension()
+            build_extension.extensions = cythonize([extension], include_path=cython_include_dirs, **kwds)
+            build_extension.build_temp = os.path.dirname(pyx_file)
+            build_extension.build_lib  = lib_dir
+            build_extension.run()
+        module = imp.load_dynamic(module_name, module_path)
+    return module
 
 _cython_inline_cache = {}
 _cython_inline_default_context = _create_context(('.',))

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -137,6 +137,9 @@ def inline(f, *args, **kwds):
         assert len(args) == len(kwds) == 0
         return f
 
+def inline_module(code, *args, **kwds):
+    from Cython.Build.Inline import cython_inline_module
+    return cython_inline_module(code, *args, **kwds)
 
 def compile(f):
     from Cython.Build.Inline import RuntimeCompiledFunction

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -127,19 +127,32 @@ binding = lambda _: _empty_decorator
 
 
 _cython_inline = None
-def inline(f, *args, **kwds):
-    if isinstance(f, basestring):
-        global _cython_inline
-        if _cython_inline is None:
-            from Cython.Build.Inline import cython_inline as _cython_inline
-        return _cython_inline(f, *args, **kwds)
-    else:
+def inline(code, *args, **kwds):
+    if not isinstance(code, basestring):
         assert len(args) == len(kwds) == 0
-        return f
+        return code
+    global _cython_inline
+    if _cython_inline is None:
+        from Cython.Build.Inline import cython_inline as _cython_inline
+    return _cython_inline(code, *args, **kwds)
 
+
+_cython_inline_module = None
 def inline_module(code, *args, **kwds):
-    from Cython.Build.Inline import cython_inline_module
-    return cython_inline_module(code, *args, **kwds)
+    """Compiles code to a python extension and returns the imported module.
+
+    To use numpy within the code, please to not forget to set its:
+
+        c_include_dirs=[np.get_include()]
+
+    IMPORTANT: The code is compiled as a independent module.
+               Names within the enclosing scope are not available.
+    """
+    global _cython_inline_module
+    if _cython_inline_module is None:
+        from Cython.Build.Inline import cython_inline_module as _cython_inline_module
+    return _cython_inline_module(code, *args, **kwds)
+
 
 def compile(f):
     from Cython.Build.Inline import RuntimeCompiledFunction


### PR DESCRIPTION
Closes #555.

@nevion's description in #555:
> allows JIT/slightly AOC module compilation, similar to that of OpenCL/PyCUDA/PyOpenCL.
> 
> This is useful for maximum performance with simpler reusable modules and simplifies flow code-fragment acceleration. The intent is to compile a (C/C++) module in initialization when all algorithm details are known (say those dependent on configuration or input data) - then put it in immediate high-performance use.

Illustration of above point. Currently the use of `cdef function():` is not permitted in `inline`. This is however essential for specifying callback to c-libraries:
```
module = inline_module(
    """
    from libc.stdint cimport uintptr_t

    cdef foo(x):
        return x * x

    foo_ptr = <uintptr_t>&foo
    """)

print(module.foo_ptr)
```
