### PR TITLE
Add std::optional for c++17 (GH-3293)

### DIFF
--- a/Cython/Includes/libcpp/optional.pxd
+++ b/Cython/Includes/libcpp/optional.pxd
@@ -17,6 +17,7 @@ cdef extern from "<optional>" namespace "std" nogil:
         T& value_or[U](U& default_value)
         void swap(optional&)
         void reset()
+        T& emplace(...)
         T& operator*()
         #T* operator->() # Not Supported
         optional& operator=(optional&)

--- a/Cython/Includes/libcpp/optional.pxd
+++ b/Cython/Includes/libcpp/optional.pxd
@@ -1,0 +1,24 @@
+from libcpp cimport bool
+
+cdef extern from "<optional>" namespace "std" nogil:
+    cdef cppclass optional[T]:
+        ctypedef T value_type
+        optional()
+        optional(optional&) except +
+        optional(T&) except +
+        bool has_value()
+        T& value()
+        T& value_or[U](U& default_value)
+        void swap(optional& other)
+        void reset()
+        T& operator*()
+        #T* operator->() # Not Supported
+        optional& operator=(optional& other)
+        optional& operator=[U](U& other)
+        bool operator==(optional&, optional&)
+        bool operator!=(optional&, optional&)
+        bool operator<(optional&, optional&)
+        bool operator>(optional&, optional&)
+        bool operator<=(optional&, optional&)
+        bool operator>=(optional&, optional&)
+        bool operator bool()

--- a/Cython/Includes/libcpp/optional.pxd
+++ b/Cython/Includes/libcpp/optional.pxd
@@ -1,24 +1,33 @@
 from libcpp cimport bool
 
 cdef extern from "<optional>" namespace "std" nogil:
+    cdef cppclass nullopt_t:
+        nullopt_t()
+
+    cdef nullopt_t nullopt
+
     cdef cppclass optional[T]:
         ctypedef T value_type
         optional()
+        optional(nullopt_t)
         optional(optional&) except +
         optional(T&) except +
         bool has_value()
         T& value()
         T& value_or[U](U& default_value)
-        void swap(optional& other)
+        void swap(optional&)
         void reset()
         T& operator*()
         #T* operator->() # Not Supported
-        optional& operator=(optional& other)
-        optional& operator=[U](U& other)
-        bool operator==(optional&, optional&)
-        bool operator!=(optional&, optional&)
-        bool operator<(optional&, optional&)
-        bool operator>(optional&, optional&)
-        bool operator<=(optional&, optional&)
-        bool operator>=(optional&, optional&)
+        optional& operator=(optional&)
+        optional& operator=[U](U&)
         bool operator bool()
+        bool operator!()
+        bool operator==[U](optional&, U&)
+        bool operator!=[U](optional&, U&)
+        bool operator<[U](optional&, U&)
+        bool operator>[U](optional&, U&)
+        bool operator<=[U](optional&, U&)
+        bool operator>=[U](optional&, U&)
+
+    optional[T] make_optional[T](...) except +

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -1,7 +1,7 @@
 # ticket: 3293
 # mode: run
-# tag: cpp, werror
-# distutils: extra_compile_args=-std=c++17
+# tag: cpp, cpp17
+### tag: werror  -- would be nice to have, but fails in Py2.7 due to header file incompatibilities.
 
 from cython.operator cimport dereference as deref
 from libcpp.optional cimport optional, nullopt, make_optional

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -1,7 +1,6 @@
 # ticket: 3293
 # mode: run
-# tag: cpp, cpp17
-### tag: werror  -- would be nice to have, but fails in Py2.7 due to header file incompatibilities.
+# tag: cpp, cpp17, werror
 
 from cython.operator cimport dereference as deref
 from libcpp.optional cimport optional, nullopt, make_optional

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -4,15 +4,14 @@
 # distutils: extra_compile_args=-std=c++17
 
 from cython.operator cimport dereference as deref
-from libcpp.optional cimport optional
-from libcpp cimport bool
+from libcpp.optional cimport optional, nullopt, make_optional
+from libcpp.string cimport string
 
 def simple_test():
     """
     >>> simple_test()
     """
     cdef optional[int] o
-    
     assert(not o.has_value())
     o = 5
     assert(o.has_value())
@@ -20,3 +19,46 @@ def simple_test():
     o.reset()
     assert(not o.has_value())
 
+def operator_test():
+    """
+    >>> operator_test()
+    """
+    cdef optional[int] o1, o2
+
+    # operator bool
+    assert(not o1)
+    o1 = 5
+    assert(o1)
+
+    # operator *
+    assert(deref(o1) == 5)
+
+    # operator =,==,!=,>,<,>=,<=
+    assert(not o1 == o2)
+    assert(o1 != o2)
+    o2 = o1
+    assert(o1 == o2)
+    assert(not o1 > o2)
+    assert(not o1 < o2)
+    assert(o1 >= o2)
+    assert(o1 <= o2)
+
+    # operators =,== for other types (all related operators are identical)
+    o1 = 6
+    assert(o1 == 6)
+    o2 = nullopt
+    assert(o2 == nullopt)
+
+def misc_methods_test():
+    """
+    >>> misc_methods_test()
+    """
+
+    # make_optional
+    cdef optional[int] o
+    o = make_optional[int](5)
+    assert(o == 5)
+
+    # swap
+    o.swap(optional[int](6))
+    assert(o == 6)

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -1,0 +1,22 @@
+# ticket: 3293
+# mode: run
+# tag: cpp, werror
+# distutils: extra_compile_args=-std=c++17
+
+from cython.operator cimport dereference as deref
+from libcpp.optional cimport optional
+from libcpp cimport bool
+
+def simple_test():
+    """
+    >>> simple_test()
+    """
+    cdef optional[int] o
+    
+    assert(not o.has_value())
+    o = 5
+    assert(o.has_value())
+    assert(o.value()==5)
+    o.reset()
+    assert(not o.has_value())
+

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -6,6 +6,7 @@
 from cython.operator cimport dereference as deref
 from libcpp.optional cimport optional, nullopt, make_optional
 from libcpp.string cimport string
+from libcpp.pair cimport pair
 
 def simple_test():
     """
@@ -62,3 +63,11 @@ def misc_methods_test():
     # swap
     o.swap(optional[int](6))
     assert(o == 6)
+
+    # emplace
+    cdef optional[pair[int,int]] op
+    cdef pair[int,int]* val_ptr = &op.emplace(1,2)
+    assert(op.has_value())
+    assert(op.value() == pair[int,int](1,2))
+    assert(&op.value() == val_ptr) # check returned reference
+    


### PR DESCRIPTION
Issue: https://github.com/cython/cython/issues/3293

- Added the std::optional declarations (pxd) as `from libcpp.optional cimport optional`
- Added tests, which run with -std=c++17

_Side note: This is a great alternative for having to use pointers for classes that do not have a default constructur available, and avoids using the heap or memory management, but still offers lifetime control through emplace() and reset()._

### Concerns:
I've used "distutils" tag in the testing framework to force c++17 support which seemed to work fine since this is a c++17 only feature. I am unsure of whether there are any other places where a c++ version check is required and if so how, please advise.

Also, please note that although this may break Cython builds on non c++17 builds, such builds should never try to include this declaration as the underlying c++ wouldn't use it. Hence I see no reason not to have std version specific features which are only optionally included by projects that need them.  