### PR TITLE
Tests for cppclass docstrings.

### DIFF
--- a/tests/run/cpp_classes.pyx
+++ b/tests/run/cpp_classes.pyx
@@ -30,6 +30,12 @@ cdef extern from "shapes.h" namespace "shapes":
     cdef cppclass Empty(Shape):
         pass
 
+    cdef cppclass EmptyWithDocstring(Shape):
+        """
+        This is a docstring !
+        """
+
+
     int constructor_count, destructor_count
 
 

--- a/tests/run/cpp_classes_def.pyx
+++ b/tests/run/cpp_classes_def.pyx
@@ -249,3 +249,17 @@ def test_uncopyable_constructor_argument():
     cdef UncopyableConstructorArgument *c = new UncopyableConstructorArgument(
         unique_ptr[vector[int]](new vector[int]()))
     del c
+
+cdef cppclass CppClassWithDocstring:
+    """
+    This is a docstring !
+    """
+
+def test_CppClassWithDocstring():
+    """
+    >>> test_CppClassWithDocstring()
+    OK
+    """
+    cdef CppClassWithDocstring *c = new CppClassWithDocstring()
+    del c
+    print "OK"

--- a/tests/run/shapes.h
+++ b/tests/run/shapes.h
@@ -59,6 +59,11 @@ namespace shapes {
         float area() const { return 0; }
     };
 
+    class EmptyWithDocstring : public Shape {
+    public:
+        float area() const { return 0; }
+    };
+
 }
 
 #endif


### PR DESCRIPTION
These are the companion tests for PR [#3183](https://github.com/cython/cython/pull/3183).