### PR TITLE
Cleanup of string initialization code for limited API

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1535,14 +1535,6 @@ class GlobalState(object):
                         py_string.intern
                         ))
                     w_not_limited_writer.putln("#else")
-                w_limited_writer.putln("{0, %s, sizeof(%s), %s, %d, %d, %d}," % (
-                    c_cname if not py_string.py3str_cstring else py_string.py3str_cstring.cname,
-                    c_cname if not py_string.py3str_cstring else py_string.py3str_cstring.cname,
-                    encoding if not py_string.py3str_cstring else '0',
-                    py_string.is_unicode,
-                    py_string.is_str,
-                    py_string.intern
-                    ))
                 w_not_limited_writer.putln("{&%s, %s, sizeof(%s), %s, %d, %d, %d}," % (
                     py_string.cname,
                     c_cname,
@@ -1554,6 +1546,14 @@ class GlobalState(object):
                     ))
                 if py_string.py3str_cstring:
                     w_not_limited_writer.putln("#endif")
+                w_limited_writer.putln("{0, %s, sizeof(%s), %s, %d, %d, %d}," % (
+                    c_cname if not py_string.py3str_cstring else py_string.py3str_cstring.cname,
+                    c_cname if not py_string.py3str_cstring else py_string.py3str_cstring.cname,
+                    encoding if not py_string.py3str_cstring else '0',
+                    py_string.is_unicode,
+                    py_string.is_str,
+                    py_string.intern
+                    ))
                 init_globals_limited_api.putln("if (__Pyx_InitString(%s[%d], &%s) < 0) %s;" % (
                     Naming.stringtab_cname,
                     idx,


### PR DESCRIPTION
The initialization now appears in a few large blocks rather than many

```
 # if CYTHON_LIMITED_API
   individual string line
 # endif
```

-----------------------

On the fairly simple `compute_prange` example (arbitrary example, chosen just because that's what I was looking at at the time) it saves about 900 lines of preprocessor statements (about 3% of the total file length).

See #2542 