### PR TITLE
Initialize tp_print in Python 3.8

### DIFF
--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -424,6 +424,9 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                          /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                          /*tp_print*/
+#endif
 };
 
 
@@ -656,6 +659,9 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                          /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                          /*tp_print*/
+#endif
 };
 
 
@@ -767,6 +773,9 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                          /*tp_vectorcall*/
+#endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                          /*tp_print*/
 #endif
 };
 
@@ -1049,6 +1058,9 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                          /*tp_vectorcall*/
+#endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                          /*tp_print*/
 #endif
 };
 

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1526,6 +1526,9 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
+#endif
 };
 
 #if PY_VERSION_HEX < 0x030500B1 || defined(__Pyx_IterableCoroutine_USED) || CYTHON_USE_ASYNC_SLOTS
@@ -1680,6 +1683,9 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
+#endif
 };
 
 static int __pyx_Coroutine_init(void) {
@@ -1788,6 +1794,9 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
+#endif
 };
 
 
@@ -1892,6 +1901,9 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
+#endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
 #endif
 };
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -886,6 +886,9 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
 #endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
+#endif
 };
 
 
@@ -1361,6 +1364,9 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b1
     0,                                  /*tp_vectorcall*/
+#endif
+#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    0,                                  /*tp_print*/
 #endif
 };
 


### PR DESCRIPTION
This should complete #3171 in silencing `-Wmissing-field-initializers`.