### PR TITLE
Fused functions safe with wraparound+boundscheck off

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -595,13 +595,15 @@ class FusedCFuncDefNode(StatListNode):
                     for sig in <dict>signatures:
                         sigindex_node = _fused_sigindex
                         sig_series = sig.strip('()').split('|')
-                        for sig_type in sig_series[:-1]:
+                        for sig_type in sig_series[:(len(sig_series)-1)]:
                             if sig_type not in sigindex_node:
                                 sigindex_node[sig_type] = sigindex_node = {}
                             else:
                                 sigindex_node = sigindex_node[sig_type]
-                        sigindex_node[sig_series[-1]] = sig
+                        sigindex_node[sig_series[len(sig_series)-1]] = sig
             """
+            # use "len(sig_series)-1" to avoid problems if wraparound is externally
+            # set to False
         )
 
     def make_fused_cpdef(self, orig_py_func, env, is_def):

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -594,16 +594,14 @@ class FusedCFuncDefNode(StatListNode):
                 if not _fused_sigindex:
                     for sig in <dict>signatures:
                         sigindex_node = _fused_sigindex
-                        sig_series = sig.strip('()').split('|')
-                        for sig_type in sig_series[:(len(sig_series)-1)]:
+                        *sig_series, last_type = sig.strip('()').split('|')
+                        for sig_type in sig_series:
                             if sig_type not in sigindex_node:
                                 sigindex_node[sig_type] = sigindex_node = {}
                             else:
                                 sigindex_node = sigindex_node[sig_type]
-                        sigindex_node[sig_series[len(sig_series)-1]] = sig
+                        sigindex_node[last_type] = sig
             """
-            # use "len(sig_series)-1" to avoid problems if wraparound is externally
-            # set to False
         )
 
     def make_fused_cpdef(self, orig_py_func, env, is_def):

--- a/tests/compile/fused_wraparound.pyx
+++ b/tests/compile/fused_wraparound.pyx
@@ -1,0 +1,22 @@
+# mode: compile
+# tag: fused, werror
+
+"""
+Very short test for https://github.com/cython/cython/issues/3492
+(Needs its own file since werror fails on the main fused-test files)
+wraparound and boundscheck directives shouldn't break the fused
+dispatcher function
+"""
+
+cimport cython
+
+ctypedef fused fused_t:
+    str
+    int
+    long
+    complex
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def func(fused_t a, cython.floating b):
+    return a, b


### PR DESCRIPTION
It seemed difficult to reliably change the directives
applied to the __pyx_fused_cpdef dispatch function,
so instead wrote code that should be generally valid

Fixes https://github.com/cython/cython/issues/3492 (and then indirectly https://github.com/pandas-dev/pandas/issues/33372)