### PR TITLE
Make it easier for tools like cython_freeze to work

### DIFF
--- a/new.txt
+++ b/new.txt
@@ -1,0 +1,1 @@
+test file

--- a/new.txt
+++ b/new.txt
@@ -1,1 +1,2 @@
 test file
+fix C++


### PR DESCRIPTION
Currently there is no clean way to resolve name conflicts between 2 Cython modules that have the same PyInit_module function. Also C++ Cython modules can't be initialized.