### PR TITLE
Improved Cython debugger documentation

### DIFF
--- a/docs/src/userguide/debugging.rst
+++ b/docs/src/userguide/debugging.rst
@@ -21,6 +21,8 @@ source, and then running::
     make
     sudo make install
 
+Installing the Cython debugger can be quite tricky. `This installation script and example code <https://gitlab.com/volkerweissmann/cygdb_installation>`_ might be useful.
+
 The debugger will need debug information that the Cython compiler can export.
 This can be achieved from within the setup script by passing ``gdb_debug=True``
 to ``cythonize()``::


### PR DESCRIPTION
Hello,

I've spend the last three days trying to install the Cython debugger cygdb. After I finally managed to do this I decided to wrote an installation script and simple example code. I added a link to this code in the documentation of the Cython debugger and a note that cy print  and cy exec is currently broken.

Note to those that think that we don't need the installation script, because the explanation is simple enough:
The reason why it took me three days even tough my script looks simple, is that if you do it in a different way that also seems doable, you end up with a much tougher problem. If e.g. you try to install the --with-pydebug version of python by compiling it from source instead of using pyenv, the problem becomes much harder. Another problem, is that if you do it wrong you end up with error messages that don't hint at the problem.