### PR TITLE
Fixed crash with default arguments and bound fused functions

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1104,6 +1104,9 @@ __pyx_FusedFunction_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     // since otherwise it will be freed on destruction of meth despite
     // belonging to func rather than meth
     if (func->func.defaults) {
+        PyObject **pydefaults;
+        int i;
+
         if (!__Pyx_CyFunction_InitDefaults((PyObject*)meth,
                                       func->func.defaults_size,
                                       func->func.defaults_pyobjects)) {
@@ -1111,6 +1114,10 @@ __pyx_FusedFunction_descr_get(PyObject *self, PyObject *obj, PyObject *type)
             return NULL;
         }
         memcpy(meth->func.defaults, func->func.defaults, func->func.defaults_size);
+
+        pydefaults = __Pyx_CyFunction_Defaults(PyObject *, meth);
+        for (i = 0; i < meth->func.defaults_pyobjects; i++)
+            Py_XINCREF(pydefaults[i]);
     }
 
     Py_XINCREF(func->func.func_classobj);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -39,6 +39,7 @@ typedef struct {
     // Dynamic default args and annotations
     void *defaults;
     int defaults_pyobjects;
+    size_t defaults_size;  // used by FusedFunction for copying defaults
     int flags;
 
     // Defaults info
@@ -497,6 +498,7 @@ static PyObject *__Pyx_CyFunction_New(PyTypeObject *type, PyMethodDef *ml, int f
     op->func_code = code;
     // Dynamic Default args
     op->defaults_pyobjects = 0;
+    op->defaults_size = 0;
     op->defaults = NULL;
     op->defaults_tuple = NULL;
     op->defaults_kwdict = NULL;
@@ -946,6 +948,7 @@ static CYTHON_INLINE void *__Pyx_CyFunction_InitDefaults(PyObject *func, size_t 
         return PyErr_NoMemory();
     memset(m->defaults, 0, size);
     m->defaults_pyobjects = pyobjects;
+    m->defaults_size = size;
     return m->defaults;
 }
 
@@ -1096,6 +1099,19 @@ __pyx_FusedFunction_descr_get(PyObject *self, PyObject *obj, PyObject *type)
                     ((__pyx_CyFunctionObject *) func)->func_code);
     if (!meth)
         return NULL;
+
+    // defaults needs copying fully rather than just copying the pointer
+    // since otherwise it will be freed on destruction of meth despite
+    // belonging to func rather than meth
+    if (func->func.defaults) {
+        if (!__Pyx_CyFunction_InitDefaults((PyObject*)meth,
+                                      func->func.defaults_size,
+                                      func->func.defaults_pyobjects)) {
+            Py_XDECREF((PyObject*)meth);
+            return NULL;
+        }
+        memcpy(meth->func.defaults, func->func.defaults, func->func.defaults_size);
+    }
 
     Py_XINCREF(func->func.func_classobj);
     meth->func.func_classobj = func->func.func_classobj;

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -405,3 +405,31 @@ def test_decorators(cython.floating arg):
     >>> test_decorators.order
     [3, 2, 1]
     """
+
+@cython.binding(True)
+def bind_me(self, cython.floating a=1.):
+    return a
+
+cdef class HasBound:
+    """
+    Using default arguments of bound specialized fused functions used to cause a segfault
+    https://github.com/cython/cython/issues/3370
+    >>> inst = HasBound()
+    >>> inst.func()
+    1.0
+    >>> inst.func(2)
+    2.0
+    >>> inst.func_fused()
+    1.0
+    >>> inst.func_fused(2.)
+    2.0
+    >>> bind_me.__defaults__
+    (1.0,)
+    >>> inst.func.__defaults__
+    (1.0,)
+    >>> inst.func_fused.__defaults__
+    (1.0,)
+    """
+    func = bind_me[float]
+
+    func_fused = bind_me


### PR DESCRIPTION
Default arguments are now copied when the bound fused function is created rather than being left as a NULL pointer.

Fixes https://github.com/cython/cython/issues/3370 and enables https://github.com/cython/cython/pull/3366 to proceed using a local default argument to store the dict.