### PR TITLE
Remove deprecated import of imp module

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -32,6 +32,14 @@ if sys.version_info[0] < 3:
 else:
     to_unicode = lambda x: x
 
+if sys.version_info[:2] < (3, 3):
+    import imp
+    def load_dynamic(name, module_path):
+        return imp.load_dynamic(name, module_path)
+else:
+    from importlib.machinery import ExtensionFileLoader
+    def load_dynamic(name, module_path):
+        return ExtensionFileLoader(name, module_path).load_module()
 
 class UnboundSymbols(EnvTransform, SkipDeclarations):
     def __init__(self):
@@ -246,7 +254,7 @@ def __invoke(%(params)s):
             build_extension.build_lib  = lib_dir
             build_extension.run()
 
-        module = imp.load_dynamic(module_name, module_path)
+        module = load_dynamic(module_name, module_path)
 
     _cython_inline_cache[orig_code, arg_sigs] = module.__invoke
     arg_list = [kwds[arg] for arg in arg_names]


### PR DESCRIPTION
Fixes gh-3306

Using `imp` is deprecated. Add an alternative incantation from `importlib` which was [added in Python 3.3](https://docs.python.org/3/library/importlib.html?highlight=extensionfileloader#importlib.machinery.ExtensionFileLoader)