### PR TITLE
Fixed a bug that broke cy exec

### DIFF
--- a/Cython/Debugger/libpython.py
+++ b/Cython/Debugger/libpython.py
@@ -2608,7 +2608,7 @@ class PythonCodeExecutor(object):
         return pointer
 
     def free(self, pointer):
-        gdb.parse_and_eval("free((void *) %d)" % pointer)
+        gdb.parse_and_eval("(void) free((void *) %d)" % pointer)
 
     def incref(self, pointer):
         "Increment the reference count of a Python object in the inferior."


### PR DESCRIPTION
Without this patch, cy exec 3+4 outputs:

> Python Exception <class 'gdb.error'> 'free' has unknown return type; cast the call to its declared return type: 
> Error occurred in Python: 'free' has unknown return type; cast the call to its declared return type

The problem was that cygdb ran gdb.parse_and_eval("free(ptr)") . I changed that to gdb.parse_and_eval("(void) free(ptr)") . This seems to work, but it would be nice if someone who actually knows what he is doing could check if this is correct.