### PR TITLE
Symbol table with c++ methods overloading support

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6888,6 +6888,10 @@ class AttributeNode(ExprNode):
                         ubcm_entry.func_cname = entry.func_cname
                         ubcm_entry.is_unbound_cmethod = 1
                         ubcm_entry.scope = entry.scope
+                        if type.is_cpp_class:
+                            ubcm_entry.overloaded_alternatives = [
+                                Symtab.Entry(entry.name, entry.func_cname, entry.type) for entry in entry.overloaded_alternatives
+                            ]
                     return self.as_name_node(env, ubcm_entry, target=False)
             elif type.is_enum:
                 if self.attribute in type.values:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -470,16 +470,21 @@ class Scope(object):
             warning(pos, "'%s' is a reserved name in C." % cname, -1)
 
         entries = self.entries
+        old_index = -1
         if name and name in entries and not shadow:
             old_entry = entries[name]
 
             # Reject redeclared C++ functions only if they have the same type signature.
             cpp_override_allowed = False
-            if type.is_cfunction and old_entry.type.is_cfunction and self.is_cpp():
-                for alt_entry in old_entry.all_alternatives():
-                    if type == alt_entry.type:
+            if type.is_cfunction and old_entry.type.is_cfunction and self.is_cpp_class_scope:
+                for index, alt_entry in enumerate(old_entry.all_alternatives()):
+                    if type.compatible_signature_with(alt_entry.type):
                         if name == '<init>' and not type.args:
                             # Cython pre-declares the no-args constructor - allow later user definitions.
+                            old_index = index
+                            cpp_override_allowed = True
+                        elif alt_entry.is_inherited:
+                            old_index = index
                             cpp_override_allowed = True
                         break
                 else:
@@ -503,12 +508,18 @@ class Scope(object):
         entry.create_wrapper = create_wrapper
         if name:
             entry.qualified_name = self.qualify_name(name)
-#            if name in entries and self.is_cpp():
-#                entries[name].overloaded_alternatives.append(entry)
-#            else:
-#                entries[name] = entry
             if not shadow:
-                entries[name] = entry
+                if name in entries and self.is_cpp_class_scope and type.is_cfunction:
+                    if old_index > -1:
+                        if old_index > 0:
+                            entries[name].overloaded_alternatives[old_index-1] = entry
+                        else:
+                            entry.overloaded_alternatives = entries[name].overloaded_alternatives
+                            entries[name] = entry
+                    else:
+                        entries[name].overloaded_alternatives.append(entry)
+                else:
+                    entries[name] = entry
 
         if type.is_memoryviewslice:
             from . import MemoryView
@@ -2479,8 +2490,8 @@ class CppClassScope(Scope):
         entry = self.declare_var(name, type, pos,
                                  defining=defining,
                                  cname=cname, visibility=visibility)
-        if prev_entry and not defining:
-            entry.overloaded_alternatives = prev_entry.all_alternatives()
+        #if prev_entry and not defining:
+        #    entry.overloaded_alternatives = prev_entry.all_alternatives()
         entry.utility_code = utility_code
         type.entry = entry
         return entry

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2441,15 +2441,17 @@ class CppClassScope(Scope):
             cname = name
         entry = self.lookup_here(name)
         if defining and entry is not None:
-            if entry.type.same_as(type):
+            if type.is_cfunction:
+                entry = self.declare(name, cname, type, pos, visibility)
+            elif entry.type.same_as(type):
                 # Fix with_gil vs nogil.
                 entry.type = entry.type.with_with_gil(type.with_gil)
-            elif type.is_cfunction and type.compatible_signature_with(entry.type):
-                entry.type = type
             else:
                 error(pos, "Function signature does not match previous declaration")
         else:
             entry = self.declare(name, cname, type, pos, visibility)
+            if type.is_cfunction and not defining:
+                entry.is_inherited = 1
         entry.is_variable = 1
         if type.is_cfunction and self.type:
             if not self.type.get_fused_types():
@@ -2486,7 +2488,8 @@ class CppClassScope(Scope):
                 if base_entry and not base_entry.type.nogil:
                     error(pos, "Constructor cannot be called without GIL unless all base constructors can also be called without GIL")
                     error(base_entry.pos, "Base constructor defined here.")
-        prev_entry = self.lookup_here(name)
+        # The previous entries management is now done directly in Scope.declare
+        #prev_entry = self.lookup_here(name)
         entry = self.declare_var(name, type, pos,
                                  defining=defining,
                                  cname=cname, visibility=visibility)

--- a/tests/errors/cpp_no_constructor.pyx
+++ b/tests/errors/cpp_no_constructor.pyx
@@ -9,5 +9,5 @@ cdef extern from *:
 new Foo(1, 2)
 
 _ERRORS = u"""
-9:7: Call with wrong number of arguments (expected 1, got 2)
+9:7: Call with wrong number of arguments (expected 0, got 2)
 """

