### PR TITLE
Fix typos

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -885,7 +885,7 @@ cdef int slice_memviewslice(
         dst.shape[new_ndim] = new_shape
         dst.suboffsets[new_ndim] = suboffset
 
-    # Add the slicing or idexing offsets to the right suboffset or base data *
+    # Add the slicing or indexing offsets to the right suboffset or base data *
     if suboffset_dim[0] < 0:
         dst.data += start * stride
     else:

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -927,7 +927,7 @@ __pyx_fill_slice_{{dtype_name}}({{type_decl}} *p, Py_ssize_t extent, Py_ssize_t 
 ////////// FillStrided1DScalar //////////
 
 /* Fill a slice with a scalar value. The dimension is direct and strided or contiguous */
-/* This can be used as a callback for the memoryview object to efficienty assign a scalar */
+/* This can be used as a callback for the memoryview object to efficiently assign a scalar */
 /* Currently unused */
 static void
 __pyx_fill_slice_{{dtype_name}}({{type_decl}} *p, Py_ssize_t extent, Py_ssize_t stride,

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1668,7 +1668,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
     target->method = method;
 #if CYTHON_COMPILING_IN_CPYTHON
     #if PY_MAJOR_VERSION >= 3
-    // method dscriptor type isn't exported in Py2.x, cannot easily check the type there
+    // method descriptor type isn't exported in Py2.x, cannot easily check the type there
     if (likely(__Pyx_TypeCheck(method, &PyMethodDescr_Type)))
     #endif
     {

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ versions.
 
 The latest version of Pyrex can be found `here <http://www.cosc.canterbury.ac.nz/~greg/python/Pyrex/>`_.
 
-| Greg Ewing, Computer Science Dept
+| Greg Ewing, Computer Science Depth
 | University of Canterbury
 | Christchurch, New Zealand
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ versions.
 
 The latest version of Pyrex can be found `here <http://www.cosc.canterbury.ac.nz/~greg/python/Pyrex/>`_.
 
-| Greg Ewing, Computer Science Depth
+| Greg Ewing, Computer Science Dept
 | University of Canterbury
 | Christchurch, New Zealand
 

--- a/pyximport/test/test_pyximport.py
+++ b/pyximport/test/test_pyximport.py
@@ -68,7 +68,7 @@ def make_ext(name, filename):
 
     time.sleep(1) # sleep a second to get safer mtimes
     open(os.path.join(tempdir, "abc.txt"), "w").write(" ")
-    print("Here goes the reolad")
+    print("Here goes the reload")
     reload(dummy)
     assert len(pyximport._test_files) == 1, pyximport._test_files
 

--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -165,7 +165,7 @@ def char3int(fmt):
     >>> char3int("c3xiii")
     >>> char3int("cxxxiii")
 
-    Standard alignment (assming int size is 4)
+    Standard alignment (assuming int size is 4)
     >>> char3int("=c3xiii")
     >>> char3int("=ciii")
     Traceback (most recent call last):

--- a/tests/compile/find_pxd.srctree
+++ b/tests/compile/find_pxd.srctree
@@ -41,7 +41,7 @@ ctypedef int my_type
 
 ######## path/numpy/__init__.pxd ########
 
-# gh-2905: This should be found before Cython/Inlude/numpy/__init__.pxd
+# gh-2905: This should be found before Cython/Includes/numpy/__init__.pxd
 
 ctypedef int my_type
 

--- a/tests/errors/unicode_identifiers_e3.pyx
+++ b/tests/errors/unicode_identifiers_e3.pyx
@@ -3,7 +3,7 @@
 
 def f():
     a = 1
-    ́b = 2 # looks like an identation error but is actually a combining accent as the first letter of column 4
+    ́b = 2 # looks like an indentation error but is actually a combining accent as the first letter of column 4
     c = 3
 
 _ERRORS = u"""

--- a/tests/run/trashcan.pyx
+++ b/tests/run/trashcan.pyx
@@ -92,7 +92,7 @@ cdef class RecurseList(list):
 
 
 # Some tests where the trashcan is NOT used. When the trashcan is not used
-# in a big recursive deallocation, the __dealloc__s of the base classs are
+# in a big recursive deallocation, the __dealloc__s of the base classes are
 # only run after the __dealloc__s of the subclasses.
 # We use this to detect trashcan usage.
 cdef int base_deallocated = 0

--- a/tests/run/unicode_identifiers.pyx
+++ b/tests/run/unicode_identifiers.pyx
@@ -84,7 +84,7 @@ cdef class A:
         return self.ναμε==1
     def regular_function(self):
         """
-        Can use unicode cdef functions and (private) attributes iternally
+        Can use unicode cdef functions and (private) attributes internally
         >>> A().regular_function()
         True
         """


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.