### PR TITLE
Optimize iterating over char*/bytes/unicode slices

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4892,6 +4892,12 @@ class SliceIndexNode(ExprNode):
             node.type = py_object_type
         return node
 
+    Pyx_strlen_func_type = PyrexTypes.CFuncType(
+        PyrexTypes.c_size_t_type, [
+            PyrexTypes.CFuncTypeArg("bytes", PyrexTypes.c_const_char_ptr_type, None)
+        ],
+        nogil=True)
+
     def analyse_types(self, env, getting=True):
         self.base = self.base.analyse_types(env)
 
@@ -4958,10 +4964,13 @@ class SliceIndexNode(ExprNode):
                 # Coerce to Py_ssize_t, but allow None as meaning the default slice bound.
                 from .UtilNodes import EvalWithTempExprNode, ResultRefNode
 
+                if not node.may_be_none():
+                    return node
+
                 node_ref = ResultRefNode(node)
                 new_expr = CondExprNode(
                     node.pos,
-                    true_val=IntNode(
+                    true_val=default_value if isinstance(default_value, ExprNode) else IntNode(
                         node.pos,
                         type=c_int,
                         value=default_value,
@@ -4981,9 +4990,21 @@ class SliceIndexNode(ExprNode):
                 if self.start.type.is_pyobject:
                     self.start = allow_none(self.start, '0', env)
                 self.start = self.start.coerce_to(c_int, env)
+            if self.base.type.is_string and getting:
+                default = PythonCapiCallNode(
+                    self.stop.pos if self.stop else self.pos,
+                    "strlen",
+                    self.Pyx_strlen_func_type,
+                    args=[self.base],
+                    is_temp=False,
+                    utility_code=UtilityCode.load_cached("IncludeStringH", "StringTools.c"))
+                if self.stop is None:
+                    self.stop = default
+                elif self.stop.type.is_pyobject:
+                    self.stop = allow_none(self.stop, default, env)
+            elif self.stop and self.stop.type.is_pyobject:
+                self.stop = allow_none(self.stop, 'PY_SSIZE_T_MAX', env)
             if self.stop:
-                if self.stop.type.is_pyobject:
-                    self.stop = allow_none(self.stop, 'PY_SSIZE_T_MAX', env)
                 self.stop = self.stop.coerce_to(c_int, env)
         self.is_temp = 1
         return self
@@ -5049,24 +5070,25 @@ class SliceIndexNode(ExprNode):
                 type_name = 'ByteArray'
             else:
                 type_name = self.type.name.title()
-            if self.stop is None:
-                code.putln(
-                    "%s = __Pyx_Py%s_FromString(%s + %s); %s" % (
-                        result,
-                        type_name,
-                        base_result,
-                        start_code,
-                        code.error_goto_if_null(result, self.pos)))
-            else:
-                code.putln(
-                    "%s = __Pyx_Py%s_FromStringAndSize(%s + %s, %s - %s); %s" % (
-                        result,
-                        type_name,
-                        base_result,
-                        start_code,
-                        stop_code,
-                        start_code,
-                        code.error_goto_if_null(result, self.pos)))
+            assert self.stop is not None
+            code.putln(
+                "if (unlikely(%s <= %s)) { %s = %s; }" % (
+                    stop_code,
+                    start_code,
+                    result,
+                    Naming.empty_bytes))
+            code.putln("else")
+            code.putln("{")
+            code.putln(
+                "%s = __Pyx_Py%s_FromStringAndSize(%s + %s, %s - %s); %s" % (
+                    result,
+                    type_name,
+                    base_result,
+                    start_code,
+                    stop_code,
+                    start_code,
+                    code.error_goto_if_null(result, self.pos)))
+            code.putln("}")
         elif self.base.type.is_pyunicode_ptr:
             base_result = self.base.result()
             if self.base.type != PyrexTypes.c_py_unicode_ptr_type:

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -222,7 +222,9 @@ class IterationTransform(Visitor.EnvTransform):
             return self._transform_set_iteration(node, iterable)
 
         # C array (slice) iteration?
-        if iterable.type.is_ptr or iterable.type.is_array:
+        # note that a slice of char* is typed as bytes, but we can still treat it as a ptr here
+        if iterable.type.is_ptr or iterable.type.is_array \
+                or isinstance(iterable, ExprNodes.SliceIndexNode) and iterable.base.type.is_string:
             return self._transform_carray_iteration(node, iterable, reversed=reversed)
         if iterable.type is Builtin.bytes_type:
             return self._transform_bytes_iteration(node, iterable, reversed=reversed)

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2875,3 +2875,61 @@ static CYTHON_INLINE PyObject *__Pyx_PyUnicode_ConcatInPlaceImpl(PyObject **p_le
     PyNumber_Add(a, b) : __Pyx_PyStr_Concat(a, b))
 #define __Pyx_PyStr_ConcatInPlaceSafe(a, b) ((unlikely((a) == Py_None) || unlikely((b) == Py_None)) ? \
     PyNumber_InPlaceAdd(a, b) : __Pyx_PyStr_ConcatInPlace(a, b))
+
+
+/////////////// PySlice_AdjustIndices.proto ///////////////
+
+#if (PY_VERSION_HEX >= 0x03050400 && PY_VERSION_HEX < 0x03060000) || PY_VERSION_HEX >= 0x03060100
+    #define __Pyx_PySlice_AdjustIndices PySlice_AdjustIndices
+#else
+static CYTHON_INLINE Py_ssize_t __Pyx_PySlice_AdjustIndices(Py_ssize_t length,
+                                                      Py_ssize_t *start, Py_ssize_t *stop,
+                                                      Py_ssize_t step); /* proto */
+#endif
+
+/////////////// PySlice_AdjustIndices ///////////////
+
+#if (PY_VERSION_HEX >= 0x03050400 && PY_VERSION_HEX < 0x03060000) || PY_VERSION_HEX >= 0x03060100
+#else
+// copied from PySlice_AdjustIndicies in CPython 3.6.1+
+static Py_ssize_t __Pyx_PySlice_AdjustIndices(Py_ssize_t length,
+                                                            Py_ssize_t *start, Py_ssize_t *stop,
+                                                            Py_ssize_t step) {
+    /* this is harder to get right than you might think */
+
+    assert(step != 0);
+    assert(step >= -PY_SSIZE_T_MAX);
+
+    if (*start < 0) {
+        *start += length;
+        if (*start < 0) {
+            *start = (step < 0) ? -1 : 0;
+        }
+    }
+    else if (*start >= length) {
+        *start = (step < 0) ? length - 1 : length;
+    }
+
+    if (*stop < 0) {
+        *stop += length;
+        if (*stop < 0) {
+            *stop = (step < 0) ? -1 : 0;
+        }
+    }
+    else if (*stop >= length) {
+        *stop = (step < 0) ? length - 1 : length;
+    }
+
+    if (step < 0) {
+        if (*stop < *start) {
+            return (*start - *stop - 1) / (-step) + 1;
+        }
+    }
+    else {
+        if (*start < *stop) {
+            return (*stop - *start - 1) / step + 1;
+        }
+    }
+    return 0;
+}
+#endif

--- a/tests/run/carray_slicing.pyx
+++ b/tests/run/carray_slicing.pyx
@@ -149,6 +149,104 @@ def slice_charptr_for_loop_c_enumerate():
     print [ (i,c) for i,c in enumerate(cstring[1:5]) ]
     print [ (i,c) for i,c in enumerate(cstring[4:9]) ]
 
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def omit_start_charptr():
+    """
+    >>> omit_start_charptr()
+    abcABCq
+    abcABCqt
+    ['a', 'b', 'c', 'A', 'B', 'C', 'q', 't', 'p']
+    """
+    cdef char c
+    print str(cstring[:7]).replace("b'", "").replace("'", "")
+    print cstring[:8].decode("utf8")
+    print [chr(c) for c in cstring[:9]]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def explicit_none_start_charptr():
+    """
+    >>> explicit_none_start_charptr()
+    abcABCq
+    abcABCqt
+    ['a', 'b', 'c', 'A', 'B', 'C', 'q', 't', 'p']
+    """
+    cdef char c
+    print str(cstring[None:7]).replace("b'", "").replace("'", "")
+    print cstring[None:8].decode("utf8")
+    print [chr(c) for c in cstring[None:9]]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def runtime_start_charptr(object o):
+    """
+    >>> runtime_start_charptr(None)
+    abcABCq
+    abcABCqt
+    ['a', 'b', 'c', 'A', 'B', 'C', 'q', 't', 'p']
+    >>> runtime_start_charptr(3)
+    ABCq
+    ABCqt
+    ['A', 'B', 'C', 'q', 't', 'p']
+    """
+    cdef char c
+    print str(cstring[o:7]).replace("b'", "").replace("'", "")
+    print cstring[o:8].decode("utf8")
+    print [chr(c) for c in cstring[o:9]]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def omit_stop_charptr():
+    """
+    >>> omit_stop_charptr()
+    ABCqtp
+    BCqtp
+    ['C', 'q', 't', 'p']
+    """
+    cdef char c
+    print str(cstring[3:]).replace("b'", "").replace("'", "")
+    print cstring[4:].decode("utf8")
+    print [chr(c) for c in cstring[5:]]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def explicit_none_stop_charptr():
+    """
+    >>> explicit_none_stop_charptr()
+    ABCqtp
+    BCqtp
+    ['C', 'q', 't', 'p']
+    """
+    cdef char c
+    print str(cstring[3:None]).replace("b'", "").replace("'", "")
+    print cstring[4:None].decode("utf8")
+    print [chr(c) for c in cstring[5:None]]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def runtime_stop_charptr(object o):
+    """
+    >>> runtime_stop_charptr(None)
+    ABCqtp
+    BCqtp
+    ['C', 'q', 't', 'p']
+    >>> runtime_stop_charptr(7)
+    ABCq
+    BCq
+    ['C', 'q']
+    """
+    cdef char c
+    print str(cstring[3:o]).replace("b'", "").replace("'", "")
+    print cstring[4:o].decode("utf8")
+    print [chr(c) for c in cstring[5:o]]
+
 
 ############################################################
 # tests for int* slicing

--- a/tests/run/carray_slicing.pyx
+++ b/tests/run/carray_slicing.pyx
@@ -13,27 +13,24 @@ def slice_charptr_end():
     """
     return cstring[:1], cstring[:3], cstring[:9]
 
-#### BROKEN: this test assumes that the result of a char* iteration
-#### becomes a bytes object, which is not the case when applying
-#### carray iteration.  Contradiction.
-##
-## @cython.test_assert_path_exists("//ForFromStatNode",
-##                                 "//ForFromStatNode//SliceIndexNode")
-## @cython.test_fail_if_path_exists("//ForInStatNode")
-## def slice_charptr_for_loop_py():
-##     """
-##     >>> slice_charptr_for_loop_py()
-##     ['a', 'b', 'c']
-##     ['b', 'c', 'A', 'B']
-##     ['B', 'C', 'q', 't', 'p']
-##     """
-##     print str([ c for c in cstring[:3] ]).replace(" b'", " '").replace("[b'", "['")
-##     print str([ c for c in cstring[1:5] ]).replace(" b'", " '").replace("[b'", "['")
-##     print str([ c for c in cstring[4:9] ]).replace(" b'", " '").replace("[b'", "['")
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//SliceIndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def slice_charptr_for_loop_py():
+    """
+    >>> slice_charptr_for_loop_py()
+    ['a', 'b', 'c']
+    ['b', 'c', 'A', 'B']
+    ['B', 'C', 'q', 't', 'p']
+    """
+    print str([ c for c in cstring[:3] ]).replace(" b'", " '").replace("[b'", "['")
+    print str([ c for c in cstring[1:5] ]).replace(" b'", " '").replace("[b'", "['")
+    print str([ c for c in cstring[4:9] ]).replace(" b'", " '").replace("[b'", "['")
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_charptr_for_loop_c():
     """
     >>> slice_charptr_for_loop_c()
@@ -48,9 +45,9 @@ def slice_charptr_for_loop_c():
     print [ chr(c) for c in cstring[1:5] ]
     print [ chr(c) for c in cstring[4:9] ]
 
-#@cython.test_assert_path_exists("//ForFromStatNode",
-#                                "//ForFromStatNode//IndexNode")
-#@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//SliceIndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
 def slice_charptr_for_loop_c_to_bytes():
     """
     >>> slice_charptr_for_loop_c_to_bytes()
@@ -67,7 +64,8 @@ def slice_charptr_for_loop_c_to_bytes():
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_charptr_for_loop_c_step():
     """
     >>> slice_charptr_for_loop_c_step()
@@ -93,7 +91,8 @@ def slice_charptr_for_loop_c_step():
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_charptr_for_loop_c_dynamic_bounds():
     """
     >>> slice_charptr_for_loop_c_dynamic_bounds()
@@ -114,27 +113,24 @@ cdef return4(): return 4
 cdef return5(): return 5
 cdef return9(): return 9
 
-#### BROKEN: this test assumes that the result of a char* iteration
-#### becomes a bytes object, which is not the case when applying
-#### carray iteration.  Contradiction.
-##
-## @cython.test_assert_path_exists("//ForFromStatNode",
-##                                 "//ForFromStatNode//SliceIndexNode")
-## @cython.test_fail_if_path_exists("//ForInStatNode")
-## def slice_charptr_for_loop_py_enumerate():
-##     """
-##     >>> slice_charptr_for_loop_py_enumerate()
-##     [(0, 'a'), (1, 'b'), (2, 'c')]
-##     [(0, 'b'), (1, 'c'), (2, 'A'), (3, 'B')]
-##     [(0, 'B'), (1, 'C'), (2, 'q'), (3, 't'), (4, 'p')]
-##     """
-##     print str([ (i,c) for i,c in enumerate(cstring[:3]) ]).replace(" b'", " '")
-##     print str([ (i,c) for i,c in enumerate(cstring[1:5]) ]).replace(" b'", " '")
-##     print str([ (i,c) for i,c in enumerate(cstring[4:9]) ]).replace(" b'", " '")
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//SliceIndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def slice_charptr_for_loop_py_enumerate():
+    """
+    >>> slice_charptr_for_loop_py_enumerate()
+    [(0, 'a'), (1, 'b'), (2, 'c')]
+    [(0, 'b'), (1, 'c'), (2, 'A'), (3, 'B')]
+    [(0, 'B'), (1, 'C'), (2, 'q'), (3, 't'), (4, 'p')]
+    """
+    print str([ (i,c) for i,c in enumerate(cstring[:3]) ]).replace(" b'", " '")
+    print str([ (i,c) for i,c in enumerate(cstring[1:5]) ]).replace(" b'", " '")
+    print str([ (i,c) for i,c in enumerate(cstring[4:9]) ]).replace(" b'", " '")
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_charptr_for_loop_c_enumerate():
     """
     >>> slice_charptr_for_loop_c_enumerate()
@@ -148,6 +144,24 @@ def slice_charptr_for_loop_c_enumerate():
     print [ (i,c) for i,c in enumerate(cstring[None:3]) ]
     print [ (i,c) for i,c in enumerate(cstring[1:5]) ]
     print [ (i,c) for i,c in enumerate(cstring[4:9]) ]
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
+def slice_charptr_for_loop_c_reversed():
+    """
+    >>> slice_charptr_for_loop_c_reversed()
+    ['c', 'b', 'a']
+    ['c', 'b', 'a']
+    ['B', 'A', 'c', 'b']
+    ['p', 't', 'q', 'C', 'B']
+    """
+    cdef char c
+    print [ chr(c) for c in reversed(cstring[:3]) ]
+    print [ chr(c) for c in reversed(cstring[None:3]) ]
+    print [ chr(c) for c in reversed(cstring[1:5]) ]
+    print [ chr(c) for c in reversed(cstring[4:9]) ]
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
@@ -257,7 +271,8 @@ for i in range(6):
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_intarray_for_loop_c():
     """
     >>> slice_intarray_for_loop_c()
@@ -274,7 +289,8 @@ def slice_intarray_for_loop_c():
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def iter_intarray_for_loop_c():
     """
     >>> iter_intarray_for_loop_c()
@@ -285,7 +301,8 @@ def iter_intarray_for_loop_c():
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_intptr_for_loop_c():
     """
     >>> slice_intptr_for_loop_c()
@@ -313,7 +330,8 @@ cdef double* cdoubles_ptr = cdoubles
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def slice_doublptr_for_loop_c():
     """
     >>> slice_doublptr_for_loop_c()
@@ -344,7 +362,8 @@ def slice_doublptr_for_loop_c():
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def iter_doublearray_for_loop_c():
     """
     >>> iter_doublearray_for_loop_c()
@@ -359,7 +378,8 @@ cdef struct MyStruct:
 
 @cython.test_assert_path_exists("//ForFromStatNode",
                                 "//ForFromStatNode//IndexNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def struct_ptr_iter():
     """
     >>> struct_ptr_iter()

--- a/tests/run/for_in_string.pyx
+++ b/tests/run/for_in_string.pyx
@@ -11,6 +11,11 @@ unicode_abc_null = u'a\0b\0c'
 unicode_ABC_null = u'A\0B\0C'
 
 
+# no optimization as Py2 and Py3 behave differently here: Py2->bytes, Py3->integer
+# @cython.test_assert_path_exists("//ForFromStatNode",
+#                                 "//ForFromStatNode//IndexNode")
+# @cython.test_fail_if_path_exists("//ForInStatNode",
+#                                  "//SliceIndexNode")
 def for_in_bytes(bytes s):
     """
     >>> for_in_bytes(bytes_abc)
@@ -29,8 +34,10 @@ def for_in_bytes(bytes s):
     else:
         return 'X'
 
-@cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_char_in_bytes(bytes s):
     """
     >>> for_char_in_bytes(bytes_abc)
@@ -49,29 +56,53 @@ def for_char_in_bytes(bytes s):
     else:
         return 'X'
 
-#### Py2 and Py3 behave differently here: Py2->bytes, Py3->integer
-##
-## @cython.test_assert_path_exists("//ForFromStatNode")
-## @cython.test_fail_if_path_exists("//ForInStatNode")
-## def for_obj_in_bytes_slice(bytes s):
-##     """
-##     >>> for_obj_in_bytes_slice(bytes_abc)
-##     'X'
-##     >>> for_obj_in_bytes_slice(bytes_ABC)
-##     'B'
-##     >>> for_obj_in_bytes_slice(bytes_abc_null)
-##     'X'
-##     >>> for_obj_in_bytes_slice(bytes_ABC_null)
-##     'B'
-##     """
-##     for c in s[1:-1]:
-##         if c == b'B':
-##             return 'B'
-##     else:
-##         return 'X'
-
 @cython.test_assert_path_exists("//ForFromStatNode")
 @cython.test_fail_if_path_exists("//ForInStatNode")
+def for_bytes_in_bytes(bytes s):
+    """
+    >>> for_bytes_in_bytes(bytes_abc)
+    'X'
+    >>> for_bytes_in_bytes(bytes_ABC)
+    'C'
+    >>> for_bytes_in_bytes(bytes_abc_null)
+    'X'
+    >>> for_bytes_in_bytes(bytes_ABC_null)
+    'C'
+    """
+    cdef bytes c
+    for c in s:
+        if c == b'C':
+            return 'C'
+    else:
+        return 'X'
+
+#### no optimization as Py2 and Py3 behave differently here: Py2->bytes, Py3->integer
+## @cython.test_assert_path_exists("//ForFromStatNode",
+##                                 "//ForFromStatNode//IndexNode")
+## @cython.test_fail_if_path_exists("//ForInStatNode",
+##                                  "//SliceIndexNode")
+def for_obj_in_bytes_slice(bytes s):
+    """
+    >>> for_obj_in_bytes_slice(bytes_abc)
+    'X'
+    >>> for_obj_in_bytes_slice(bytes_ABC)
+    'B'
+    >>> for_obj_in_bytes_slice(bytes_abc_null)
+    'X'
+    >>> for_obj_in_bytes_slice(bytes_ABC_null)
+    'B'
+    """
+    for c in s[1:-1]:
+        # Py2/Py3
+        if c == b'B' or c == c'B':
+            return 'B'
+    else:
+        return 'X'
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_char_in_bytes_slice(bytes s):
     """
     >>> for_char_in_bytes_slice(bytes_abc)
@@ -92,6 +123,28 @@ def for_char_in_bytes_slice(bytes s):
 
 @cython.test_assert_path_exists("//ForFromStatNode")
 @cython.test_fail_if_path_exists("//ForInStatNode")
+def for_bytes_in_bytes_slice(bytes s):
+    """
+    >>> for_char_in_bytes_slice(bytes_abc)
+    'X'
+    >>> for_char_in_bytes_slice(bytes_ABC)
+    'B'
+    >>> for_char_in_bytes_slice(bytes_abc_null)
+    'X'
+    >>> for_char_in_bytes_slice(bytes_ABC_null)
+    'B'
+    """
+    cdef bytes c
+    for c in s[1:-1]:
+        if c == b'B':
+            return 'B'
+    else:
+        return 'X'
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_char_in_enumerate_bytes(bytes s):
     """
     >>> for_char_in_enumerate_bytes(bytes_abc)

--- a/tests/run/for_in_string.pyx
+++ b/tests/run/for_in_string.pyx
@@ -111,40 +111,103 @@ def for_char_in_enumerate_bytes(bytes s):
     else:
         return 'X'
 
-#### Py2 and Py3 behave differently here: Py2->bytes, Py3->integer
-##
-## @cython.test_assert_path_exists("//ForFromStatNode")
-## @cython.test_fail_if_path_exists("//ForInStatNode")
-## def for_pyvar_in_char_ptr(char* c_string):
-##     """
-##     >>> for_pyvar_in_char_ptr( (bytes_abc+bytes_ABC) * 2 )
-##     [True, True, True, False, False, False, True, True, True, False]
-##     >>> for_pyvar_in_char_ptr( bytes_abc_null * 2 )
-##     [True, False, True, False, True, True, False, True, False, True]
-##     """
-##     in_test = []
-##     cdef object c
-##     for c in c_string[:10]:
-##         in_test.append( c in b'abc' )
-##     return in_test
+#@cython.test_assert_path_exists("//ForFromStatNode")
+#@cython.test_fail_if_path_exists("//ForInStatNode")
+def for_pyvar_in_char_ptr(char* c_string):
+    """
+    >>> for_pyvar_in_char_ptr( (bytes_abc+bytes_ABC) * 2 )
+    [True, True, True, False, False, False, True, True, True, False, False, False]
+    >>> for_pyvar_in_char_ptr( bytes_abc_null * 2 )
+    [True]
+    """
+    in_test = []
+    cdef object c
+    for c in c_string:
+        in_test.append( c in b'abc' )
+    return in_test
 
-@cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_char_in_char_ptr(char* c_string):
     """
     >>> for_char_in_char_ptr( (bytes_abc+bytes_ABC) * 2 )
-    [True, True, True, False, False, False, True, True, True, False]
+    [True, True, True, False, False, False, True, True, True, False, False, False]
     >>> for_char_in_char_ptr( bytes_abc_null * 2 )
-    [True, False, True, False, True, True, False, True, False, True]
+    [True]
     """
     in_test = []
     cdef char c
-    for c in c_string[:10]:
+    for c in c_string:
         in_test.append( c in b'abc' )
     return in_test
 
 @cython.test_assert_path_exists("//ForFromStatNode")
 @cython.test_fail_if_path_exists("//ForInStatNode")
+def for_bytes_in_char_ptr(char* c_string):
+    """
+    >>> for_bytes_in_char_ptr( (bytes_abc+bytes_ABC) * 2 )
+    [True, True, True, False, False, False, True, True, True, False, False, False]
+    >>> for_bytes_in_char_ptr( bytes_abc_null * 2 )
+    [True]
+    """
+    in_test = []
+    cdef bytes c
+    for c in c_string:
+        in_test.append( c in b'abc' )
+    return in_test
+
+@cython.test_assert_path_exists("//ForFromStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def for_pyvar_in_char_ptr_slice(char* c_string):
+    """
+    >>> for_pyvar_in_char_ptr_slice( (bytes_abc+bytes_ABC) * 2 )
+    [True, False, False, False, True, True, True, False]
+    >>> for_pyvar_in_char_ptr_slice( bytes_abc_null * 2 )
+    [True, False, True, True, False, True, False, True]
+    """
+    in_test = []
+    cdef object c
+    for c in c_string[2:10]:
+        in_test.append( c in b'abc' )
+    return in_test
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//IndexNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
+def for_char_in_char_ptr_slice(char* c_string):
+    """
+    >>> for_char_in_char_ptr_slice( (bytes_abc+bytes_ABC) * 2 )
+    [True, False, False, False, True, True, True, False]
+    >>> for_char_in_char_ptr_slice( bytes_abc_null * 2 )
+    [True, False, True, True, False, True, False, True]
+    """
+    in_test = []
+    cdef char c
+    for c in c_string[2:10]:
+        in_test.append( c in b'abc' )
+    return in_test
+
+@cython.test_assert_path_exists("//ForFromStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def for_bytes_in_char_ptr_slice(char* c_string):
+    """
+    >>> for_bytes_in_char_ptr_slice( (bytes_abc+bytes_ABC) * 2 )
+    [True, False, False, False, True, True, True, False]
+    >>> for_bytes_in_char_ptr_slice( bytes_abc_null * 2 )
+    [True, False, True, True, False, True, False, True]
+    """
+    in_test = []
+    cdef bytes c
+    for c in c_string[2:10]:
+        in_test.append( c in b'abc' )
+    return in_test
+
+@cython.test_assert_path_exists("//ForFromStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_pyunicode_in_unicode(unicode s):
     """
     >>> for_pyunicode_in_unicode(unicode_abc)

--- a/tests/run/for_in_string.pyx
+++ b/tests/run/for_in_string.pyx
@@ -280,7 +280,8 @@ def for_pyunicode_in_unicode(unicode s):
         return 'X'
 
 @cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_pyunicode_in_enumerate_unicode(unicode s):
     """
     >>> for_pyunicode_in_enumerate_unicode(unicode_abc)
@@ -301,7 +302,8 @@ def for_pyunicode_in_enumerate_unicode(unicode s):
         return 'X'
 
 @cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_pyucs4_in_unicode(unicode s):
     """
     >>> for_pyucs4_in_unicode(unicode_abc)
@@ -321,7 +323,8 @@ def for_pyucs4_in_unicode(unicode s):
         return 'X'
 
 @cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
 def for_pyucs4_in_enumerate_unicode(unicode s):
     """
     >>> for_pyucs4_in_enumerate_unicode(unicode_abc)
@@ -338,5 +341,47 @@ def for_pyucs4_in_enumerate_unicode(unicode s):
     for i, c in enumerate(s):
         if c == u'C':
             return i
+    else:
+        return 'X'
+
+@cython.test_assert_path_exists("//ForFromStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
+def for_unicode_in_unicode(unicode s):
+    """
+    >>> for_unicode_in_unicode(unicode_abc)
+    'X'
+    >>> for_unicode_in_unicode(unicode_ABC)
+    'C'
+    >>> for_unicode_in_unicode(unicode_abc_null)
+    'X'
+    >>> for_unicode_in_unicode(unicode_ABC_null)
+    'C'
+    """
+    cdef unicode c
+    for c in s:
+        if c == u'C':
+            return 'C'
+    else:
+        return 'X'
+
+@cython.test_assert_path_exists("//ForFromStatNode")
+@cython.test_fail_if_path_exists("//ForInStatNode",
+                                 "//SliceIndexNode")
+def for_unicode_in_unicode_slice(unicode s):
+    """
+    >>> for_unicode_in_unicode_slice(unicode_abc)
+    'X'
+    >>> for_unicode_in_unicode_slice(unicode_ABC)
+    'B'
+    >>> for_unicode_in_unicode_slice(unicode_abc_null)
+    'X'
+    >>> for_unicode_in_unicode_slice(unicode_ABC_null)
+    'B'
+    """
+    cdef unicode c
+    for c in s[1:-1]:
+        if c == u'B':
+            return 'B'
     else:
         return 'X'


### PR DESCRIPTION
Fixes #3536.

This also partially fixes #3539 (for the non-negative case) as `with_gil` otherwise regresses (it does `for c in char_ptr[10:]` and if our testsuite relies on it working it seems quite plausible elsewhere does.

An alternative fix here would be to special case the `for-in` optimization to not raise a compile-time error of "C array iteration requires known end index", but the current fix ensures consistent behaviour across all operations.