### PR TITLE
Generate a compiler warning on PyInit_ModuleName

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -240,8 +240,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
             h_code.putln("#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 5 "
-                "&& (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
-            h_code.putln("#if defined(__GNUC__) || defined(__clang__)")
+                "&& (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER) "
+                "|| (defined(__cplusplus) && __cplusplus >= 201402L))")
+            h_code.putln("#if defined(__cplusplus) && __cplusplus >= 201402L")
+            h_code.putln("[[deprecated(%s)]] inline" % warning_string.as_c_string_literal())
+            h_code.putln("#elif defined(__GNUC__) || defined(__clang__)")
             h_code.putln('__attribute__ ((__deprecated__(%s), __unused__)) __inline__' % (
                 warning_string.as_c_string_literal()))
             h_code.putln("#elif defined(_MSC_VER)")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -239,7 +239,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln('/* WARNING: %s from Python 3.5 */' % warning_string.rstrip('.'))
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
-            h_code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT "
+            h_code.putln("#if PY_VERSION_HEX >= 0x03050000 "
                 "&& (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER) "
                 "|| (defined(__cplusplus) && __cplusplus >= 201402L))")
             h_code.putln("#if defined(__cplusplus) && __cplusplus >= 201402L")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -234,19 +234,19 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln("PyMODINIT_FUNC init%s(void);" % py2_mod_name)
             h_code.putln("#else")
             py3_mod_func_name = self.mod_init_func_cname('PyInit', env)
