### PR TITLE
Make C++ typeid accept specializations of fused types

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1962,11 +1962,10 @@ class NameNode(AtomicExprNode):
             entry = env.lookup(self.name)
         if entry and entry.is_type:
             if entry.type.is_fused and env.fused_to_specific:
-                try:
+                if entry.type in env.fused_to_specific:
                     return entry.type.specialize(env.fused_to_specific)
-                except KeyError:
-                    pass # lots of valid reasons why we may not be able to get a specific type
-                    # so don't fail
+                # else lots of valid reasons why we may not be able to get a specific type
+                # so don't fail
             return entry.type
         else:
             return None
@@ -6916,10 +6915,9 @@ class AttributeNode(ExprNode):
             if base_type and hasattr(base_type, 'scope') and base_type.scope is not None:
                 tp = base_type.scope.lookup_type(self.attribute)
         if tp and tp.is_fused and env.fused_to_specific:
-            try:
+            if tp in env.fused_to_specific:
                 tp = tp.specialize(env.fused_to_specific)
-            except KeyError:
-                pass # just use unspecialized type
+            # else just use unspecialized type
         return tp
 
     def analyse_as_extension_type(self, env):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1961,6 +1961,12 @@ class NameNode(AtomicExprNode):
         if not entry:
             entry = env.lookup(self.name)
         if entry and entry.is_type:
+            if entry.type.is_fused and env.fused_to_specific:
+                try:
+                    return entry.type.specialize(env.fused_to_specific)
+                except KeyError:
+                    pass # lots of valid reasons why we may not be able to get a specific type
+                    # so don't fail
             return entry.type
         else:
             return None

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -657,14 +657,14 @@ class ExprNode(Node):
 
     def analyse_as_specialized_type(self, env):
         type = self.analyse_as_type(env)
-        if type.is_fused and env.fused_to_specific:
+        if type and type.is_fused and env.fused_to_specific:
             # while it would be nice to test "if entry.type in env.fused_to_specific"
             # rather than try/catch this doesn't work reliably (mainly for nested fused types)
             try:
                 return type.specialize(env.fused_to_specific)
             except KeyError:
                 pass
-        if type.is_fused:
+        if type and type.is_fused:
             error(self.pos, "Type is not specific")
         return type
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3279,12 +3279,7 @@ class ReplaceFusedTypeChecks(VisitorTransform):
     def visit_PrimaryCmpNode(self, node):
         with Errors.local_errors(ignore=True):
           type1 = node.operand1.analyse_as_type(self.local_scope)
-          # type2 should not be specialized here as a special case
-          # we always want to check against the global fused type
-          fused_to_specific = self.local_scope.fused_to_specific
-          self.local_scope.fused_to_specific = None
           type2 = node.operand2.analyse_as_type(self.local_scope)
-          self.local_scope.fused_to_specific = fused_to_specific
 
         if type1 and type2:
             false_node = ExprNodes.BoolNode(node.pos, value=False)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3279,7 +3279,12 @@ class ReplaceFusedTypeChecks(VisitorTransform):
     def visit_PrimaryCmpNode(self, node):
         with Errors.local_errors(ignore=True):
           type1 = node.operand1.analyse_as_type(self.local_scope)
+          # type2 should not be specialized here as a special case
+          # we always want to check against the global fused type
+          fused_to_specific = self.local_scope.fused_to_specific
+          self.local_scope.fused_to_specific = None
           type2 = node.operand2.analyse_as_type(self.local_scope)
+          self.local_scope.fused_to_specific = fused_to_specific
 
         if type1 and type2:
             false_node = ExprNodes.BoolNode(node.pos, value=False)

--- a/tests/run/fused_cpp.pyx
+++ b/tests/run/fused_cpp.pyx
@@ -30,3 +30,14 @@ def typeid_call(C x):
     """
     cdef const type_info* a = &typeid(C)
     return a[0] == tidint[0]
+
+cimport cython
+
+def typeid_call2(cython.integral x):
+    """
+    For GH issue 3203
+    >>> typeid_call2[int](1)
+    True
+    """
+    cdef const type_info* a = &typeid(cython.integral)
+    return a[0] == tidint[0]

--- a/tests/run/fused_cpp.pyx
+++ b/tests/run/fused_cpp.pyx
@@ -2,6 +2,8 @@
 
 cimport cython
 from libcpp.vector cimport vector
+from libcpp.typeinfo cimport type_info
+from cython.operator cimport typeid
 
 def test_cpp_specialization(cython.floating element):
     """
@@ -14,3 +16,17 @@ def test_cpp_specialization(cython.floating element):
     cdef vector[cython.floating] *v = new vector[cython.floating]()
     v.push_back(element)
     print cython.typeof(v), cython.typeof(element), v.at(0)
+
+cdef fused C:
+   int
+   object
+
+cdef const type_info* tidint = &typeid(int)
+def typeid_call(C x):
+    """
+    For GH issue 3203
+    >>> typeid_call(1)
+    True
+    """
+    cdef const type_info* a = &typeid(C)
+    return a[0] == tidint[0]


### PR DESCRIPTION
Gets the specialized type if possible from
NameNode.analyse_as_type

This does introduce a potential new bug:
```
cimport cython
from cython cimport floating

just_float = cython.fused_type(float)

cdef OK1(just_float x):
    return just_float in floating

cdef fail1(just_float x, floating y):
    return just_float in floating

cdef fail2(floating x):
    return floating in floating

def show():
    """
    >>> show()
    True
    True
    True
    True
    """
    print(OK1(1.0))
    print(fail1(1.0, 2.0))
    print(fail1[float, double](1.0, 2.0))
    print(fail2[float](1.0))
```
fail1 and fail2 work before this patch but fail with it. It isn't
clear to me if this should actually be considered a bug. It
works in both versions with `cython.floating`, which possibly
suggests analyse_as_type in AttributeNode should also be changed

Closes #3203 