### PR TITLE
Fix overflow_check

### DIFF
--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -371,12 +371,18 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
 /////////////// LeftShift.proto ///////////////
 
 static CYTHON_INLINE {{TYPE}} __Pyx_lshift_{{NAME}}_checking_overflow({{TYPE}} a, {{TYPE}} b, int *overflow) {
-    *overflow |=
+    int overflow_check =
 #if {{SIGNED}}
-        (b < 0) |
+        (a < 0) || (b < 0) ||
 #endif
-        (b > ({{TYPE}}) (8 * sizeof({{TYPE}}))) | (a > (__PYX_MAX({{TYPE}}) >> b));
-    return a << b;
+        // the following must be a _logical_ OR as the RHS is undefined if the LHS is true
+        (b >= ({{TYPE}}) (8 * sizeof({{TYPE}}))) || (a > (__PYX_MAX({{TYPE}}) >> b));
+    if (overflow_check) {
+        *overflow |= 1;
+        return 0;
+    } else {
+        return a << b;
+    }
 }
 #define __Pyx_lshift_const_{{NAME}}_checking_overflow __Pyx_lshift_{{NAME}}_checking_overflow
 

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -170,17 +170,17 @@ static CYTHON_INLINE {{INT}} __Pyx_add_const_{{NAME}}_checking_overflow({{INT}} 
     } else if (b < 0) {
         *overflow |= a < __PYX_MIN({{INT}}) - b;
     }
-    return a + b;
+    return ({{INT}}) ((unsigned {{INT}}) a + (unsigned {{INT}}) b);
 }
 
 static CYTHON_INLINE {{INT}} __Pyx_sub_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     *overflow |= b == __PYX_MIN({{INT}});
-    return __Pyx_add_{{NAME}}_checking_overflow(a, -b, overflow);
+    return __Pyx_add_{{NAME}}_checking_overflow(a, ({{INT}}) -((unsigned {{INT}}) b), overflow);
 }
 
 static CYTHON_INLINE {{INT}} __Pyx_sub_const_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     *overflow |= b == __PYX_MIN({{INT}});
-    return __Pyx_add_const_{{NAME}}_checking_overflow(a, -b, overflow);
+    return __Pyx_add_const_{{NAME}}_checking_overflow(a, ({{INT}}) -((unsigned {{INT}}) b), overflow);
 }
 
 static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
@@ -197,12 +197,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
         return ({{INT}}) r;
 #endif
     } else {
-        {{INT}} prod = a * b;
-        double dprod = ((double) a) * ((double) b);
-        // Overflow results in an error of at least 2^sizeof(INT),
-        // whereas rounding represents an error on the order of 2^(sizeof(INT)-53).
-        *overflow |= fabs(dprod - prod) > (__PYX_MAX({{INT}}) / 2);
-        return prod;
+        return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
     }
 }
 
@@ -216,7 +211,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
         *overflow |= a > __PYX_MIN({{INT}}) / b;
         *overflow |= a < __PYX_MAX({{INT}}) / b;
     }
-    return a * b;
+    return ({{INT}}) ((unsigned {{INT}}) a * (unsigned {{INT}}) b);
 }
 
 static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
@@ -225,7 +220,7 @@ static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{I
         return 0;
     }
     *overflow |= (a == __PYX_MIN({{INT}})) & (b == -1);
