### PR TITLE
updated documentation to mention 'const' for read-only buffers

### DIFF
--- a/docs/src/tutorial/strings.rst
+++ b/docs/src/tutorial/strings.rst
@@ -220,14 +220,15 @@ object.  This can simply be done as follows:
 
 .. literalinclude:: ../../examples/tutorial/string/return_memview.pyx
 
-If the byte input is actually encoded text, and the further processing
-should happen at the Unicode level, then the right thing to do is to
-decode the input straight away.  This is almost only a problem in Python
-2.x, where Python code expects that it can pass a byte string (:obj:`str`)
-with encoded text into a text API.  Since this usually happens in more
-than one place in the module's API, a helper function is almost always the
-way to go, since it allows for easy adaptation of the input normalisation
-process later.
+For read-only buffers, like :obj:`bytes`, the memoryview item type should
+be declared as ``const`` (see :ref:`readonly_views`). If the byte input is
+actually encoded text, and the further processing should happen at the
+Unicode level, then the right thing to do is to decode the input straight
+away.  This is almost only a problem in Python 2.x, where Python code
+expects that it can pass a byte string (:obj:`str`) with encoded text into
+a text API.  Since this usually happens in more than one place in the
+module's API, a helper function is almost always the way to go, since it
+allows for easy adaptation of the input normalisation process later.
 
 This kind of input normalisation function will commonly look similar to
 the following:

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -153,6 +153,9 @@ As for NumPy, new axes can be introduced by indexing an array with ``None`` ::
 One may mix new axis indexing with all other forms of indexing and slicing.
 See also an example_.
 
+
+.. _readonly_views:
+
 Read-only views
 ---------------
 


### PR DESCRIPTION
Updated the docs for [Accepting strings from Python code](https://cython.readthedocs.io/en/latest/src/tutorial/strings.html#accepting-strings-from-python-code) to mention that read-only buffers require a `const` type declaration (per the [Read-only views](https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html#read-only-views) section under Typed Memoryviews). Should hopefully close #1682.