-            warning_string = EncodedString(
-                'Use PyImport_AppendInittab("%s", %s) instead of calling %s directly.' % (
-                                    py2_mod_name, py3_mod_func_name, py3_mod_func_name))
-            h_code.putln('/* WARNING: From Python 3.5 %s */' % warning_string)
+            warning_string = EncodedString('Use PyImport_AppendInittab("%s", %s) instead of calling %s directly.' % (
+                py2_mod_name, py3_mod_func_name, py3_mod_func_name))
+            h_code.putln('/* WARNING: %s from Python 3.5 */' % warning_string[:-1])
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
-            h_code.putln("#if PY_MINOR_VERSION >= 5 && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
+            h_code.putln("#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 5 "
+                "&& (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
             h_code.putln("#if defined(__GNUC__) || defined(__clang__)")
             h_code.putln('__attribute__ ((__deprecated__(%s), __unused__)) __inline__' % (
-                            warning_string.as_c_string_literal()))
+                warning_string.as_c_string_literal()))
             h_code.putln("#elif defined(_MSC_VER)")
             h_code.putln('__declspec(deprecated(%s)) __inline' % (
-                            warning_string.as_c_string_literal()))
+                warning_string.as_c_string_literal()))
             h_code.putln('#endif')
             h_code.putln("static PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
             h_code.putln("return res;")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -236,7 +236,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             py3_mod_func_name = self.mod_init_func_cname('PyInit', env)
             warning_string = EncodedString('Use PyImport_AppendInittab("%s", %s) instead of calling %s directly.' % (
                 py2_mod_name, py3_mod_func_name, py3_mod_func_name))
-            h_code.putln('/* WARNING: %s from Python 3.5 */' % warning_string[:-1])
+            h_code.putln('/* WARNING: %s from Python 3.5 */' % warning_string.rstrip('.'))
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
             h_code.putln("#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 5 "

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -239,7 +239,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln('/* WARNING: %s from Python 3.5 */' % warning_string.rstrip('.'))
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
-            h_code.putln("#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 5 "
+            h_code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT "
                 "&& (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER) "
                 "|| (defined(__cplusplus) && __cplusplus >= 201402L))")
             h_code.putln("#if defined(__cplusplus) && __cplusplus >= 201402L")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -234,22 +234,21 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln("PyMODINIT_FUNC init%s(void);" % py2_mod_name)
             h_code.putln("#else")
             py3_mod_func_name = self.mod_init_func_cname('PyInit', env)
-            warning_string1 = EncodedString('Use PyImport_AppendInittab("%s", %s)' % (
-                                    py2_mod_name, py3_mod_func_name))
-            warning_string2 = 'instead of calling %s directly.' % py3_mod_func_name
-            h_code.putln('/* WARNING: From Python 3.5 %s */' % warning_string1)
-            h_code.putln("/* %s */" % warning_string2)
+            warning_string = EncodedString(
+                'Use PyImport_AppendInittab("%s", %s) instead of calling %s directly.' % (
+                                    py2_mod_name, py3_mod_func_name, py3_mod_func_name))
+            h_code.putln('/* WARNING: From Python 3.5 %s */' % warning_string)
             h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
             h_code.putln("")
             h_code.putln("#if PY_MINOR_VERSION >= 5 && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
             h_code.putln("#if defined(__GNUC__) || defined(__clang__)")
-            h_code.putln('__attribute__ ((__deprecated__(%s" %s"), __unused__)) __inline__' % (
-                warning_string1.as_c_string_literal(), warning_string2))
+            h_code.putln('__attribute__ ((__deprecated__(%s), __unused__)) __inline__' % (
+                            warning_string.as_c_string_literal()))
             h_code.putln("#elif defined(_MSC_VER)")
-            h_code.putln('__declspec(deprecated(%s" %s")) __inline' % (
-                warning_string1.as_c_string_literal(), warning_string2))
+            h_code.putln('__declspec(deprecated(%s)) __inline' % (
+                            warning_string.as_c_string_literal()))
             h_code.putln('#endif')
-            h_code.putln("PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
+            h_code.putln("static PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
             h_code.putln("return res;")
             h_code.putln("}")
             # Function call is converted to warning macro; uncalled (pointer) is not

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -233,8 +233,30 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 h_code.putln('#error "Unicode module names are not supported in Python 2";')
             h_code.putln("PyMODINIT_FUNC init%s(void);" % py2_mod_name)
             h_code.putln("#else")
-            h_code.putln("PyMODINIT_FUNC %s(void);" % self.mod_init_func_cname('PyInit', env))
-            h_code.putln("#endif")
+            py3_mod_func_name = self.mod_init_func_cname('PyInit', env)
+            warning_string1 = EncodedString('Use PyImport_AppendInittab("%s", %s)' % (
+                                    py2_mod_name, py3_mod_func_name))
+            warning_string2 = 'instead of calling %s directly.' % py3_mod_func_name
+            h_code.putln('/* WARNING: From Python 3.5 %s */' % warning_string1)
+            h_code.putln("/* %s */" % warning_string2)
+            h_code.putln("PyMODINIT_FUNC %s(void);" % py3_mod_func_name)
+            h_code.putln("")
+            h_code.putln("#if PY_MINOR_VERSION >= 5 && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
+            h_code.putln("#if defined(__GNUC__) || defined(__clang__)")
+            h_code.putln('__attribute__ ((__deprecated__(%s" %s"), __unused__))' % (
+                warning_string1.as_c_string_literal(), warning_string2))
+            h_code.putln("#elif defined(_MSC_VER)")
+            h_code.putln('__declspec(deprecated(%s" %s"))' % (
+                warning_string1.as_c_string_literal(), warning_string2))
+            h_code.putln('#endif')
+            h_code.putln("inline PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
+            h_code.putln("return res;")
+            h_code.putln("}")
+            # Function call is converted to warning macro; uncalled (pointer) is not
+            h_code.putln('#define %s() __PYX_WARN_IF_INIT_CALLED(%s())' % (
+                py3_mod_func_name, py3_mod_func_name))
+            h_code.putln('#endif')
+            h_code.putln('#endif')
             h_code.putln("")
             h_code.putln("#endif /* !%s */" % h_guard)
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -243,13 +243,13 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln("")
             h_code.putln("#if PY_MINOR_VERSION >= 5 && (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))")
             h_code.putln("#if defined(__GNUC__) || defined(__clang__)")
-            h_code.putln('__attribute__ ((__deprecated__(%s" %s"), __unused__))' % (
+            h_code.putln('__attribute__ ((__deprecated__(%s" %s"), __unused__)) __inline__' % (
                 warning_string1.as_c_string_literal(), warning_string2))
             h_code.putln("#elif defined(_MSC_VER)")
-            h_code.putln('__declspec(deprecated(%s" %s"))' % (
+            h_code.putln('__declspec(deprecated(%s" %s")) __inline' % (
                 warning_string1.as_c_string_literal(), warning_string2))
             h_code.putln('#endif')
-            h_code.putln("inline PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
+            h_code.putln("PyObject* __PYX_WARN_IF_INIT_CALLED(PyObject* res) {")
             h_code.putln("return res;")
             h_code.putln("}")
             # Function call is converted to warning macro; uncalled (pointer) is not


### PR DESCRIPTION
For 3.5+ (where inittab should be used instead). Generates a warning for GCC, Clang
and MSVC.

I'm relatively confident of the MSVC version but haven't actually been able to test it so please don't merge without looking at the windows tests!

-------------------------

Related to https://github.com/cython/cython/issues/3510

This is an attempt to reduce the number of bug reports of "I'm embedding a module and it crashed" due to calling the init function. It obviously adds a little bit of not very readable boilerplate code, but I can't see a better way of doing it and I think the warning is worthwhile.