### PR TITLE
Make CodeWriter inherit from ExpressionWriter

### DIFF
--- a/Cython/Compiler/AutoDocTransforms.py
+++ b/Cython/Compiler/AutoDocTransforms.py
@@ -9,6 +9,9 @@ from .Errors import warning
 
 
 class AnnotationWriter(ExpressionWriter):
+    """
+    A Cython code writer for Python expressions in argument/variable annotations.
+    """
     def __init__(self, description=None):
         """description is optional. If specified it is used in
         warning messages for the nodes that don't convert to string properly.

--- a/Cython/Tests/TestCodeWriter.py
+++ b/Cython/Tests/TestCodeWriter.py
@@ -68,9 +68,18 @@ class TestCodeWriter(CythonTest):
                     else:
                         print(43)
                 """)
+        self.t(u"""
+                    for abc in (1, 2, 3):
+                        print(x, y, z)
+                    else:
+                        print(43)
+                """)
 
     def test_inplace_assignment(self):
         self.t(u"x += 43")
+
+    def test_cascaded_assignment(self):
+        self.t(u"x = y = z = abc = 43")
 
     def test_attribute(self):
         self.t(u"a.x")


### PR DESCRIPTION
This allows it to support all kinds of expressions without duplicating code between the different writers.

See https://github.com/cython/cython/issues/3513#issuecomment-613849055
