### PR TITLE
Fixed initialization of the array with the list which was broken in GH-3244

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -269,8 +269,11 @@ class PointerType(CythonType):
 
 class ArrayType(PointerType):
 
-    def __init__(self):
-        self._items = [None] * self._n
+    def __init__(self, value=None):
+        if value is None:
+            self._items = [None] * self._n
+        else:
+            super(ArrayType, self).__init__(value)
 
 
 class StructType(CythonType):

--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -537,3 +537,14 @@ def none_declare():
     f = None
     f2 = cython.declare(Foo, f)
     return f2
+
+def array_init_with_list():
+    """
+    >>> array_init_with_list()
+    [10, 42]
+    """
+    x = cython.declare(cython.int[20], list(range(20)))
+    x[12] = 42
+
+    return [x[10], x[12]]
+


### PR DESCRIPTION
Fixes `x = cython.declare(cython.int[20], list(range(20)))` which was broken in GH-3244