### PR TITLE
Fix IpythonMagic for IPython >= 7.11

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -69,7 +69,13 @@ from distutils.command.build_ext import build_ext
 from IPython.core import display
 from IPython.core import magic_arguments
 from IPython.core.magic import Magics, magics_class, cell_magic
-from IPython.utils import py3compat
+try:
+    from IPython.utils.py3compat import unicode_to_str, cast_bytes_py2
+except ImportError:
+    # IPython >= 7.11
+    def no_code(x, encoding=None):
+        return x
+    unicode_to_str = cast_bytes_py2 = no_code
 try:
     from IPython.paths import get_ipython_cache_dir
 except ImportError:
@@ -307,7 +313,7 @@ class CythonMagics(Magics):
             key += (time.time(),)
 
         if args.name:
-            module_name = py3compat.unicode_to_str(args.name)
+            module_name = unicode_to_str(args.name)
         else:
             module_name = "_cython_magic_" + hashlib.sha1(str(key).encode('utf-8')).hexdigest()
         html_file = os.path.join(lib_dir, module_name + '.html')
@@ -407,7 +413,7 @@ class CythonMagics(Magics):
 
     def _cythonize(self, module_name, code, lib_dir, args, quiet=True):
         pyx_file = os.path.join(lib_dir, module_name + '.pyx')
-        pyx_file = py3compat.cast_bytes_py2(pyx_file, encoding=sys.getfilesystemencoding())
+        pyx_file = cast_bytes_py2(pyx_file, encoding=sys.getfilesystemencoding())
 
         c_include_dirs = args.include
         c_src_files = list(map(str, args.src))
@@ -526,10 +532,10 @@ class CythonMagics(Magics):
         build_extension = _build_ext(dist)
         build_extension.finalize_options()
         if temp_dir:
-            temp_dir = py3compat.cast_bytes_py2(temp_dir, encoding=sys.getfilesystemencoding())
+            temp_dir = cast_bytes_py2(temp_dir, encoding=sys.getfilesystemencoding())
             build_extension.build_temp = temp_dir
         if lib_dir:
-            lib_dir = py3compat.cast_bytes_py2(lib_dir, encoding=sys.getfilesystemencoding())
+            lib_dir = cast_bytes_py2(lib_dir, encoding=sys.getfilesystemencoding())
             build_extension.build_lib = lib_dir
         if extension is not None:
             build_extension.extensions = [extension]


### PR DESCRIPTION
In IPython 7.11.0, [a number of function in the py3compat have been removed](https://github.com/ipython/ipython/blob/master/docs/source/whatsnew/version7.rst#ipython-711).

Fixes https://github.com/ipython/ipython/issues/12068

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-84ee719fa1da> in <module>
----> 1 get_ipython().run_cell_magic('cython', '', '\ndef tmp():\n    return 0\n')

X:\Python37\lib\site-packages\IPython\core\interactiveshell.py in run_cell_magic(self, magic_name, line, cell)
   2350             with self.builtin_trap:
   2351                 args = (magic_arg_s, cell)
-> 2352                 result = fn(*args, **kwargs)
   2353             return result
   2354 

<X:\Python37\lib\site-packages\decorator.py:decorator-gen-159> in cython(self, line, cell)

X:\Python37\lib\site-packages\IPython\core\magic.py in <lambda>(f, *a, **k)
    185     # but it's overkill for just that one bit of state.
    186     def magic_deco(arg):
--> 187         call = lambda f, *a, **k: f(*a, **k)
    188 
    189         if callable(arg):

X:\Python37\lib\site-packages\Cython\Build\IpythonMagic.py in cython(self, line, cell)
    322         extension = None
    323         if need_cythonize:
--> 324             extensions = self._cythonize(module_name, code, lib_dir, args, quiet=args.quiet)
    325             if extensions is None:
    326                 # Compilation failed and printed error message

X:\Python37\lib\site-packages\Cython\Build\IpythonMagic.py in _cythonize(self, module_name, code, lib_dir, args, quiet)
    407     def _cythonize(self, module_name, code, lib_dir, args, quiet=True):
    408         pyx_file = os.path.join(lib_dir, module_name + '.pyx')
--> 409         pyx_file = py3compat.cast_bytes_py2(pyx_file, encoding=sys.getfilesystemencoding())
    410 
    411         c_include_dirs = args.include

AttributeError: module 'IPython.utils.py3compat' has no attribute 'cast_bytes_py2'
```