### PR TITLE
Added mechanism for moving rather than copying C++ temps

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -448,6 +448,7 @@ class ExprNode(Node):
 
     saved_subexpr_nodes = None
     is_temp = False
+    has_temp_moved = False  # if True then attempting to do anything but free the temp is invalid
     is_target = False
     is_starred = False
 
@@ -490,6 +491,7 @@ class ExprNode(Node):
 
     def result(self):
         if self.is_temp:
+            assert not self.has_temp_moved, "Attempting to get a result that has already been moved"
             #if not self.temp_code:
             #    pos = (os.path.basename(self.pos[0].get_description()),) + self.pos[1:] if self.pos else '(?)'
             #    raise RuntimeError("temp result name not set in %s at %r" % (
@@ -497,6 +499,16 @@ class ExprNode(Node):
             return self.temp_code
         else:
             return self.calculate_result_code()
+
+    def _make_move_result_rhs(self, result):
+        if self.is_temp and self.type.is_cpp_class:
+            self.has_temp_moved = True
+            return "__PYX_STD_MOVE_IF_SUPPORTED({0})".format(result)
+        else:
+            return result
+
+    def move_result_rhs(self):
+        return self._make_move_result_rhs(self.result())
 
     def pythran_result(self, type_=None):
         if is_pythran_supported_node_or_none(self):
@@ -519,6 +531,9 @@ class ExprNode(Node):
             # reflect the actual type (e.g. an extension type)
             return typecast(type, py_object_type, self.result())
         return typecast(type, self.ctype(), self.result())
+
+    def move_result_as_rhs(self, type = None):
+        return self._make_move_result_rhs(self.result_as(type))
 
     def py_result(self):
         #  Return the result code cast to PyObject *.
@@ -723,6 +738,11 @@ class ExprNode(Node):
                 return
             self.temp_code = code.funcstate.allocate_temp(
                 type, manage_ref=self.use_managed_ref)
+
+            if self.type.is_cpp_class:
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("MoveIfSupported", "CppSupport.cpp")
+                    )
         else:
             self.temp_code = None
 
@@ -790,7 +810,9 @@ class ExprNode(Node):
                 # postponed from self.generate_evaluation_code()
                 self.generate_subexpr_disposal_code(code)
                 self.free_subexpr_temps(code)
-            if self.result():
+            if (not self.type.is_cpp_class  # check this before calling result()
+                    # since result may have been moved
+                    and self.result()):
                 if self.type.is_pyobject:
                     code.put_decref_clear(self.result(), self.ctype())
                 elif self.type.is_memoryviewslice:
@@ -2373,7 +2395,7 @@ class NameNode(AtomicExprNode):
             if not self.type.is_memoryviewslice:
                 if not assigned:
                     if overloaded_assignment:
-                        result = rhs.result()
+                        result = rhs.move_result_rhs()
                         if exception_check == '+':
                             translate_cpp_exception(
                                 code, self.pos,
@@ -2383,7 +2405,7 @@ class NameNode(AtomicExprNode):
                         else:
                             code.putln('%s = %s;' % (self.result(), result))
                     else:
-                        result = rhs.result_as(self.ctype())
+                        result = rhs.move_result_as_rhs(self.ctype())
 
                         if is_pythran_expr(self.type):
                             code.putln('new (&%s) decltype(%s){%s};' % (self.result(), self.result(), result))
@@ -5606,6 +5628,7 @@ class SimpleCallNode(CallNode):
             self.analyse_c_function_call(env)
             if func_type.exception_check == '+':
                 self.is_temp = True
+
         return self
 
     def function_type(self):
@@ -5842,7 +5865,7 @@ class SimpleCallNode(CallNode):
         expected_nargs = max_nargs - func_type.optional_arg_count
         actual_nargs = len(self.args)
         for formal_arg, actual_arg in args[:expected_nargs]:
-                arg_code = actual_arg.result_as(formal_arg.type)
+                arg_code = actual_arg.move_result_as_rhs(formal_arg.type)
                 arg_list_code.append(arg_code)
 
         if func_type.is_overridable:
@@ -5856,7 +5879,7 @@ class SimpleCallNode(CallNode):
             arg_list_code.append(optional_args)
 
         for actual_arg in self.args[len(formal_args):]:
-            arg_list_code.append(actual_arg.result())
+            arg_list_code.append(actual_arg.move_result_rhs())
 
         result = "%s(%s)" % (self.function.result(), ', '.join(arg_list_code))
         return result
@@ -7254,7 +7277,7 @@ class AttributeNode(ExprNode):
                 code.putln(
                     "%s = %s;" % (
                         select_code,
-                        rhs.result_as(self.ctype())))
+                        rhs.move_result_as_rhs(self.ctype())))
                         #rhs.result()))
             rhs.generate_post_assignment_code(code)
             rhs.free_temps(code)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3340,8 +3340,15 @@ class DefNodeWrapper(FuncDefNode):
         for arg in self.args:
             if arg.hdr_type and not (arg.type.is_memoryviewslice or
                                      arg.type.is_struct or
-                                     arg.type.is_complex):
+                                     arg.type.is_complex or
+                                     arg.type.is_cpp_class):
                 args.append(arg.type.cast_code(arg.entry.cname))
