### PR TITLE
Unicode identifiers (C structures)

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1436,7 +1436,7 @@ class CStructOrUnionDefNode(StatNode):
     def analyse_declarations(self, env):
         scope = None
         if self.attributes is not None:
-            scope = StructOrUnionScope(self.name)
+            scope = StructOrUnionScope(self.name, self.visibility)
         self.declare(env, scope)
         if self.attributes is not None:
             if self.in_pxd and not env.in_cinclude:
@@ -1586,9 +1586,9 @@ class CEnumDefNode(StatNode):
                     item.cname,
                     code.error_goto_if_null(temp, item.pos)))
                 code.put_gotref(temp)
-                code.putln('if (PyDict_SetItemString(%s, "%s", %s) < 0) %s' % (
+                code.putln('if (PyDict_SetItemString(%s, %s, %s) < 0) %s' % (
                     Naming.moddict_cname,
-                    item.name,
+                    item.name.as_c_string_literal(),
                     temp,
                     code.error_goto(item.pos)))
                 code.put_decref_clear(temp, PyrexTypes.py_object_type)

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2920,6 +2920,8 @@ def p_c_simple_declarator(s, ctx, empty, is_type, cmethod_flag,
                             fatal=False)
                 name = name + ' ' + op
                 s.next()
+        name = EncodedString(name)
+        if cname is not None: cname = EncodedString(cname)
         result = Nodes.CNameDeclaratorNode(pos,
             name = name, cname = cname, default = rhs)
     result.calling_convention = calling_convention

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2891,7 +2891,7 @@ def p_c_simple_declarator(s, ctx, empty, is_type, cmethod_flag,
             name = ""
             cname = None
         if cname is None and ctx.namespace is not None and nonempty:
-            cname = ctx.namespace + "::" + name
+            cname = EncodedString(ctx.namespace + "::" + name)
         if name == 'operator' and ctx.visibility == 'extern' and nonempty:
             op = s.sy
             if [1 for c in op if c in '+-*/<=>!%&|([^~,']:
@@ -2921,7 +2921,6 @@ def p_c_simple_declarator(s, ctx, empty, is_type, cmethod_flag,
                 name = name + ' ' + op
                 s.next()
         name = EncodedString(name)
-        if cname is not None: cname = EncodedString(cname)
         result = Nodes.CNameDeclaratorNode(pos,
             name = name, cname = cname, default = rhs)
     result.calling_convention = calling_convention

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3869,7 +3869,8 @@ class CppClassType(CType):
                 break
 
         func_type = CFuncType(self, [], exception_check='+', nogil=nogil)
-        return self.scope.declare_cfunction(u'<init>', func_type, pos)
+        return self.scope.declare_cfunction(
+                StringEncoding.EncodedString(u'<init>'), func_type, pos)
 
     def check_nullary_constructor(self, pos, msg="stack allocated"):
         constructor = self.scope.lookup(u'<init>')

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -20,6 +20,7 @@ from ..Plex.Errors import UnrecognizedInput
 from .Errors import error, warning
 from .Lexicon import any_string_prefix, make_lexicon, IDENT
 from .Future import print_function
+from .StringEncoding import EncodedString
 
 debug_scanner = 0
 trace_scanner = 0
@@ -346,7 +347,13 @@ class PyrexScanner(Scanner):
         try:
             text.encode('ascii') # really just name.isascii but supports Python 2 and 3
         except UnicodeEncodeError:
+            old_text = text
             text = normalize('NFKC', text)
+            if text != old_text:
+                text = EncodedString(text) # most strings haven't been wrapped at this stage, 
+                    # so need to do so to add an attribute
+                text.unnormalized = old_text
+                
         self.produce(IDENT, text)
 
     def commentline(self, text):

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -350,10 +350,10 @@ class PyrexScanner(Scanner):
             old_text = text
             text = normalize('NFKC', text)
             if text != old_text:
-                text = EncodedString(text) # most strings haven't been wrapped at this stage, 
+                text = EncodedString(text) # most strings haven't been wrapped at this stage,
                     # so need to do so to add an attribute
                 text.unnormalized = old_text
-                
+
         self.produce(IDENT, text)
 
     def commentline(self, text):

--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -145,22 +145,22 @@ class EncodedString(_unicode):
         else:
             s = bytes_literal(self.byteencode(), self.encoding)
         return s.as_c_string_literal()
-    
+
     def as_cu_string(self):
         r"""Encodes to \u escaped. Not quotes"""
         return encoded_string(
                 self.encode('ASCII', errors='backslashreplace').decode('ASCII'),
                 'ASCII')
-    
+
     @property
     def unnormalized(self):
         """Returns the unnormalized string if available, otherwise returns self
-        
+
         Sometimes a unicode string will differ after normalization; it's
         sometimes useful to store the original and this decorator helps with
         that"""
         return getattr(self, '_unnormalized', self)
-    
+
     @unnormalized.setter
     def unnormalized(self, value):
         self._unnormalized = value

--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -145,6 +145,25 @@ class EncodedString(_unicode):
         else:
             s = bytes_literal(self.byteencode(), self.encoding)
         return s.as_c_string_literal()
+    
+    def as_cu_string(self):
+        r"""Encodes to \u escaped. Not quotes"""
+        return encoded_string(
+                self.encode('ASCII', errors='backslashreplace').decode('ASCII'),
+                'ASCII')
+    
+    @property
+    def unnormalized(self):
+        """Returns the unnormalized string if available, otherwise returns self
+        
+        Sometimes a unicode string will differ after normalization; it's
+        sometimes useful to store the original and this decorator helps with
+        that"""
+        return getattr(self, '_unnormalized', self)
+    
+    @unnormalized.setter
+    def unnormalized(self, value):
+        self._unnormalized = value
 
 
 def string_contains_surrogates(ustring):

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -425,11 +425,11 @@ class Scope(object):
         if self.parent_scope:
             return self.parent_scope.mangle_class_private_name(name)
         return name
-    
+
     def nomangle(self, name):
         r"""
         Allows unicode names to be translated to valid C/C++ code
-        
+
         Unicode identifiers are allowed in C/C__, but most compilers only
         accept escaped (\u or \U) characters rather than the raw characters.
         Additionally, we should use the unnormalized name and trust the
@@ -443,7 +443,7 @@ class Scope(object):
                     "If your generated C code fails to compile then check "
                     "that you are using the name consistently."
                     )
-        
+
         return name.unnormalized.as_cu_string()
 
     def next_id(self, name=None):
@@ -726,7 +726,7 @@ class Scope(object):
                 cname = self.nomangle(name)
             else:
                 cname = self.mangle(Naming.var_prefix, name)
-            
+
         if type.is_cpp_class and visibility != 'extern':
             type.check_nullary_constructor(pos)
         entry = self.declare(name, cname, type, pos, visibility)
@@ -1529,7 +1529,7 @@ class ModuleScope(Scope):
             typeobj_cname=None, typeptr_cname=None, visibility='private',
             typedef_flag=0, api=0, check_size=None,
             buffer_defaults=None, shadow=0):
-        
+
         # If this is a non-extern typedef class, expose the typedef, but use
         # the non-typedef struct internally to avoid needing forward
         # declarations for anonymous structs.
@@ -1557,7 +1557,7 @@ class ModuleScope(Scope):
                         error(pos, "Base type does not match previous declaration")
                 if base_type and not type.base_type:
                     type.base_type = base_type
-        
+
         # ensure that if any unicode names are supplied they are converted
         # into a form suitable for C
         if objstruct_cname:
@@ -1568,7 +1568,7 @@ class ModuleScope(Scope):
             typeptr_cname = self.nomangle(typeptr_cname)
         if objtypedef_cname:
             objtypedef_cname = self.nomangle(objtypedef_cname)
-                    
+
         #
         #  Make a new entry if needed
         #

--- a/Cython/Utility/CConvert.pyx
+++ b/Cython/Utility/CConvert.pyx
@@ -18,7 +18,7 @@ cdef {{struct_type}} {{funcname}}(obj) except *:
         value = obj['{{member.name}}']
     except KeyError:
         raise ValueError("No value specified for struct attribute '{{member.name}}'")
-    result.{{member.cname}} = value
+    result.{{member.name}} = value
     {{endfor}}
     return result
 

--- a/tests/run/unicode_identifiers_c.srctree
+++ b/tests/run/unicode_identifiers_c.srctree
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# tag: pep3131
+
+# Two modules:
+#  one contains public declarations 
+#  one uses those declarations
+
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import doctest; import decl; exit(doctest.testmod(decl)[0])"
+PYTHON -c "import doctest; import use_external; exit(doctest.testmod(use_external)[0])"
+
+
+########## setup.py #########
+
+from distutils.core import setup
+from Cython.Build import cythonize
+
+setup(
+    ext_modules = cythonize(["decl.pyx", "use_external.pyx"])
+)
+
+######### decl.pyx #############
+# -*- coding: utf-8 -*-
+
+cpdef public enum Eνm:
+    α1 = 10
+    β2 = 20
+
+cdef public struct ΣtructnamePublic:
+    int α
+    double β
+
+cdef public class CDefClaσσPublic [object CDCΕχτ_Obj, type CDCΕχτ_Type]:
+    cdef int α
+
+cdef public int α = 5
+
+cdef public φunction(CDefClaσσPublic x):
+    x.α += 1
+    return x
+
+import sys
+
+if sys.version_info[0] > 2:
+    __doc__ = u"""
+    >>> Eνm.α1 * Eνm.β2
+    200
+    """
+else:
+    __doc__ = ""
+    __test__ = {}
+
+
+def test_enum():
+    """
+    >>> test_enum()
+    30
+
+    Test to check cpdef wrapper works is in module docstring (Py3 only)
+    """
+    return Eνm.α1 + Eνm.β2
+
+    
+########### use_external.pyx ###########
+# -*- coding: utf-8 -*-
+
+cdef extern from "decl.h":
+    cdef struct ΣtructnamePublic:
+        int α
+        double β
+
+    cdef class decl.CDefClaσσPublic [ object CDCΕχτ_Obj ]:
+        cdef int α
+
+    cdef enum Eνm:
+        α1
+        β2
+
+    cdef struct ΣtructnamePublic:
+        int α
+        double β
+
+
+cdef extern from *:
+    r"""
+    int C\u03c6unction (int x) {
+        return x;
+    }
+    """
+    int Cφunction(int)
+
+import decl
+
+def test_class():
+    """
+    >>> test_class()
+    1
+    """
+    cdef CDefClaσσPublic x = CDefClaσσPublic()
+    x.α = 1
+    return x.α
+
+def test_enum():
+    """
+    >>> test_enum()
+    200
+    """
+    return Eνm.α1 * Eνm.β2
+
+def test_cfunction():
+    """
+    >>> test_cfunction()
+    10
+    """
+    return Cφunction(10)
+
+def test_struct():
+    """
+    >>> test_struct()
+    True
+    """
+    cdef ΣtructnamePublic s
+    s.α = 2
+    s.β = 2.0
+    return s.α*s.β > 3
+
+

--- a/tests/run/unicode_identifiers_cpp.pyx
+++ b/tests/run/unicode_identifiers_cpp.pyx
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# distutils: language = c++
+# mode: run
+# tag: cpp
+
+
+cdef extern from *:
+    r"""
+    class MyCppCla\u03a3\u03a3 {
+        public:
+            int \u03b1;
+            MyCppCla\u03a3\u03a3(int x) :
+            \u03b1(x)
+            {}
+
+            int \u03c6unction() {
+                return \u03b1*2;
+            }
+    };
+    """
+    cppclass MyCppClaΣΣ:
+        MyCppClaΣΣ(int)
+        int α
+        int φunction()
+
+def example_function():
+    """
+    >>> example_function()
+    10
+    """
+    cdef MyCppClaΣΣ* c = new MyCppClaΣΣ(10)
+    try:
+        return c.φunction() - c.α
+    finally:
+        del c

--- a/tests/run/unicode_identifiers_mangled.pyx
+++ b/tests/run/unicode_identifiers_mangled.pyx
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# distutils: language = c++
+# mode: run
+# tag: cpp11
+
+#cnames should be mangled for ΣtructnameInternal but not for ΣtructnamePublic
+cdef struct ΣtructnameInternal:
+    int α
+
+cdef public struct ΣtructnamePublic:
+    int α
+
+from libcpp cimport bool
+
+# use C template tricks to check the existance of an α attribute
+cdef extern from *:
+    r"""
+    template <typename T>
+    int has_alpha_impl(decltype(T::\u03b1)*) {
+        return true;
+    }
+    template <typename T>
+    int has_alpha_impl(...) {
+        return false;
+    }
+
+    template <typename T>
+    bool has_alpha() {
+        return has_alpha_impl<T>(nullptr);
+    }
+
+    // a compile-time assertion that (sigma)tructnamePublic exists
+    //  (the "internal" varient would fail)
+    void name_exists(struct \u03a3tructnamePublic* ) {}
+    """
+    bool has_alpha[T]()
+
+
+def internal_has_alpha():
+    """
+    >>> internal_has_alpha()
+    False
+    """
+    return has_alpha[ΣtructnameInternal]()
+
+def public_has_alpha():
+    """
+    >>> public_has_alpha()
+    True
+    """
+    return has_alpha[ΣtructnamePublic]()
+


### PR DESCRIPTION
This is a separate pull request for the parts of https://github.com/cython/cython/pull/3119 that needed more discussion. These were essentially the features that go beyond Python compatibility.

Support for unicode identifiers in C/C++ features such as structs and cppclasses. For structs used purely in Python I've mangled the names with punycode. For features that are exported/imported to C with "public" or "extern", I've translated the names to be \uXXXX escaped (without any mangling or normalization). Pretty much every modern C/C++ compiler supports unicode in identifiers in this form (only Clang supports it in raw form I think), so this this seems like the most compatible thing to do. I've trusted that the user knows what names they want and not performed any normalization for these (I don't think normalization is yet defined in C/C++ standards, so it's hard to do anything else).