### PR TITLE
Fixing declaration of inner OpenMP privates

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -9456,12 +9456,15 @@ class ParallelRangeNode(ParallelStatNode):
         code.putln("%(target)s = (%(target_type)s)(%(start)s + %(step)s * %(i)s);" % fmt_dict)
         self.initialize_privates_to_nan(code, exclude=self.target.entry)
 
-        if self.is_parallel:
+        if self.is_parallel and not self.is_nested_prange:
+            # nested pranges are not omp'ified, temps go to outer loops
             code.funcstate.start_collecting_temps()
 
         self.body.generate_execution_code(code)
         self.trap_parallel_exit(code, should_flush=True)
-        self.privatize_temps(code)
+        if self.is_parallel and not self.is_nested_prange:
+            # nested pranges are not omp'ified, temps go to outer loops
+            self.privatize_temps(code)
 
         if self.breaking_label_used:
             # Put a guard around the loop body in case return, break or

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -378,10 +378,6 @@ def test_prange_continue():
 
 def test_nested_break_continue():
     """
-    DISABLED. For some reason this fails intermittently on jenkins, with
-    the first line of output being '0 0 0 0'. The generated code looks
-    awfully correct though... needs investigation
-
     >> test_nested_break_continue()
     6 7 6 7
     8

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -378,7 +378,7 @@ def test_prange_continue():
 
 def test_nested_break_continue():
     """
-    >> test_nested_break_continue()
+    >>> test_nested_break_continue()
     6 7 6 7
     8
     """


### PR DESCRIPTION
Currently inner/nested pranges are not translated to an active OpenMP parallel for.
The private temporary variables identified for these inner loops were only declared in the 
```
#if 0
#pragma omp for private....
#endif
```
but not anywhere else. This apparently causes races.
The suggested code propagates the privatization to the outer construct so that it gets actually exposed.