### PR TITLE
#2740 emit_code_comments - removed from options, updated documentation

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -63,7 +63,7 @@ def generate_c_code_config(env, options):
     else:
         emit_linenums = options.emit_linenums
 
-    if "emit_code_comments" in options:
+    if hasattr(options, "emit_code_comments"):
         print('Warning: option emit_code_comments is deprecated. '
               'Instead, use compiler directive emit_code_comments.')
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -63,6 +63,10 @@ def generate_c_code_config(env, options):
     else:
         emit_linenums = options.emit_linenums
 
+    if "emit_code_comments" in options:
+        print('Warning: option emit_code_comments is deprecated. '
+              'Instead, use compiler directive emit_code_comments.')
+
     return Code.CCodeConfig(
         emit_linenums=emit_linenums,
         emit_code_comments=env.directives['emit_code_comments'],

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -52,11 +52,6 @@ docstrings = True
 #: Embed the source code position in the docstrings of functions and classes.
 embed_pos_in_docstring = False
 
-#: Copy the original source code line by line into C code comments
-#: in the generated code file to help with understanding the output.
-#: This is also required for coverage analysis.
-emit_code_comments = True
-
 # undocumented
 pre_import = None
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -678,7 +678,6 @@ Here are the options that are available:
 
 .. autodata:: Cython.Compiler.Options.docstrings
 .. autodata:: Cython.Compiler.Options.embed_pos_in_docstring
-.. autodata:: Cython.Compiler.Options.emit_code_comments
 .. pre_import
 .. autodata:: Cython.Compiler.Options.generate_cleanup_code
 .. autodata:: Cython.Compiler.Options.clear_to_none
@@ -866,6 +865,10 @@ Cython code.  Here is the list of currently supported directives:
     annotations, setting to False gives greater compatibility with Python code.
     Must be set globally.
 
+``emit_code_comments`` (True / False)
+    Copy the original source code line by line into C code comments in the generated
+    code file to help with understanding the output.
+    This is also required for coverage analysis.
 
 .. _configurable_optimisations:
 


### PR DESCRIPTION
See https://github.com/cython/cython/issues/2740  