### PR TITLE
Enable pypy as a required Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,14 @@ matrix:
       env: BACKEND=c
     - python: pypy3
       env: BACKEND=c
+# a secondary pypy3 test which is allowed to fail and which specifically
+# tests known bugs
+    - python: pypy3
+      env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"
   allow_failures:
     - python: 3.9-dev
     - python: pypy
-    - python: pypy3
+    - env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,14 +71,16 @@ matrix:
       env: BACKEND=c
     - python: pypy3
       env: BACKEND=c
-# a secondary pypy3 test which is allowed to fail and which specifically
+# a secondary pypy tests which is allowed to fail and which specifically
 # tests known bugs
     - python: pypy3
       env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"
+    - python: pypy2
+      env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt --listfile=tests/pypy2_bugs.txt bugs"
   allow_failures:
     - python: 3.9-dev
-    - python: pypy
     - env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"
+    - env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt --listfile=tests/pypy2_bugs.txt bugs"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,10 @@ matrix:
       env: BACKEND=c
 # a secondary pypy tests which is allowed to fail and which specifically
 # tests known bugs
+    - python: pypy
+      env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt --listfile=tests/pypy2_bugs.txt bugs"
     - python: pypy3
       env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"
-    - python: pypy2
-      env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt --listfile=tests/pypy2_bugs.txt bugs"
   allow_failures:
     - python: 3.9-dev
     - env: BACKEND=c EXCLUDE="--listfile=tests/pypy_bugs.txt bugs"

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -622,7 +622,7 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
   #define __Pyx_PyNumber_InPlaceDivide(x,y)  PyNumber_InPlaceDivide(x,y)
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07010100)
+#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07020000)
 #define __Pyx_PyDict_GetItemWithError PyDict_GetItemWithError
 #define __Pyx_PyDict_GetItemWithError_ErrOccurred PyErr_Occurred
 #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -622,6 +622,14 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
   #define __Pyx_PyNumber_InPlaceDivide(x,y)  PyNumber_InPlaceDivide(x,y)
 #endif
 
+#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07010100)
+#define __Pyx_PyDict_GetItemWithError PyDict_GetItemWithError
+#define __Pyx_PyDict_GetItemWithError_ErrOccurred PyErr_Occurred
+#else
+#define __Pyx_PyDict_GetItemWithError PyDict_GetItem
+#define __Pyx_PyDict_GetItemWithError_ErrOccurred() (0)  // use to avoid unnecessary calls to PyErr_Occurred()
+#endif
+
 #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX > 0x030600B4 && CYTHON_USE_UNICODE_INTERNALS
 // _PyDict_GetItem_KnownHash() exists since CPython 3.5, but it was
 // dropping exceptions. Since 3.6, exceptions are kept.
@@ -631,8 +639,8 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStr(PyObject *dict, PyObject
     if (res == NULL) PyErr_Clear();
     return res;
 }
-#elif PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030100)
-#define __Pyx_PyDict_GetItemStrWithError  PyDict_GetItemWithError
+#elif PY_MAJOR_VERSION >= 3
+#define __Pyx_PyDict_GetItemStrWithError  __Pyx_PyDict_GetItemWithError
 #define __Pyx_PyDict_GetItemStr           PyDict_GetItem
 #else
 static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict, PyObject *name) {

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -622,14 +622,6 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
   #define __Pyx_PyNumber_InPlaceDivide(x,y)  PyNumber_InPlaceDivide(x,y)
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07020000)
-#define __Pyx_PyDict_GetItemWithError PyDict_GetItemWithError
-#define __Pyx_PyDict_GetItemWithError_ErrOccurred PyErr_Occurred
-#else
-#define __Pyx_PyDict_GetItemWithError PyDict_GetItem
-#define __Pyx_PyDict_GetItemWithError_ErrOccurred() (0)  // use to avoid unnecessary calls to PyErr_Occurred()
-#endif
-
 #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX > 0x030600B4 && CYTHON_USE_UNICODE_INTERNALS
 // _PyDict_GetItem_KnownHash() exists since CPython 3.5, but it was
 // dropping exceptions. Since 3.6, exceptions are kept.
