### PR TITLE
Unify cli for cython and cythonize

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -11,7 +11,9 @@ from .Dependencies import cythonize, extended_iglob
 from ..Utils import is_package_dir
 from ..Compiler import Options
 
-from ..Compiler.CmdLine import create_cythonize_argparser, multiprocessing
+from ..Compiler.CmdLine import (
+    create_cythonize_argparser, parse_args_raw, multiprocessing
+)
 
 
 class _FakePool(object):
@@ -110,20 +112,6 @@ def run_distutils(args):
             os.chdir(cwd)
             if temp_dir and os.path.isdir(temp_dir):
                 shutil.rmtree(temp_dir)
-
-
-def parse_args_raw(parser, args):
-    options, unknown = parser.parse_known_args(args)
-    sources = options.sources
-    # if positional arguments were interspersed
-    # some of them are in unknown
-    for option in unknown:
-        if option.startswith('-'):
-            parser.error("unknown option "+option)
-        else:
-            sources.append(option)
-    del options.sources
-    return (options, sources)
 
 
 def parse_args(args):

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -9,12 +9,8 @@ from distutils.core import setup
 
 from .Dependencies import cythonize, extended_iglob
 from ..Utils import is_package_dir
-from ..Compiler import Options
 
-from ..Compiler.CmdLine import (
-    create_cythonize_argparser, parse_args_raw,
-    multiprocessing, apply_options
-)
+from ..Compiler.CmdLine import parse_command_line_cythonize
 
 
 class _FakePool(object):
@@ -115,29 +111,8 @@ def run_distutils(args):
                 shutil.rmtree(temp_dir)
 
 
-def parse_args(args):
-    parser = create_cythonize_argparser()
-    options, args = parse_args_raw(parser, args)
-
-    if not args:
-        parser.error("no source files provided")
-    if multiprocessing is None:
-        options.parallel = 0
-
-    # handle global_options:
-    from ..Compiler.CmdLine import GLOBAL_OPTIONS
-    apply_options(Options, getattr(options, GLOBAL_OPTIONS, {}))
-    # no longer needed:
-    try:
-        delattr(options, GLOBAL_OPTIONS)
-    except AttributeError:
-        pass
-
-    return options, args
-
-
 def main(args=None):
-    options, paths = parse_args(args)
+    options, paths = parse_command_line_cythonize(args)
 
     for path in paths:
         cython_compile(path, options)

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -121,7 +121,7 @@ def create_args_parser():
     from argparse import ArgumentParser
     from ..Compiler.CmdLine import (ParseDirectivesActionToLocal, ParseOptionsAction,
           ParseCompileTimeEnvActionToLocal, SetLenientAction, StoreToSubargument,
-          GLOBAL_OPTIONS, LOCAL_OPTIONS)
+          SetBuildInplace, GLOBAL_OPTIONS, LOCAL_OPTIONS)
 
     parser = ArgumentParser()
 
@@ -157,7 +157,7 @@ def create_args_parser():
 
     parser.add_argument('-b', '--build', dest='build', action='store_true', default=None,
                       help='build extension modules using distutils')
-    parser.add_argument('-i', '--inplace', dest='build_inplace', action='store_true', default=None,
+    parser.add_argument('-i', '--inplace', dest='build_inplace', action=SetBuildInplace, nargs=0,
                       help='build extension modules in place using distutils (implies -b)')
     parser.add_argument('-j', '--parallel', dest='parallel', metavar='N',
                       type=int, default=parallel_compiles,
@@ -198,8 +198,6 @@ def parse_args(args):
 
     if not args:
         parser.error("no source files provided")
-    if options.build_inplace:
-        options.build = True
     if multiprocessing is None:
         options.parallel = 0
 

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -121,7 +121,7 @@ def create_args_parser():
     from argparse import ArgumentParser
     from ..Compiler.CmdLine import (ParseDirectivesActionToLocal, ParseOptionsAction,
           ParseCompileTimeEnvActionToLocal, SetLenientAction, StoreToSubargument,
-          GLOBAL_OPTIONS)
+          GLOBAL_OPTIONS, LOCAL_OPTIONS)
 
     parser = ArgumentParser()
 
@@ -137,11 +137,14 @@ def create_args_parser():
                       dest='options', default={}, type=str,
                       action=ParseOptionsAction,
                       help='set a cythonize option')
-    parser.add_argument('-2', dest='language_level', action='store_const', const=2, default=None,
+    parser.add_argument('-2', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 2), nargs=0,
                       help='use Python 2 syntax mode by default')
-    parser.add_argument('-3', dest='language_level', action='store_const', const=3,
+    parser.add_argument('-3', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 3), nargs=0,
                       help='use Python 3 syntax mode by default')
-    parser.add_argument('--3str', dest='language_level', action='store_const', const='3str',
+    parser.add_argument('--3str', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, '3str'), nargs=0,
                       help='use Python 3 syntax mode by default')
     parser.add_argument('-a', '--annotate', action=StoreToSubargument(GLOBAL_OPTIONS, 'default'), nargs=0, dest='annotate',
                       help='Produce a colorized HTML version of the source.')
@@ -199,9 +202,6 @@ def parse_args(args):
         options.build = True
     if multiprocessing is None:
         options.parallel = 0
-    if options.language_level:
-        assert options.language_level in (2, 3, '3str')
-        options.options['language_level'] = options.language_level
 
     # handle global_options:
     from ..Compiler.CmdLine import GLOBAL_OPTIONS

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -12,7 +12,8 @@ from ..Utils import is_package_dir
 from ..Compiler import Options
 
 from ..Compiler.CmdLine import (
-    create_cythonize_argparser, parse_args_raw, multiprocessing
+    create_cythonize_argparser, parse_args_raw,
+    multiprocessing, apply_options
 )
 
 
@@ -125,10 +126,12 @@ def parse_args(args):
 
     # handle global_options:
     from ..Compiler.CmdLine import GLOBAL_OPTIONS
-    global_options = getattr(options, GLOBAL_OPTIONS, {})
-    for name, value in global_options.items():
-        if value is not None:
-            setattr(Options, name, value)
+    apply_options(Options, getattr(options, GLOBAL_OPTIONS, {}))
+    # no longer needed:
+    try:
+        delattr(options, GLOBAL_OPTIONS)
+    except AttributeError:
+        pass
 
     return options, args
 

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -70,7 +70,6 @@ def cython_compile(path_pattern, options):
                 nthreads=options.parallel,
                 exclude_failures=options.keep_going,
                 exclude=options.excludes,
-                compiler_directives=options.directives,
                 force=options.force,
                 quiet=options.quiet,
                 **options.options)
