### PR TITLE
Add std::move wrapper to utility library

### DIFF
--- a/Cython/Includes/libcpp/utility.pxd
+++ b/Cython/Includes/libcpp/utility.pxd
@@ -13,3 +13,17 @@ cdef extern from "<utility>" namespace "std" nogil:
         bint operator>(pair&, pair&)
         bint operator<=(pair&, pair&)
         bint operator>=(pair&, pair&)
+
+cdef extern from * namespace "cython_std" nogil:
+    """
+    #if __cplusplus > 199711L
+    #include <type_traits>
+
+    namespace cython_std {
+    template <typename T> typename std::remove_reference<T>::type&& move(T& t) noexcept { return std::move(t); }
+    template <typename T> typename std::remove_reference<T>::type&& move(T&& t) noexcept { return std::move(t); }
+    }
+
+    #endif
+    """
+    cdef T move[T](T)

--- a/tests/run/cpp_move.pyx
+++ b/tests/run/cpp_move.pyx
@@ -1,0 +1,34 @@
+# mode: run
+# tag: cpp, werror, cpp11
+
+from libcpp cimport nullptr
+from libcpp.memory cimport shared_ptr, make_shared
+from libcpp.utility cimport move
+from cython.operator cimport dereference
+
+cdef extern from *:
+    """
+    #include <string>
+
+    template<typename T> const char* move_helper(T&) { return "lvalue-ref"; }
+    template<typename T> const char* move_helper(T&&) { return "rvalue-ref"; }
+    """
+    const char* move_helper[T](T)
+
+def test_move_assignment():
+    """
+    >>> test_move_assignment()
+    """
+    cdef shared_ptr[int] p1, p2
+    p1 = make_shared[int](1337)
+    p2 = move(p1)
+    assert p1 == nullptr
+    assert dereference(p2) == 1337
+
+def test_move_func_call():
+    """
+    >>> test_move_func_call()
+    """
+    cdef shared_ptr[int] p
+    assert move_helper(p) == b'lvalue-ref'
+    assert move_helper(move(p)) == b'rvalue-ref'


### PR DESCRIPTION
This PR adds a wrapper for std::move as discussed in #2169.

If-guard is used to avoid causing any issues in case `libcpp.utility` is cimported without C++11 (e.g. for using `std::pair`). Namespace `cython_std` is used for implementation details. 

Closes #2169.