### PR TITLE
Fixed a bug with C++ comparison operators

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12483,7 +12483,8 @@ class CmpNode(object):
                     result_code if self.type.is_pyobject else None,
                     self.exception_value,
                     self.in_nogil_context)
-            code.putln(statement)
+            else:
+                code.putln(statement)
 
     def c_operator(self, op):
         if op == 'is':

--- a/tests/run/cpp_operator_exc_handling.pyx
+++ b/tests/run/cpp_operator_exc_handling.pyx
@@ -42,6 +42,10 @@ cdef extern from "cpp_operator_exc_handling_helper.hpp" nogil:
         wrapped_int &operator=(const wrapped_int &other) except +ArithmeticError
         wrapped_int &operator=(const long long &vao) except +
 
+    cdef cppclass second_call_is_different:
+        second_call_is_different()
+        bool operator<(const second_call_is_different&) except +
+
 
 def assert_raised(f, *args, **kwargs):
     err = kwargs.get('err', None)
@@ -268,3 +272,13 @@ def test_operator_exception_handling():
     assert_raised(separate_exceptions, 4, 1, 1, 1, 3, err=ArithmeticError)
     assert_raised(call_temp_separation, 2, 1, 4, err=AttributeError)
     assert_raised(call_temp_separation, 2, 4, 1, err=IndexError)
+
+def test_only_single_call():
+    """
+    Previous version of the operator handling code called the operator twice
+    (Resulting in a crash)
+    >>> test_only_single_call()
+    False
+    """
+    cdef second_call_is_different inst
+    return inst<inst

--- a/tests/run/cpp_operator_exc_handling_helper.hpp
+++ b/tests/run/cpp_operator_exc_handling_helper.hpp
@@ -201,3 +201,16 @@ public:
     return *this;
   }
 };
+
+class second_call_is_different {
+    int count;
+    public:
+        second_call_is_different(): count(0) {}
+    bool operator<(const second_call_is_different& lhs) {
+        if (count>0) {
+            return true;
+        }
+        ++count;
+        return false;
+    }
+};


### PR DESCRIPTION
They'd generate two calls - one exception checked and one not

--------------------------------

```
return c1 < c1
```

currently translates to

```
try {
    __pyx_t_1 = (__pyx_v_c1 < __pyx_v_c1);
  } catch(...) {
    __Pyx_CppExn2PyErr();
    __PYX_ERR(0, 27, __pyx_L1_error)
  }
  __pyx_t_1 = (__pyx_v_c1 < __pyx_v_c1);
```

i.e. it does the comparison twice, and doesn't check for exceptions on the second one.