### PR TITLE
Use platform dependent test for unpacked_struct_with_arrays

### DIFF
--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import struct
 
 # Tests buffer format string parsing.
 
@@ -442,7 +443,10 @@ def packed_struct_with_arrays(fmt):
 @testcase
 def unpacked_struct_with_arrays(fmt):
     """
-    >>> unpacked_struct_with_arrays("T{i:a:(8)f:b:f:c:Q:d:(5)i:e:i:f:i:g:xxxx(4)d:h:i:i:}")
+    >>> if struct.calcsize('P') == 8:  # 64 bit
+    ...     unpacked_struct_with_arrays("T{i:a:(8)f:b:f:c:Q:d:(5)i:e:i:f:i:g:xxxx(4)d:h:i:i:}")
+    ... elif struct.calcsize('P') == 4:  # 32 bit
+    ...     unpacked_struct_with_arrays("T{i:a:(8)f:b:f:c:Q:d:(5)i:e:i:f:i:g:(4)d:h:i:i:}")
     """
 
     cdef object[UnpackedStructWithArrays] buf = MockBuffer(


### PR DESCRIPTION
An attempt to address #3620.

I'm not sure about the recommended way to make the tests conditional on the platform, however, hopefully this is ok. I'm very happy to readdress the the issue using a different method though if that is preferred.

Please note that I also do not have access to a 32bit OS to test this on (I attempted to use an i386 Alpine linux docker image but was unable to get things running).

I'll also add further discussion to #3620...