### PR TITLE
FIX: Ignore unused ctuples (GH-3543)

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -615,7 +615,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             definition = module is env
             type_entries = []
             for entry in module.type_entries:
-                if entry.type.is_ctuple:
+                if entry.type.is_ctuple and entry.used:
                     if entry.name not in ctuple_names:
                         ctuple_names.add(entry.name)
                         type_entries.append(entry)

--- a/tests/compile/ctuple_unused_T3543.pyx
+++ b/tests/compile/ctuple_unused_T3543.pyx
@@ -1,0 +1,9 @@
+# ticket: 3543
+# mode: compile
+
+# Views define unused ctuples, including (long,)
+from cython cimport view
+
+# Implicitly generate a ctuple (long,)
+obj = None
+obj or (1,)


### PR DESCRIPTION
generate_type_definitions maintained a list of ctuples for which code
was already generated, but the logic did not match the logic used in
generate_type_header_code, which does not generate code if the entry is
marked as unused.

If the first ctuple of a certain type was marked unused, but later
instances were not, this could result in no code being generated for
the ctuple at all. Resolve by verifying whether the ctuple entry is used
before adding it to the list.