### PR TITLE
BLD: update the trove classifier to include python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: C",


### PR DESCRIPTION
I was trying to sort out what the minimum version of cython that works on py38 is, thought I would check the trove clasifiers and discovered no version of cython reports supporting py38, hence the PR ;)