### PR TITLE
w_undeclared fix

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1765,7 +1765,9 @@ if VALUE is not None:
                 },
                 level='c_class', pipeline=[NormalizeTree(None)]).substitute({})
             pickle_func.analyse_declarations(node.scope)
+            self.enter_scope(node, node.scope)  # functions should be visited in the class scope
             self.visit(pickle_func)
+            self.exit_scope()
             node.body.stats.append(pickle_func)
 
     def _handle_fused_def_decorators(self, old_decorators, env, node):


### PR DESCRIPTION
The pickle functions `__reduce__` and `__setstate_cython__` were being
visited in the module scope (where they were undeclared) rather
than the class scope where they were declared