### PR TITLE
Relax class private names for c types

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -920,39 +920,47 @@ class Scope(object):
                 return None
         return scope
 
-    def lookup(self, name, _no_mangle=False):
+    def lookup(self, name):
         # Look up name in this scope or an enclosing one.
         # Return None if not found.
-        # _no_mangle is internal, used to have a second go at looking up without
-        # class private mangling
-        original_name = name
-        # https://github.com/cython/cython/issues/3544
-        # Have two goes at lookup, with or without class private mangling
-        names = [ name ] if _no_mangle else [ self.mangle_class_private_name(name), name ]
-        no_mangle_settings = [ True ] if _no_mangle else [ False, True ]
-        for name, no_mangle in zip(names, no_mangle_settings):
-            entry = (self.lookup_here(name, _no_mangle=no_mangle)
-                or (self.outer_scope and self.outer_scope.lookup(name, _no_mangle=no_mangle))
-                or None)
-            if entry:
-                if no_mangle and entry.is_pyglobal:
-                    # warning points to the right place?
-                    warning(entry.pos, "Global name %s matched from within class scope "
-                            "in contradiction to to Python 'class private name' rules. "
-                            "This may change in a future release." % name, 1)
-                return entry
-        return None
 
-    def lookup_here(self, name, _no_mangle=False):
+        mangled_name = self.mangle_class_private_name(name)
+        entry = (self.lookup_here(name)  # lookup here also does mangling
+                or (self.outer_scope and self.outer_scope.lookup(mangled_name))
+                or None)
+        if entry:
+            return entry
+
+        # look up the original name in the outer scope
+        # Not strictly Python behaviour but see https://github.com/cython/cython/issues/3544
+        entry = (self.outer_scope and self.outer_scope.lookup(name)) or None
+        if entry and entry.is_pyglobal:
+            self._lookup_python_mangled_warning(entry.pos, name)
+        return entry
+
+    def lookup_here(self, name):
         # Look up in this scope only, return None if not found.
-        if not _no_mangle:
-            name = self.mangle_class_private_name(name)
+
+        # if the name is already declared in the scope then return it, even if
+        # mangling should give us something else. This is to support things like
+        # global __foo which makes a declaration for __foo
+        entry = self.entries.get(name, None)
+        if entry:
+            return entry
+        name = self.mangle_class_private_name(name)
+        return self.entries.get(name, None)
+
+    def lookup_here_unmangled(self, name):
         return self.entries.get(name, None)
 
     def lookup_target(self, name):
         # Look up name in this scope only. Declare as Python
         # variable if not found.
         entry = self.lookup_here(name)
+        if not entry:
+            entry = self.lookup_here_unmangled(name)
+            if entry and entry.is_pyglobal:
+                self._lookup_python_mangled_warning(entry.pos, name)
         if not entry:
             entry = self.declare_var(name, py_object_type, None)
         return entry
@@ -1003,6 +1011,11 @@ class Scope(object):
             pass
         operands = [FakeOperand(pos, type=type) for type in types]
         return self.lookup_operator(operator, operands)
+
+    def _lookup_python_mangled_warning(self, pos, name):
+        warning(pos, "Global name %s matched from within class scope "
+                            "in contradiction to to Python 'class private name' rules. "
+                            "This may change in a future release." % name, 1)
 
     def use_utility_code(self, new_code):
         self.global_scope().use_utility_code(new_code)
@@ -1069,14 +1082,14 @@ class BuiltinScope(Scope):
             cname, type = definition
             self.declare_var(name, type, None, cname)
 
-    def lookup(self, name, language_level=None, str_is_str=None, _no_mangle=False):
+    def lookup(self, name, language_level=None, str_is_str=None):
         # 'language_level' and 'str_is_str' are passed by ModuleScope
         if name == 'str':
             if str_is_str is None:
                 str_is_str = language_level in (None, 2)
             if not str_is_str:
                 name = 'unicode'
-        return Scope.lookup(self, name, _no_mangle=_no_mangle)
+        return Scope.lookup(self, name)
 
     def declare_builtin(self, name, pos):
         if not hasattr(builtins, name):
