### PR TITLE
More tweaks for reference counting with binding=True

### DIFF
--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -626,6 +626,7 @@ def addref(*args):
 def decref(*args):
     for item in args: Py_DECREF(item)
 
+@cython.binding(False)
 def get_refcount(x):
     return (<PyObject*>x).ob_refcnt
 

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -1058,6 +1058,7 @@ def addref(*args):
 def decref(*args):
     for item in args: Py_DECREF(item)
 
+@cython.binding(False)
 def get_refcount(x):
     return (<PyObject*>x).ob_refcnt
 
@@ -2141,8 +2142,8 @@ def test_object_dtype_copying():
     7
     8
     9
-    3 5
-    2 5
+    5
+    1 5
     """
     cdef int i
 
@@ -2162,10 +2163,12 @@ def test_object_dtype_copying():
         print m2[i]
 
     obj = m2[5]
-    print get_refcount(obj), obj
+    refcount1 = get_refcount(obj)
+    print obj
 
     del m2
-    print get_refcount(obj), obj
+    refcount2 = get_refcount(obj)
+    print refcount1 - refcount2, obj
 
     assert unique_refcount == get_refcount(unique), (unique_refcount, get_refcount(unique))
 


### PR DESCRIPTION
It looks like different Python versions will now
generate different reference counts during function
calls to CyFunction (due to vectorcall).

Disabled binding for the `get_refcount` function
(since it really doesn't need this complication)
and made one test relative instead of absolute.

Hopefully this fixes the remaining reference
counting mismatches on the enable_binding branch.

--------------------------------

I think this should just leave `w_undeclared` and possible profiling failing (unless there's something I've missed). Writing tests for version-dependent reference counts does look like a nightmare for the future though.