### PR TITLE
Reimplement __Pyx_PyDict_GetItemStrWithError() in Py2 to fix a refleak

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Bugs fixed
   could fail to acquire the GIL in some cases on function exit.
   (Github issue #3590 etc.)
 
+* A reference leak when processing keyword arguments in Py2 was resolved,
+  that appeared in 3.0a1.
+  (Github issue #3578)
+
 * The outdated getbuffer/releasebuffer implementations in the NumPy
   declarations were removed so that buffers declared as ``ndarray``
   now use the normal implementation in NumPy.


### PR DESCRIPTION
Reimplement __Pyx_PyDict_GetItemStrWithError() as a hacky version in Py2 to get the semantics right of returning a borrowed reference with non-KeyError exceptions left in place.

Closes https://github.com/cython/cython/issues/3578
Supersedes https://github.com/cython/cython/pull/3592.