### PR TITLE
FIX: cygdb for recent virtualenvs like pyenv and venv (GH-1961)

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -50,11 +50,24 @@ def make_command_file(path_to_debug_info, prefix_code='', no_import=False):
                 import os
                 virtualenv = os.getenv('VIRTUAL_ENV')
                 if virtualenv:
-                    path_to_activate_this_py = os.path.join(virtualenv, 'bin', 'activate_this.py')
-                    print("gdb command file: Activating virtualenv: %s; path_to_activate_this_py: %s" % (
-                        virtualenv, path_to_activate_this_py))
-                    with open(path_to_activate_this_py) as f:
-                        exec(f.read(), dict(__file__=path_to_activate_this_py))
+                    import sys
+                    import site
+                    print("gdb_command_file: Activating virtualenv: %s" % virtualenv)
+                    prev_len = len(sys.path)
+                    if sys.platform == 'win32':
+                        site_packages = os.path.join(virtualenv, 'Lib', 'site-packages')
+                    else:
+                        site_packages = os.path.join(virtualenv, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+                    orig_path = sys.path[:]
+                    site.addsitedir(site_packages)
+                    # prepend newly added virtualenv paths to sys.path
+                    new_added = []
+                    for item in list(sys.path):
+                        if item not in orig_path:
+                            new_added.append(item)
+                            sys.path.remove(item)
+                    sys.path[:0] = new_added
+                    sys.prefix = virtualenv
                 from Cython.Debugger import libcython, libpython
             except Exception as ex:
                 from traceback import print_exc

--- a/tests/run/cygdb_venv.srctree
+++ b/tests/run/cygdb_venv.srctree
@@ -3,43 +3,28 @@
 # ticket: 1961
 
 PYTHON -m venv venv
-PYTHON test_runner.py
+venv/bin/python setup.py build_ext -i
+venv/bin/python -m pip install dummy_module_dir/
+venv/bin/python test_runner.py
 
 ######## test_runner.py ########
 
 import sys, os
 import subprocess
 
-venv_args = 'source venv/bin/activate'
-build_args = 'python setup.py build_ext -i'
-dummy_install_args = 'python -m pip install dummy_module_dir/'
-cygdb_run_args = 'python -c "from Cython.Debugger import Cygdb as cygdb; cygdb.main()" . -- -ex "run test_inside_gdb.py" -ex quit python'
-
-command = ' && '.join([
-    venv_args,
-    build_args,
-    dummy_install_args,
-    cygdb_run_args,
+subprocess.check_call([sys.executable,
+    '-c',
+    'from Cython.Debugger import Cygdb as cygdb; cygdb.main()',
+    '.',
+    '--',
+    '-ex', 'run test_inside_gdb.py',
+    '-ex', 'quit',
+    sys.executable
 ])
 
-p = subprocess.Popen(['bash', '-c', command], stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
-_out, _err = p.communicate()
-res = p.returncode
-
-def print_and_exit():
-    print("STDOUT:-")
-    print(_out)
-    print("STDERR:-")
-    print(_err)
-    # exit with return code 1
+# gdb run might have error, check for that
+if not os.path.isfile('SUCCESS'):
     sys.exit(1)
-
-if res == 0:
-    # gdb run might have error, check for that
-    if not os.path.isfile('SUCCESS'):
-        print_and_exit()
-else:
-    print_and_exit()
 
 
 ######## setup.py ########

--- a/tests/run/cygdb_venv.srctree
+++ b/tests/run/cygdb_venv.srctree
@@ -1,0 +1,81 @@
+# mode: run
+# tag: py3only, gdb
+# ticket: 1961
+
+PYTHON -m venv venv
+PYTHON test_runner.py
+
+######## test_runner.py ########
+
+import sys, os
+import subprocess
+
+venv_args = 'source venv/bin/activate'
+build_args = 'python setup.py build_ext -i'
+dummy_install_args = 'python -m pip install dummy_module_dir/'
+cygdb_run_args = 'python -c "from Cython.Debugger import Cygdb as cygdb; cygdb.main()" . -- -ex "run test_inside_gdb.py" -ex quit python'
+
+command = ' && '.join([
+    venv_args,
+    build_args,
+    dummy_install_args,
+    cygdb_run_args,
+])
+
+p = subprocess.Popen(['bash', '-c', command], stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+_out, _err = p.communicate()
+res = p.returncode
+
+def print_and_exit():
+    print("STDOUT:-")
+    print(_out)
+    print("STDERR:-")
+    print(_err)
+    # exit with return code 1
+    sys.exit(1)
+
+if res == 0:
+    # gdb run might have error, check for that
+    if not os.path.isfile('SUCCESS'):
+        print_and_exit()
+else:
+    print_and_exit()
+
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(
+  ext_modules = cythonize("*.pyx", gdb_debug=True),
+)
+
+
+######## dummy_ext.pyx ########
+
+__version__ = '1.0'
+
+
+######## test_inside_gdb.py ########
+
+import dummy_module_cygdb
+assert dummy_module_cygdb.SECRET_VAR == "cygdb"
+
+with open('SUCCESS', 'w') as fp:
+    fp.write('')
+
+
+######## dummy_module_dir/setup.py ########
+
+import setuptools
+
+setuptools.setup(
+    name = 'dummy_module_cygdb',
+    packages = ['dummy_module_cygdb', ],
+)
+
+
+######## dummy_module_dir/dummy_module_cygdb/__init__.py ########
+
+SECRET_VAR = 'cygdb'


### PR DESCRIPTION
This fix the `activate_this.py` not found error in cygdb as describe in issue #1961 
```
gdb command file: Activating virtualenv: /home/varma/Projects/pyxpdf/venv; path_to_activate_this_py: /home/varma/Projects/pyxpdf/venv/bin/activate_this.py
Traceback (most recent call last):
  File "<string>", line 8, in <module>
FileNotFoundError: [Errno 2] No such file or directory: '/home/varma/Projects/pyxpdf/venv/bin/activate_this.py'
```

This remove the dependence on `activate_this.py` to activate virtualvenvs.