### PR TITLE
Fixed in-place operators "+=" and "-=".

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2849,6 +2849,7 @@ supported_overloaded_operators = cython.declare(set, set([
     '==', '!=', '>=', '>', '<=', '<',
     '[]', '()', '!', '=',
     'bool',
+    '+=', '-=',
 ]))
 
 def p_c_simple_declarator(s, ctx, empty, is_type, cmethod_flag,


### PR DESCRIPTION
Importing C++ in-place operators "+-" and "-=" currently fail with "Overloading operator [...] not yet supported.". Just adding them to the supported_overloaded_operators seems to fix that and seems to be working fine.