### PR TITLE
Fixed annotations with binding enabled [fixes test `embedsignatures`]

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3207,9 +3207,11 @@ class DefNode(FuncDefNode):
     def analyse_expressions(self, env):
         self.local_scope.directives = env.directives
         self.analyse_default_values(env)
-        self.analyse_annotations(env)
-        if self.return_type_annotation:
-            self.return_type_annotation = self.analyse_annotation(env, self.return_type_annotation)
+        if env.directives['binding'] == False:
+            # when binding == True delegate this to the wrapper class
+            self.analyse_annotations(env)
+            if self.return_type_annotation:
+                self.return_type_annotation = self.analyse_annotation(env, self.return_type_annotation)
 
         if not self.needs_assignment_synthesis(env) and self.decorators:
             for decorator in self.decorators[::-1]:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2242,6 +2242,14 @@ class AnalyseExpressionsTransform(CythonTransform):
         if node.is_fused_index and not node.type.is_error:
             node = node.base
         return node
+    
+    def visit_AlreadyAnalysedNode(self, node):
+        """Avoid going any further in analysing"""
+        subexprs = node.subexprs
+        if len(subexprs)==1:
+            return subexprs[0]
+        else:
+            return subexprs
 
 class ReplacePropertyNode(CythonTransform):
     def visit_CFuncDefNode(self, node):

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -401,12 +401,12 @@ class EnvTransform(CythonTransform):
         return node
 
     def visit_CArgDeclNode(self, node):
-        # default arguments are evaluated in the outer scope
-        if node.default:
-            attrs = [attr for attr in node.child_attrs if attr != 'default']
+        # default/annotation arguments are evaluated in the outer scope
+        if any(getattr(node,attr) for attr in node.outer_attrs):
+            attrs = [attr for attr in node.child_attrs if attr not in node.outer_attrs]
             self._process_children(node, attrs)
             self.enter_scope(node, self.current_env().outer_scope)
-            self.visitchildren(node, ('default',))
+            self.visitchildren(node, node.outer_attrs)
             self.exit_scope()
         else:
             self._process_children(node)

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -375,9 +375,13 @@ class EnvTransform(CythonTransform):
         attrs = [attr for attr in node.child_attrs if attr != "return_type_annotation"]
         self.enter_scope(node, node.local_scope)
         self._process_children(node, attrs)
+        outer_scope = self.current_env().outer_scope
         self.exit_scope()
+
         if getattr(node, "return_type_annotation", None) is not None:
+            self.enter_scope(node, outer_scope)
             self._process_children(node, ("return_type_annotation",))
+            self.exit_scope()
         return node
 
     def visit_GeneratorBodyDefNode(self, node):

--- a/tests/run/embedsignatures.pyx
+++ b/tests/run/embedsignatures.pyx
@@ -438,7 +438,7 @@ cdef class Foo:
    # m30 removed
     def m31(self, double[::1] a): pass
     def m32(self, a: S): pass # Cython specific syntax, should become string
-    def m33(self, *args: 1): pass
+    def m33(self, *args: 1) -> {str(i): i for i in range(3)}: pass
     def m34(self, **kwargs: 2): pass
 
 # Print from __annotations__ for a few of these: __annotations__ is evaluated while the signature is not
@@ -451,6 +451,8 @@ Foo.m01(self, a: ...) -> Ellipsis
 
 >>> print(Foo.m02.__doc__)
 Foo.m02(self, a: True, b: False) -> bool
+>>> Foo.m02.__annotations__['return'] == bool # Python type, not string
+True
 
 >>> print(Foo.m03.__doc__)
 Foo.m03(self, a: 42, b: 42, c: -42) -> int
@@ -547,7 +549,9 @@ Foo.m32(self, a: S)
 S
 
 >>> print(Foo.m33.__doc__)
-Foo.m33(self, *args: 1)
+Foo.m33(self, *args: 1) -> {str(i): i for i in range(3)}
+>>> print(len(Foo.m33.__annotations__['return']))
+3
 
 >>> print(Foo.m34.__doc__)
 Foo.m34(self, **kwargs: 2)


### PR DESCRIPTION
https://github.com/cython/cython/pull/2864

* No longer analyse annotations in FuncDef - the analysis was
not really used anyway, only typing was used
* Added helper code to help get sensible PyObjects when annotations
are Cython types
* A bit more testing (and removal of some tests that go against Python
behaviour)
* Block reanalysis of internals of `__annotations__` dictionary - I feel `AlreadyAnalysedNode` is a bit of a hack though, but I couldn't seem too many other options.

This seems to work although could probably do with a bit more testing that the annotations that come out are correct. It adds a new failure in `pep492_badsyntax_async2`. I'm not 100% sure what to do about this - I've never used the `async` syntax so I don't understand it. The code also doesn't seem to fail when run in Python3 (although I suspect it's nonsense) so I'm not sure how important the error is.