### PR TITLE
Changed always_allow_keywords_T295 for Py3.9

### DIFF
--- a/tests/run/always_allow_keywords_T295.pyx
+++ b/tests/run/always_allow_keywords_T295.pyx
@@ -9,7 +9,9 @@ def assert_typeerror_no_keywords(func, *args, **kwds):
     try:
         func(*args, **kwds)
     except TypeError as e:
-        assert e.args[0].endswith(" takes no keyword arguments")
+        assert e.args[0].endswith(" takes no keyword arguments"), e.args[0]
+    else:
+        assert False, "call did not raise TypeError"
 
 
 def func1(arg):

--- a/tests/run/always_allow_keywords_T295.pyx
+++ b/tests/run/always_allow_keywords_T295.pyx
@@ -2,15 +2,21 @@
 
 cimport cython
 
+def assert_typeerror_no_keywords(func, *args, **kwds):
+    # Python 3.9 produces an slightly different error message
+    # to previous versions, so doctest isn't matching the
+    # traceback
+    try:
+        func(*args, **kwds)
+    except TypeError as e:
+        assert e.args[0].endswith(" takes no keyword arguments")
+
 
 def func1(arg):
     """
     >>> func1(None)
     >>> func1(*[None])
-    >>> func1(arg=None)
-    Traceback (most recent call last):
-    ...
-    TypeError: func1() takes no keyword arguments
+    >>> assert_typeerror_no_keywords(func1, arg=None)
     """
     pass
 
@@ -19,10 +25,7 @@ def func2(arg):
     """
     >>> func2(None)
     >>> func2(*[None])
-    >>> func2(arg=None)
-    Traceback (most recent call last):
-    ...
-    TypeError: func2() takes no keyword arguments
+    >>> assert_typeerror_no_keywords(func2, arg=None)
     """
     pass
 
@@ -39,16 +42,10 @@ cdef class A:
     """
     >>> A().meth1(None)
     >>> A().meth1(*[None])
-    >>> A().meth1(arg=None)
-    Traceback (most recent call last):
-    ...
-    TypeError: meth1() takes no keyword arguments
+    >>> assert_typeerror_no_keywords(A().meth1, arg=None)
     >>> A().meth2(None)
     >>> A().meth2(*[None])
-    >>> A().meth2(arg=None)
-    Traceback (most recent call last):
-    ...
-    TypeError: meth2() takes no keyword arguments
+    >>> assert_typeerror_no_keywords(A().meth2, arg=None)
     >>> A().meth3(None)
     >>> A().meth3(*[None])
     >>> A().meth3(arg=None)


### PR DESCRIPTION
https://bugs.python.org/issue37645 appears to change some error
messages slightly (including the qualname and not just the
function name). This change just allows doctest to cope with
both the new and old messages.

-----------------------------------

Fixes (part of) https://github.com/cython/cython/issues/3349. I'm
slightly surprised that the change to Python didn't break more
of the Cython tests.