@@ -1243,8 +1256,8 @@ class ModuleScope(Scope):
     def global_scope(self):
         return self
 
-    def lookup(self, name, language_level=None, str_is_str=None, _no_mangle=False):
-        entry = self.lookup_here(name, _no_mangle=_no_mangle)
+    def lookup(self, name, language_level=None, str_is_str=None):
+        entry = self.lookup_here(name)
         if entry is not None:
             return entry
 
@@ -1254,8 +1267,7 @@ class ModuleScope(Scope):
             str_is_str = language_level == 2 or (
                 self.context is not None and Future.unicode_literals not in self.context.future_directives)
 
-        return self.outer_scope.lookup(name, language_level=language_level, str_is_str=str_is_str,
-                                       _no_mangle=False)
+        return self.outer_scope.lookup(name, language_level=language_level, str_is_str=str_is_str)
 
     def declare_tuple_type(self, pos, components):
         components = tuple(components)
@@ -1856,11 +1868,11 @@ class LocalScope(Scope):
             if entry is None or not entry.from_closure:
                 error(pos, "no binding for nonlocal '%s' found" % name)
 
-    def lookup(self, name, _no_mangle=False):
+    def lookup(self, name):
         # Look up name in this scope or an enclosing one.
         # Return None if not found.
 
-        entry = Scope.lookup(self, name, _no_mangle=_no_mangle)
+        entry = Scope.lookup(self, name)
         if entry is not None:
             entry_scope = entry.scope
             while entry_scope.is_genexpr_scope:
@@ -2037,8 +2049,8 @@ class ClassScope(Scope):
         self.class_name = name
         self.doc = None
 
-    def lookup(self, name, _no_mangle=False):
-        entry = Scope.lookup(self, name, _no_mangle=_no_mangle)
+    def lookup(self, name):
+        entry = Scope.lookup(self, name)
         if entry:
             return entry
         if name == "classmethod":
@@ -2287,10 +2299,10 @@ class CClassScope(ClassScope):
         self.pyfunc_entries.append(entry)
         return entry
 
-    def lookup_here(self, name, _no_mangle=False):
+    def lookup_here(self, name):
         if not self.is_closure_class_scope and name == "__new__":
             name = EncodedString("__cinit__")
-        entry = ClassScope.lookup_here(self, name, _no_mangle=_no_mangle)
+        entry = ClassScope.lookup_here(self, name)
         if entry and entry.is_builtin_cmethod:
             if not self.parent_type.is_builtin_type:
                 # For subtypes of builtin types, we can only return
@@ -2630,8 +2642,8 @@ class CConstOrVolatileScope(Scope):
         self.is_const = is_const
         self.is_volatile = is_volatile
 