-    return a / b;
+    return ({{INT}}) ((unsigned {{INT}}) a / (unsigned {{INT}}) b);
 }
 
 

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -56,8 +56,10 @@ static int __Pyx_check_twos_complement(void) {
 
 #if defined(__GNUC__)
 #  define __Pyx_is_constant(x) (__builtin_constant_p(x))
-#elif (defined(__has_builtin) && __has_builtin(__builtin_constant_p))
-#  define __Pyx_is_constant(x) (__builtin_constant_p(x))
+#elif (defined(__has_builtin))
+#  if __has_builtin(__builtin_constant_p))
+#    define __Pyx_is_constant(x) (__builtin_constant_p(x))
+#  endif
 #else
 #  define __Pyx_is_constant(x) (0)
 #endif

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -46,6 +46,14 @@ static int __Pyx_check_twos_complement(void) {
 #define __Pyx_div_no_overflow(a, b, overflow) ((a) / (b))
 #define __Pyx_div_const_no_overflow(a, b, overflow) ((a) / (b))
 
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_add_overflow) && !defined(__ibmxl__)
+#    define HAVE_BUILTIN_OVERFLOW
+#  endif
+#elif defined(__GNUC__) && (__GNUC__ >= 5) && (!defined(__INTEL_COMPILER) || (__INTEL_COMPILER >= 1800))
+#  define HAVE_BUILTIN_OVERFLOW
+#endif
+
 #if defined(__GNUC__)
 #  define __Pyx_constant_p(x) (__builtin_constant_p(x))
 #elif (defined(__has_builtin) && __has_builtin(__builtin_constant_p))
@@ -72,10 +80,36 @@ static CYTHON_INLINE {{UINT}} __Pyx_div_{{NAME}}_checking_overflow({{UINT}} a, {
 // Use these when b is known at compile time.
 #define __Pyx_add_const_{{NAME}}_checking_overflow __Pyx_add_{{NAME}}_checking_overflow
 #define __Pyx_sub_const_{{NAME}}_checking_overflow __Pyx_sub_{{NAME}}_checking_overflow
+#if defined(HAVE_BUILTIN_OVERFLOW)
+#define __Pyx_mul_const_{{NAME}}_checking_overflow __Pyx_mul_{{NAME}}_checking_overflow
+#else
 static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} constant, int *overflow);
+#endif
 #define __Pyx_div_const_{{NAME}}_checking_overflow __Pyx_div_{{NAME}}_checking_overflow
 
 /////////////// BaseCaseUnsigned ///////////////
+
+#if defined(HAVE_BUILTIN_OVERFLOW)
+
+static CYTHON_INLINE {{UINT}} __Pyx_add_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
+    {{UINT}} result;
+    *overflow |= __builtin_add_overflow(a, b, &result);
+    return result;
+}
+
+static CYTHON_INLINE {{UINT}} __Pyx_sub_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
+    {{UINT}} result;
+    *overflow |= __builtin_sub_overflow(a, b, &result);
+    return result;
+}
+
+static CYTHON_INLINE {{UINT}} __Pyx_mul_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
+    {{UINT}} result;
+    *overflow |= __builtin_mul_overflow(a, b, &result);
+    return result;
+}
+
+#else
 
 static CYTHON_INLINE {{UINT}} __Pyx_add_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
     {{UINT}} r = a + b;
@@ -131,6 +165,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}
         *overflow |= a > (__PYX_MAX({{UINT}}) / b);
     return prod;
 }
+#endif // HAVE_BUILTIN_OVERFLOW
 
 
 static CYTHON_INLINE {{UINT}} __Pyx_div_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
@@ -153,10 +188,36 @@ static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{I
 // Use when b is known at compile time.
 #define __Pyx_add_const_{{NAME}}_checking_overflow __Pyx_add_{{NAME}}_checking_overflow
 #define __Pyx_sub_const_{{NAME}}_checking_overflow __Pyx_sub_{{NAME}}_checking_overflow
+#if defined(HAVE_BUILTIN_OVERFLOW)
+#define __Pyx_mul_const_{{NAME}}_checking_overflow __Pyx_mul_{{NAME}}_checking_overflow
+#else
 static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} a, {{INT}} constant, int *overflow);
+#endif
 #define __Pyx_div_const_{{NAME}}_checking_overflow __Pyx_div_{{NAME}}_checking_overflow
 
 /////////////// BaseCaseSigned ///////////////
+
+#if defined(HAVE_BUILTIN_OVERFLOW)
+
+static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
+    {{INT}} result;
+    *overflow |= __builtin_add_overflow(a, b, &result);
+    return result;
+}
+
+static CYTHON_INLINE {{INT}} __Pyx_sub_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
+    {{INT}} result;
+    *overflow |= __builtin_sub_overflow(a, b, &result);
+    return result;
+}
+
+static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
+    {{INT}} result;
+    *overflow |= __builtin_mul_overflow(a, b, &result);
+    return result;
+}
+
+#else
 
 static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     if ((sizeof({{INT}}) < sizeof(long))) {
@@ -241,6 +302,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
     }
     return ({{INT}}) (((unsigned {{INT}})a) * ((unsigned {{INT}}) b));
 }
