### PR TITLE
Initialization isn't required in sizeof or typeid

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -885,6 +885,12 @@ class ControlFlowAnalysis(CythonTransform):
         self.mark_position(node)
         return node
 
+    def visit_SizeofVarNode(self, node):
+        return node
+
+    def visit_TypeidNode(self, node):
+        return node
+
     def visit_IfStatNode(self, node):
         next_block = self.flow.newblock()
         parent = self.flow.block

--- a/tests/errors/w_uninitialized.pyx
+++ b/tests/errors/w_uninitialized.pyx
@@ -112,6 +112,10 @@ def class_py3k_args():
     args = []
     kwargs = {}
 
+def uninitialized_in_sizeof():
+    cdef int i
+    print sizeof(i)
+
 _ERRORS = """
 6:10: local variable 'a' referenced before assignment
 12:11: local variable 'a' might be referenced before assignment

--- a/tests/errors/w_uninitialized_cpp.pyx
+++ b/tests/errors/w_uninitialized_cpp.pyx
@@ -1,0 +1,12 @@
+# cython: warn.maybe_uninitialized=True
+# mode: error
+# tag: cpp, werror
+
+from cython.operator import typeid
+
+def uninitialized_in_typeid():
+    cdef int i
+    print typeid(i) == typeid(i)
+
+_ERRORS = """
+"""


### PR DESCRIPTION
I am not sure whether I put the tests in the right place. `typeid` should probably only be used in C++ mode.

Ideally, `type()` should also be supported, but since it's a python callable, it can be aliased in many ways that are not analayzable.

Closes #3575