### PR TITLE
Memoryviews of arrays of structs fix

### DIFF
--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -661,7 +661,7 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
   int got_Z = 0;
 
   while (1) {
-    puts(ts);
+    /* puts(ts); */
     switch(*ts) {
       case 0:
         if (ctx->enc_type != 0 && ctx->head == NULL) {

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -602,9 +602,8 @@ static PyObject *
 __pyx_buffmt_parse_array(__Pyx_BufFmt_Context* ctx, const char** tsp)
 {
     const char *ts = *tsp;
-    int i = 0, number;
-    int ndim = ctx->head->field->type->ndim;
-;
+    int i = 0, number, ndim;
+
     ++ts;
     if (ctx->new_count != 1) {
         PyErr_SetString(PyExc_ValueError,
@@ -614,6 +613,9 @@ __pyx_buffmt_parse_array(__Pyx_BufFmt_Context* ctx, const char** tsp)
 
     /* Process the previous element */
     if (__Pyx_BufFmt_ProcessTypeChunk(ctx) == -1) return NULL;
+
+    // store ndim now, as field advanced by __Pyx_BufFmt_ProcessTypeChunk call
+    ndim = ctx->head->field->type->ndim;
 
     /* Parse all numbers in the format string */
     while (*ts && *ts != ')') {
@@ -659,7 +661,7 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
   int got_Z = 0;
 
   while (1) {
-    /* puts(ts); */
+    puts(ts);
     switch(*ts) {
       case 0:
         if (ctx->enc_type != 0 && ctx->head == NULL) {

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -758,7 +758,7 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
       case 'f': case 'd': case 'g':
       case 'O': case 'p':
         if ((ctx->enc_type == *ts) && (got_Z == ctx->is_complex) &&
-            (ctx->enc_packmode == ctx->new_packmode) &! (ctx->is_valid_array)) {
+            (ctx->enc_packmode == ctx->new_packmode) && (!ctx->is_valid_array)) {
           /* Continue pooling same type */
           ctx->enc_count += ctx->new_count;
           ctx->new_count = 1;

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -757,8 +757,8 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
       case 'l': case 'L': case 'q': case 'Q':
       case 'f': case 'd': case 'g':
       case 'O': case 'p':
-        if (ctx->enc_type == *ts && got_Z == ctx->is_complex &&
-            ctx->enc_packmode == ctx->new_packmode) {
+        if ((ctx->enc_type == *ts) && (got_Z == ctx->is_complex) &&
+            (ctx->enc_packmode == ctx->new_packmode) &! (ctx->is_valid_array)) {
           /* Continue pooling same type */
           ctx->enc_count += ctx->new_count;
           ctx->new_count = 1;

--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -406,6 +406,59 @@ def packed_struct_with_strings(fmt):
         fmt, sizeof(PackedStructWithCharArrays))
 
 
+ctypedef struct PackedStructWithArrays:
+    double a[16]
+    double b[16]
+    double c
+
+ctypedef struct UnpackedStructWithArrays:
+    int a
+    float b[8]
+    float c
+    unsigned long d
+    int e[5]
+    int f
+    int g
+    double h[4]
+    int i
+
+ctypedef struct PackedStructWithNDArrays:
+    double a
+    double b[2][2]
+    float c
+    float d
+
+
+@testcase
+def packed_struct_with_arrays(fmt):
+    """
+    >>> packed_struct_with_arrays("T{(16)d:a:(16)d:b:d:c:}")
+    """
+
+    cdef object[PackedStructWithArrays] buf = MockBuffer(
+        fmt, sizeof(PackedStructWithArrays))
+
+
+@testcase
+def unpacked_struct_with_arrays(fmt):
+    """
+    >>> unpacked_struct_with_arrays("T{i:a:(8)f:b:f:c:L:d:(5)i:e:i:f:i:g:xxxx(4)d:h:i:i:}")
+    """
+
+    cdef object[UnpackedStructWithArrays] buf = MockBuffer(
+        fmt, sizeof(UnpackedStructWithArrays))
+
+
+@testcase
+def packed_struct_with_ndarrays(fmt):
+    """
+    >>> packed_struct_with_ndarrays("T{d:a:(2,2)d:b:f:c:f:d:}")
+    """
+
+    cdef object[PackedStructWithNDArrays] buf = MockBuffer(
+        fmt, sizeof(PackedStructWithNDArrays))
+
+
 # TODO: empty struct
 # TODO: Incomplete structs
 # TODO: mixed structs

--- a/tests/memoryview/numpy_memoryview.pyx
+++ b/tests/memoryview/numpy_memoryview.pyx
@@ -718,3 +718,19 @@ def test_boundscheck_and_wraparound(double[:, :] x):
         x[i]
         x[i, ...]
         x[i, :]
+
+
+ctypedef struct SameTypeAfterArraysStruct:
+    double a[16]
+    double b[16]
+    double c
+
+@testcase
+def same_type_after_arrays():
+    """
+    >>> same_type_after_arrays()
+    """
+
+    cdef SameTypeAfterArraysStruct element
+    arr = np.ones(2, np.asarray(<SameTypeAfterArraysStruct[:1]>&element).dtype)
+    cdef SameTypeAfterArraysStruct[:] memview = arr

--- a/tests/memoryview/numpy_memoryview.pyx
+++ b/tests/memoryview/numpy_memoryview.pyx
@@ -720,17 +720,39 @@ def test_boundscheck_and_wraparound(double[:, :] x):
         x[i, :]
 
 
-ctypedef struct SameTypeAfterArraysStruct:
+ctypedef struct SameTypeAfterArraysStructSimple:
     double a[16]
     double b[16]
     double c
 
 @testcase
-def same_type_after_arrays():
+def same_type_after_arrays_simple():
     """
-    >>> same_type_after_arrays()
+    >>> same_type_after_arrays_simple()
     """
 
-    cdef SameTypeAfterArraysStruct element
-    arr = np.ones(2, np.asarray(<SameTypeAfterArraysStruct[:1]>&element).dtype)
-    cdef SameTypeAfterArraysStruct[:] memview = arr
+    cdef SameTypeAfterArraysStructSimple element
+    arr = np.ones(2, np.asarray(<SameTypeAfterArraysStructSimple[:1]>&element).dtype)
+    cdef SameTypeAfterArraysStructSimple[:] memview = arr
+
+
+ctypedef struct SameTypeAfterArraysStructComposite:
+    int a
+    float b[8]
+    float c
+    unsigned long d
+    int e[5]
+    int f
+    int g
+    double h[4]
+    int i
+
+@testcase
+def same_type_after_arrays_composite():
+    """
+    >>> same_type_after_arrays_composite()
+    """
+
+    cdef SameTypeAfterArraysStructComposite element
+    arr = np.ones(2, np.asarray(<SameTypeAfterArraysStructComposite[:1]>&element).dtype)
+    cdef SameTypeAfterArraysStructComposite[:] memview = arr


### PR DESCRIPTION
This is an attempt to address #1407. In particular the case where there is a struct with array members, followed by a single element of the same type, such as:

```cython
ctypedef struct SameTypeAfterArraysStruct:
    double a[16]
    double b[16]
    double c
```

A new test is included for this also.  I _think_ this addresses the issue with no side-effects (based on a before and after comparison of the test suite results).  This is also my first PR to Cython and attempt to look into the code base, so my apologies if I have misused some terminology.