### PR TITLE
BUG: PyArray_SearchSorted signature

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -302,7 +302,6 @@ cdef extern from "numpy/arrayobject.h":
             """
             return PyArray_BYTES(self)
 
-
     ctypedef unsigned char      npy_bool
 
     ctypedef signed char      npy_byte
@@ -655,7 +654,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_Choose (ndarray, object, ndarray, NPY_CLIPMODE)
     int PyArray_Sort (ndarray, int, NPY_SORTKIND)
     object PyArray_ArgSort (ndarray, int, NPY_SORTKIND)
-    object PyArray_SearchSorted (ndarray, object, NPY_SEARCHSIDE)
+    object PyArray_SearchSorted (ndarray, object, NPY_SEARCHSIDE, PyObject*)
     object PyArray_ArgMax (ndarray, int, ndarray)
     object PyArray_ArgMin (ndarray, int, ndarray)
     object PyArray_Reshape (ndarray, object)

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -944,3 +944,15 @@ def test_broadcast_comparison(np.ndarray[double, ndim=1] a):
     cdef object obj = a
     return a == 0, obj == 0, a == 1, obj == 1
 
+
+@testcase
+def test_c_api_searchsorted():
+    cdef:
+        np.ndarray arr = np.random.randn(10)
+
+    other = np.random.randn(5)
+
+    result = np.PyArray_SearchSorted(arr, other, np.NPY_SEARCHRIGHT, NULL)
+
+    expected = arr.searchsorted(other, side="right")
+    import (result == expected).all()

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -946,13 +946,15 @@ def test_broadcast_comparison(np.ndarray[double, ndim=1] a):
 
 
 @testcase
-def test_c_api_searchsorted():
-    cdef:
-        np.ndarray arr = np.random.randn(10)
-
-    other = np.random.randn(5)
-
+def test_c_api_searchsorted(np.ndarray arr, other):
+    """
+    >>> arr = np.random.randn(10)
+    >>> other = np.random.randn(5)
+    >>> result, expected = test_c_api_searchsorted(arr, other)
+    >>> (result == expected).all()
+    True
+    """
     result = np.PyArray_SearchSorted(arr, other, np.NPY_SEARCHRIGHT, NULL)
 
     expected = arr.searchsorted(other, side="right")
-    import (result == expected).all()
+    return result, expected


### PR DESCRIPTION
xref https://stackoverflow.com/questions/28184211/calling-pyarray-searchsorted-from-cython-3-or-4-arguments/28184301