### PR TITLE
Fix --parallel support in build_ext.build_extensions()

### DIFF
--- a/Cython/Distutils/old_build_ext.py
+++ b/Cython/Distutils/old_build_ext.py
@@ -191,7 +191,8 @@ class old_build_ext(_build_ext.build_ext):
 
         for ext in self.extensions:
             ext.sources = self.cython_sources(ext.sources, ext)
-            self.build_extension(ext)
+        # Call original build_extensions
+        _build_ext.build_ext.build_extensions(self)
 
     def cython_sources(self, sources, extension):
         """


### PR DESCRIPTION
In Python 3.5, distutils added a `--parallel / -j` option to allow extensions to be compiled in parallel. setuptools leverages this by default unless Cython is present because it uses the build_ext provided by Cython instead. Cython overrides `build_extensions()` entirely assuming that it just calls `build_extension` (which it did before Python 3.5).
This change defers back to the original `build_extensions()` call in `build_ext` after mutating the sources so that --parallel works with Cython properly.