@@ -120,15 +119,15 @@ def run_distutils(args):
 
 def create_args_parser():
     from argparse import ArgumentParser
-    from ..Compiler.CmdLine import (ParseDirectivesAction, ParseOptionsAction,
+    from ..Compiler.CmdLine import (ParseDirectivesActionToLocal, ParseOptionsAction,
           ParseCompileTimeEnvActionToLocal, SetLenientAction, StoreToSubargument,
           GLOBAL_OPTIONS)
 
     parser = ArgumentParser()
 
     parser.add_argument('-X', '--directive', metavar='NAME=VALUE,...',
-                      dest='directives', default={}, type=str,
-                      action=ParseDirectivesAction,
+                      dest='compiler_directives', type=str,
+                      action=ParseDirectivesActionToLocal,
                       help='set a compiler directive')
     parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
                       dest='compile_time_env', type=str,

--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -71,7 +71,6 @@ def cython_compile(path_pattern, options):
                 exclude_failures=options.keep_going,
                 exclude=options.excludes,
                 compiler_directives=options.directives,
-                compile_time_env=options.compile_time_env,
                 force=options.force,
                 quiet=options.quiet,
                 **options.options)
@@ -121,7 +120,7 @@ def run_distutils(args):
 
 def create_args_parser():
     from argparse import ArgumentParser
-    from ..Compiler.CmdLine import ParseDirectivesAction, ParseOptionsAction, ParseCompileTimeEnvAction
+    from ..Compiler.CmdLine import ParseDirectivesAction, ParseOptionsAction, ParseCompileTimeEnvActionToLocal
 
     parser = ArgumentParser()
 
@@ -130,8 +129,8 @@ def create_args_parser():
                       action=ParseDirectivesAction,
                       help='set a compiler directive')
     parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
-                      dest='compile_time_env', default={}, type=str,
-                      action=ParseCompileTimeEnvAction,
+                      dest='compile_time_env', type=str,
+                      action=ParseCompileTimeEnvActionToLocal,
                       help='set a compile time environment variable')
     parser.add_argument('-s', '--option', metavar='NAME=VALUE',
                       dest='options', default={}, type=str,

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -99,8 +99,10 @@ class TestCythonizeArgsParser(TestCase):
                 ('c_string_type', 'bytearray'),
                 ('c_string_type', 'unicode'),
                 ('c_string_encoding', 'ascii'),
-                ('language_level', 2),
-                ('language_level', 3),
+                # ('language_level', 2),
+                ('language_level', '2'),
+                # ('language_level', 3),
+                ('language_level', '3'),
                 ('language_level', '3str'),
                 ('set_initial_path', 'my_initial_path'),
         ]
@@ -113,11 +115,11 @@ class TestCythonizeArgsParser(TestCase):
 
     def test_directives_wrong(self):
         directives = [
-                ('auto_pickle', 42),       # for bool type
-                ('auto_pickle', 'NONONO'), # for bool type
+                ('auto_pickle', 42),        # for bool type
+                ('auto_pickle', 'NONONO'),  # for bool type
                 ('c_string_type', 'bites'),
-                #('c_string_encoding', 'a'),
-                #('language_level', 4),
+                # ('c_string_encoding', 'a'),
+                # ('language_level', 4),
         ]
         for key, value in directives:
             cmd = '{key}={value}'.format(key=key, value=str(value))

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -1,9 +1,9 @@
-from Cython.Build.Cythonize import (
-    parse_args_raw, parse_args
-)
-
 from Cython.Compiler import Options
-from Cython.Compiler.CmdLine import create_cythonize_argparser, parallel_compiles
+from Cython.Compiler.CmdLine import (
+    create_cythonize_argparser, parallel_compiles,
+    parse_args_raw
+)
+from Cython.Compiler.CmdLine import parse_command_line_cythonize as parse_args
 from Cython.Compiler.Tests.Utils import backup_Options, restore_Options, check_global_options
 
 from unittest import TestCase
@@ -91,20 +91,20 @@ class TestCythonizeArgsParser(TestCase):
             options, args = self.parse_args(['-X', 'cdivision'])
 
     def test_directives_types(self):
-        directives = {
-                'auto_pickle': True,
-                'c_string_type': 'bytearray',
-                'c_string_type': 'bytes',
-                'c_string_type': 'str',
-                'c_string_type': 'bytearray',
-                'c_string_type': 'unicode',
-                'c_string_encoding' : 'ascii',
-                'language_level' : 2,
-                'language_level' : 3,
-                'language_level' : '3str',
-                'set_initial_path' : 'my_initial_path',
-        }
-        for key, value in directives.items():
+        directives = [
+                ('auto_pickle', True),
+                ('c_string_type', 'bytearray'),
+                ('c_string_type', 'bytes'),
+                ('c_string_type', 'str'),
+                ('c_string_type', 'bytearray'),
+                ('c_string_type', 'unicode'),
+                ('c_string_encoding', 'ascii'),
+                ('language_level', 2),
+                ('language_level', 3),
+                ('language_level', '3str'),
+                ('set_initial_path', 'my_initial_path'),
+        ]
+        for key, value in directives:
             cmd = '{key}={value}'.format(key=key, value=str(value))
             options, args = self.parse_args(['-X', cmd])
             self.assertFalse(args)
@@ -112,14 +112,14 @@ class TestCythonizeArgsParser(TestCase):
             self.assertEqual(options.options['compiler_directives'][key], value, msg="Error for option: " + cmd)
 
     def test_directives_wrong(self):
-        directives = {
-                'auto_pickle': 42,       # for bool type
-                'auto_pickle': 'NONONO', # for bool type
-                'c_string_type': 'bites',
-                #'c_string_encoding' : 'a',
-                #'language_level' : 4,
-        }
-        for key, value in directives.items():
+        directives = [
+                ('auto_pickle', 42),       # for bool type
+                ('auto_pickle', 'NONONO'), # for bool type
+                ('c_string_type', 'bites'),
+                #('c_string_encoding', 'a'),
+                #('language_level', 4),
+        ]
+        for key, value in directives:
             cmd = '{key}={value}'.format(key=key, value=str(value))
             with self.assertRaises(ValueError, msg="Error for option: " + cmd):
                 options, args = self.parse_args(['-X', cmd])

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -23,7 +23,7 @@ class TestCythonizeArgsParser(TestCase):
 
     def are_default(self, options, skip):
         # empty containers
-        empty_containers = ['directives', 'options', 'excludes']
+        empty_containers = ['options', 'excludes']
         are_none = ['language_level', 'build', 'build_inplace', 'force', 'quiet', 'keep_going']
         for opt_name in empty_containers:
             if len(getattr(options, opt_name)) != 0 and (opt_name not in skip):
