### PR TITLE
Always bind Cython functions in py3

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -548,6 +548,7 @@ static int __Pyx_CyFunction_traverse(__pyx_CyFunctionObject *m, visitproc visit,
 
 static PyObject *__Pyx_CyFunction_descr_get(PyObject *func, PyObject *obj, PyObject *type)
 {
+#if PY_MAJOR_VERSION < 3
     __pyx_CyFunctionObject *m = (__pyx_CyFunctionObject *) func;
 
     if (m->flags & __Pyx_CYFUNCTION_STATICMETHOD) {
@@ -563,6 +564,7 @@ static PyObject *__Pyx_CyFunction_descr_get(PyObject *func, PyObject *obj, PyObj
 
     if (obj == Py_None)
         obj = NULL;
+#endif
     return __Pyx_PyMethod_New(func, obj, type);
 }
 


### PR DESCRIPTION
Rebased 1bb26b964060392ecb08c3b6c8ca4626e5c1eec7 for cython 0.29.x, and made conditional to Python 3.  This
does not solve the original staticmethod problem in Python 2 but it does
resolve classmethod problems in Python 3.9.  Therefore, it unbreaks
other packages on Python 3.9, improves overall state for Python 3
and does not introduce regressions in Python 2.