### PR TITLE
Add missing declarations to slice.pxd

### DIFF
--- a/Cython/Includes/cpython/slice.pxd
+++ b/Cython/Includes/cpython/slice.pxd
@@ -45,3 +45,26 @@ cdef extern from "Python.h":
     #
     # Changed in version 3.2: The parameter type for the slice parameter was
     # PySliceObject* before.
+
+    int PySlice_Unpack(object slice, Py_ssize_t *start, Py_ssize_t *stop,
+                       Py_ssize_t *step) except -1
+    # Extract the start, stop and step data members from a slice object as C
+    # integers. Silently reduce values larger than PY_SSIZE_T_MAX to
+    # PY_SSIZE_T_MAX, silently boost the start and stop values less than
+    # PY_SSIZE_T_MIN to PY_SSIZE_T_MIN, and silently boost the step values
+    # less than -PY_SSIZE_T_MAX to -PY_SSIZE_T_MAX.
+
+    # Return -1 on error, 0 on success.
+
+    # New in version 3.6.1.
+
+    Py_ssize_t PySlice_AdjustIndices(Py_ssize_t length, Py_ssize_t *start,
+                                     Py_ssize_t *stop, Py_ssize_t step)
+    # Adjust start/end slice indices assuming a sequence of the specified
+    # length. Out of bounds indices are clipped in a manner consistent with
+    # the handling of normal slices.
+
+    # Return the length of the slice. Always successful. Doesn’t call Python
+    # code.
+
+    # New in version 3.6.1.


### PR DESCRIPTION
PySlice_Unpack() and PySlice_AdjustIndices() were missing from
slice.pxd.

The comments are taken from the C API documentation
(https://docs.python.org/3.8/c-api/slice.html).