### PR TITLE
Doc mention of a module

### DIFF
--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -466,7 +466,7 @@ Also take a look at the `cython_freeze
 It can generate the necessary boilerplate code for linking one or more
 modules into a single Python executable.
 
-You can also utilize the `cython-multibuild<https://github.com/smok-serwis/cython-multibuild>`_ module to automatically generate wrappers and stubs for your module, for using them with a standard Python runtime.
+You can also utilize the `cython-multibuild <https://github.com/smok-serwis/cython-multibuild>`_ module to automatically generate wrappers and stubs for your module, for using them with a standard Python runtime.
 
 .. _pyximport:
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -466,6 +466,7 @@ Also take a look at the `cython_freeze
 It can generate the necessary boilerplate code for linking one or more
 modules into a single Python executable.
 
+You can also utilize the `cython-multibuild<https://github.com/smok-serwis/cython-multibuild>` module to automatically generate wrappers and stubs for your module, for using them with a standard Python runtime.
 
 .. _pyximport:
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -466,7 +466,7 @@ Also take a look at the `cython_freeze
 It can generate the necessary boilerplate code for linking one or more
 modules into a single Python executable.
 
-You can also utilize the `cython-multibuild<https://github.com/smok-serwis/cython-multibuild>` module to automatically generate wrappers and stubs for your module, for using them with a standard Python runtime.
+You can also utilize the `cython-multibuild<https://github.com/smok-serwis/cython-multibuild>`_ module to automatically generate wrappers and stubs for your module, for using them with a standard Python runtime.
 
 .. _pyximport:
 


### PR DESCRIPTION
Here's a module that I crafted over the weekend being particularly inspired by this [StackOverflow](https://stackoverflow.com/questions/30157363/collapse-multiple-submodules-to-one-cython-extension) discussion.

I suppose it's useful enough to be mentioned within the Cython docs themselves.