### PR TITLE
tests: Demonstrate failure of @staticmethod with implicit `object` argument type

### DIFF
--- a/tests/run/static_methods.pxd
+++ b/tests/run/static_methods.pxd
@@ -1,3 +1,6 @@
 cdef class FromPxd:
     @staticmethod
     cdef static_cdef(int* x)
+
+    @staticmethod
+    cdef static_cdef_with_implicit_object(obj)

--- a/tests/run/static_methods.pyx
+++ b/tests/run/static_methods.pyx
@@ -87,6 +87,10 @@ cdef class FromPxd:
     cdef static_cdef(int* x):
         return 'pxd_cdef', x[0]
 
+    @staticmethod
+    cdef static_cdef_with_implicit_object(obj):
+        return obj+1
+
 def call_static_pxd_cdef(int x):
     """
     >>> call_static_pxd_cdef(2)
@@ -94,3 +98,11 @@ def call_static_pxd_cdef(int x):
     """
     cdef int *x_ptr = &x
     return FromPxd.static_cdef(x_ptr)
+
+def call_static_pxd_cdef_with_implicit_object(int x):
+    """
+    # currently fails: https://github.com/cython/cython/issues/3174
+    >>> call_static_pxd_cdef_with_implicit_object(2) # doctest: +SKIP
+    3
+    """
+    return FromPxd.static_cdef_with_implicit_object(x)


### PR DESCRIPTION
See https://github.com/cython/cython/issues/3174.
If I remove `# doctest: +SKIP`, the test fails as:

    FAIL: call_static_pxd_cdef_with_implicit_object (line 102) (static_methods.__test__)
    Doctest: static_methods.__test__.call_static_pxd_cdef_with_implicit_object (line 102)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 2224, in runTest
        raise self.failureException(self.format_failure(new.getvalue()))
    AssertionError: Failed doctest test for static_methods.__test__.call_static_pxd_cdef_with_implicit_object (line 102)
      File "/home/kirr/src/tools/py/cython/TEST_TMP/run/c/static_methods/static_methods.so", line unknown line number, in call_static_pxd_cdef_with_implicit_object (line 102)

    ----------------------------------------------------------------------
    File "/home/kirr/src/tools/py/cython/TEST_TMP/run/c/static_methods/static_methods.so", line ?, in static_methods.__test__.call_static_pxd_cdef_with_implicit_object (line 102)
    Failed example:
        call_static_pxd_cdef_with_implicit_object(2)
    Exception raised:
        Traceback (most recent call last):
          File "/usr/lib/python2.7/doctest.py", line 1315, in __run
            compileflags, 1) in test.globs
          File "<doctest static_methods.__test__.call_static_pxd_cdef_with_implicit_object (line 102)[0]>", line 1, in <module>
            call_static_pxd_cdef_with_implicit_object(2)
          File "tests/run/static_methods.pyx", line 108, in static_methods.call_static_pxd_cdef_with_implicit_object
            return FromPxd.static_cdef_with_implicit_object(x)
        TypeError: Cannot convert int to static_methods.FromPxd

/cc @robertwb