### PR TITLE
Check for exceptions also when @returns() is used, not only for "->" return type annotations

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2445,8 +2445,8 @@ class AdjustDefByDirectives(CythonTransform, SkipDeclarations):
             if return_type_node is not None and except_val is None:
                 except_val = (None, True)  # except *
         elif except_val is None:
-            # backward compatible default: no exception check
-            except_val = (None, False)
+            # backward compatible default: no exception check, unless there's also a "@returns" declaration
+            except_val = (None, True if return_type_node else False)
         if 'ccall' in self.directives:
             node = node.as_cfunction(
                 overridable=True, modifiers=modifiers, nogil=nogil,


### PR DESCRIPTION
From https://github.com/cython/cython/issues/3625#issuecomment-631931675

When you use Python type annotations, it would be weird if you lost Python exception propagation semantics along the way, just by compiling the code. So the default behaviour is "except? -1" here for C integer types.

Arguably, this would also be a better default for the decorator case.