### PR TITLE
Simplify the utility code loading

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -324,39 +324,14 @@ class UtilityCodeBase(object):
         return utilities
 
     @classmethod
-    def load(cls, util_code_name, from_file=None, **kwargs):
+    def load(cls, util_code_name, from_file, **kwargs):
         """
         Load utility code from a file specified by from_file (relative to
-        Cython/Utility) and name util_code_name.  If from_file is not given,
-        load it from the file util_code_name.*.  There should be only one
-        file matched by this pattern.
+        Cython/Utility) and name util_code_name.
         """
         if '::' in util_code_name:
             from_file, util_code_name = util_code_name.rsplit('::', 1)
-        if not from_file:
-            utility_dir = get_utility_dir()
-            prefix = util_code_name + '.'
-            try:
-                listing = os.listdir(utility_dir)
-            except OSError:
-                # XXX the code below assumes as 'zipimport.zipimporter' instance
-                # XXX should be easy to generalize, but too lazy right now to write it
-                import zipfile
-                global __loader__
-                loader = __loader__
-                archive = loader.archive
-                with closing(zipfile.ZipFile(archive)) as fileobj:
-                    listing = [os.path.basename(name)
-                               for name in fileobj.namelist()
-                               if os.path.join(archive, name).startswith(utility_dir)]
-            files = [filename for filename in listing
-                     if filename.startswith(prefix)]
-            if not files:
-                raise ValueError("No match found for utility code " + util_code_name)
-            if len(files) > 1:
-                raise ValueError("More than one filename match found for utility code " + util_code_name)
-            from_file = files[0]
-
+        assert from_file
         utilities = cls.load_utilities_from_file(from_file)
         proto, impl, tags = utilities[util_code_name]
 
@@ -393,7 +368,7 @@ class UtilityCodeBase(object):
         return cls(**kwargs)
 
     @classmethod
-    def load_cached(cls, utility_code_name, from_file=None, __cache={}):
+    def load_cached(cls, utility_code_name, from_file, __cache={}):
         """
         Calls .load(), but using a per-type cache based on utility name and file name.
         """
@@ -406,7 +381,7 @@ class UtilityCodeBase(object):
         return code
 
     @classmethod
-    def load_as_string(cls, util_code_name, from_file=None, **kwargs):
+    def load_as_string(cls, util_code_name, from_file, **kwargs):
         """
         Load a utility code as a string. Returns (proto, implementation)
         """

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3286,4 +3286,4 @@ packed_struct_utility_code = UtilityCode(proto="""
 #endif
 """, impl="", proto_block='utility_code_proto_before_types')
 
-capsule_utility_code = UtilityCode.load("Capsule")
+capsule_utility_code = UtilityCode.load("Capsule", "Capsule.c")

--- a/Cython/Compiler/Tests/TestUtilityLoad.py
+++ b/Cython/Compiler/Tests/TestUtilityLoad.py
@@ -22,24 +22,17 @@ class TestUtilityLoader(unittest.TestCase):
     cls = Code.UtilityCode
 
     def test_load_as_string(self):
-        got = strip_2tup(self.cls.load_as_string(self.name))
-        self.assertEqual(got, self.expected)
-
         got = strip_2tup(self.cls.load_as_string(self.name, self.filename))
         self.assertEqual(got, self.expected)
 
     def test_load(self):
-        utility = self.cls.load(self.name)
+        utility = self.cls.load(self.name, from_file=self.filename)
         got = strip_2tup((utility.proto, utility.impl))
         self.assertEqual(got, self.expected)
 
         required, = utility.requires
         got = strip_2tup((required.proto, required.impl))
         self.assertEqual(got, self.required)
-
-        utility = self.cls.load(self.name, from_file=self.filename)
-        got = strip_2tup((utility.proto, utility.impl))
-        self.assertEqual(got, self.expected)
 
         utility = self.cls.load_cached(self.name, from_file=self.filename)
         got = strip_2tup((utility.proto, utility.impl))
@@ -59,11 +52,11 @@ class TestTempitaUtilityLoader(TestUtilityLoader):
     cls = Code.TempitaUtilityCode
 
     def test_load_as_string(self):
-        got = strip_2tup(self.cls.load_as_string(self.name, context=self.context))
+        got = strip_2tup(self.cls.load_as_string(self.name, self.filename, context=self.context))
         self.assertEqual(got, self.expected_tempita)
 
     def test_load(self):
-        utility = self.cls.load(self.name, context=self.context)
+        utility = self.cls.load(self.name, self.filename, context=self.context)
         got = strip_2tup((utility.proto, utility.impl))
         self.assertEqual(got, self.expected_tempita)
 


### PR DESCRIPTION
Requires the source file to be named explicitly. It was almost always passed anyway, so having a non-trivial search algorithm in place for a rare case of unnecessary laziness is just code bloat.