### PR TITLE
Explicitly initialize tp_print in Python 3.8

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -893,8 +893,8 @@ PyAsyncMethods = (
 
 slot_table = (
     ConstructorSlot("tp_dealloc", '__dealloc__'),
-    EmptySlot("tp_print", ifdef="PY_VERSION_HEX <= 0x030400b4"),
-    EmptySlot("tp_vectorcall_offset", ifdef="PY_VERSION_HEX >= 0x030400b4"),
+    EmptySlot("tp_print", ifdef="PY_VERSION_HEX < 0x030800b4"),
+    EmptySlot("tp_vectorcall_offset", ifdef="PY_VERSION_HEX >= 0x030800b4"),
     EmptySlot("tp_getattr"),
     EmptySlot("tp_setattr"),
 
@@ -957,7 +957,7 @@ slot_table = (
     EmptySlot("tp_version_tag"),
     EmptySlot("tp_finalize", ifdef="PY_VERSION_HEX >= 0x030400a1"),
     EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1"),
-    EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b1"),
+    EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4"),
 )
 
 #------------------------------------------------------------------------------------------

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -893,7 +893,8 @@ PyAsyncMethods = (
 
 slot_table = (
     ConstructorSlot("tp_dealloc", '__dealloc__'),
-    EmptySlot("tp_print"), #MethodSlot(printfunc, "tp_print", "__print__"),
+    EmptySlot("tp_print", ifdef="PY_VERSION_HEX <= 0x030400b4"),
+    EmptySlot("tp_vectorcall_offset", ifdef="PY_VERSION_HEX >= 0x030400b4"),
     EmptySlot("tp_getattr"),
     EmptySlot("tp_setattr"),
 
@@ -956,6 +957,7 @@ slot_table = (
     EmptySlot("tp_version_tag"),
     EmptySlot("tp_finalize", ifdef="PY_VERSION_HEX >= 0x030400a1"),
     EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1"),
+    EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b1"),
 )
 
 #------------------------------------------------------------------------------------------


### PR DESCRIPTION
When compiling cython-generated extension modules in Python3.8rc1
this error is emitted by the compiler:

  _ext.cpp:8104:1: error: missing initializer for member ‘_typeobject::tp_print’ [-Werror=missing-field-initializers]

The reason is that Python3.8 moved the tp_print slot (commit d917cfe4051) to
the end of the _typeobject struct and reused the original position for
tp_vectorcall_offset. The current generated code does not initialize the
deprecated tp_print slot that was moved to the end of the struct.