+            elif arg.hdr_type and arg.type.is_cpp_class:
+                # it's safe to move converted C++ types because they aren't
+                # used again afterwards
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("MoveIfSupported", "CppSupport.cpp"))
+                args.append("__PYX_STD_MOVE_IF_SUPPORTED(%s)" % arg.entry.cname)
             else:
                 args.append(arg.entry.cname)
         if self.star_arg:

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -58,3 +58,12 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 }
 
 #define __Pyx_PythranShapeAccessor(x) (x.shape().array())
+
+////////////// MoveIfSupported.proto //////////////////
+
+#if __cplusplus >= 201103L
+  #include <utility>
+  #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
+#else
+  #define __PYX_STD_MOVE_IF_SUPPORTED(x) x
+#endif

--- a/tests/compile/cpp_temp_assignment.pyx
+++ b/tests/compile/cpp_temp_assignment.pyx
@@ -1,0 +1,65 @@
+# tag: cpp
+# mode: compile
+
+cdef extern from *:
+    """
+    #if __cplusplus >= 201103L
+    class NoAssign {
+        public:
+            NoAssign() {}
+            NoAssign(NoAssign&) = delete;
+            NoAssign(NoAssign&&) {}
+            NoAssign& operator=(NoAssign&) = delete;
+            NoAssign& operator=(NoAssign&&) { return *this; }
+            void func() {}
+    };
+    #else
+    // the test becomes meaningless
+    // (but just declare something to ensure it passes)
+    class NoAssign {
+        public:
+            void func() {}
+    };
+    #endif
+
+    NoAssign get_NoAssign_Py() {
+        return NoAssign{};
+    }
+    NoAssign get_NoAssign_Cpp() {
+        return NoAssign{};
+    }
+    """
+    cdef cppclass NoAssign:
+        void func()
+
+    # might raise Python exception (thus needs a temp)
+    NoAssign get_NoAssign_Py() except *
+    # might raise C++ exception (thus needs a temp)
+    NoAssign get_NoAssign_Cpp() except +
+
+cdef internal_cpp_func(NoAssign arg):
+    pass
+
+def test_call_to_function():
+    # will fail to compile if move constructors aren't used
+    internal_cpp_func(get_NoAssign_Py())
+    internal_cpp_func(get_NoAssign_Cpp())
+
+def test_assignment_to_name():
+    # will fail if move constructors aren't used
+    cdef NoAssign value
+    value = get_NoAssign_Py()
+    value = get_NoAssign_Cpp()
+
+def test_assignment_to_scope():
+    cdef NoAssign value
+    value = get_NoAssign_Py()
+    value = get_NoAssign_Cpp()
+    def inner():
+        value.func()
+
+cdef class AssignToClassAttr:
+    cdef NoAssign attr
+    def __init__(self):
+        self.attr = get_NoAssign_Py()
+        self.attr = get_NoAssign_Cpp()


### PR DESCRIPTION
It has the potential to break things if misused so I've made it an opt-in feature.
Right now it's used in a few simple cases (function call and single assignment).

---------------------------

Fixes https://github.com/cython/cython/issues/3253 (on modern compilers). My real interest is that it can be used to reduce unnecessary copies of C++ objects on https://github.com/cython/cython/pull/3323.

On pre C++-11 compilers it generates copies as normal, so non-copyable types will continue to fail as before.