--- a/tests/run/cpp_classes_def.pyx
+++ b/tests/run/cpp_classes_def.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror, cpp11
+# tag: cpp, cpp11
 # cython: experimental_cpp_class_def=True
 
 cdef double pi
@@ -249,3 +249,7 @@ def test_uncopyable_constructor_argument():
     cdef UncopyableConstructorArgument *c = new UncopyableConstructorArgument(
         unique_ptr[vector[int]](new vector[int]()))
     del c
+
+_WARNINGS="""
+23:4: Unraisable exception in function 'RegularPolygon.area'.
+"""

--- a/tests/run/cpp_method_overloading.pyx
+++ b/tests/run/cpp_method_overloading.pyx
@@ -1,0 +1,77 @@
+# mode: run
+# tag: cpp
+
+cdef extern from "cpp_method_overloading_support.h":
+    cdef cppclass Base:
+        __init__()
+        __init__(int a)
+        int foo(double)
+        int foo(double*)
+
+cdef cppclass Derived(Base):
+    pass
+
+cdef cppclass DefinedBase:
+    int state
+
+    __init__():
+        # If we skip this one, inheritance won't work because of the
+        # derived class constructor implicitely calling default constructor
+        this.__init__(0)
+
+    __init__(int a):
+        this.state = a
+
+    int getter():
+        return this.state
+
+    void setter(int a):
+        this.state = a
+
+    void setter(int* a):
+        if a != NULL:
+            this.state = a[0]
+
+cdef cppclass DefinedDerived(DefinedBase):
+    __init__(int a):
+        DefinedBase.__init__(a)
+
+def testDeclared():
+    """
+    >>> testDeclared()
+    4 3
+    """
+    #pass
+    cdef double a = 4.2
+    cdef double *b = &a
+    cdef Derived d
+    rst_a = d.foo(a)
+    rst_b = d.foo(b)
+    print rst_a, rst_b
+
+def testDefined():
+    """
+    >>> testDefined()
+    24 42 42
+    """
+
+    dd = new DefinedDerived(24)
+
+    dorig = dd.getter()
+
+    cdef int val = 42
+
+    dd.setter(val)
+
+    dstate = dd.getter()
+    # dstate should be 42
+
+    da_addr = &dstate
+
+    dd.setter(da_addr)
+
+    # dstate2 should be 42
+    dstate2 = dd.getter()
+
+    print dorig, dstate, dstate2
+    del dd

--- a/tests/run/cpp_method_overloading_support.h
+++ b/tests/run/cpp_method_overloading_support.h
@@ -1,0 +1,9 @@
+class Base {
+public:
+    int foo(double a) {
+        return (int) (a+0.5);
+    }
+    int foo(double* a) {
+      return (int) (*a+0.5) - 1;
+    }
+};


### PR DESCRIPTION
This is a subset of changes proposed in pull request [#2951](https://github.com/cython/cython/pull/2951), which contained too many different things to be reviewed in a reasonnable amount of time.

This pull request contains the changes solving issue [#1357](https://github.com/cython/cython/issues/1357).

Below you'll find the comment of the above-mentionned pull request about this chunk of changes.

------------

In the current implementation of `CClassScope`, when we declare a cfunction, we check for the presence
of an entry with the same name, and if this is the case, we shout if the function signature is different or if the entry is already defined.
So we cannot have declaration and/or definition of different function types with the same name.
You can declare then define a function, as it's the same function signature, so everything is fine.

In the current implementation of `CppClassScope`, when we declare a cfunction, we check for the presence of an entry with the same name and if we try to define, not just declare, the new entry.
If this is the case, we update the type if the signatures (function types) are compatible, else we shout.
In any other cases (no previous entry or new entry is just declared, not defined), override the entry.
This checks are performed in `CppClassScope.declare_var`. This also explains why the cpp methods are in the `var_entries` array.
Polymorphism is usable because in `CppClassScope.declare_cfunction` (which calls the above-mentioned `declare_var`), we link the previously declared entries to the new one if we're just declaring the entry, not defining it.
Moreover, in this `declare_cfunction`, we never touch `cfunc_entries`. This explains why this array is always empty in a `CppClassScope`.
For a classic (non-special) method, the flow is:
CppClassScope.declare_cfunction (will link the alternatives to have polymorphism)
----> calls CppClassScope.declare_var (make the checks, if we create a new entry, add it to var_entries)
-----------> calls Scope.declare (blindly create and override the entry in the entries dict)

Wrapping C++ class is possible, because we fall into the "override the entry" clause (we never define an entry).

A real issue is method inheritance.
When inheriting methods with the same name, only one is kept because of the continuous override in `Scope.declare`.
The kept method will be, in my current understanding of the code, the last (in the base) upper (not deep in the inheritance chain: the "parenthesied" bases, not base of base) right-most (in the parenthesis) base method with this name:
```
cdef cppclass Base1:
    int method(int a)

cdef cppclass Base2:
    int method(double a)

cdef cppclass HiddenBase:
    int method(double b, double b)

cdef cppclass Base3(HiddenBase):
    int method(double b, int a)
    int method(int a, double b) # <=== This one will be the only method kept in Derived by inheritance

cdef cppclass Derived(Base1, Base2, Base3):
    pass
    # The only method Derived is aware of is Base3.method(int, double), the other ones were (sadly) lost in the process
```
So we may have lost a lot of alternatives.
This is exactly what is described in issue #1357.

The proposed approach deals with the alternative management directly in `Scope.declare`.
The behaviour is quite simple: we scan the previous alternatives for a compatible function signature.
If there is a match and the previous method is marked as inherited (or the default init), we override it.
If there is a match and it's not an inherited method, shout.
If there is no match, add the new entry to the alternatives.

This involves six changes:
a) Change `Symtab.declare` logic for cppclass methods: the `overloaded_entry` array is properly managed in this code (the switch from is_cpp to is_cpp_class_scope is intentional: it restricts this overloading to cppclass, otherwise it is available to everything when cython produces c++ code)
b) Change the `declare_var` and `declare_cfunction` in CppClassScope to use the previous changes
c) Add the `overloaded_alternative` array to ubcm_entry created with a Type.method() statement
d) Amend a test case (cpp_no_constructor) because the error message is not the same:
Below is a long text explaining why this is not a stupid idea to modify this test.
Beware, there is e) and f) change sets under it.

