### PR TITLE
add tests for ndarray

### DIFF
--- a/tests/run/numpy_attributes.pyx
+++ b/tests/run/numpy_attributes.pyx
@@ -1,0 +1,37 @@
+# mode: run
+# tag: numpy
+
+import numpy as np
+cimport numpy as cnp
+
+cnp.import_array()
+
+def access_shape():
+    """
+    >>> access_shape()
+    10
+    """
+    cdef cnp.ndarray[double, ndim=2, mode='c'] array_in = \
+                    1e10 * np.ones((10, 10))
+
+    return array_in.shape[0]
+
+def access_size():
+    """
+    >>> access_size()
+    100
+    """
+    cdef cnp.ndarray[double, ndim=2, mode='c'] array_in = \
+                    1e10 * np.ones((10, 10))
+
+    return array_in.size
+
+def access_strides():
+    """
+    >>> access_strides()
+    (80, 8)
+    """
+    cdef cnp.ndarray[double, ndim=2, mode='c'] array_in = \
+                    1e10 * np.ones((10, 10), dtype=np.float64)
+
+    return (array_in.strides[0], array_in.strides[1])


### PR DESCRIPTION
Strangely, this test passes. It seems the argument name in a cdef getter is not important, since the name in [`ndarray.size`](https://github.com/cython/cython/blob/3.0a1/Cython/Includes/numpy/__init__.pxd#L265) is `ndarray`, not `self`.