### PR TITLE
Small changes to get `--cython-compile-all` working again

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -323,7 +323,8 @@ def strip_string_literals(code, prefix='__Pyx_L'):
     in_quote = False
     hash_mark = single_q = double_q = -1
     code_len = len(code)
-    quote_type = quote_len = None
+    quote_type = None
+    quote_len = -1
 
     while True:
         if hash_mark < q:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1356,7 +1356,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                         self.generate_richcmp_function(scope, code)
                     for slot in TypeSlots.PyNumberMethods:
                         if slot.is_binop and scope.defines_any_special(slot.user_methods):
-                            self.generate_binop_function(scope, slot, code)
+                            self.generate_binop_function(scope, slot, code, entry.pos)
                     self.generate_property_accessors(scope, code)
                     self.generate_method_table(scope, code)
                     self.generate_getset_table(scope, code)
@@ -2035,7 +2035,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("}")  # switch
         code.putln("}")
 
-    def generate_binop_function(self, scope, slot, code):
+    def generate_binop_function(self, scope, slot, code, pos):
         func_name = scope.mangle_internal(slot.slot_name)
         if scope.directives['c_api_binop_methods']:
             code.putln('#define %s %s' % (func_name, slot.left_slot.slot_code(scope)))
@@ -2054,7 +2054,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             extra_arg = ', extra_arg'
             extra_arg_decl = ', PyObject* extra_arg'
         else:
-            error(entry.pos, "Unexpected type lost signature: %s" % slot)
+            error(pos, "Unexpected type lost signature: %s" % slot)
 
         def has_slot_method(method_name):
             entry = scope.lookup(method_name)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2961,7 +2961,9 @@ class GilCheck(VisitorTransform):
             self.visitchildren(node, outer_attrs)
 
         self.nogil = gil_state
-        self.visitchildren(node, exclude=outer_attrs)
+        # FIXME: attrs needs to be passed explicitly to avoid "C function call is missing argument 'attrs'".
+        # This looks like a bug
+        self.visitchildren(node, attrs=None, exclude=outer_attrs)
         self.nogil = was_nogil
 
     def visit_FuncDefNode(self, node):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2961,8 +2961,6 @@ class GilCheck(VisitorTransform):
             self.visitchildren(node, outer_attrs)
 
         self.nogil = gil_state
-        # FIXME: attrs needs to be passed explicitly to avoid "C function call is missing argument 'attrs'".
-        # This looks like a bug
         self.visitchildren(node, attrs=None, exclude=outer_attrs)
         self.nogil = was_nogil
 


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/3647

At least one (in ModuleNode) is a real bug. The others are just
getting the code compatible with Cython again`