### PR TITLE
Slight adjustment to documentation of "quiet" parameter for `cythonize()`.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -913,7 +913,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     variable called ``foo`` as a string, and then call
                     ``cythonize(..., aliases={'MY_HEADERS': foo})``.
 
-    :param quiet: If True, Cython won't print error and warning messages during the compilation.
+    :param quiet: If True, Cython won't print error, warning, or status messages during the
+                  compilation.
 
     :param force: Forces the recompilation of the Cython modules, even if the timestamps
                   don't indicate that a recompilation is necessary.


### PR DESCRIPTION
As far as I can tell, `cythonize(quiet=True)` also suppresses non-error and non-warning messages on `stdout`, like `f"Compiling {filepath} because it changed."`, `f"[{n}/{t}] Cythonizing {filepath}"`, etc.

It's a minor distinction in a single flag, but I ran into it when trying to write a `doctest` for `Shadow.inline()`.