### PR TITLE
Compiled Plex.Machines as part of default build

### DIFF
--- a/Cython/Plex/Machines.pxd
+++ b/Cython/Plex/Machines.pxd
@@ -1,0 +1,4 @@
+import cython
+
+@cython.locals(code0=cython.long, code1=cython.long)
+cdef _add_transitions(dict state, event, new_state, cython.long maxint)

--- a/Cython/Plex/Machines.py
+++ b/Cython/Plex/Machines.py
@@ -160,16 +160,7 @@ class FastMachine(object):
         self.initial_states[name] = state
 
     def add_transitions(self, state, event, new_state, maxint=maxint):
-        if type(event) is tuple:
-            code0, code1 = event
-            if code0 == -maxint:
-                state['else'] = new_state
-            elif code1 != maxint:
-                while code0 < code1:
-                    state[unichr(code0)] = new_state
-                    code0 += 1
-        else:
-            state[event] = new_state
+        _add_transitions(state, event, new_state, maxint)
 
     def get_initial_state(self, name):
         return self.initial_states[name]
@@ -245,3 +236,17 @@ class FastMachine(object):
             return repr(c1)
         else:
             return "%s..%s" % (repr(c1), repr(c2))
+
+# moved out of class to make it easier to accelerate
+def _add_transitions(state, event, new_state, maxint):
+    if isinstance(event, tuple):
+        code0, code1 = event
+        if code0 == -maxint:
+            state['else'] = new_state
+        elif code1 != maxint:
+            _unichr = unichr
+            while code0 < code1:
+                state[_unichr(code0)] = new_state
+                code0 += 1
+    else:
+        state[event] = new_state

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ def compile_cython_modules(profile=False, compile_more=False, cython_with_refnan
     source_root = os.path.abspath(os.path.dirname(__file__))
     compiled_modules = [
         "Cython.Plex.Scanners",
+        "Cython.Plex.Machines",
         "Cython.Plex.Actions",
         "Cython.Compiler.Scanning",
         "Cython.Compiler.Visitor",
@@ -236,24 +237,24 @@ def run_build():
         The Cython language makes writing C extensions for the Python language as
         easy as Python itself.  Cython is a source code translator based on Pyrex_,
         but supports more cutting edge functionality and optimizations.
-    
+
         The Cython language is a superset of the Python language (almost all Python
         code is also valid Cython code), but Cython additionally supports optional
         static typing to natively call C functions, operate with C++ classes and
         declare fast C types on variables and class attributes.  This allows the
         compiler to generate very efficient C code from Cython code.
-    
+
         This makes Cython the ideal language for writing glue code for external
         C/C++ libraries, and for fast C modules that speed up the execution of
         Python code.
-    
+
         Note that for one-time builds, e.g. for CI/testing, on platforms that are not
         covered by one of the wheel packages provided on PyPI *and* the pure Python wheel
         that we provide is not used, it is substantially faster than a full source build
         to install an uncompiled (slower) version of Cython with::
-    
+
             pip install Cython --install-option="--no-cython-compile"
-    
+
         .. _Pyrex: https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/
         """),
         license='Apache',


### PR DESCRIPTION
add_transitions takes significantly longer when unicode
characters are allowed. This change recovers about 1/3 of the lost
performance (on my PC it gets back 0.1s per Cython startup)