### PR TITLE
Reduce unnecessary verbiage

### DIFF
--- a/docs/src/userguide/early_binding_for_speed.rst
+++ b/docs/src/userguide/early_binding_for_speed.rst
@@ -20,7 +20,7 @@ slowness compared to 'early binding' languages such as C++.
 However with Cython it is possible to gain significant speed-ups through the
 use of 'early binding' programming techniques.
 
-For example, consider the following (silly) code example:
+For example, consider the following code example:
 
 .. literalinclude:: ../../examples/userguide/early_binding_for_speed/rectangle.pyx
 


### PR DESCRIPTION
Hi,

I don't believe the word "silly" -- either explicitly used or implied -- fits within the official Cython documentation, which is otherwise fantastic.

I would assume that programmers looking to use the library have a good idea surrounding OOP basics and might want to optimize some code or integrate previous C/C++ code into their Python projects.   But, other programmers who don't regularly use C++ might still view the section since C++ is know for being a high-performance language.  Reading across that section and seeing the word "silly" seems to convey that if the reader doesn't know simple C++, they must be an idiot.

Let's compare the following original and edited passages and see if 'silly' adds any additional clarity to what the reader is about to view - 

Original: `For example, consider the following (silly) code example:`

Updated: `For example, consider the following code example:`

"Silly" doesn't seem necessary here as readers will still able to understand what the subsequent passage will contain without it.