+#endif  // defined(HAVE_BUILTIN_OVERFLOW)
 
 static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     if (b == 0) {

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -149,8 +149,11 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_{{NAME}}_checking_overflow({{UINT}} a, {
 }
 
 static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
+    // note that deliberately the overflow check is written such that it divides by b; this
+    // function is used when b is a constant thus the compiler should be able to eliminate the
+    // (very slow on most CPUs!) division operation
     if (__Pyx_is_constant(a) && !__Pyx_is_constant(b)) {
-        // paranoia
+        // if a is a compile-time constant and b isn't, swap them
         {{UINT}} temp = b;
         b = a;
         a = temp;
@@ -271,10 +274,10 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
 
 static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     // note that deliberately all these comparisons are written such that they divide by b; this
-    // function is used when b is a constant thus the compiler can eliminate the (very slow on most
-    // CPUs!) division operations
+    // function is used when b is a constant thus the compiler should be able to eliminate the
+    // (very slow on most CPUs!) division operations
     if (__Pyx_is_constant(a) && !__Pyx_is_constant(b)) {
-        // paranoia
+        // if a is a compile-time constant and b isn't, swap them
         {{INT}} temp = b;
         b = a;
         a = temp;

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -48,10 +48,10 @@ static int __Pyx_check_twos_complement(void) {
 
 #if defined(__has_builtin)
 #  if __has_builtin(__builtin_add_overflow) && !defined(__ibmxl__)
-#    define HAVE_BUILTIN_OVERFLOW
+#    define __PYX_HAVE_BUILTIN_OVERFLOW
 #  endif
 #elif defined(__GNUC__) && (__GNUC__ >= 5) && (!defined(__INTEL_COMPILER) || (__INTEL_COMPILER >= 1800))
-#  define HAVE_BUILTIN_OVERFLOW
+#  define __PYX_HAVE_BUILTIN_OVERFLOW
 #endif
 
 #if defined(__GNUC__)
@@ -80,7 +80,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_div_{{NAME}}_checking_overflow({{UINT}} a, {
 // Use these when b is known at compile time.
 #define __Pyx_add_const_{{NAME}}_checking_overflow __Pyx_add_{{NAME}}_checking_overflow
 #define __Pyx_sub_const_{{NAME}}_checking_overflow __Pyx_sub_{{NAME}}_checking_overflow
-#if defined(HAVE_BUILTIN_OVERFLOW)
+#if defined(__PYX_HAVE_BUILTIN_OVERFLOW)
 #define __Pyx_mul_const_{{NAME}}_checking_overflow __Pyx_mul_{{NAME}}_checking_overflow
 #else
 static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} constant, int *overflow);
@@ -89,7 +89,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}
 
 /////////////// BaseCaseUnsigned ///////////////
 
-#if defined(HAVE_BUILTIN_OVERFLOW)
+#if defined(__PYX_HAVE_BUILTIN_OVERFLOW)
 
 static CYTHON_INLINE {{UINT}} __Pyx_add_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
     {{UINT}} result;
@@ -165,7 +165,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}
         *overflow |= a > (__PYX_MAX({{UINT}}) / b);
     return prod;
 }
-#endif // HAVE_BUILTIN_OVERFLOW
+#endif // __PYX_HAVE_BUILTIN_OVERFLOW
 
 
 static CYTHON_INLINE {{UINT}} __Pyx_div_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
@@ -188,7 +188,7 @@ static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{I
 // Use when b is known at compile time.
 #define __Pyx_add_const_{{NAME}}_checking_overflow __Pyx_add_{{NAME}}_checking_overflow
 #define __Pyx_sub_const_{{NAME}}_checking_overflow __Pyx_sub_{{NAME}}_checking_overflow
-#if defined(HAVE_BUILTIN_OVERFLOW)
+#if defined(__PYX_HAVE_BUILTIN_OVERFLOW)
 #define __Pyx_mul_const_{{NAME}}_checking_overflow __Pyx_mul_{{NAME}}_checking_overflow
 #else
 static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} a, {{INT}} constant, int *overflow);
@@ -197,7 +197,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
 
 /////////////// BaseCaseSigned ///////////////
 
-#if defined(HAVE_BUILTIN_OVERFLOW)
+#if defined(__PYX_HAVE_BUILTIN_OVERFLOW)
 
 static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     {{INT}} result;
@@ -302,7 +302,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
     }
     return ({{INT}}) (((unsigned {{INT}})a) * ((unsigned {{INT}}) b));
 }
