### PR TITLE
docs: external C code

### DIFF
--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -17,7 +17,7 @@ to be less frequent, but you might want to do it, for example, if you are
 Cython module can be used as a bridge to allow Python code to call C code, it
 can also be used to allow C code to call Python code.
 
-.. _embedding Python: http://www.freenet.org.nz/python/embeddingpyrex/
+.. _embedding Python: https://web.archive.org/web/20120225082358/http://www.freenet.org.nz:80/python/embeddingpyrex/
 
 External declarations
 =======================


### PR DESCRIPTION
* Updated URL for the "embedding Python" link in external_C_code.rst
  in the userguide.
* The freenet.org.nz domain has clearly expired at some point and now
  the original link goes spam links, but there are copies in the
  Wayback Machine.
* The updated (fixed) URL uses the most recent archive for the
  original page (author: June, 2004; web archive: Feb, 2012).