TL;DR: Method alternatives order in the entries corresponds to the declaration order. Before the patch, the alternatives order corresponded to reversed declaration order.

`PyrexTypes.best_match` shouts when it does not find a suitable alternative.
When doing so, it uses the "principal alternative" as a reference.
Principal alternative here refers to the entry which is in `entries[name]` in the type scope.
The other ones are held in the `overloaded_alternatives` array of this principal alternative.

Before the a) change set, alternatives in a `CppClassScope` are always overridden, and it is the duty
of `CppClassScope.declare_cfunction` to fill the `overloaded_alternative` array of the newly created alternative.
So the principal alternative is always changing, and the last alternative declared will effectively be the principal one.
Consequently, when `PyrexTypes.best_match` shouts, it uses the last declared alternative as a reference (for argument number and such).

After the a and b change set, `Scope.declare` takes care of the alternatives, and overrides an alternative in a `CppClassScope` only if it is an inherited one with the same signature as the new one. As the signature is the same, each info used by `PyrexTypes.best_match` when shouting doesn't change between old overridden alternative and new one.
Consequently, a signature represented by an alternative never change position: if it is carried by the principal alternative, it will always be carried by the principal one, therefore `PyrexTypes.best_match`, when taking the principal alternative as a reference, is effectively taking the first defined alternative as reference.

As `cpp_no_constructor` is an error test about failing to find the correct alternative, it expects `PyrexTypes.best_match` to shout.
The expected string refers to the last (2nd / 2 defined alternatives) alternative, whereas with a & b changes, it should refer to the first alternative, because that's what is expected.

This commit does this.

e) Amend a test case (cpp_classes_def) because one warning must stand:
It is, again, a long text explaining why I'm not mad.

TL;DR: The test module lacked a _WARNINGS variable to catch the RegularPolygon.area warning since the beginning. It's just that it wasn't noticeable before.

In `cpp_classes_def` (in the tests/run directory), we have some defined method (area) in a class (RegularPolygon) which has no exception indication, but is performing a division.
Consequently, a divide-by-zero check is performed, and we should, theorically, raise an exception if the check is true.
As there is no except indication on this method, we have a compile-time warning : Unraisable exception in function 'RegularPolygon.area'.
This is not a bug, it's a feature.

So we should have a warning from cython when compiling this test module. A warning that should be reported when running the test suite.
With the a) & b) changes in Symtab, this is what's happening.
This wasn't before, and the reason is quite tricky.

`RegularPolygon` has a base class, `Shape`, which is declared as 'extern'. Shape has the `area` method.
So, RegularPolygon inherits area from Shape before overloading it.
`Shape.area` and `RegularPolygon.area` have exactly the same signature.
In `CppClassScope.declare_var`, we are in the following situation: previous entry and defining.
This leads to:
*We update the type if the signatures (function types) are compatible, else we shout*
As types are compatible, we just modify the entry type, keeping the inherited entry for all other attributes.
The side effect is that we didn't change `entry.pos`. An inherited entry has a pos equal to None, because the corresponding attribute is declared nowhere in the subclass body.

Consequently, when making the warning, the entry has no pos therefore it is discarded by the test suite when trying to match actual warnings from expected ones.

This commit adds the warning from RegularPolygon.area to the expected warnings. It also removes werror to the tags, since this warning is not a runtime blocker.

f) Provide test for the feature (which is failing on the current master as it is related to issue #1357)