-#endif  // defined(HAVE_BUILTIN_OVERFLOW)
+#endif  // defined(__PYX_HAVE_BUILTIN_OVERFLOW)
 
 static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     if (b == 0) {

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -55,11 +55,11 @@ static int __Pyx_check_twos_complement(void) {
 #endif
 
 #if defined(__GNUC__)
-#  define __Pyx_constant_p(x) (__builtin_constant_p(x))
+#  define __Pyx_is_constant(x) (__builtin_constant_p(x))
 #elif (defined(__has_builtin) && __has_builtin(__builtin_constant_p))
-#  define __Pyx_constant_p(x) (__builtin_constant_p(x))
+#  define __Pyx_is_constant(x) (__builtin_constant_p(x))
 #else
-#  define __Pyx_constant_p(x) (0)
+#  define __Pyx_is_constant(x) (0)
 #endif
 
 /////////////// Common.init ///////////////
@@ -125,9 +125,9 @@ static CYTHON_INLINE {{UINT}} __Pyx_sub_{{NAME}}_checking_overflow({{UINT}} a, {
 
 static CYTHON_INLINE {{UINT}} __Pyx_mul_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
     // if we have a constant, use the constant version
-    if (__Pyx_constant_p(b)) {
+    if (__Pyx_is_constant(b)) {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
-    } else if (__Pyx_constant_p(a)) {
+    } else if (__Pyx_is_constant(a)) {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(b, a, overflow);
     } else if ((sizeof({{UINT}}) < sizeof(unsigned long))) {
         unsigned long big_r = ((unsigned long) a) * ((unsigned long) b);
@@ -154,7 +154,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_{{NAME}}_checking_overflow({{UINT}} a, {
 }
 
 static CYTHON_INLINE {{UINT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{UINT}} a, {{UINT}} b, int *overflow) {
-    if (__Pyx_constant_p(a) && !__Pyx_constant_p(b)) {
+    if (__Pyx_is_constant(a) && !__Pyx_is_constant(b)) {
         // paranoia
         {{UINT}} temp = b;
         b = a;
@@ -253,9 +253,9 @@ static CYTHON_INLINE {{INT}} __Pyx_sub_{{NAME}}_checking_overflow({{INT}} a, {{I
 
 static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     // if we have a constant, use the constant version
-    if (__Pyx_constant_p(b)) {
+    if (__Pyx_is_constant(b)) {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
-    } else if (__Pyx_constant_p(a)) {
+    } else if (__Pyx_is_constant(a)) {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(b, a, overflow);
     } else if ((sizeof({{INT}}) < sizeof(long))) {
         long big_r = ((long) a) * ((long) b);
@@ -285,7 +285,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
     // note that deliberately all these comparisons are written such that they divide by b; this
     // function is used when b is a constant thus the compiler can eliminate the (very slow on most
     // CPUs!) division operations
-    if (__Pyx_constant_p(a) && !__Pyx_constant_p(b)) {
+    if (__Pyx_is_constant(a) && !__Pyx_is_constant(b)) {
         // paranoia
         {{INT}} temp = b;
         b = a;

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -231,7 +231,9 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
         return r;
 #endif
     } else {
-        // Signed overflow undefined, but unsigned overflow is well defined.
+        // Signed overflow undefined, but unsigned overflow is well defined. Casting is
+        // implementation-defined, but we assume two's complement (see __Pyx_check_twos_complement
+        // above), and arithmetic in two's-complement is the same as unsigned arithmetic.
         unsigned {{INT}} r = (unsigned {{INT}}) a + (unsigned {{INT}}) b;
         // Overflow happened if the operands have the same sign, but the result
         // has opposite sign.
@@ -241,7 +243,7 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
 }
 
 static CYTHON_INLINE {{INT}} __Pyx_sub_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
-    // Compilers don't handle widening as well in the subtraction case
+    // Compilers don't handle widening as well in the subtraction case, so don't bother
     unsigned {{INT}} r = (unsigned {{INT}}) a - (unsigned {{INT}}) b;
     // Overflow happened if the operands differing signs, and the result
     // has opposite sign to a.

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -144,14 +144,7 @@ static CYTHON_INLINE {{UINT}} __Pyx_mul_{{NAME}}_checking_overflow({{UINT}} a, {
         return r;
 #endif
     } else {
-        // somewhat surprisingly, at least on x86_64 it's quicker to use floats (c.f. the const
-        // variant below)
-        {{UINT}} r = a * b;
-        float fprod = ((float) a) * ((float) b);
-        // Overflow results in an error of at least 2^sizeof(UINT),
-        // whereas rounding represents an error on the order of 2^(sizeof(UINT)-23).
-        *overflow |= fabs(fprod - r) > ((float)(__PYX_MAX({{UINT}})) / 2);
-        return r;
+        return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
     }
 }
 
@@ -272,14 +265,7 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
         return ({{INT}}) r;
 #endif
     } else {
-        // somewhat surprisingly, at least on x86_64 it's quicker to use floats (c.f. the const
-        // variant below)
-        {{INT}} r = ({{INT}}) (((unsigned {{INT}})a) * ((unsigned {{INT}}) b));
-        float fprod = ((float) a) * ((float) b);
-        // Overflow results in an error of at least 2^sizeof(UINT),
-        // whereas rounding represents an error on the order of 2^(sizeof(UINT)-23).
-        *overflow |= fabs(fprod - r) > ((float)(__PYX_MAX({{INT}})) / 2);
-        return r;
+        return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
     }
 }
 

--- a/tests/run/overflow_check.pxi
+++ b/tests/run/overflow_check.pxi
@@ -1,14 +1,15 @@
 cimport cython
 
 cdef object two = 2
-cdef int size_in_bits = sizeof(INT) * 8
 
+cdef int size_in_bits_ = sizeof(INT) * 8
 cdef bint is_signed_ = not ((<INT>-1) > 0)
-cdef INT max_value_ = <INT>(two ** (size_in_bits - is_signed_) - 1)
+cdef INT max_value_ = <INT>(two ** (size_in_bits_ - is_signed_) - 1)
 cdef INT min_value_ = ~max_value_
 cdef INT half_ = max_value_ // <INT>2
 
 # Python visible.
+size_in_bits = size_in_bits_
 is_signed = is_signed_
 max_value = max_value_
 min_value = min_value_
@@ -230,6 +231,17 @@ def test_lshift(INT a, int b):
     """
     >>> test_lshift(1, 10)
     1024
+    >>> test_lshift(1, size_in_bits - 2) == 1 << (size_in_bits - 2)
+    True
+    >>> test_lshift(0, size_in_bits - 1)
+    0
+    >>> test_lshift(1, size_in_bits - 1) == 1 << (size_in_bits - 1) if not is_signed else True
+    True
+    >>> if is_signed: expect_overflow(test_lshift, 1, size_in_bits - 1)
+    >>> expect_overflow(test_lshift, 0, size_in_bits)
+    >>> expect_overflow(test_lshift, 1, size_in_bits)
+    >>> expect_overflow(test_lshift, 0, size_in_bits + 1)
+    >>> expect_overflow(test_lshift, 1, size_in_bits + 1)
     >>> expect_overflow(test_lshift, 1, 100)
     >>> expect_overflow(test_lshift, max_value, 1)
     >>> test_lshift(max_value, 0) == max_value


### PR DESCRIPTION
Fixes #3588, and while we're at it improves all the (arithmetic) overflow detection code, including adding support for the gcc 5+/clang 3.4+ `__builtin_XXX_overflow`.

Looking at `Demos/benchmarks/chaos.py` (the only file in that directory significantly affected by enabling `overflowcheck`, with the non-`__builtin_XXX_overflow` code paths we gain 2%, and with them we gain 4% (and that's then only 1% behind `overflowcheck=False`).