@@ -41,54 +41,54 @@ class TestCythonizeArgsParser(TestCase):
 
     # testing directives:
     def test_directive_short(self):
-        options, args =  self.parse_args(['-X', 'cdivision=True'])
+        options, args = self.parse_args(['-X', 'cdivision=True'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], True)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], True)
 
     def test_directive_long(self):
-        options, args =  self.parse_args(['--directive', 'cdivision=True'])
+        options, args = self.parse_args(['--directive', 'cdivision=True'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], True)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], True)
 
     def test_directive_multiple(self):
-        options, args =  self.parse_args(['-X', 'cdivision=True', '-X', 'c_string_type=bytes'])
+        options, args = self.parse_args(['-X', 'cdivision=True', '-X', 'c_string_type=bytes'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], True)
-        self.assertEqual(options.directives['c_string_type'], 'bytes')
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], True)
+        self.assertEqual(options.options['compiler_directives']['c_string_type'], 'bytes')
 
     def test_directive_multiple_v2(self):
-        options, args =  self.parse_args(['-X', 'cdivision=True,c_string_type=bytes'])
+        options, args = self.parse_args(['-X', 'cdivision=True,c_string_type=bytes'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], True)
-        self.assertEqual(options.directives['c_string_type'], 'bytes')
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], True)
+        self.assertEqual(options.options['compiler_directives']['c_string_type'], 'bytes')
 
     def test_directive_value_yes(self):
-        options, args =  self.parse_args(['-X', 'cdivision=YeS'])
+        options, args = self.parse_args(['-X', 'cdivision=YeS'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], True)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], True)
 
     def test_directive_value_no(self):
-        options, args =  self.parse_args(['-X', 'cdivision=no'])
+        options, args = self.parse_args(['-X', 'cdivision=no'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['directives']))
-        self.assertEqual(options.directives['cdivision'], False)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compiler_directives']['cdivision'], False)
 
     def test_directive_value_invalid(self):
-        with self.assertRaises(ValueError) as context:
-            options, args =  self.parse_args(['-X', 'cdivision=sadfasd'])
+        with self.assertRaises(ValueError):
+            options, args = self.parse_args(['-X', 'cdivision=sadfasd'])
 
     def test_directive_key_invalid(self):
-        with self.assertRaises(ValueError) as context:
-            options, args =  self.parse_args(['-X', 'abracadabra'])
+        with self.assertRaises(ValueError):
+            options, args = self.parse_args(['-X', 'abracadabra'])
 
     def test_directive_no_value(self):
-        with self.assertRaises(ValueError) as context:
-            options, args =  self.parse_args(['-X', 'cdivision'])
+        with self.assertRaises(ValueError):
+            options, args = self.parse_args(['-X', 'cdivision'])
 
     def test_directives_types(self):
         directives = {
@@ -106,10 +106,10 @@ class TestCythonizeArgsParser(TestCase):
         }
         for key, value in directives.items():
             cmd = '{key}={value}'.format(key=key, value=str(value))
-            options, args =  self.parse_args(['-X', cmd])
+            options, args = self.parse_args(['-X', cmd])
             self.assertFalse(args)
