### PR TITLE
Fused arguments specified by annotation or locals

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1434,11 +1434,7 @@ def _analyse_name_as_type(name, pos, env):
         return type
 
     global_entry = env.global_scope().lookup(name)
-    if global_entry and global_entry.type and (
-            global_entry.type.is_extension_type
-            or global_entry.type.is_struct_or_union
-            or global_entry.type.is_builtin_type
-            or global_entry.type.is_cpp_class):
+    if global_entry and global_entry.is_type and global_entry.type:
         return global_entry.type
 
     from .TreeFragment import TreeFragment

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -878,6 +878,8 @@ class CArgDeclNode(Node):
             # inject type declaration from annotations
             # this is called without 'env' by AdjustDefByDirectives transform before declaration analysis
             if (self.annotation and env and env.directives['annotation_typing']
+                    # CSimpleBaseTypeNode has a name attribute; CAnalysedBaseTypeNode
+                    # (and maybe other options) doesn't
                     and getattr(self.base_type, "name", None) is None):
                 arg_type = self.inject_type_from_annotations(env)
                 if arg_type is not None:
@@ -1680,7 +1682,7 @@ class FuncDefNode(StatNode, BlockNode):
         if other_type is None:
             error(type_node.pos, "Not a type")
         elif other_type.is_fused and any(orig_type.same_as(t) for t in other_type.types):
-            arg.type = orig_type  # use specialized rather than fused type
+            pass # use specialized rather than fused type
         elif orig_type is not py_object_type and not orig_type.same_as(other_type):
             error(arg.base_type.pos, "Signature does not agree with previous declaration")
             error(type_node.pos, "Previous declaration here")

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -877,7 +877,8 @@ class CArgDeclNode(Node):
 
             # inject type declaration from annotations
             # this is called without 'env' by AdjustDefByDirectives transform before declaration analysis
-            if self.annotation and env and env.directives['annotation_typing'] and self.base_type.name is None:
+            if (self.annotation and env and env.directives['annotation_typing']
+                    and getattr(self.base_type, "name", None) is None):
                 arg_type = self.inject_type_from_annotations(env)
                 if arg_type is not None:
                     base_type = arg_type
@@ -1678,6 +1679,8 @@ class FuncDefNode(StatNode, BlockNode):
             return arg
         if other_type is None:
             error(type_node.pos, "Not a type")
+        elif other_type.is_fused and any(orig_type.same_as(t) for t in other_type.types):
+            arg.type = orig_type  # use specialized rather than fused type
         elif orig_type is not py_object_type and not orig_type.same_as(other_type):
             error(arg.base_type.pos, "Signature does not agree with previous declaration")
             error(type_node.pos, "Previous declaration here")
@@ -2934,9 +2937,6 @@ class DefNode(FuncDefNode):
                 arg.name = name_declarator.name
                 arg.type = type
 
-                if type.is_fused:
-                    self.has_fused_arguments = True
-
             self.align_argument_type(env, arg)
             if name_declarator and name_declarator.cname:
                 error(self.pos, "Python function argument cannot have C name specification")
@@ -2967,6 +2967,9 @@ class DefNode(FuncDefNode):
                     error(arg.pos, "Only Python type arguments can have 'not None'")
                 if arg.or_none:
                     error(arg.pos, "Only Python type arguments can have 'or None'")
+
+            if arg.type.is_fused:
+                self.has_fused_arguments = True
         env.fused_to_specific = f2s
 
         if has_np_pythran(env):

--- a/tests/run/pure_fused.pxd
+++ b/tests/run/pure_fused.pxd
@@ -1,0 +1,6 @@
+ctypedef fused NotInPy:
+    int
+    float
+
+cdef class TestCls:
+    cpdef cpfunc(self, NotInPy arg)

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -1,0 +1,39 @@
+# mode: run
+# tag: fused,
+# tag: pure3.7
+
+#cython: annotation_typing=True
+
+from __future__ import annotations
+
+import cython
+
+class TestCls:
+    def func1(self, arg: NotInPy):
+        """
+        >>> TestCls().func1(1.0)
+        'float'
+        >>> TestCls().func1(2)
+        'int'
+        """
+        return cython.typeof(arg)
+
+    if cython.compiled:
+        @cython.locals(arg = NotInPy)  # NameError in pure Python
+        def func2(self, arg):
+            """
+            >>> TestCls().func2(1.0)
+            'float'
+            >>> TestCls().func2(2)
+            'int'
+            """
+            return cython.typeof(arg)
+
+    def cpfunc(self, arg):
+        """
+        >>> TestCls().cpfunc(1.0)
+        'float'
+        >>> TestCls().cpfunc(2)
+        'int'
+        """
+        return cython.typeof(arg)

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -3,8 +3,6 @@
 
 #cython: annotation_typing=True
 
-from __future__ import annotations
-
 import cython
 
 InPy = cython.fused_type(cython.int, cython.float)

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -1,6 +1,5 @@
 # mode: run
-# tag: fused,
-# tag: pure3.7
+# tag: fused, pure3.0
 
 #cython: annotation_typing=True
 
@@ -8,8 +7,12 @@ from __future__ import annotations
 
 import cython
 
+InPy = cython.fused_type(cython.int, cython.float)
+
 class TestCls:
-    def func1(self, arg: NotInPy):
+    # although annotations as strings isn't recommended and generates a warning
+    # it does allow the test to run on more (pure) Python versions
+    def func1(self, arg: 'NotInPy'):
         """
         >>> TestCls().func1(1.0)
         'float'
@@ -37,3 +40,23 @@ class TestCls:
         'int'
         """
         return cython.typeof(arg)
+
+    def func1_inpy(self, arg: InPy):
+        """
+        >>> TestCls().func1_inpy(1.0)
+        'float'
+        >>> TestCls().func1_inpy(2)
+        'int'
+        """
+        return cython.typeof(arg)
+
+    @cython.locals(arg = InPy)
+    def func2_inpy(self, arg):
+        """
+        >>> TestCls().func2_inpy(1.0)
+        'float'
+        >>> TestCls().func2_inpy(2)
+        'int'
+        """
+        return cython.typeof(arg)
+


### PR DESCRIPTION
Issues were:
1. DefNode.has_fused_arguments was set too early (before
locals/annotations) were evalutated, so function was not treated
as fused.
2. When re-evaluating the specializations of the fused function
it was treated as a redefinition because the locals/annotation was
reapplied over the specialized type.