### PR TITLE
FIX: do not include tp_print for py39

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -957,7 +957,7 @@ slot_table = (
     EmptySlot("tp_version_tag"),
     EmptySlot("tp_finalize", ifdef="PY_VERSION_HEX >= 0x030400a1"),
     EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1"),
-    EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4"),
+    EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
 )
 
 #------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is more follow up to https://bugs.python.org/issue37250

The action taken is:
 - restore tp_print to not break all of the sdists on pypi for py38
 - remove tp_print for real in py39

In https://github.com/cython/cython/pull/3171 tp_print was initialized
for PY_VERSION_HEX >= 0x030800b4 however, when trying to use cython
with cpython master (aka py39) there are compile time exceptions due
to too many initializers:

   error: too many initializers for ‘PyTypeObject’ {aka ‘_typeobject’}

This fixes that by putting an upper bound on the ifdef of including
pt_print at the end of the object.

The current test suite fails to on cpython master without this patch.

This should be back-ported to 0.29.x as well.