### PR TITLE
Run ParallelRangeTransform on function arguments

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1175,7 +1175,7 @@ class ParallelRangeTransform(CythonTransform, SkipDeclarations):
     def visit_CallNode(self, node):
         self.visit(node.function)
         if not self.parallel_directive:
-            self.visitchildren(node)
+            self.visitchildren(node, exclude=('function',))
             return node
 
         # We are a parallel directive, replace this node with the

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1175,6 +1175,7 @@ class ParallelRangeTransform(CythonTransform, SkipDeclarations):
     def visit_CallNode(self, node):
         self.visit(node.function)
         if not self.parallel_directive:
+            self.visitchildren(node)
             return node
 
         # We are a parallel directive, replace this node with the

--- a/tests/run/parallel.pyx
+++ b/tests/run/parallel.pyx
@@ -8,6 +8,9 @@ from libc.stdlib cimport malloc, free
 
 openmp.omp_set_nested(1)
 
+cdef int forward(int x) nogil:
+    return x
+
 def test_parallel():
     """
     >>> test_parallel()
@@ -20,6 +23,7 @@ def test_parallel():
 
     with nogil, cython.parallel.parallel():
         buf[threadid()] = threadid()
+        buf[forward(cython.parallel.threadid())] = forward(threadid()) # previously (GH3594) recognise threadid as a function argument
 
     for i in range(maxthreads):
         assert buf[i] == i

--- a/tests/run/parallel.pyx
+++ b/tests/run/parallel.pyx
@@ -23,7 +23,9 @@ def test_parallel():
 
     with nogil, cython.parallel.parallel():
         buf[threadid()] = threadid()
-        buf[forward(cython.parallel.threadid())] = forward(threadid()) # previously (GH3594) recognise threadid as a function argument
+        # Recognise threadid() also when it's used in a function argument.
+        # See https://github.com/cython/cython/issues/3594
+        buf[forward(cython.parallel.threadid())] = forward(threadid())
 
     for i in range(maxthreads):
         assert buf[i] == i


### PR DESCRIPTION
This is @Celelibi's suggestion for https://github.com/cython/cython/issues/3594. It looks like the right idea - I just want to see which tests it fails for and why....