@@ -639,8 +631,8 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStr(PyObject *dict, PyObject
     if (res == NULL) PyErr_Clear();
     return res;
 }
-#elif PY_MAJOR_VERSION >= 3
-#define __Pyx_PyDict_GetItemStrWithError  __Pyx_PyDict_GetItemWithError
+#elif PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07020000)
+#define __Pyx_PyDict_GetItemStrWithError  PyDict_GetItemWithError
 #define __Pyx_PyDict_GetItemStr           PyDict_GetItem
 #else
 static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict, PyObject *name) {

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -631,7 +631,7 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStr(PyObject *dict, PyObject
     if (res == NULL) PyErr_Clear();
     return res;
 }
-#elif PY_MAJOR_VERSION >= 3
+#elif PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030100)
 #define __Pyx_PyDict_GetItemStrWithError  PyDict_GetItemWithError
 #define __Pyx_PyDict_GetItemStr           PyDict_GetItem
 #else

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -190,26 +190,22 @@ static PyObject* __Pyx_PyDict_GetItemDefault(PyObject* d, PyObject* key, PyObjec
 
 static PyObject* __Pyx_PyDict_GetItemDefault(PyObject* d, PyObject* key, PyObject* default_value) {
     PyObject* value;
-#if PY_MAJOR_VERSION >= 3 && !CYTHON_COMPILING_IN_PYPY
-    value = PyDict_GetItemWithError(d, key);
-    if (unlikely(!value)) {
-        if (unlikely(PyErr_Occurred()))
-            return NULL;
-        value = default_value;
-    }
-    Py_INCREF(value);
-    // avoid C compiler warning about unused utility functions
-    if ((1));
+#if PY_MAJOR_VERSION >= 3
+    if ((1)) {
 #else
     if (PyString_CheckExact(key) || PyUnicode_CheckExact(key) || PyInt_CheckExact(key)) {
         /* these presumably have safe hash functions */
-        value = PyDict_GetItem(d, key);
+#endif
+        value = __Pyx_PyDict_GetItemWithError(d, key);
         if (unlikely(!value)) {
+            if (unlikely(__Pyx_PyDict_GetItemWithError_ErrOccurred()))
+                return NULL;
             value = default_value;
         }
         Py_INCREF(value);
     }
-#endif
+    // avoid C compiler warning about unused utility functions
+    if ((1));
     else {
         if (default_value == Py_None)
             value = CALL_UNBOUND_METHOD(PyDict_Type, "get", d, key);
@@ -238,27 +234,20 @@ static CYTHON_INLINE PyObject *__Pyx_PyDict_SetDefault(PyObject *d, PyObject *ke
 #else
     if (is_safe_type == 1 || (is_safe_type == -1 &&
         /* the following builtins presumably have repeatably safe and fast hash functions */
-#if PY_MAJOR_VERSION >= 3 && !CYTHON_COMPILING_IN_PYPY
+#if PY_MAJOR_VERSION >= 3
             (PyUnicode_CheckExact(key) || PyString_CheckExact(key) || PyLong_CheckExact(key)))) {
-        value = PyDict_GetItemWithError(d, key);
-        if (unlikely(!value)) {
-            if (unlikely(PyErr_Occurred()))
-                return NULL;
-            if (unlikely(PyDict_SetItem(d, key, default_value) == -1))
-                return NULL;
-            value = default_value;
-        }
-        Py_INCREF(value);
 #else
             (PyString_CheckExact(key) || PyUnicode_CheckExact(key) || PyInt_CheckExact(key) || PyLong_CheckExact(key)))) {
-        value = PyDict_GetItem(d, key);
+#endif
+        value = __Pyx_PyDict_GetItemWithError(d, key);
         if (unlikely(!value)) {
+            if (unlikely(__Pyx_PyDict_GetItemWithError_ErrOccurred()))
+                return NULL;
             if (unlikely(PyDict_SetItem(d, key, default_value) == -1))
                 return NULL;
             value = default_value;
         }
         Py_INCREF(value);
-#endif
 #endif
     } else {
         value = CALL_UNBOUND_METHOD(PyDict_Type, "setdefault", d, key, default_value);

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -190,20 +190,26 @@ static PyObject* __Pyx_PyDict_GetItemDefault(PyObject* d, PyObject* key, PyObjec
 
 static PyObject* __Pyx_PyDict_GetItemDefault(PyObject* d, PyObject* key, PyObject* default_value) {
     PyObject* value;
-#if PY_MAJOR_VERSION >= 3
-    if ((1)) {
+#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07020000)
+    value = PyDict_GetItemWithError(d, key);
+    if (unlikely(!value)) {
+        if (unlikely(PyErr_Occurred()))
+            return NULL;
+        value = default_value;
+    }
+    Py_INCREF(value);
+    // avoid C compiler warning about unused utility functions
+    if ((1));
 #else
     if (PyString_CheckExact(key) || PyUnicode_CheckExact(key) || PyInt_CheckExact(key)) {
         /* these presumably have safe hash functions */
-#endif
-        value = __Pyx_PyDict_GetItemWithError(d, key);
+        value = PyDict_GetItem(d, key);
         if (unlikely(!value)) {
-            if (unlikely(__Pyx_PyDict_GetItemWithError_ErrOccurred()))
-                return NULL;
             value = default_value;
         }
         Py_INCREF(value);
     }
+#endif
     else {
         if (default_value == Py_None)
             value = CALL_UNBOUND_METHOD(PyDict_Type, "get", d, key);
@@ -232,20 +238,27 @@ static CYTHON_INLINE PyObject *__Pyx_PyDict_SetDefault(PyObject *d, PyObject *ke
 #else
     if (is_safe_type == 1 || (is_safe_type == -1 &&
         /* the following builtins presumably have repeatably safe and fast hash functions */
-#if PY_MAJOR_VERSION >= 3
+#if PY_MAJOR_VERSION >= 3 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07020000)
             (PyUnicode_CheckExact(key) || PyString_CheckExact(key) || PyLong_CheckExact(key)))) {
-#else
-            (PyString_CheckExact(key) || PyUnicode_CheckExact(key) || PyInt_CheckExact(key) || PyLong_CheckExact(key)))) {
-#endif
-        value = __Pyx_PyDict_GetItemWithError(d, key);
+        value = PyDict_GetItemWithError(d, key);
         if (unlikely(!value)) {
-            if (unlikely(__Pyx_PyDict_GetItemWithError_ErrOccurred()))
+            if (unlikely(PyErr_Occurred()))
                 return NULL;
             if (unlikely(PyDict_SetItem(d, key, default_value) == -1))
                 return NULL;
             value = default_value;
         }
         Py_INCREF(value);
+#else
+            (PyString_CheckExact(key) || PyUnicode_CheckExact(key) || PyInt_CheckExact(key) || PyLong_CheckExact(key)))) {
+        value = PyDict_GetItem(d, key);
+        if (unlikely(!value)) {
+            if (unlikely(PyDict_SetItem(d, key, default_value) == -1))
+                return NULL;
+            value = default_value;
+        }
+        Py_INCREF(value);
+#endif
 #endif
     } else {
         value = CALL_UNBOUND_METHOD(PyDict_Type, "setdefault", d, key, default_value);

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -204,8 +204,6 @@ static PyObject* __Pyx_PyDict_GetItemDefault(PyObject* d, PyObject* key, PyObjec
         }
         Py_INCREF(value);
     }
-    // avoid C compiler warning about unused utility functions
-    if ((1));
     else {
         if (default_value == Py_None)
             value = CALL_UNBOUND_METHOD(PyDict_Type, "get", d, key);

--- a/runtests.py
+++ b/runtests.py
@@ -1885,13 +1885,6 @@ class FileListExcluder(object):
                   % (testname, self._list_file))
         return exclude
 
-class CombinedExcluder(object):
-    def __init__(self, excluders):
-        self.excluders = excluders
-
-    def __call__(self, testname, tags=None):
-        return any(ex(testname, tags=tags) for ex in self.excluders)
-
 
 class TagsSelector(object):
     def __init__(self, tag, value):
@@ -2317,6 +2310,16 @@ def runtests_callback(args):
 
 
 def runtests(options, cmd_args, coverage=None):
+    # faulthandler should be able to provide a limited traceback
+    # in the event of a segmentation fault. Hopefully better than Travis
+    # just keeping running until timeout. Only available on Python 3.3+
+    try:
+        import faulthandler
+    except ImportError:
+        pass  # OK - not essential
+    else:
+        faulthandler.enable()
+
 
     WITH_CYTHON = options.with_cython
     ROOTDIR = os.path.abspath(options.root_dir)

--- a/runtests.py
+++ b/runtests.py
@@ -2436,6 +2436,7 @@ def runtests(options, cmd_args, coverage=None):
         bug_files = [
             ('bugs.txt', True),
             ('pypy_bugs.txt', IS_PYPY),
+            ('pypy2_bugs.txt', IS_PYPY and IS_PY2),
             ('pypy_crash_bugs.txt', IS_PYPY),
             ('pypy_implementation_detail_bugs.txt', IS_PYPY),
             ('limited_api_bugs.txt', options.limited_api),

--- a/runtests.py
+++ b/runtests.py
@@ -1878,8 +1878,7 @@ class FileListExcluder(object):
                     self.excludes[line.split()[0]] = True
 
     def __call__(self, testname, tags=None):
-        exclude = (testname in self.excludes
-                   or testname.split('.')[-1] in self.excludes)
+        exclude = any(string_selector(ex)(testname) for ex in self.excludes)
         if exclude and self.verbose:
             print("Excluding %s because it's listed in %s"
                   % (testname, self._list_file))

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -1,0 +1,12 @@
+# Specific bugs that only apply to pypy2
+
+build.cythonize_script_package
+run.initial_file_path
+run.reduce_pickle
+run.final_in_pxd
+run.cdef_multiple_inheritance
+run.cdef_multiple_inheritance_nodict
+run.extstarargs
+
+# looks like a "when does the GC run?" issue - slightly surprised it's OK on pypy3
+memoryview.numpy_memoryview

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -10,6 +10,10 @@ run.cdef_multiple_inheritance_nodict
 run.extstarargs
 run.cpython_capi
 run.isnot
+
+# pypy 2 seems to be preferring .py files to .so files
+# https://foss.heptapod.net/pypy/pypy/issues/3185
+run.language_level
 run.pure_pxd
 
 # Silly error with doctest matching slightly different string outputs rather than 

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -8,5 +8,9 @@ run.cdef_multiple_inheritance
 run.cdef_multiple_inheritance_nodict
 run.extstarargs
 
+# Silly error with doctest matching slightly different string outputs rather than 
+# an actual bug but one I can't easily resolve
+run.with_gil
+
 # looks like a "when does the GC run?" issue - slightly surprised it's OK on pypy3
 memoryview.numpy_memoryview

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -1,5 +1,6 @@
 # Specific bugs that only apply to pypy2
 
+build.cythonize_script
 build.cythonize_script_package
 run.initial_file_path
 run.reduce_pickle
@@ -7,10 +8,14 @@ run.final_in_pxd
 run.cdef_multiple_inheritance
 run.cdef_multiple_inheritance_nodict
 run.extstarargs
+run.cpython_capi
+run.isnot
+run.pure_pxd
 
 # Silly error with doctest matching slightly different string outputs rather than 
 # an actual bug but one I can't easily resolve
 run.with_gil
+
 
 # looks like a "when does the GC run?" issue - slightly surprised it's OK on pypy3
 memoryview.numpy_memoryview

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -4,7 +4,7 @@
 
 broken_exception
 bufaccess
-memoryview.memoryview
+memoryview.memoryview$
 sequential_parallel
 
 yield_from_pep380

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -4,36 +4,53 @@
 
 broken_exception
 bufaccess
-memoryview
-memslice
+run.memoryview
 sequential_parallel
 
 yield_from_pep380
 memoryview_inplace_division
 
+run.unicodemethods
+run.unicode_imports
+run.tp_new
+run.test_fstring
+run.test_exceptions
+run.test_dictviews
+run.str_subclass_kwargs
+run.special_method_docstrings
+run.slice_ptr
+compile.min_async
+run.cython_includes
+run.pyarray
+run.test_unicode
+run.__getattribute__
+run.__getattribute_subclasses__
+run.__debug__
+run.array_cimport
+run.builtin_abs
+run.builtincomplex
+run.cdef_multiple_inheritance_errors
+run.cdivision_CEP_516
+run.cyfunction
+run.final_cdef_class
+run.index
+run.pyclass_special_methods
+run.reimport_from_package
+pkg.cimportfrom
+test_embed
+run.ext_auto_richcmp
+
+# very little coroutine-related seems to work
+run.test_asyncgen
+run.test_coroutines_pep492
+run.async_iter_pep492
+run.embedsignatures
+run.py35_asyncio_async_def
+
 # gc issue?
-memoryview_in_subclasses
 external_ref_reassignment
 run.exttype_dealloc
 
 # bugs in cpyext
 run.special_methods_T561
 run.special_methods_T561_py2
-
-# tests for things that don't exist in cpyext
-compile.pylong
-run.datetime_pxd
-run.datetime_cimport
-run.datetime_members
-run.extern_builtins_T258
-run.line_trace
-run.line_profile_test
-run.pstats_profile_test
-run.longintrepr
-
-# refcounting-specific tests
-double_dealloc_T796
-run.exceptionrefcount
-run.capiimpl
-run.refcount_in_meth
-

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -4,7 +4,7 @@
 
 broken_exception
 bufaccess
-run.memoryview
+memoryview.memoryview
 sequential_parallel
 
 yield_from_pep380
@@ -36,9 +36,15 @@ run.final_cdef_class
 run.index
 run.pyclass_special_methods
 run.reimport_from_package
+run.reimport_from_subinterpreter
 pkg.cimportfrom
-test_embed
+embed
+TestCyCache
 run.ext_auto_richcmp
+run.coverage_cmd
+run.coverage_cmd_src_layout
+run.coverage_installed_pkg
+run.coverage_api
 
 # very little coroutine-related seems to work
 run.test_asyncgen
@@ -46,6 +52,7 @@ run.test_coroutines_pep492
 run.async_iter_pep492
 run.embedsignatures
 run.py35_asyncio_async_def
+run.asyncio_generators
 
 # gc issue?
 external_ref_reassignment
@@ -54,3 +61,13 @@ run.exttype_dealloc
 # bugs in cpyext
 run.special_methods_T561
 run.special_methods_T561_py2
+
+# looks to be fixed in PyPy 7.3.0
+# TODO - remove when Travis updates
+run.py_unicode_strings
+run.unicodeliterals
+run.unicode_identifiers
+run.unicode_identifiers_import
+run.tracebacks
+run.fstring
+run.unicode_identifiers_normalization

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -38,13 +38,14 @@ run.pyclass_special_methods
 run.reimport_from_package
 run.reimport_from_subinterpreter
 pkg.cimportfrom
-embed
+embedded
 TestCyCache
 run.ext_auto_richcmp
 run.coverage_cmd
 run.coverage_cmd_src_layout
 run.coverage_installed_pkg
 run.coverage_api
+run.coverage_nogil
 
 # very little coroutine-related seems to work
 run.test_asyncgen
@@ -68,6 +69,7 @@ run.py_unicode_strings
 run.unicodeliterals
 run.unicode_identifiers
 run.unicode_identifiers_import
+errors.unicode_identifiers_e4
 run.tracebacks
 run.fstring
 run.unicode_identifiers_normalization

--- a/tests/pypy_crash_bugs.txt
+++ b/tests/pypy_crash_bugs.txt
@@ -1,0 +1,13 @@
+# Bugs that causes hard crashes that we certainly don't 
+# want to run because it will break the testsuite
+
+# segfault
+run.fastcall
+memslice
+
+# """Fatal RPython error: NotImplementedError
+# Aborted (core dumped)"""
+run.py35_pep492_interop
+
+# gc issue?
+memoryview_in_subclasses

--- a/tests/pypy_implementation_detail_bugs.txt
+++ b/tests/pypy_implementation_detail_bugs.txt
@@ -1,0 +1,45 @@
+# PyPy "bugs" that are probably implementation differences from
+# CPython rather than actual bugs. Therefore they aren't targets
+# to be fixed (but there *may* be other details in the testfile
+# that should be tested on PyPy?)
+
+run.starargs
+
+# refcounting-specific tests
+double_dealloc_T796
+run.exceptionrefcount
+run.capiimpl
+run.refcount_in_meth
+# Ideally just disable the reference-counting tests on PyPy?
+run.fused_types
+run.generator_frame_cycle
+run.generators_in_refcycles
+run.generators_py
+run.parallel
+
+# "sys.getsizeof(object, default) will always return default on PyPy, and
+# raise a TypeError if default is not provided."
+buildenv
+
+# tests for things that don't exist in cpyext
+compile.pylong
+run.datetime_pxd
+run.datetime_cimport
+run.datetime_members
+run.extern_builtins_T258
+run.line_trace
+run.line_profile_test
+run.pstats_profile_test
+run.longintrepr
+
+# tests probably rely on immediate GC (although maybe the tests could be tweaked so
+# only these bits don't run in PyPy?)
+buffers.buffer
+buffers.userbuffer
+memoryview.cythonarray
+memoryview.memoryview_pep489_typing
+run.cpp_classes
+run.cpp_classes_def
+
+# missing pypy feature?
+matrix_multiplier

--- a/tests/run/callargs.pyx
+++ b/tests/run/callargs.pyx
@@ -168,15 +168,15 @@ def test_int_kwargs(f):
     """
     >>> test_int_kwargs(e)     # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     >>> test_int_kwargs(f)     # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     >>> test_int_kwargs(g)     # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     >>> test_int_kwargs(h)     # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     """
     f(a=1,b=2,c=3, **{10:20,30:40})

--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -143,10 +143,12 @@ def test_typedef_vector(o):
     Traceback (most recent call last):
     ...
     OverflowError: ...
+
+    "TypeError: an integer is required" on CPython
     >>> test_typedef_vector([1, 2, None])       #doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: an integer is required
+    TypeError: ...int...
     """
     cdef vector[my_int] v = o
     return v

--- a/tests/run/importfrom.pyx
+++ b/tests/run/importfrom.pyx
@@ -68,7 +68,7 @@ def typed_imports():
     try:
         from sys import version_info as maxunicode
     except TypeError, e:
-        if '__pypy__' in sys.builtin_module_names:
+        if getattr(sys, "pypy_version_info", None):
             # translate message
             if e.args[0].startswith("int() argument must be"):
                 e = "an integer is required"

--- a/tests/run/importfrom.pyx
+++ b/tests/run/importfrom.pyx
@@ -68,6 +68,10 @@ def typed_imports():
     try:
         from sys import version_info as maxunicode
     except TypeError, e:
+        if '__pypy__' in sys.builtin_module_names:
+            # translate message
+            if e.args[0].startswith("int() argument must be"):
+                e = "an integer is required"
         print(e)
 
     try:

--- a/tests/run/kwargproblems.pyx
+++ b/tests/run/kwargproblems.pyx
@@ -4,7 +4,7 @@ def test(**kw):
     >>> d = {1 : 2}
     >>> test(**d)       # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     >>> d
     {1: 2}
     >>> d = {}

--- a/tests/run/list_pop.pyx
+++ b/tests/run/list_pop.pyx
@@ -206,7 +206,7 @@ def crazy_pop(L):
     """
     >>> crazy_pop(list(range(10)))    # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: pop... at most ... argument...
+    TypeError: pop... argument...
     >>> crazy_pop(A())
     (1, 2, 3)
     """

--- a/tests/run/modop.pyx
+++ b/tests/run/modop.pyx
@@ -9,7 +9,7 @@ def modobj(obj2, obj3):
     '5'
     >>> modobj(1, 0)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ZeroDivisionError: ... division or modulo by zero
+    ZeroDivisionError: integer... modulo by zero
     """
     obj1 = obj2 % obj3
     return obj1
@@ -17,9 +17,9 @@ def modobj(obj2, obj3):
 
 def mod_10_obj(int2):
     """
-    >>> mod_10_obj(0)
+    >>> mod_10_obj(0)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ZeroDivisionError: ... division or modulo by zero
+    ZeroDivisionError: ... division ...by zero
     >>> 10 % 1
     0
     >>> mod_10_obj(1)

--- a/tests/run/modop.pyx
+++ b/tests/run/modop.pyx
@@ -9,7 +9,7 @@ def modobj(obj2, obj3):
     '5'
     >>> modobj(1, 0)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ZeroDivisionError: integer division or modulo by zero
+    ZeroDivisionError: ... division or modulo by zero
     """
     obj1 = obj2 % obj3
     return obj1
@@ -19,7 +19,7 @@ def mod_10_obj(int2):
     """
     >>> mod_10_obj(0)
     Traceback (most recent call last):
-    ZeroDivisionError: integer division or modulo by zero
+    ZeroDivisionError: ... division or modulo by zero
     >>> 10 % 1
     0
     >>> mod_10_obj(1)

--- a/tests/run/modop.pyx
+++ b/tests/run/modop.pyx
@@ -19,7 +19,7 @@ def mod_10_obj(int2):
     """
     >>> mod_10_obj(0)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ZeroDivisionError: ... division ...by zero
+    ZeroDivisionError: ... modulo by zero
     >>> 10 % 1
     0
     >>> mod_10_obj(1)

--- a/tests/run/pep448_test_extcall.pyx
+++ b/tests/run/pep448_test_extcall.pyx
@@ -326,7 +326,7 @@ def errors_non_string_kwarg():
     """
     >>> errors_non_string_kwarg()  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ...keywords must be strings
+    TypeError: ...keywords must be strings...
     """
     f(**{1:2})
 
@@ -463,10 +463,10 @@ def call_builtin_empty_dict():
 
 def call_builtin_nonempty_dict():
     """
-    >>> call_builtin_nonempty_dict()
+    >>> call_builtin_nonempty_dict() # doctest: +ELLIPSIS
     Traceback (most recent call last):
       ...
-    TypeError: id() takes no keyword arguments
+    TypeError: id() ... keyword argument...
     """
     return id(1, **{'foo': 1})
 

--- a/tests/run/powop.pyx
+++ b/tests/run/powop.pyx
@@ -125,7 +125,7 @@ def optimised_pow2(n):
     True
     >>> optimised_pow2('test') # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ... operand... ** ...
+    TypeError: ...operand... **...
     """
     if isinstance(n, (int, long)) and 0 <= n < 1000:
         assert isinstance(2.0 ** n, float), 'float %s' % n
@@ -155,7 +155,7 @@ def optimised_pow2_inplace(n):
     True
     >>> optimised_pow2_inplace('test') # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: ... operand... ** ...
+    TypeError: ...operand... **...
     """
     x = 2
     x **= n

--- a/tests/run/powop.pyx
+++ b/tests/run/powop.pyx
@@ -123,9 +123,9 @@ def optimised_pow2(n):
     0.5
     >>> optimised_pow2(0.5) == 2 ** 0.5
     True
-    >>> optimised_pow2('test')
+    >>> optimised_pow2('test') # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: unsupported operand type(s) for ** or pow(): 'int' and 'str'
+    TypeError: ... operand... ** ...
     """
     if isinstance(n, (int, long)) and 0 <= n < 1000:
         assert isinstance(2.0 ** n, float), 'float %s' % n
@@ -153,9 +153,9 @@ def optimised_pow2_inplace(n):
     0.5
     >>> optimised_pow2_inplace(0.5) == 2 ** 0.5
     True
-    >>> optimised_pow2_inplace('test')
+    >>> optimised_pow2_inplace('test') # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: unsupported operand type(s) for ** or pow(): 'int' and 'str'
+    TypeError: ... operand... ** ...
     """
     x = 2
     x **= n

--- a/tests/run/pure.pyx
+++ b/tests/run/pure.pyx
@@ -25,10 +25,12 @@ def test_declare(n):
     (100, 100)
     >>> test_declare(100.5)
     (100, 100)
-    >>> test_declare(None)
+
+    # CPython: "TypeError: an integer is required"
+    >>> test_declare(None) # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: an integer is required
+    TypeError: ...int...
     """
     x = cython.declare(cython.int)
     y = cython.declare(cython.int, n)

--- a/tests/run/py_hash_t.pyx
+++ b/tests/run/py_hash_t.pyx
@@ -25,7 +25,7 @@ def assign_py_hash_t(x):
     >>> assign_py_hash_t(IntLike(1.5))  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: __index__ ... (type float)
+    TypeError: __index__ ... (type ...float...)
     """
     cdef Py_hash_t h = x
     return h

--- a/tests/run/with_gil.pyx
+++ b/tests/run/with_gil.pyx
@@ -13,7 +13,6 @@ def redirect_stderr(func, *args, **kwargs):
     Helper function that redirects stderr to stdout for doctest.
     """
     stderr, sys.stderr = sys.stderr, sys.stdout
-    print("Dummy line")  # otherwise doctest interprets ... at the start of the line as a continuation
     func(*args, **kwargs)
     sys.stderr = stderr
 
@@ -277,8 +276,7 @@ cdef void void_nogil_nested_gil() nogil:
 def test_nogil_void_funcs_with_gil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_gil)  # doctest: +ELLIPSIS
-    Dummy line
-    ...ExceptionWithMsg: This is swallowed
+    with_gil.ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section
     nogil section
@@ -291,8 +289,7 @@ def test_nogil_void_funcs_with_gil():
 def test_nogil_void_funcs_with_nogil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_nogil)  # doctest: +ELLIPSIS
-    Dummy line
-    ...ExceptionWithMsg: This is swallowed
+    with_gil.ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section
     nogil section

--- a/tests/run/with_gil.pyx
+++ b/tests/run/with_gil.pyx
@@ -13,6 +13,7 @@ def redirect_stderr(func, *args, **kwargs):
     Helper function that redirects stderr to stdout for doctest.
     """
     stderr, sys.stderr = sys.stderr, sys.stdout
+    print("Dummy line")  # otherwise doctest interprets ... at the start of the line as a continuation
     func(*args, **kwargs)
     sys.stderr = stderr
 
@@ -276,6 +277,7 @@ cdef void void_nogil_nested_gil() nogil:
 def test_nogil_void_funcs_with_gil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_gil)  # doctest: +ELLIPSIS
+    Dummy line
     ...ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section
@@ -289,6 +291,7 @@ def test_nogil_void_funcs_with_gil():
 def test_nogil_void_funcs_with_nogil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_nogil)  # doctest: +ELLIPSIS
+    Dummy line
     ...ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section

--- a/tests/run/with_gil.pyx
+++ b/tests/run/with_gil.pyx
@@ -276,7 +276,7 @@ cdef void void_nogil_nested_gil() nogil:
 def test_nogil_void_funcs_with_gil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_gil)  # doctest: +ELLIPSIS
-    with_gil.ExceptionWithMsg: This is swallowed
+    ...ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section
     nogil section
@@ -289,7 +289,7 @@ def test_nogil_void_funcs_with_gil():
 def test_nogil_void_funcs_with_nogil():
     """
     >>> redirect_stderr(test_nogil_void_funcs_with_nogil)  # doctest: +ELLIPSIS
-    with_gil.ExceptionWithMsg: This is swallowed
+    ...ExceptionWithMsg: This is swallowed
     Exception... ignored...
     Inner gil section
     nogil section


### PR DESCRIPTION
Reasoning being that this make it easier to catch pypy
regressions as they happen.

* Fixed some very simple pypy failures (largely to do with
  different exception strings)
* Splits pypy_bugs.txt into four files
  - one for bugs that cause hard crashes (which we don't want to
    run in Travis at all);
  - one for bugs that are probably unfixable because they're just
    due to implementation details (e.g. when destructors are
    called).
  - one file for pypy2-only bugs
  - all other bugs remain in pypy_bugs.txt
  (The categorization has been done fairly quickly, so some bugs
  may be in the wrong place)
* Made sure (hopefully) all bugs are now categorized, so a basic
  runtests.py with pypy should hopefully pass
* Changed pypy to be required in Travis
* Added an extra (optional) test that runs through pypy_bugs.txt.
  The majority of this is expected to fail. This requires an
  extra option to runtest.py "--listfile", which just runs through
  the tests listed in the file.

~I haven't made pypy2 a required test in this commit - since
Python2 support is deprecated soon, there seemed limited value in
putting much effort into pypy2.~