-            self.assertTrue(self.are_default(options, ['directives']), msg = "Error for option: "+cmd)
-            self.assertEqual(options.directives[key], value, msg = "Error for option: "+cmd)
+            self.assertTrue(self.are_default(options, ['options']), msg="Error for option: " + cmd)
+            self.assertEqual(options.options['compiler_directives'][key], value, msg="Error for option: " + cmd)
 
     def test_directives_wrong(self):
         directives = {

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -482,3 +482,21 @@ class TestParseArgs(TestCase):
         self.assertEqual(sources, ['foo.pyx'])
         self.assertEqual(Options.docstrings, False)
         self.check_default_global_options(['docstrings'])
+
+    def test_language_level2(self):
+        options, sources = parse_args(['foo.pyx', '-2'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(options.options['language_level'], 2)
+        self.check_default_global_options()
+
+    def test_language_level3(self):
+        options, sources = parse_args(['foo.pyx', '-3'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(options.options['language_level'], 3)
+        self.check_default_global_options()
+
+    def test_language_level3str(self):
+        options, sources = parse_args(['foo.pyx', '--3str'])
+        self.assertEqual(sources, ['foo.pyx'])
+        self.assertEqual(options.options['language_level'], '3str')
+        self.check_default_global_options()

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -305,19 +305,21 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(options.build, True)
 
     def test_inplace_short(self):
-        options, args =  self.parse_args(['-i'])
+        options, args = self.parse_args(['-i'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['build_inplace']))
+        self.assertTrue(self.are_default(options, ['build_inplace', 'build']))
         self.assertEqual(options.build_inplace, True)
+        self.assertEqual(options.build, True)
 
     def test_inplace_long(self):
-        options, args =  self.parse_args(['--inplace'])
+        options, args = self.parse_args(['--inplace'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['build_inplace']))
+        self.assertTrue(self.are_default(options, ['build_inplace', 'build']))
         self.assertEqual(options.build_inplace, True)
+        self.assertEqual(options.build, True)
 
     def test_parallel_short(self):
-        options, args =  self.parse_args(['-j', '42'])
+        options, args = self.parse_args(['-j', '42'])
         self.assertFalse(args)
         self.assertTrue(self.are_default(options, ['parallel']))
         self.assertEqual(options.parallel, 42)
@@ -388,20 +390,23 @@ class TestCythonizeArgsParser(TestCase):
         options, args = self.parse_args(['-i', 'file.pyx'])
         self.assertEqual(args, ['file.pyx'])
         self.assertEqual(options.build_inplace, True)
-        self.assertTrue(self.are_default(options, ['build_inplace']))
+        self.assertEqual(options.build, True)
+        self.assertTrue(self.are_default(options, ['build_inplace', 'build']))
 
     def test_file_inbetween(self):
         options, args = self.parse_args(['-i', 'file.pyx', '-a'])
         self.assertEqual(args, ['file.pyx'])
         self.assertEqual(options.build_inplace, True)
+        self.assertEqual(options.build, True)
         self.assertEqual(options.global_options['annotate'], 'default')
-        self.assertTrue(self.are_default(options, ['build_inplace', 'global_options']))
+        self.assertTrue(self.are_default(options, ['build_inplace', 'build', 'global_options']))
 
     def test_option_trailing(self):
         options, args = self.parse_args(['file.pyx', '-i'])
         self.assertEqual(args, ['file.pyx'])
         self.assertEqual(options.build_inplace, True)
-        self.assertTrue(self.are_default(options, ['build_inplace']))
+        self.assertEqual(options.build, True)
+        self.assertTrue(self.are_default(options, ['build_inplace', 'build']))
 
     def test_interspersed_positional(self):
         options, sources = self.parse_args([

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -1,9 +1,9 @@
 from Cython.Build.Cythonize import (
-    create_args_parser, parse_args_raw, parse_args,
-    parallel_compiles
+    parse_args_raw, parse_args
 )
 
 from Cython.Compiler import Options
+from Cython.Compiler.CmdLine import create_cythonize_argparser, parallel_compiles
 from Cython.Compiler.Tests.Utils import backup_Options, restore_Options, check_global_options
 
 from unittest import TestCase
@@ -19,7 +19,7 @@ class TestCythonizeArgsParser(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.parse_args = lambda x, parser=create_args_parser(): parse_args_raw(parser, x)
+        self.parse_args = lambda x, parser=create_cythonize_argparser(): parse_args_raw(parser, x)
 
     def are_default(self, options, skip):
         # empty containers

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -226,22 +226,22 @@ class TestCythonizeArgsParser(TestCase):
         self.assertEqual(options.options['abracadabra'], True)
 
     def test_language_level_2(self):
-        options, args =  self.parse_args(['-2'])
+        options, args = self.parse_args(['-2'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['language_level']))
-        self.assertEqual(options.language_level, 2)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['language_level'], 2)
 
     def test_language_level_3(self):
-        options, args =  self.parse_args(['-3'])
+        options, args = self.parse_args(['-3'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['language_level']))
-        self.assertEqual(options.language_level, 3)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['language_level'], 3)
 
     def test_language_level_3str(self):
-        options, args =  self.parse_args(['--3str'])
+        options, args = self.parse_args(['--3str'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['language_level']))
-        self.assertEqual(options.language_level, '3str')
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['language_level'], '3str')
 
     def test_annotate_short(self):
         options, args = self.parse_args(['-a'])
@@ -270,12 +270,12 @@ class TestCythonizeArgsParser(TestCase):
     def test_annotate_and_optional(self):
         options, args = self.parse_args(['-a', '--3str'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['global_options', 'language_level']))
+        self.assertTrue(self.are_default(options, ['global_options', 'options']))
         self.assertEqual(options.global_options['annotate'], 'default')
-        self.assertEqual(options.language_level, '3str')
+        self.assertEqual(options.options['language_level'], '3str')
 
     def test_exclude_short(self):
-        options, args =  self.parse_args(['-x', '*.pyx'])
+        options, args = self.parse_args(['-x', '*.pyx'])
         self.assertFalse(args)
         self.assertTrue(self.are_default(options, ['excludes']))
         self.assertTrue('*.pyx' in options.excludes)

--- a/Cython/Build/Tests/TestCythonizeArgsParser.py
+++ b/Cython/Build/Tests/TestCythonizeArgsParser.py
@@ -19,22 +19,21 @@ class TestCythonizeArgsParser(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.parse_args = lambda x, parser=create_args_parser() : parse_args_raw(parser, x)
-
+        self.parse_args = lambda x, parser=create_args_parser(): parse_args_raw(parser, x)
 
     def are_default(self, options, skip):
         # empty containers
-        empty_containers = ['directives', 'compile_time_env', 'options', 'excludes']
+        empty_containers = ['directives', 'options', 'excludes']
         are_none = ['language_level', 'annotate', 'build', 'build_inplace', 'force', 'quiet', 'lenient', 'keep_going', 'no_docstrings']
         for opt_name in empty_containers:
-            if len(getattr(options, opt_name))!=0 and (not opt_name in skip):
-                self.assertEqual(opt_name,"", msg="For option "+opt_name)
+            if len(getattr(options, opt_name)) != 0 and (opt_name not in skip):
+                self.assertEqual(opt_name, "", msg="For option " + opt_name)
                 return False
         for opt_name in are_none:
-            if (getattr(options, opt_name) is not None) and (not opt_name in skip):
-                self.assertEqual(opt_name,"", msg="For option "+opt_name)
+            if (getattr(options, opt_name) is not None) and (opt_name not in skip):
+                self.assertEqual(opt_name, "", msg="For option " + opt_name)
                 return False
-        if options.parallel!=parallel_compiles and (not 'parallel' in skip):
+        if options.parallel != parallel_compiles and ('parallel' not in skip):
             return False
         return True
 
@@ -120,38 +119,38 @@ class TestCythonizeArgsParser(TestCase):
         }
         for key, value in directives.items():
             cmd = '{key}={value}'.format(key=key, value=str(value))
-            with self.assertRaises(ValueError, msg = "Error for option: "+cmd) as context:
-                options, args =  self.parse_args(['-X', cmd])
+            with self.assertRaises(ValueError, msg="Error for option: " + cmd):
+                options, args = self.parse_args(['-X', cmd])
 
     def test_compile_time_env_short(self):
-        options, args =  self.parse_args(['-E', 'MYSIZE=10'])
+        options, args = self.parse_args(['-E', 'MYSIZE=10'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['compile_time_env']))
-        self.assertEqual(options.compile_time_env['MYSIZE'], 10)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compile_time_env']['MYSIZE'], 10)
 
     def test_compile_time_env_long(self):
-        options, args =  self.parse_args(['--compile-time-env', 'MYSIZE=10'])
+        options, args = self.parse_args(['--compile-time-env', 'MYSIZE=10'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['compile_time_env']))
-        self.assertEqual(options.compile_time_env['MYSIZE'], 10)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compile_time_env']['MYSIZE'], 10)
 
     def test_compile_time_env_multiple(self):
-        options, args =  self.parse_args(['-E', 'MYSIZE=10', '-E', 'ARRSIZE=11'])
+        options, args = self.parse_args(['-E', 'MYSIZE=10', '-E', 'ARRSIZE=11'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['compile_time_env']))
-        self.assertEqual(options.compile_time_env['MYSIZE'], 10)
-        self.assertEqual(options.compile_time_env['ARRSIZE'], 11)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compile_time_env']['MYSIZE'], 10)
+        self.assertEqual(options.options['compile_time_env']['ARRSIZE'], 11)
 
     def test_compile_time_env_multiple_v2(self):
-        options, args =  self.parse_args(['-E', 'MYSIZE=10,ARRSIZE=11'])
+        options, args = self.parse_args(['-E', 'MYSIZE=10,ARRSIZE=11'])
         self.assertFalse(args)
-        self.assertTrue(self.are_default(options, ['compile_time_env']))
-        self.assertEqual(options.compile_time_env['MYSIZE'], 10)
-        self.assertEqual(options.compile_time_env['ARRSIZE'], 11)
+        self.assertTrue(self.are_default(options, ['options']))
+        self.assertEqual(options.options['compile_time_env']['MYSIZE'], 10)
+        self.assertEqual(options.options['compile_time_env']['ARRSIZE'], 11)
 
-    #testing options
+    # testing options
     def test_option_short(self):
-        options, args =  self.parse_args(['-s', 'docstrings=True'])
+        options, args = self.parse_args(['-s', 'docstrings=True'])
         self.assertFalse(args)
         self.assertTrue(self.are_default(options, ['options']))
         self.assertEqual(options.options['docstrings'], True)

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -10,6 +10,7 @@ from . import Options
 
 
 GLOBAL_OPTIONS = 'global_options'
+DEBUG_FLAGS = 'debug_flags'
 
 
 def set_values_to_subargument(namespace, subargument_name, value_map):
@@ -183,7 +184,7 @@ def create_cython_argparser():
     for name in vars(DebugFlags):
         if name.startswith("debug"):
             option_name = name.replace('_', '-')
-            parser.add_argument("--" + option_name, action=StoreToSubargument('debug_flags', True), nargs=0, help=SUPPRESS)
+            parser.add_argument("--" + option_name, action=StoreToSubargument(DEBUG_FLAGS, True), nargs=0, help=SUPPRESS)
 
     return parser
 
@@ -230,7 +231,7 @@ def parse_command_line(args):
 
     options = Options.CompilationOptions(Options.default_options)
     for name, value in vars(arguments).items():
-        if name in ('debug_flags', GLOBAL_OPTIONS):
+        if name in (DEBUG_FLAGS, GLOBAL_OPTIONS):
             continue
         elif hasattr(Options, name):
             setattr(Options, name, value)
@@ -243,7 +244,7 @@ def parse_command_line(args):
         setattr(Options, name, value)
 
     # handle debug flags
-    debug_flags = getattr(arguments, 'debug_flags', {})
+    debug_flags = getattr(arguments, DEBUG_FLAGS, {})
     for name, value in debug_flags.items():
         from . import DebugFlags
         setattr(DebugFlags, name, value)

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -288,14 +288,8 @@ def parse_command_line(args):
     parser = create_cython_argparser()
     arguments, sources = parse_command_line_raw(parser, args)
 
-    options = Options.CompilationOptions(Options.default_options)
-    for name, value in vars(arguments).items():
-        if name in (DEBUG_FLAGS, GLOBAL_OPTIONS, LOCAL_OPTIONS):
-            continue
-        else:
-            setattr(options, name, value)
-
     # handle local_options:
+    options = Options.CompilationOptions(Options.default_options)
     local_options = getattr(arguments, LOCAL_OPTIONS, {})
     for name, value in local_options.items():
         setattr(options, name, value)
@@ -311,6 +305,7 @@ def parse_command_line(args):
         from . import DebugFlags
         setattr(DebugFlags, name, value)
 
+    # additinal checks
     if options.use_listing_file and len(sources) > 1:
         parser.error("cython: Only one source file allowed when using -o\n")
     if len(sources) == 0 and not options.show_version:

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -66,14 +66,16 @@ class SetLenientAction(Action):
 
 class SetGDBDebugAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        namespace.gdb_debug = True
-        namespace.output_dir = os.curdir
+        value_map = {'gdb_debug': True,
+                     'output_dir': os.curdir}
+        set_values_to_subargument(namespace, LOCAL_OPTIONS, value_map)
 
 
 class SetGDBDebugOutputAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        namespace.gdb_debug = True
-        namespace.output_dir = values
+        value_map = {'gdb_debug': True,
+                     'output_dir': values}
+        set_values_to_subargument(namespace, LOCAL_OPTIONS, value_map)
 
 
 class SetAnnotateCoverageAction(Action):

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -118,6 +118,14 @@ def StoreToSubargument(subargument_name, default_value=None):
     return StoreToSubargumentClass
 
 
+def AppendToSubargument(subargument_name):
+    class AppendToSubargumentClass(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            current_list = getattr(namespace, subargument_name, {}).get(self.dest, [])
+            set_values_to_subargument(namespace, subargument_name, {self.dest: current_list + values})
+    return AppendToSubargumentClass
+
+
 def create_cython_argparser():
     description = "Cython (https://cython.org/) is a compiler for code written in the "\
                   "Cython language.  Cython is based on Pyrex by Greg Ewing."
@@ -130,7 +138,8 @@ def create_cython_argparser():
     parser.add_argument("-l", "--create-listing", dest='use_listing_file',
                       action=StoreToSubargument(LOCAL_OPTIONS, 1), nargs=0,
                       help='Write error messages to a listing file')
-    parser.add_argument("-I", "--include-dir", dest='include_path', action='append',
+    parser.add_argument("-I", "--include-dir", dest='include_path',
+                      action=AppendToSubargument(LOCAL_OPTIONS), nargs=1,
                       help='Search for include files in named directory '
                            '(multiple include directories are allowed).')
     parser.add_argument("-o", "--output-file", dest='output_file',

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -8,6 +8,13 @@ import os
 from argparse import ArgumentParser, Action, SUPPRESS
 from . import Options
 
+try:
+    import multiprocessing
+    parallel_compiles = int(multiprocessing.cpu_count() * 1.5)
+except ImportError:
+    multiprocessing = None
+    parallel_compiles = 0
+
 
 GLOBAL_OPTIONS = 'global_options'
 DEBUG_FLAGS = 'debug_flags'
@@ -131,6 +138,62 @@ def CountToSubargument(subargument_name):
             current_value = getattr(namespace, subargument_name, {}).get(self.dest, 0)
             set_values_to_subargument(namespace, subargument_name, {self.dest: current_value + 1})
     return CountToSubargumentClass
+
+
+def create_cythonize_argparser():
+    parser = ArgumentParser()
+
+    parser.add_argument('-X', '--directive', metavar='NAME=VALUE,...',
+                      dest='compiler_directives', type=str,
+                      action=ParseDirectivesActionToLocal,
+                      help='set a compiler directive')
+    parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
+                      dest='compile_time_env', type=str,
+                      action=ParseCompileTimeEnvActionToLocal,
+                      help='set a compile time environment variable')
+    parser.add_argument('-s', '--option', metavar='NAME=VALUE',
+                      dest='options', default={}, type=str,
+                      action=ParseOptionsAction,
+                      help='set a cythonize option')
+    parser.add_argument('-2', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 2), nargs=0,
+                      help='use Python 2 syntax mode by default')
+    parser.add_argument('-3', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 3), nargs=0,
+                      help='use Python 3 syntax mode by default')
+    parser.add_argument('--3str', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, '3str'), nargs=0,
+                      help='use Python 3 syntax mode by default')
+    parser.add_argument('-a', '--annotate', action=StoreToSubargument(GLOBAL_OPTIONS, 'default'), nargs=0, dest='annotate',
+                      help='Produce a colorized HTML version of the source.')
+    parser.add_argument('--annotate-fullc', action=StoreToSubargument(GLOBAL_OPTIONS, 'fullc'), nargs=0, dest='annotate',
+                      help='Produce a colorized HTML version of the source '
+                           'which includes entire generated C/C++-code.')
+    parser.add_argument('-x', '--exclude', metavar='PATTERN', dest='excludes',
+                      action='append', default=[],
+                      help='exclude certain file patterns from the compilation')
+
+    parser.add_argument('-b', '--build', dest='build', action='store_true', default=None,
+                      help='build extension modules using distutils')
+    parser.add_argument('-i', '--inplace', dest='build_inplace', action=SetBuildInplace, nargs=0,
+                      help='build extension modules in place using distutils (implies -b)')
+    parser.add_argument('-j', '--parallel', dest='parallel', metavar='N',
+                      type=int, default=parallel_compiles,
+                      help=('run builds in N parallel jobs (default: %d)' %
+                            parallel_compiles or 1))
+    parser.add_argument('-f', '--force', dest='force', action='store_true', default=None,
+                      help='force recompilation')
+    parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', default=None,
+                      help='be less verbose during compilation')
+
+    parser.add_argument('--lenient', dest='lenient', action=SetLenientAction, nargs=0,
+                      help='increase Python compatibility by ignoring some compile time errors')
+    parser.add_argument('-k', '--keep-going', dest='keep_going', action='store_true', default=None,
+                      help='compile as much as possible, ignore compilation failures')
+    parser.add_argument('--no-docstrings', dest='docstrings', action=StoreToSubargument(GLOBAL_OPTIONS, False), nargs=0, default=None,
+                      help='strip docstrings')
+    parser.add_argument('sources', nargs='*')
+    return parser
 
 
 def create_cython_argparser():

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -11,6 +11,7 @@ from . import Options
 
 GLOBAL_OPTIONS = 'global_options'
 DEBUG_FLAGS = 'debug_flags'
+LOCAL_OPTIONS = 'options'
 
 
 def set_values_to_subargument(namespace, subargument_name, value_map):
@@ -99,18 +100,23 @@ def create_cython_argparser():
 
     parser = ArgumentParser(description=description, argument_default=SUPPRESS)
 
-    parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
+    parser.add_argument("-V", "--version", dest='show_version',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 1), nargs=0,
                       help='Display version number of cython compiler')
-    parser.add_argument("-l", "--create-listing", dest='use_listing_file', action='store_const', const=1,
+    parser.add_argument("-l", "--create-listing", dest='use_listing_file',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 1), nargs=0,
                       help='Write error messages to a listing file')
     parser.add_argument("-I", "--include-dir", dest='include_path', action='append',
                       help='Search for include files in named directory '
                            '(multiple include directories are allowed).')
-    parser.add_argument("-o", "--output-file", dest='output_file', action='store', type=str,
+    parser.add_argument("-o", "--output-file", dest='output_file',
+                      action=StoreToSubargument(LOCAL_OPTIONS), nargs=1, type=str,
                       help='Specify name of generated C file')
-    parser.add_argument("-t", "--timestamps", dest='timestamps', action='store_const', const=1,
+    parser.add_argument("-t", "--timestamps", dest='timestamps',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 1), nargs=0,
                       help='Only compile newer source files')
-    parser.add_argument("-f", "--force", dest='timestamps', action='store_const', const=0,
+    parser.add_argument("-f", "--force", dest='timestamps',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 0), nargs=0,
                       help='Compile all source files (overrides implied -t)')
     parser.add_argument("-v", "--verbose", dest='verbose', action='count',
                       help='Be verbose, print file names on multiple compilation')
@@ -122,7 +128,8 @@ def create_cython_argparser():
                       action=StoreToSubargument(GLOBAL_OPTIONS), nargs=1, type=int,
                       help='Release interned objects on python exit, for memory debugging. '
                            'Level indicates aggressiveness, default 0 releases nothing.')
-    parser.add_argument("-w", "--working", dest='working_path', action='store', type=str,
+    parser.add_argument("-w", "--working", dest='working_path',
+                      action=StoreToSubargument(LOCAL_OPTIONS), nargs=1, type=str,
                       help='Sets the working directory for Cython (the directory modules are searched from)')
     parser.add_argument("--gdb", action=SetGDBDebugAction, nargs=0,
                       help='Output debug information for cygdb')
@@ -138,24 +145,30 @@ def create_cython_argparser():
                            'which includes entire generated C/C++-code.')
     parser.add_argument("--annotate-coverage", dest='annotate_coverage_xml', action=SetAnnotateCoverageAction, type=str,
                       help='Annotate and include coverage information from cov.xml.')
-    parser.add_argument("--line-directives", dest='emit_linenums', action='store_true',
+    parser.add_argument("--line-directives", dest='emit_linenums',
+                      action=StoreToSubargument(LOCAL_OPTIONS, True), nargs=0,
                       help='Produce #line directives pointing to the .pyx source')
-    parser.add_argument("-+", "--cplus", dest='cplus', action='store_const', const=1,
+    parser.add_argument("-+", "--cplus", dest='cplus',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 1), nargs=0,
                       help='Output a C++ rather than C file.')
     parser.add_argument('--embed', action='store_const', const='main',
                       help='Generate a main() function that embeds the Python interpreter. '
                            'Pass --embed=<method_name> for a name other than main().')
-    parser.add_argument('-2', dest='language_level', action='store_const', const=2,
+    parser.add_argument('-2', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 2), nargs=0,
                       help='Compile based on Python-2 syntax and code semantics.')
-    parser.add_argument('-3', dest='language_level', action='store_const', const=3,
+    parser.add_argument('-3', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, 3), nargs=0,
                       help='Compile based on Python-3 syntax and code semantics.')
-    parser.add_argument('--3str', dest='language_level', action='store_const', const='3str',
+    parser.add_argument('--3str', dest='language_level',
+                      action=StoreToSubargument(LOCAL_OPTIONS, '3str'), nargs=0,
                       help='Compile based on Python-3 syntax and code semantics without '
                            'assuming unicode by default for string literals under Python 2.')
     parser.add_argument("--lenient", action=SetLenientAction, nargs=0,
                       help='Change some compile time errors to runtime errors to '
                            'improve Python compatibility')
-    parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true',
+    parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes',
+                      action=StoreToSubargument(LOCAL_OPTIONS, True), nargs=0,
                       help='Add cincluded headers to any auto-generated header files.')
     parser.add_argument("--fast-fail", dest='fast_fail',
                       action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0,
@@ -179,7 +192,7 @@ def create_cython_argparser():
     # TODO: add help
     parser.add_argument("-z", "--pre-import", dest='pre_import', action=StoreToSubargument(GLOBAL_OPTIONS), nargs=1, help=SUPPRESS)
     parser.add_argument("--convert-range", dest='convert_range', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
-    parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action='store_false', help=SUPPRESS)
+    parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action=StoreToSubargument(LOCAL_OPTIONS, False), nargs=0, help=SUPPRESS)
     parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
     parser.add_argument("--old-style-globals", dest='old_style_globals', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
 
@@ -235,10 +248,15 @@ def parse_command_line(args):
 
     options = Options.CompilationOptions(Options.default_options)
     for name, value in vars(arguments).items():
-        if name in (DEBUG_FLAGS, GLOBAL_OPTIONS):
+        if name in (DEBUG_FLAGS, GLOBAL_OPTIONS, LOCAL_OPTIONS):
             continue
         else:
             setattr(options, name, value)
+
+    # handle local_options:
+    local_options = getattr(arguments, LOCAL_OPTIONS, {})
+    for name, value in local_options.items():
+        setattr(options, name, value)
 
     # handle global_options:
     global_options = getattr(arguments, GLOBAL_OPTIONS, {})

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -61,6 +61,15 @@ class ParseCompileTimeEnvAction(Action):
         setattr(namespace, self.dest, new_env)
 
 
+class ParseCompileTimeEnvActionToLocal(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        subarguments = getattr(namespace, LOCAL_OPTIONS, {})
+        old_env = dict(subarguments.get(self.dest, {}))
+        new_env = Options.parse_compile_time_env(values, current_settings=old_env)
+        subarguments[self.dest] = new_env
+        setattr(namespace, LOCAL_OPTIONS, subarguments)
+
+
 class ActivateAllWarningsAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         subarguments = getattr(namespace, LOCAL_OPTIONS, {})
@@ -200,7 +209,7 @@ def create_cython_argparser():
                       help='Overrides a compiler directive')
     parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
                       dest='compile_time_env', type=str,
-                      action=ParseCompileTimeEnvAction,
+                      action=ParseCompileTimeEnvActionToLocal,
                       help='Provides compile time env like DEF would do.')
     parser.add_argument('sources', nargs='*', default=[])
 

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -126,6 +126,14 @@ def AppendToSubargument(subargument_name):
     return AppendToSubargumentClass
 
 
+def CountToSubargument(subargument_name):
+    class CountToSubargumentClass(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            current_value = getattr(namespace, subargument_name, {}).get(self.dest, 0)
+            set_values_to_subargument(namespace, subargument_name, {self.dest: current_value + 1})
+    return CountToSubargumentClass
+
+
 def create_cython_argparser():
     description = "Cython (https://cython.org/) is a compiler for code written in the "\
                   "Cython language.  Cython is based on Pyrex by Greg Ewing."
@@ -151,7 +159,8 @@ def create_cython_argparser():
     parser.add_argument("-f", "--force", dest='timestamps',
                       action=StoreToSubargument(LOCAL_OPTIONS, 0), nargs=0,
                       help='Compile all source files (overrides implied -t)')
-    parser.add_argument("-v", "--verbose", dest='verbose', action='count',
+    parser.add_argument("-v", "--verbose", dest='verbose',
+                      action=CountToSubargument(LOCAL_OPTIONS), nargs=0,
                       help='Be verbose, print file names on multiple compilation')
     parser.add_argument("-p", "--embed-positions", dest='embed_pos_in_docstring',
                       action=StoreToSubargument(GLOBAL_OPTIONS, 1), nargs=0,

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -54,13 +54,6 @@ class ParseOptionsAction(Action):
         setattr(namespace, self.dest, options)
 
 
-class ParseCompileTimeEnvAction(Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        old_env = dict(getattr(namespace, self.dest, {}))
-        new_env = Options.parse_compile_time_env(values, current_settings=old_env)
-        setattr(namespace, self.dest, new_env)
-
-
 class ParseCompileTimeEnvActionToLocal(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         subarguments = getattr(namespace, LOCAL_OPTIONS, {})

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -301,7 +301,7 @@ def parse_args_raw(parser, args):
     return (options, sources)
 
 
-def parse_command_line_raw(parser, args):
+def parse_args_raw_cython(parser, args):
     # special handling for --embed and --embed=xxxx as they aren't correctly parsed
     def filter_out_embed_options(args):
         with_embed, without_embed = [], []
@@ -335,7 +335,7 @@ def apply_options(target, options):
 
 def parse_command_line(args):
     parser = create_cython_argparser()
-    arguments, sources = parse_command_line_raw(parser, args)
+    arguments, sources = parse_args_raw_cython(parser, args)
 
     # handle local_options:
     options = Options.CompilationOptions(Options.default_options)
@@ -355,3 +355,23 @@ def parse_command_line(args):
     if Options.embed and len(sources) > 1:
         parser.error("cython: Only one source file allowed when using -embed\n")
     return options, sources
+
+
+def parse_command_line_cythonize(args):
+    parser = create_cythonize_argparser()
+    options, args = parse_args_raw(parser, args)
+
+    if not args:
+        parser.error("no source files provided")
+    if multiprocessing is None:
+        options.parallel = 0
+
+    # handle global_options:
+    apply_options(Options, getattr(options, GLOBAL_OPTIONS, {}))
+    # no longer needed:
+    try:
+        delattr(options, GLOBAL_OPTIONS)
+    except AttributeError:
+        pass
+
+    return options, args

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -118,7 +118,8 @@ def create_cython_argparser():
                       action=StoreToSubargument(GLOBAL_OPTIONS, 1), nargs=0,
                       help='If specified, the positions in Cython files of each '
                            'function definition is embedded in its docstring.')
-    parser.add_argument("--cleanup", dest='generate_cleanup_code', action='store', type=int,
+    parser.add_argument("--cleanup", dest='generate_cleanup_code',
+                      action=StoreToSubargument(GLOBAL_OPTIONS), nargs=1, type=int,
                       help='Release interned objects on python exit, for memory debugging. '
                            'Level indicates aggressiveness, default 0 releases nothing.')
     parser.add_argument("-w", "--working", dest='working_path', action='store', type=str,
@@ -127,7 +128,8 @@ def create_cython_argparser():
                       help='Output debug information for cygdb')
     parser.add_argument("--gdb-outdir", action=SetGDBDebugOutputAction, type=str,
                       help='Specify gdb debug information output directory. Implies --gdb.')
-    parser.add_argument("-D", "--no-docstrings", dest='docstrings', action='store_false',
+    parser.add_argument("-D", "--no-docstrings", dest='docstrings',
+                      action=StoreToSubargument(GLOBAL_OPTIONS, False), nargs=0,
                       help='Strip docstrings from the compiled module.')
     parser.add_argument('-a', '--annotate', action=StoreToSubargument(GLOBAL_OPTIONS, 'default'), nargs=0, dest='annotate',
                       help='Produce a colorized HTML version of the source.')
@@ -155,9 +157,11 @@ def create_cython_argparser():
                            'improve Python compatibility')
     parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true',
                       help='Add cincluded headers to any auto-generated header files.')
-    parser.add_argument("--fast-fail", dest='fast_fail', action='store_true',
+    parser.add_argument("--fast-fail", dest='fast_fail',
+                      action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0,
                       help='Abort the compilation on the first error')
-    parser.add_argument("-Werror", "--warning-errors", dest='warning_errors', action='store_true',
+    parser.add_argument("-Werror", "--warning-errors", dest='warning_errors',
+                      action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0,
                       help='Make all warnings into errors')
     parser.add_argument("-Wextra", "--warning-extra", action=ActivateAllWarningsAction, nargs=0,
                       help='Enable extra warnings')
@@ -173,11 +177,11 @@ def create_cython_argparser():
     parser.add_argument('sources', nargs='*', default=[])
 
     # TODO: add help
-    parser.add_argument("-z", "--pre-import", dest='pre_import', action='store', type=str, help=SUPPRESS)
-    parser.add_argument("--convert-range", dest='convert_range', action='store_true', help=SUPPRESS)
+    parser.add_argument("-z", "--pre-import", dest='pre_import', action=StoreToSubargument(GLOBAL_OPTIONS), nargs=1, help=SUPPRESS)
+    parser.add_argument("--convert-range", dest='convert_range', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
     parser.add_argument("--no-c-in-traceback", dest='c_line_in_traceback', action='store_false', help=SUPPRESS)
-    parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action='store_true', help=SUPPRESS)
-    parser.add_argument("--old-style-globals", dest='old_style_globals', action='store_true', help=SUPPRESS)
+    parser.add_argument("--cimport-from-pyx", dest='cimport_from_pyx', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
+    parser.add_argument("--old-style-globals", dest='old_style_globals', action=StoreToSubargument(GLOBAL_OPTIONS, True), nargs=0, help=SUPPRESS)
 
     # debug stuff:
     from . import DebugFlags
@@ -220,7 +224,7 @@ def parse_command_line_raw(parser, args):
             name = 'main'  # default value
         else:
             name = x[len('--embed='):]
-        setattr(arguments, 'embed', name)
+        set_values_to_subargument(arguments, GLOBAL_OPTIONS, {'embed': name})
 
     return arguments, sources
 
@@ -233,8 +237,6 @@ def parse_command_line(args):
     for name, value in vars(arguments).items():
         if name in (DEBUG_FLAGS, GLOBAL_OPTIONS):
             continue
-        elif hasattr(Options, name):
-            setattr(Options, name, value)
         else:
             setattr(options, name, value)
 

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -86,6 +86,12 @@ class SetGDBDebugAction(Action):
         set_values_to_subargument(namespace, LOCAL_OPTIONS, value_map)
 
 
+class SetBuildInplace(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, 'build', True)
+        setattr(namespace, 'build_inplace', True)
+
+
 class SetGDBDebugOutputAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         value_map = {'gdb_debug': True,

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -501,7 +501,10 @@ class CmdLineParserTest(TestCase):
                 '-X', 'c_string_type=bytes',
                 'source.pyx'
        ])
-       self.assertTrue(len(options.compiler_directives), len(Options.extra_warnings) + 1)
+       for key in Options.extra_warnings.keys():
+           self.assertEqual(options.compiler_directives[key], True)
+       self.assertEqual(options.compiler_directives['cdivision'], True)
+       self.assertEqual(options.compiler_directives['c_string_type'], 'bytes')
        self.check_default_global_options()
        self.check_default_options(options, ['compiler_directives'])
 

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -183,6 +183,16 @@ class CmdLineParserTest(TestCase):
        self.check_default_global_options(['pre_import'])
        self.check_default_options(options)
 
+    def test_short_z2(self):
+       options, sources = parse_command_line([
+                '-z', 'my_preimport',
+                '-z', 'my_preimport2',
+                'source.pyx'
+       ])
+       self.assertEqual(Options.pre_import, 'my_preimport2')
+       self.check_default_global_options(['pre_import'])
+       self.check_default_options(options)
+
     def test_convert_range(self):
        options, sources = parse_command_line([
                 '--convert-range',

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -523,4 +523,5 @@ class CmdLineParserTest(TestCase):
         error('--verbose=1')
         error('--verbose=1')
         error('--cleanup')
+        error('--cleanup=3s', 'file.pyx')
         error('--debug-disposal-code-wrong-name', 'file3.pyx')


### PR DESCRIPTION
Trying to unify arg-parser for cythinoze.py and cython.py as mentioned [here](https://github.com/cython/cython/pull/3001#issuecomment-518031897).

The patch is much bigger than I would like and maybe a little bit over engineered, here is the main idea:

  The starting point is already complicated: There are "local options", which are passed as `options`-argument to cythonize/cython,  "global options" which change Options, "debug flags" and other options (like quite for cythonize).  Because cythonize.py saves (most of) "local options" in `options.options` there is no easy way to unify them with cython.py-parser, as it doesn't have this hierarchy.

So the first step is to introduce hierarchy into the resulting parsed options:

  * `options.options` for "local options"
  * `options.global_options for changes of `Compiler.Options`
  * `debug_flag` for `DebugFlags`-stuff
  * other options

this move the somewhat brittly logic from code into the data structure and simplifies the unification.

The advantages of the result:
  *  the missing options (like `--fail-fast`) can be easily added to cythonize.py
  * common options have the same help-message and are automatically consistent for cython/cythonize

If you deceide that this is not work the trouble, I would at least like to resubmit the improvement to the unit tests. Or split into multiple PRs if this one is just too large.
