### PR TITLE
Maintain a separate copy of distutils' build_ext options

### DIFF
--- a/Cython/Distutils/old_build_ext.py
+++ b/Cython/Distutils/old_build_ext.py
@@ -84,9 +84,9 @@ class old_build_ext(_build_ext.build_ext):
     description = "build C/C++ and Cython extensions (compile/link to build directory)"
 
     sep_by = _build_ext.build_ext.sep_by
-    user_options = _build_ext.build_ext.user_options
-    boolean_options = _build_ext.build_ext.boolean_options
-    help_options = _build_ext.build_ext.help_options
+    user_options = _build_ext.build_ext.user_options[:]
+    boolean_options = _build_ext.build_ext.boolean_options[:]
+    help_options = _build_ext.build_ext.help_options[:]
 
     # Add the pyrex specific data.
     user_options.extend([


### PR DESCRIPTION
Noticed some prereleases so I thought this simple change could make it to the Cython3 release cycle.

Fixes #2209.
