### PR TITLE
bufaccess ref-counting tests and extstarargs test

### DIFF
--- a/tests/buffers/bufaccess.pyx
+++ b/tests/buffers/bufaccess.pyx
@@ -959,6 +959,7 @@ def addref(*args):
 def decref(*args):
     for item in args: Py_DECREF(item)
 
+@cython.binding(False)
 def get_refcount(x):
     return (<PyObject*>x).ob_refcnt
 
@@ -974,7 +975,7 @@ def printbuf_object(object[object] buf, shape):
 
     >>> a, b, c = "globally_unique_string_23234123", {4:23}, [34,3]
     >>> get_refcount(a), get_refcount(b), get_refcount(c)
-    (3, 3, 3)
+    (2, 2, 2)
     >>> A = ObjectMockBuffer(None, [a, b, c])
     >>> printbuf_object(A, (3,))
     'globally_unique_string_23234123' 2

--- a/tests/run/extstarargs.pyx
+++ b/tests/run/extstarargs.pyx
@@ -1,3 +1,5 @@
+cimport cython
+
 cdef sorteditems(d):
     return tuple(sorted(d.items()))
 
@@ -90,7 +92,24 @@ cdef class Silly:
         >>> s.onlyt(1, a=2)
         Traceback (most recent call last):
         TypeError: onlyt() got an unexpected keyword argument 'a'
-        >>> test_no_copy_args(s.onlyt)
+        """
+        return a
+
+    @cython.binding(False)  # passthrough of exact same tuple can't work with binding
+    def onlyt_nobinding(self, *a):
+        """
+        >>> s = Silly()
+        >>> s.onlyt_nobinding(1)
+        (1,)
+        >>> s.onlyt_nobinding(1,2)
+        (1, 2)
+        >>> s.onlyt_nobinding(a=1)
+        Traceback (most recent call last):
+        TypeError: onlyt_nobinding() got an unexpected keyword argument 'a'
+        >>> s.onlyt_nobinding(1, a=2)
+        Traceback (most recent call last):
+        TypeError: onlyt_nobinding() got an unexpected keyword argument 'a'
+        >>> test_no_copy_args(s.onlyt_nobinding)
         True
         """
         return a
@@ -130,6 +149,7 @@ cdef class Silly:
         """
         return a + sorteditems(k)
 
+    @cython.binding(False)  # passthrough of exact same tuple can't work with binding
     def t_kwonly(self, *a, k):
         """
         >>> s = Silly()


### PR DESCRIPTION
Updating some of the tests that are failing with binding enabled (and which aren't hiding real problems)

------------------------

Disabled binding on the get_refcount function. It looks like
binding generates slightly different refcounts to function arguments
on Python 3.8 (possibly to do with vectorcall?). It isn't relevant
to what's being tested so it's easier to turn it off.
    
Passing a star-arg tuple and getting the same tuple out doesn't
work with binding, so only tested that without