### PR TITLE
Fixed illegal casting of struct via ctuple

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4207,6 +4207,9 @@ class CTupleType(CType):
         env.use_utility_code(self._convert_from_py_code)
         return True
 
+    def cast_code(self, expr_code):
+        return expr_code
+
 
 def c_tuple_type(components):
     components = tuple(components)

--- a/tests/compile/ctuple_no_cast.pyx
+++ b/tests/compile/ctuple_no_cast.pyx
@@ -1,4 +1,0 @@
-# mode: compile
-
-def test((int, int) t):
-    pass

--- a/tests/compile/ctuple_no_cast.pyx
+++ b/tests/compile/ctuple_no_cast.pyx
@@ -1,0 +1,4 @@
+# mode: compile
+
+def test((int, int) t):
+    pass

--- a/tests/windows_bugs.txt
+++ b/tests/windows_bugs.txt
@@ -6,7 +6,6 @@ initial_file_path
 package_compilation
 
 carray_coercion
-ctuple
 int_float_builtins_as_casts_T400
 int_float_builtins_as_casts_T400_long_double
 list_pop


### PR DESCRIPTION
Fixes #3038. 

Structs are not allowed to be casted according to the C standard, and MSVC gives the compile error `C2440` accordingly. This is already being accounted for structs directly, but not for ctuples.

I ran into this because python accessible `def` functions generate a wrapper and call the actual function with a argument list in which ctuples were casted, which resulted in a compiler error.

Can be tested with this code:

```
def test((int, int) t):
    print(t)
```

(I hope the test case is correctly written)