### PR TITLE
Ensure utility code keeps the directives that it was compiled with

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -87,7 +87,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
     child_attrs = ["body"]
     directives = None
 
-
     def merge_in(self, tree, scope, merge_scope=False):
         # Merges in the contents of another tree, and possibly scope. With the
         # current implementation below, this must be done right prior
@@ -122,6 +121,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 entry.type.scope.directives["internal"] = True
 
             self.scope.merge_in(scope)
+
+    def to_compiler_directives_wrapped_body(self):
+        # when merging a utility code module into the main one it's useful to preserve
+        # the compiler directives. This gets the body of the module node, wrapped in its
+        # directives
+        body = Nodes.CompilerDirectivesNode(self.pos, directives=self.directives, body=self.body)
+        return body
+
 
     def analyse_declarations(self, env):
         if has_np_pythran(env):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -122,13 +122,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
             self.scope.merge_in(scope)
 
-    def to_compiler_directives_wrapped_body(self):
-        # when merging a utility code module into the main one it's useful to preserve
-        # the compiler directives. This gets the body of the module node, wrapped in its
-        # directives
+    def with_compiler_directives(self):
+        # When merging a utility code module into the user code we need to preserve
+        # the original compiler directives. This returns the body of the module node,
+        # wrapped in its set of directives.
         body = Nodes.CompilerDirectivesNode(self.pos, directives=self.directives, body=self.body)
         return body
-
 
     def analyse_declarations(self, env):
         if has_np_pythran(env):

--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -128,7 +128,7 @@ def inject_utility_code_stage_factory(context):
                         module_node.scope.utility_code_list.append(dep)
             tree = utilcode.get_tree(cython_scope=context.cython_scope)
             if tree:
-                module_node.merge_in(tree.to_compiler_directives_wrapped_body(),
+                module_node.merge_in(tree.with_compiler_directives(),
                                      tree.scope, merge_scope=True)
         return module_node
     return inject_utility_code_stage

--- a/Cython/Compiler/Pipeline.py
+++ b/Cython/Compiler/Pipeline.py
@@ -128,7 +128,8 @@ def inject_utility_code_stage_factory(context):
                         module_node.scope.utility_code_list.append(dep)
             tree = utilcode.get_tree(cython_scope=context.cython_scope)
             if tree:
-                module_node.merge_in(tree.body, tree.scope, merge_scope=True)
+                module_node.merge_in(tree.to_compiler_directives_wrapped_body(),
+                                     tree.scope, merge_scope=True)
         return module_node
     return inject_utility_code_stage
 

--- a/tests/memoryview/memoryview_no_binding_T3613.pyx
+++ b/tests/memoryview/memoryview_no_binding_T3613.pyx
@@ -1,0 +1,11 @@
+# mode: compile
+# tag: memoryview
+
+# cython: binding=False
+
+# See GH 3613 - when memoryviews were compiled with binding off they ended up in an
+# inconsistent state where different directives were applied at different stages
+# of the pipeline
+
+def f(double[:] a):
+    pass

--- a/tests/memoryview/memoryview_no_binding_T3613.pyx
+++ b/tests/memoryview/memoryview_no_binding_T3613.pyx
@@ -17,5 +17,5 @@ def g(double[:] a):
     pass
 
 @cython.binding(True)
-def g(double[:] a):
+def h(double[:] a):
     pass

--- a/tests/memoryview/memoryview_no_binding_T3613.pyx
+++ b/tests/memoryview/memoryview_no_binding_T3613.pyx
@@ -7,5 +7,15 @@
 # inconsistent state where different directives were applied at different stages
 # of the pipeline
 
+import cython
+
 def f(double[:] a):
+    pass
+
+@cython.binding(False)
+def g(double[:] a):
+    pass
+
+@cython.binding(True)
+def g(double[:] a):
     pass


### PR DESCRIPTION
When utility code is merged into the main module it gets wrapped in a CompilerDirectivesNode

Fixes https://github.com/cython/cython/issues/3613.

---------------------------

Based on the discussion in #3613 it looks like it may be worth turning off binding and the auto pickling (and https://github.com/cython/cython/commit/17af8d69966e3143038059cc00b35c06ad71a97d seems to be the start of an approach to do that). I haven't made any changes to that in this PR so the memoryview utility code will compile with the default directives I believe (but it will do so consistently now)