### PR TITLE
MNT: expose PyUnicode_GET_LENGTH

### DIFF
--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -11,7 +11,7 @@ cdef extern from *:
     # Return the size of the object. o has to be a PyUnicodeObject
     # (not checked).
     #
-    # Deprecated since version 3.3, will be removed in version 4.0:
+    # Deprecated since version 3.3, will be removed in version 3.10:
     # Part of the old-style Unicode API, please migrate to using
     # PyUnicode_GET_LENGTH().
     Py_ssize_t PyUnicode_GET_SIZE(object o)

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -10,7 +10,18 @@ cdef extern from *:
 
     # Return the size of the object. o has to be a PyUnicodeObject
     # (not checked).
+    #
+    # Deprecated since version 3.3, will be removed in version 4.0:
+    # Part of the old-style Unicode API, please migrate to using
+    # PyUnicode_GET_LENGTH().
     Py_ssize_t PyUnicode_GET_SIZE(object o)
+
+    # Return the length of the Unicode string, in code points. o has
+    # to be a Unicode object in the “canonical” representation (not
+    # checked).
+    #
+    # New in version 3.3.
+    Py_ssize_t PyUnicode_GET_LENGTH(object o)
 
     # Return the size of the object's internal buffer in bytes. o has
     # to be a PyUnicodeObject (not checked).


### PR DESCRIPTION
In https://github.com/python/cpython/pull/20878 and https://github.com/python/cpython/pull/20941 some of the old unicode APIs began to produce compiler warnings to suggest usage of APIs added in py33 instead.

While some of the unicode API added in 3.3 is already in this file, not all of it is.  I have not gone through to see what else is missing.

I found this because pandas converts warnings to errors and they import `PyUnicode_GET_SIZE` in one of their pyx files.  Given that this has been backported to py39 I think this patch should be backported as far as possible in cython as well.