-    def lookup_here(self, name, _no_mangle=False):
-        entry = self.base_type_scope.lookup_here(name, _no_mangle=_no_mangle)
+    def lookup_here(self, name):
+        entry = self.base_type_scope.lookup_here(name)
         if entry is not None:
             entry = copy.copy(entry)
             entry.type = PyrexTypes.c_const_or_volatile_type(

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2033,6 +2033,9 @@ class ClassScope(Scope):
     #  doc    string or None   Doc string
 
     def mangle_class_private_name(self, name):
+        # a few utilitycode names need to specifically be ignored
+        if name and name.lower().startswith("__pyx_"):
+            return name
         if name and name.startswith('__') and not name.endswith('__'):
             name = EncodedString('_%s%s' % (self.class_name.lstrip('_'), name))
         return name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -937,9 +937,9 @@ class Scope(object):
             if entry:
                 if no_mangle and entry.is_pyglobal:
                     # warning points to the right place?
-                    warning(entry.pos, "Global name %s not matched because of Python "
-                            "'class private name' rules" % name, 1)
-                    return None
+                    warning(entry.pos, "Global name %s matched from within class scope "
+                            "in contradiction to to Python 'class private name' rules. "
+                            "This may change in a future release." % name, 1)
                 return entry
         return None
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2033,9 +2033,6 @@ class ClassScope(Scope):
     #  doc    string or None   Doc string
 
     def mangle_class_private_name(self, name):
-        # a few utilitycode names need to specifically be ignored
-        if name and name.lower().startswith("__pyx_"):
-            return name
         if name and name.startswith('__') and not name.endswith('__'):
             name = EncodedString('_%s%s' % (self.class_name.lstrip('_'), name))
         return name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2036,9 +2036,6 @@ class ClassScope(Scope):
         # a few utilitycode names need to specifically be ignored
         if name and name.lower().startswith("__pyx_"):
             return name
-        return self.mangle_special_name(name)
-
-    def mangle_special_name(self, name):
         if name and name.startswith('__') and not name.endswith('__'):
             name = EncodedString('_%s%s' % (self.class_name.lstrip('_'), name))
         return name
@@ -2079,7 +2076,7 @@ class PyClassScope(ClassScope):
     def declare_var(self, name, type, pos,
                     cname = None, visibility = 'private',
                     api = 0, in_pxd = 0, is_cdef = 0):
-        name = self.mangle_special_name(name)
+        name = self.mangle_class_private_name(name)
         if type is unspecified_type:
             type = py_object_type
         # Add an entry for a class attribute.
@@ -2209,7 +2206,7 @@ class CClassScope(ClassScope):
     def declare_var(self, name, type, pos,
                     cname = None, visibility = 'private',
                     api = 0, in_pxd = 0, is_cdef = 0):
-        name = self.mangle_special_name(name)
+        name = self.mangle_class_private_name(name)
         if is_cdef:
             # Add an entry for an attribute.
             if self.defined:

--- a/docs/src/userguide/migrating_to_cy30.rst
+++ b/docs/src/userguide/migrating_to_cy30.rst
@@ -159,5 +159,5 @@ a ``cdef class``:
 
 Here ``Base.__bar`` is mangled to ``_Base__bar`` and ``Derived.__bar``
 to ``_Derived__bar``. Therefore ``call_bar`` will always call 
-``_Base__bar``. This matches established Pythoon behaviour and applies
+``_Base__bar``. This matches established Python behaviour and applies
 for ``def``, ``cdef`` and ``cpdef`` methods and attributes.

--- a/docs/src/userguide/migrating_to_cy30.rst
+++ b/docs/src/userguide/migrating_to_cy30.rst
@@ -128,12 +128,10 @@ Class-private name mangling
 Cython has been updated to follow the `Python rules for class-private names
 <https://docs.python.org/3/tutorial/classes.html#private-variables>`_
 more closely. Essentially any name that starts with and doesn't end with 
-``__`` within a class in mangled with the class name. Most user code
+``__`` within a class is mangled with the class name. Most user code
 should be unaffected -- unlike in Python unmangled global names will
-still be matched to ensure it is possible to use access C names
-beginning with ``__``:
-
-::
+still be matched to ensure it is possible to access C names
+beginning with ``__``::
 
      cdef extern void __foo()
      
@@ -142,9 +140,7 @@ beginning with ``__``:
             return __foo() # still calls the global name
             
 What will no-longer work is overriding methods starting with ``__`` in
-a ``cdef class``:
-
-::
+a ``cdef class``::
 
     cdef class Base:
         cdef __bar(self):

--- a/docs/src/userguide/migrating_to_cy30.rst
+++ b/docs/src/userguide/migrating_to_cy30.rst
@@ -121,3 +121,43 @@ without actually calling it, e.g.
 
     # Explicitly disable the automatic initialisation of NumPy's C-API.
     <void>import_array
+
+Class-private name mangling
+===========================
+
+Cython has been updated to follow the `Python rules for class-private names
+<https://docs.python.org/3/tutorial/classes.html#private-variables>`_
+more closely. Essentially any name that starts with and doesn't end with 
+``__`` within a class in mangled with the class name. Most user code
+should be unaffected -- unlike in Python unmangled global names will
+still be matched to ensure it is possible to use access C names
+beginning with ``__``:
+
+::
+
+     cdef extern void __foo()
+     
+     class C: # or "cdef class"
+        def call_foo(self):
+            return __foo() # still calls the global name
+            
+What will no-longer work is overriding methods starting with ``__`` in
+a ``cdef class``:
+
+::
+
+    cdef class Base:
+        cdef __bar(self):
+            return 1
+
+        def call_bar(self):
+            return self.__bar()
+
+    cdef class Derived(Base):
+        cdef __bar(self):
+            return 2
+
+Here ``Base.__bar`` is mangled to ``_Base__bar`` and ``Derived.__bar``
+to ``_Derived__bar``. Therefore ``call_bar`` will always call 
+``_Base__bar``. This matches established Pythoon behaviour and applies
+for ``def``, ``cdef`` and ``cpdef`` methods and attributes.

--- a/tests/run/methodmangling_T5.py
+++ b/tests/run/methodmangling_T5.py
@@ -4,6 +4,7 @@
 # A small number of extra tests checking:
 # 1) this works correctly with pure-Python-mode decorators - methodmangling_pure.py.
 # 2) this works correctly with cdef classes - methodmangling_cdef.pyx
+# 3) with "error_on_unknown_names" - methodmangling_unknown_names.py
 
 class CyTest(object):
     """

--- a/tests/run/methodmangling_cdef.pyx
+++ b/tests/run/methodmangling_cdef.pyx
@@ -3,6 +3,9 @@
 def call_cdt_private_cdef(CDefTest o):
     return o._CDefTest__private_cdef()
 
+cdef __c_func():
+    return "cdef function"
+
 cdef class CDefTest:
     """
     >>> cd = CDefTest()
@@ -47,6 +50,23 @@ cdef class CDefTest:
         def get(o):
             return o._CDefTest__x, o.__x, o.__private()
         return get(self)
+
+    def get_c_func(self):
+        """
+        Should still be able to access C function with __names
+        >>> CDefTest().get_c_func()
+        'cdef function'
+        """
+        return __c_func()
+
+    def get_c_func2(self):
+        """
+        Should find mangled name before C __name
+        >>> CDefTest().get_c_func2()
+        'lambda'
+        """
+        _CDefTest__c_func = lambda: "lambda"
+        return __c_func()
 
 def call_inpdx_private_cdef(InPxd o):
     return o._InPxd__private_cdef()

--- a/tests/run/methodmangling_cdef.pyx
+++ b/tests/run/methodmangling_cdef.pyx
@@ -6,6 +6,8 @@ def call_cdt_private_cdef(CDefTest o):
 cdef __c_func():
     return "cdef function"
 
+cdef __c_var = "Shouldn't see this"
+
 cdef class CDefTest:
     """
     >>> cd = CDefTest()
@@ -67,6 +69,15 @@ cdef class CDefTest:
         """
         _CDefTest__c_func = lambda: "lambda"
         return __c_func()
+
+    def get_c_var(self):
+        """
+        >>> CDefTest().get_c_var()
+        'c var'
+        """
+        global __c_var
+        __c_var = "c var"
+        return __c_var
 
 def call_inpdx_private_cdef(InPxd o):
     return o._InPxd__private_cdef()

--- a/tests/run/methodmangling_unknown_names.py
+++ b/tests/run/methodmangling_unknown_names.py
@@ -1,0 +1,25 @@
+# mode: run
+# tag: allow_unknown_names, pure2.0, pure3.0
+
+class Test(object):
+    def run(self):
+        """
+        >>> Test().run()
+        NameError1
+        NameError2
+        found mangled
+        """
+        try:
+            print(__something)
+        except NameError:
+            print("NameError1") # correct - shouldn't exist
+        globals()['__something'] = 'found unmangled'
+        try:
+            print(__something)
+        except NameError:
+            print("NameError2") # correct - shouldn't exist
+        globals()['_Test__something'] = 'found mangled'
+        try:
+            print(__something) # should print this
+        except NameError:
+            print("NameError3")


### PR DESCRIPTION
Allow C functions/variables with names starting with "__" to be found
from within classes, even though their names would normally be
inaccessible due to the Python "class private names" mechanism.
https://github.com/cython/cython/issues/3544

Where globals are looked up by name (e.g. with error_on_unknown_names =
False) make sure to lookup the mangled name