### PR TITLE
Fixed issue where fused functions didn't register as cyfunctions

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1405,7 +1405,8 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     // __doc__ is None for the fused function type, but we need it to be
     // a descriptor for the instance's __doc__, so rebuild descriptors in our subclass
     __pyx_CyFunction_getsets,           /*tp_getset*/
-    &__pyx_CyFunctionType_type,         /*tp_base - NOTE placeholder value, replaced in module initialization*/
+    // NOTE: tp_base may be changed later during module initialisation when importing CyFunction across modules.
+    &__pyx_CyFunctionType_type,         /*tp_base*/
     0,                                  /*tp_dict*/
     __pyx_FusedFunction_descr_get,      /*tp_descr_get*/
     0,                                  /*tp_descr_set*/
@@ -1443,7 +1444,8 @@ static int __pyx_FusedFunction_init(void) {
     __pyx_FusedFunctionType = __Pyx_FetchCommonTypeFromSpec(&__pyx_FusedFunctionType_spec, bases);
     Py_DECREF(bases);
 #else
-    __pyx_FusedFunctionType_type.tp_base = __pyx_CyFunctionType;  // the value set from __Pyx_FetchCommonTypeFromSpec, not the static value
+    // Set base from __Pyx_FetchCommonTypeFromSpec, in case it's different from the local static value.
+    __pyx_FusedFunctionType_type.tp_base = __pyx_CyFunctionType;
     __pyx_FusedFunctionType = __Pyx_FetchCommonType(&__pyx_FusedFunctionType_type);
 #endif
     if (__pyx_FusedFunctionType == NULL) {

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1405,7 +1405,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     // __doc__ is None for the fused function type, but we need it to be
     // a descriptor for the instance's __doc__, so rebuild descriptors in our subclass
     __pyx_CyFunction_getsets,           /*tp_getset*/
-    &__pyx_CyFunctionType_type,         /*tp_base*/
+    &__pyx_CyFunctionType_type,         /*tp_base - NOTE placeholder value, replaced in module initialization*/
     0,                                  /*tp_dict*/
     __pyx_FusedFunction_descr_get,      /*tp_descr_get*/
     0,                                  /*tp_descr_set*/
@@ -1443,6 +1443,7 @@ static int __pyx_FusedFunction_init(void) {
     __pyx_FusedFunctionType = __Pyx_FetchCommonTypeFromSpec(&__pyx_FusedFunctionType_spec, bases);
     Py_DECREF(bases);
 #else
+    __pyx_FusedFunctionType_type.tp_base = __pyx_CyFunctionType;  // the value set from __Pyx_FetchCommonTypeFromSpec, not the static value
     __pyx_FusedFunctionType = __Pyx_FetchCommonType(&__pyx_FusedFunctionType_type);
 #endif
     if (__pyx_FusedFunctionType == NULL) {

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -7,6 +7,9 @@ Test Python def functions without extern types
 cy = __import__("cython")
 cimport cython
 
+cdef extern from *:
+    int __Pyx_CyFunction_Check(object)
+
 cdef class Base(object):
     def __repr__(self):
         return type(self).__name__
@@ -128,6 +131,16 @@ def opt_func(fused_t obj, cython.floating myf = 1.2, cython.integral myi = 7):
     print cython.typeof(obj), cython.typeof(myf), cython.typeof(myi)
     print obj, "%.2f" % myf, myi, "%.2f" % f, i
 
+def run_cyfunction_check():
+    """
+    tp_base of the fused function was being set incorrectly meaning
+    it wasn't being identified as a CyFunction
+    >>> run_cyfunction_check()
+    fused_cython_function
+    1
+    """
+    print(type(opt_func).__name__)
+    print(__Pyx_CyFunction_Check(opt_func))  # should be True
 
 def test_opt_func():
     """


### PR DESCRIPTION
Issue https://github.com/cython/cython/issues/3384

This happened where Cython was using a shared API because the
CyFunction type imported from the shared api wasn't the same as
used to initialize the fused function tp_base