### PR TITLE
Fixed default buffer arguments with binding [Fixes `bufaccess`]

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9252,7 +9252,7 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
             for arg in nonliteral_objects:
                 type_ = arg.type
                 if type_.is_buffer:
-                    type_ = PyrexTypes.PyObjectType()
+                    type_ = type_.base
                 entry = scope.declare_var(arg.name, type_, None,
                                           Naming.arg_prefix + arg.name,
                                           allow_pyobject=True)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9250,7 +9250,10 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
             scope = Symtab.StructOrUnionScope(cname)
             self.defaults = []
             for arg in nonliteral_objects:
-                entry = scope.declare_var(arg.name, arg.type, None,
+                type_ = arg.type
+                if type_.is_buffer:
+                    type_ = PyrexTypes.PyObjectType()
+                entry = scope.declare_var(arg.name, type_, None,
                                           Naming.arg_prefix + arg.name,
                                           allow_pyobject=True)
                 self.defaults.append((arg, entry))

--- a/tests/buffers/bufaccess.pyx
+++ b/tests/buffers/bufaccess.pyx
@@ -974,7 +974,7 @@ def printbuf_object(object[object] buf, shape):
 
     >>> a, b, c = "globally_unique_string_23234123", {4:23}, [34,3]
     >>> get_refcount(a), get_refcount(b), get_refcount(c)
-    (2, 2, 2)
+    (3, 3, 3)
     >>> A = ObjectMockBuffer(None, [a, b, c])
     >>> printbuf_object(A, (3,))
     'globally_unique_string_23234123' 2
@@ -991,15 +991,16 @@ def assign_to_object(object[object] buf, int idx, obj):
     See comments on printbuf_object above.
 
     >>> a, b = [1, 2, 3], [4, 5, 6]
-    >>> get_refcount(a), get_refcount(b)
-    (2, 2)
+    >>> rca1, rcb1 = get_refcount(a), get_refcount(b)
+    >>> rca1 == rcb1
+    True
     >>> addref(a)
     >>> A = ObjectMockBuffer(None, [1, a]) # 1, ...,otherwise it thinks nested lists...
-    >>> get_refcount(a), get_refcount(b)
-    (3, 2)
+    >>> get_refcount(a) == rca1+1, get_refcount(b) == rcb1
+    (True, True)
     >>> assign_to_object(A, 1, b)
-    >>> get_refcount(a), get_refcount(b)
-    (2, 3)
+    >>> get_refcount(a) == rca1, get_refcount(b) == rcb1+1
+    (True, True)
     >>> decref(b)
     """
     buf[idx] = obj
@@ -1010,15 +1011,14 @@ def assign_temporary_to_object(object[object] buf):
     See comments on printbuf_object above.
 
     >>> a, b = [1, 2, 3], {4:23}
-    >>> get_refcount(a)
-    2
+    >>> rc1 = get_refcount(a)
     >>> addref(a)
     >>> A = ObjectMockBuffer(None, [b, a])
-    >>> get_refcount(a)
-    3
+    >>> get_refcount(a) == rc1+1
+    True
     >>> assign_temporary_to_object(A)
-    >>> get_refcount(a)
-    2
+    >>> get_refcount(a) == rc1
+    True
 
     >>> printbuf_object(A, (2,))
     {4: 23} 2


### PR DESCRIPTION
They were assigned to global scope, but buffers aren't allowed in
global scope. To fix, dropped the buffer type from the default value.

--------

Fixes the compile error. However a bunch of reference counting "errors" appear (i.e. numbers don't match existing numbers). Link to https://github.com/cython/cython/pull/2864