### PR TITLE
Marks view.* extension types as imported

### DIFF
--- a/Cython/Compiler/CythonScope.py
+++ b/Cython/Compiler/CythonScope.py
@@ -127,6 +127,17 @@ class CythonScope(ModuleScope):
                                             self.viewscope, cython_scope=self,
                                             whitelist=MemoryView.view_utility_whitelist)
 
+        # Marks the types as imported so that they can be extended from
+        # without Cython attempting to import cython.view
+        ext_types = [ entry.type
+                         for entry in view_utility_scope.entries.values()
+                         if entry.type.is_extension_type ]
+        for mod in self.context.modules.values():
+            if mod is self or mod.is_builtin_scope:
+                continue
+            mod.types_imported.update(ext_types)
+
+
         # self.entries["array"] = view_utility_scope.entries.pop("array")
 
 

--- a/Cython/Compiler/CythonScope.py
+++ b/Cython/Compiler/CythonScope.py
@@ -127,15 +127,13 @@ class CythonScope(ModuleScope):
                                             self.viewscope, cython_scope=self,
                                             whitelist=MemoryView.view_utility_whitelist)
 
-        # Marks the types as imported so that they can be extended from
-        # without Cython attempting to import cython.view
+        # Marks the types as being cython_builtin_type so that they can be
+        # extended from without Cython attempting to import cython.view
         ext_types = [ entry.type
                          for entry in view_utility_scope.entries.values()
                          if entry.type.is_extension_type ]
-        for mod in self.context.modules.values():
-            if mod is self or mod.is_builtin_scope:
-                continue
-            mod.types_imported.update(ext_types)
+        for ext_type in ext_types:
+            ext_type.is_cython_builtin_type = 1
 
 
         # self.entries["array"] = view_utility_scope.entries.pop("array")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3383,7 +3383,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
     def generate_base_type_import_code(self, env, entry, code, import_generator):
         base_type = entry.type.base_type
         if (base_type and base_type.module_name != env.qualified_name and not
-                base_type.is_builtin_type and not entry.utility_code_definition):
+                (base_type.is_builtin_type or base_type.is_cython_builtin_type)
+                 and not entry.utility_code_definition):
             self.generate_type_import_code(env, base_type, self.pos, code, import_generator)
 
     def generate_type_import_code(self, env, type, pos, code, import_generator):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -227,6 +227,7 @@ class PyrexType(BaseType):
     is_extension_type = 0
     is_final_type = 0
     is_builtin_type = 0
+    is_cython_builtin_type = 0
     is_numeric = 0
     is_int = 0
     is_float = 0

--- a/tests/memoryview/cythonarray.pyx
+++ b/tests/memoryview/cythonarray.pyx
@@ -209,3 +209,11 @@ def test_cyarray_from_carray():
 
     mslice = a
     print mslice[0, 0], mslice[1, 0], mslice[2, 5]
+
+class InheritFrom(v.array):
+    """
+    Test is just to confirm it works, not to do anything meaningful with it
+    (Be aware that itemsize isn't necessarily right)
+    >>> inst = InheritFrom(shape=(3, 3, 3), itemsize=4, format="i")
+    """
+    pass


### PR DESCRIPTION
so that they can be inherited from.

Closes https://github.com/cython/cython/issues/3396