### PR TITLE
Allow tempita includes to be more readily @required

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -241,7 +241,9 @@ class UtilityCodeBase(object):
         #@subsitute: tempita
 
         [requires tempita substitution
-         - context can't be specified here though
+         - context can't be specified here though so only
+           tempita utility that requires no external context
+           will benefit from this tag
          - only necessary when @required from non-tempita code]
 
     for prototypes and implementation respectively.  For non-python or

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -356,6 +356,7 @@ static PyObject *__Pyx_PyDict_GetItem(PyObject *d, PyObject* key) {
 #endif
 
 /////////////// GetItemInt.proto ///////////////
+//@substitute: tempita
 
 #define __Pyx_GetItemInt(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
@@ -378,6 +379,7 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i,
                                                      int is_list, int wraparound, int boundscheck);
 
 /////////////// GetItemInt ///////////////
+//@substitute: tempita
 
 static PyObject *__Pyx_GetItemInt_Generic(PyObject *o, PyObject* j) {
     PyObject *r;
@@ -796,6 +798,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyTuple_GetSlice(PyObject* src, Py_ssize_t 
 
 /////////////// SliceTupleAndList ///////////////
 //@requires: TupleAndListFromArray
+//@substitute: tempita
 
 #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE void __Pyx_crop_slice(Py_ssize_t* _start, Py_ssize_t* _stop, Py_ssize_t* _length) {


### PR DESCRIPTION
@subsitute: tempita tag ensures that they are loaded in tempita utility code class

-----------------------------

Should be no user-visible changes. This is really just to help me re-use some existing functions in https://github.com/cython/cython/pull/3346. Based on https://github.com/cython/cython/blob/8e35f7e282f0ec7e5dab48d7c0d31595f2b2c237/Cython/Utility/ObjectHandling.c#L282 this is something that's been worked round before, so maybe it'll be useful elsewhere.