### PR TITLE
Fix matching a nested pyx src coverage

### DIFF
--- a/Cython/Coverage.py
+++ b/Cython/Coverage.py
@@ -41,6 +41,15 @@ def _find_dep_file_path(main_file, file_path, relative_path_search=False):
         rel_file_path = os.path.join(os.path.dirname(main_file), file_path)
         if os.path.exists(rel_file_path):
             abs_path = os.path.abspath(rel_file_path)
+
+        # if file_path matches the main_file ending, that's it:
+        matching_abs_path = ''.join([os.path.splitext(main_file)[0], os.path.splitext(file_path)[1]])
+        if (
+                matching_abs_path.endswith(file_path)
+                and os.path.exists(matching_abs_path)
+        ):
+            return matching_abs_path
+
     # search sys.path for external locations if a valid file hasn't been found
     if not os.path.exists(abs_path):
         for sys_path in sys.path:

--- a/Cython/Coverage.py
+++ b/Cython/Coverage.py
@@ -43,11 +43,8 @@ def _find_dep_file_path(main_file, file_path, relative_path_search=False):
             abs_path = os.path.abspath(rel_file_path)
 
         # if file_path matches the main_file ending, that's it:
-        matching_abs_path = ''.join([os.path.splitext(main_file)[0], os.path.splitext(file_path)[1]])
-        if (
-                matching_abs_path.endswith(file_path)
-                and os.path.exists(matching_abs_path)
-        ):
+        matching_abs_path = os.path.splitext(main_file)[0] + os.path.splitext(file_path)[1]
+        if matching_abs_path.endswith(file_path) and os.path.exists(matching_abs_path):
             return matching_abs_path
 
     # search sys.path for external locations if a valid file hasn't been found


### PR DESCRIPTION
This change makes the coverage plugin match paths like
`src/pkg/mod.c` with `src/pkg/mod.pyx`.

Resolves #3636