### PR TITLE
RFC: Modulestate struct

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1467,7 +1467,7 @@ class GlobalState(object):
         for _, cname, c in consts:
             self.parts['module_state'].putln("%s;" % c.type.declaration_code(cname))
             self.parts['module_state_defines'].putln(
-                "#define %s %s->%s" % (cname, Naming.modulestateglobal_cname, cname))
+                "#define %s __Pyx_CGlobal(%s)" % (cname, cname))
             self.parts['module_state_clear'].putln(
                 "Py_CLEAR(clear_module_state->%s);" % cname)
             self.parts['module_state_traverse'].putln(
@@ -1559,9 +1559,8 @@ class GlobalState(object):
                     encoding = '"%s"' % py_string.encoding.lower()
 
                 self.parts['module_state'].putln("PyObject *%s;" % py_string.cname)
-                self.parts['module_state_defines'].putln("#define %s %s->%s" % (
+                self.parts['module_state_defines'].putln("#define %s __Pyx_CGlobal(%s)" % (
                     py_string.cname,
-                    Naming.modulestateglobal_cname,
                     py_string.cname))
                 self.parts['module_state_clear'].putln("Py_CLEAR(clear_module_state->%s);" %
                     py_string.cname)
@@ -1623,8 +1622,8 @@ class GlobalState(object):
         for py_type, _, _, value, value_code, c in consts:
             cname = c.cname
             self.parts['module_state'].putln("PyObject *%s;" % cname)
-            self.parts['module_state_defines'].putln("#define %s %s->%s" % (
-                cname, Naming.modulestateglobal_cname, cname))
+            self.parts['module_state_defines'].putln("#define %s __Pyx_CGlobal(%s)" % (
+                cname, cname))
             self.parts['module_state_clear'].putln(
                 "Py_CLEAR(clear_module_state->%s);" % cname)
             self.parts['module_state_traverse'].putln(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8032,7 +8032,7 @@ class TupleNode(SequenceNode):
         if len(self.args) > 0:
             return self.result_code
         else:
-            return Naming.empty_tuple
+            return str(Naming.empty_tuple)
 
     def calculate_constant_result(self):
         self.constant_result = tuple([

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1585,7 +1585,7 @@ class BytesNode(ConstNode):
 
     def generate_evaluation_code(self, code):
         if self.type.is_pyobject:
-            result = code.get_py_string_const(self.value)
+            result = code.get_py_string_cexpr(self.value)
         elif self.type.is_const:
             result = code.get_string_const(self.value)
         else:
@@ -1700,7 +1700,7 @@ class UnicodeNode(ConstNode):
                 const_code.put_error_if_neg(
                     self.pos, "__Pyx_PyUnicode_READY(%s)" % self.result_code)
             else:
-                self.result_code = code.get_py_string_const(self.value)
+                self.result_code = code.get_py_string_cexpr(self.value)
         else:
             self.result_code = code.get_pyunicode_ptr_const(self.value)
 
@@ -1762,7 +1762,7 @@ class StringNode(PyConstNode):
         return not self.is_identifier and len(self.value) == 1
 
     def generate_evaluation_code(self, code):
-        self.result_code = code.get_py_string_const(
+        self.result_code = code.get_py_string_cexpr(
             self.value, identifier=self.is_identifier, is_str=True,
             unicode_value=self.unicode_value)
 
@@ -8979,11 +8979,11 @@ class SortedDictKeysNode(ExprNode):
 
 class ModuleNameMixin(object):
     def get_py_mod_name(self, code):
-        return code.get_py_string_const(
+        return code.get_py_string_cexpr(
             self.module_name, identifier=True)
 
     def get_py_qualified_name(self, code):
-        return code.get_py_string_const(
+        return code.get_py_string_cexpr(
             self.qualname, identifier=True)
 
 
@@ -9560,11 +9560,11 @@ class CodeObjectNode(ExprNode):
             return  # already initialised
         code.mark_pos(self.pos)
         func = self.def_node
-        func_name = code.get_py_string_const(
+        func_name = code.get_py_string_cexpr(
             func.name, identifier=True, is_str=False, unicode_value=func.name)
         # FIXME: better way to get the module file path at module init time? Encoding to use?
         file_path = StringEncoding.bytes_literal(func.pos[0].get_filenametable_entry().encode('utf8'), 'utf8')
-        file_path_const = code.get_py_string_const(file_path, identifier=False, is_str=True)
+        file_path_const = code.get_py_string_cexpr(file_path, identifier=False, is_str=True)
 
         # This combination makes CPython create a new dict for "frame.f_locals" (see GH #1836).
         flags = ['CO_OPTIMIZED', 'CO_NEWLOCALS']

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2532,13 +2532,26 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln('PyObject *%s;' % Naming.empty_unicode.cname)
         if Options.pre_import is not None:
             code.putln('PyObject *%s;' % Naming.preimport_cname.cname)
-        code.putln("#if CYTHON_USE_MODULE_STATE")
+        code.putln('#ifdef __Pyx_AsyncGen_USED')
+        code.putln('PyTypeObject *%s;' % Naming.asyncgen_type_cname.cname)
+        code.putln('PyTypeObject *%s;' % Naming.asyncgen_asend_type_cname.cname)
+        code.putln('PyTypeObject *%s;' % Naming.asyncgen_athrow_type_cname.cname)
+        code.putln('PyTypeObject *%s;' % Naming.asyncgen_wrapped_value_type_cname.cname)
+        code.putln('#endif')
+        code.putln('#ifdef __Pyx_Coroutine_USED')
+        code.putln('PyTypeObject *%s;' % Naming.coroutine_type_cname.cname)
+        code.putln('PyTypeObject *%s;' % Naming.coroutine_await_type_cname.cname)
+        code.putln('#endif')
         code.putln('#ifdef __Pyx_CyFunction_USED')
-        code.putln('PyTypeObject *%s;' % Naming.cyfunction_type_cname)
+        code.putln('PyTypeObject *%s;' % Naming.cyfunction_type_cname.cname)
         code.putln('#endif')
         code.putln('#ifdef __Pyx_FusedFunction_USED')
-        code.putln('PyTypeObject *%s;' % Naming.fusedfunction_type_cname)
+        code.putln('PyTypeObject *%s;' % Naming.fusedfunction_type_cname.cname)
         code.putln('#endif')
+        code.putln('#ifdef __Pyx_Generator_USED')
+        code.putln('PyTypeObject *%s;' % Naming.generator_type_cname.cname)
+        code.putln('#endif')
+        code.putln("#if CYTHON_USE_MODULE_STATE")
 
     def generate_module_state_end(self, env, code):
         code.putln('#endif /* CYTHON_USE_MODULE_STATE */')
@@ -2557,16 +2570,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_module_state_defines_begin(self, env, code):
         code.putln("#if CYTHON_USE_MODULE_STATE")
-        code.putln('#ifdef __Pyx_CyFunction_USED')
-        code.putln('#define %s __Pyx_CGlobal(%s)' % (
-            Naming.cyfunction_type_cname,
-            Naming.cyfunction_type_cname))
-        code.putln('#endif')
-        code.putln('#ifdef __Pyx_FusedFunction_USED')
-        code.putln('#define %s __Pyx_CGlobal(%s)' %
-            (Naming.fusedfunction_type_cname,
-            Naming.fusedfunction_type_cname))
-        code.putln('#endif')
 
     def generate_module_state_defines_end(self, env, code):
         code.putln("#endif /* CYTHON_USE_MODULE_STATE */")
@@ -2591,13 +2594,33 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if Options.pre_import is not None:
             code.putln('Py_CLEAR(clear_module_state->%s);' %
                 Naming.preimport_cname.cname)
+        code.putln('#ifdef __Pyx_AsyncGen_USED')
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.asyncgen_type_cname.cname)
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.asyncgen_asend_type_cname.cname)
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.asyncgen_athrow_type_cname.cname)
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.asyncgen_wrapped_value_type_cname.cname)
+        code.putln('#endif')
+        code.putln('#ifdef __Pyx_Coroutine_USED')
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.coroutine_type_cname.cname)
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.coroutine_await_type_cname.cname)
+        code.putln('#endif')
         code.putln('#ifdef __Pyx_CyFunction_USED')
         code.putln('Py_CLEAR(clear_module_state->%s);' %
-            Naming.cyfunction_type_cname)
+            Naming.cyfunction_type_cname.cname)
         code.putln('#endif')
         code.putln('#ifdef __Pyx_FusedFunction_USED')
         code.putln('Py_CLEAR(clear_module_state->%s);' %
-            Naming.fusedfunction_type_cname)
+            Naming.fusedfunction_type_cname.cname)
+        code.putln('#endif')
+        code.putln('#ifdef __Pyx_Generator_USED')
+        code.putln('Py_CLEAR(clear_module_state->%s);' %
+            Naming.generator_type_cname.cname)
         code.putln('#endif')
 
     def generate_module_state_clear_end(self, env, code):
@@ -2625,13 +2648,33 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if Options.pre_import is not None:
             code.putln('Py_VISIT(clear_module_state->%s);' %
                 Naming.preimport_cname.cname)
+        code.putln('#ifdef __Pyx_AsyncGen_USED')
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.asyncgen_type_cname.cname)
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.asyncgen_asend_type_cname.cname)
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.asyncgen_athrow_type_cname.cname)
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.asyncgen_wrapped_value_type_cname.cname)
+        code.putln('#endif')
+        code.putln('#ifdef __Pyx_Coroutine_USED')
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.coroutine_type_cname.cname)
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.coroutine_await_type_cname.cname)
+        code.putln('#endif')
         code.putln('#ifdef __Pyx_CyFunction_USED')
         code.putln('Py_VISIT(traverse_module_state->%s);' %
-            Naming.cyfunction_type_cname)
+            Naming.cyfunction_type_cname.cname)
         code.putln('#endif')
         code.putln('#ifdef __Pyx_FusedFunction_USED')
         code.putln('Py_VISIT(traverse_module_state->%s);' %
-            Naming.fusedfunction_type_cname)
+            Naming.fusedfunction_type_cname.cname)
+        code.putln('#endif')
+        code.putln('#ifdef __Pyx_Generator_USED')
+        code.putln('Py_VISIT(traverse_module_state->%s);' %
+            Naming.generator_type_cname.cname)
         code.putln('#endif')
 
     def generate_module_state_traverse_end(self, env, code):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2552,10 +2552,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln('PyTypeObject *%s;' % Naming.generator_type_cname.cname)
         code.putln('#endif')
         code.putln('PyObject *%s[%s];' % (Naming.string_consts_cname.cname, Naming.string_tab_length_cname))
-        code.putln("#if CYTHON_USE_MODULE_STATE")
 
     def generate_module_state_end(self, env, code):
-        code.putln('#endif /* CYTHON_USE_MODULE_STATE */')
         code.putln('} %s;' % Naming.cglobals_type_cname)
         code.putln('')
         code.putln('#if !CYTHON_USE_MODULE_STATE')

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1245,18 +1245,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 module_state_traverse.putln(
                     "Py_VISIT(traverse_module_state->%s);" %
                     entry.type.typeptr_cname)
-                if entry.type.typeobj_cname is not None:
-                    module_state.putln("PyObject *%s;" % entry.type.typeobj_cname)
-                    module_state_defines.putln("#define %s %s->%s" % (
-                        entry.type.typeobj_cname,
-                        Naming.modulestateglobal_cname,
-                        entry.type.typeobj_cname))
-                    module_state_clear.putln(
-                        "Py_CLEAR(clear_module_state->%s);" % (
-                        entry.type.typeobj_cname))
-                    module_state_traverse.putln(
-                        "Py_VISIT(traverse_module_state->%s);" % (
-                        entry.type.typeobj_cname))
         code.putln("#endif")
 
     def generate_cvariable_declarations(self, env, code, definition):

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -62,8 +62,11 @@ module_is_main   = pyrex_prefix + "module_is_main"
 defaults_struct_prefix = pyrex_prefix + "defaults"
 dynamic_args_cname = pyrex_prefix + "dynamic_args"
 
+str_prefix = pyrex_prefix + "s_"
+unicode_prefix = pyrex_prefix + "u_"
+bytes_prefix = pyrex_prefix + "b_"
+
 interned_prefixes = {
-    'str': pyrex_prefix + "n_",
     'int': pyrex_prefix + "int_",
     'float': pyrex_prefix + "float_",
     'tuple': pyrex_prefix + "tuple_",

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -26,7 +26,6 @@ pywrap_prefix     = pyrex_prefix + "pw_"
 genbody_prefix    = pyrex_prefix + "gb_"
 gstab_prefix      = pyrex_prefix + "getsets_"
 prop_get_prefix   = pyrex_prefix + "getprop_"
-const_prefix      = pyrex_prefix + "k_"
 py_const_prefix   = pyrex_prefix + "kp_"
 label_prefix      = pyrex_prefix + "L"
 pymethdef_prefix  = pyrex_prefix + "mdef_"
@@ -66,14 +65,16 @@ str_prefix = pyrex_prefix + "s_"
 unicode_prefix = pyrex_prefix + "u_"
 bytes_prefix = pyrex_prefix + "b_"
 
+const_prefix = "k_"
+
 interned_prefixes = {
-    'int': pyrex_prefix + "int_",
-    'float': pyrex_prefix + "float_",
-    'tuple': pyrex_prefix + "tuple_",
-    'codeobj': pyrex_prefix + "codeobj_",
-    'slice': pyrex_prefix + "slice_",
-    'ustring': pyrex_prefix + "ustring_",
-    'umethod': pyrex_prefix + "umethod_",
+    'int': "int_",
+    'float': "float_",
+    'tuple': "tuple_",
+    'codeobj': "codeobj_",
+    'slice': "slice_",
+    'ustring': "ustring_",
+    'umethod': "umethod_",
 }
 
 

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -150,8 +150,15 @@ tp_dict_version_temp = pyrex_prefix + "tp_dict_version"
 obj_dict_version_temp = pyrex_prefix + "obj_dict_version"
 type_dict_guard_temp = pyrex_prefix + "typedict_guard"
 cython_runtime_cname = Global("cython_runtime")
-cyfunction_type_cname = pyrex_prefix + "CyFunctionType"
-fusedfunction_type_cname = pyrex_prefix + "FusedFunctionType"
+asyncgen_type_cname = Global("AsyncGenType")
+asyncgen_asend_type_cname = Global("AsyncGenASendType")
+asyncgen_athrow_type_cname = Global("AsyncGenAThrowType")
+asyncgen_wrapped_value_type_cname = Global("AsyncGenWrappedValueType")
+coroutine_type_cname = Global("CoroutineType")
+coroutine_await_type_cname = Global("CoroutineAwaitType")
+cyfunction_type_cname = Global("CyFunctionType")
+fusedfunction_type_cname = Global("FusedFunctionType")
+generator_type_cname = Global("GeneratorType")
 
 global_code_object_cache_find = pyrex_prefix + 'find_code_object'
 global_code_object_cache_insert = pyrex_prefix + 'insert_code_object'

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -73,6 +73,23 @@ interned_prefixes = {
     'umethod': pyrex_prefix + "umethod_",
 }
 
+
+class Global:
+    def __init__(self, cname):
+        self._cname = cname
+        self._expr = "__Pyx_CGlobal(%s)" % self._cname
+
+    @property
+    def cname(self):
+        return self._cname
+
+    def __str__(self):
+        return self._expr
+
+    def __repr__(self):
+        return "Global(%s)" % self._cname
+
+
 ctuple_type_prefix = pyrex_prefix + "ctuple_"
 args_cname       = pyrex_prefix + "args"
 nargs_cname      = pyrex_prefix + "nargs"
@@ -81,9 +98,9 @@ generator_cname  = pyrex_prefix + "generator"
 sent_value_cname = pyrex_prefix + "sent_value"
 pykwdlist_cname  = pyrex_prefix + "pyargnames"
 obj_base_cname   = pyrex_prefix + "base"
-builtins_cname   = pyrex_prefix + "b"
-preimport_cname  = pyrex_prefix + "i"
-moddict_cname    = pyrex_prefix + "d"
+builtins_cname   = Global("b")
+preimport_cname  = Global("i")
+moddict_cname    = Global("d")
 dummy_cname      = pyrex_prefix + "dummy"
 filename_cname   = pyrex_prefix + "filename"
 modulename_cname = pyrex_prefix + "modulename"
@@ -95,8 +112,8 @@ clineno_cname    = pyrex_prefix + "clineno"
 cfilenm_cname    = pyrex_prefix + "cfilenm"
 local_tstate_cname = pyrex_prefix + "tstate"
 module_cname     = pyrex_prefix + "m"
-modulestate_cname = pyrex_prefix + "mstate"
-modulestateglobal_cname = pyrex_prefix + "mstate_global"
+cglobals_type_cname = pyrex_prefix + "CGlobalsType"
+cglobals_cname = pyrex_prefix + "cglobals"
 moddoc_cname     = pyrex_prefix + "mdoc"
 methtable_cname  = pyrex_prefix + "methods"
 retval_cname     = pyrex_prefix + "r"
@@ -107,9 +124,9 @@ vtabslot_cname   = pyrex_prefix + "vtab"
 c_api_tab_cname  = pyrex_prefix + "c_api_tab"
 gilstate_cname   = pyrex_prefix + "state"
 skip_dispatch_cname = pyrex_prefix + "skip_dispatch"
-empty_tuple      = pyrex_prefix + "empty_tuple"
-empty_bytes      = pyrex_prefix + "empty_bytes"
-empty_unicode    = pyrex_prefix + "empty_unicode"
+empty_tuple      = Global("empty_tuple")
+empty_bytes      = Global("empty_bytes")
+empty_unicode    = Global("empty_unicode")
 print_function   = pyrex_prefix + "print"
 print_function_kwargs   = pyrex_prefix + "print_kwargs"
 cleanup_cname    = pyrex_prefix + "module_cleanup"
@@ -132,7 +149,7 @@ quick_temp_cname = pyrex_prefix + "temp"  # temp variable for quick'n'dirty temp
 tp_dict_version_temp = pyrex_prefix + "tp_dict_version"
 obj_dict_version_temp = pyrex_prefix + "obj_dict_version"
 type_dict_guard_temp = pyrex_prefix + "typedict_guard"
-cython_runtime_cname   = pyrex_prefix + "cython_runtime"
+cython_runtime_cname = Global("cython_runtime")
 cyfunction_type_cname = pyrex_prefix + "CyFunctionType"
 fusedfunction_type_cname = pyrex_prefix + "FusedFunctionType"
 

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -90,6 +90,9 @@ class Global:
         return "Global(%s)" % self._cname
 
 
+string_tab_length_cname = pyrex_prefix + "string_tab_length"
+string_consts_cname = Global("string_consts")
+
 ctuple_type_prefix = pyrex_prefix + "ctuple_"
 args_cname       = pyrex_prefix + "args"
 nargs_cname      = pyrex_prefix + "nargs"

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2127,7 +2127,7 @@ class CReturnCodeType(CIntType):
         return not format_spec
 
     def convert_to_pystring(self, cvalue, code, format_spec=None):
-        return "__Pyx_NewRef(%s)" % code.globalstate.get_py_string_const(StringEncoding.EncodedString("None")).cname
+        return "__Pyx_NewRef(%s)" % code.globalstate.get_py_string_cexpr(StringEncoding.EncodedString("None"))
 
 
 class CBIntType(CIntType):
@@ -2147,8 +2147,8 @@ class CBIntType(CIntType):
         utility_code_name = "__Pyx_PyUnicode_FromBInt_" + self.specialization_name()
         to_pyunicode_utility = TempitaUtilityCode.load_cached(
             "CBIntToPyUnicode", "TypeConversion.c", context={
-                "TRUE_CONST":  code.globalstate.get_py_string_const(StringEncoding.EncodedString("True")).cname,
-                "FALSE_CONST": code.globalstate.get_py_string_const(StringEncoding.EncodedString("False")).cname,
+                "TRUE_CONST":  code.globalstate.get_py_string_cexpr(StringEncoding.EncodedString("True")),
+                "FALSE_CONST": code.globalstate.get_py_string_cexpr(StringEncoding.EncodedString("False")),
                 "TO_PY_FUNCTION": utility_code_name,
             })
         code.globalstate.use_utility_code(to_pyunicode_utility)
@@ -3459,7 +3459,7 @@ class ToPyStructUtilityCode(object):
         code.putln("res = __Pyx_PyDict_NewPresized(%d); if (unlikely(!res)) return NULL;" %
                    len(self.type.scope.var_entries))
         for member in self.type.scope.var_entries:
-            nameconst_cname = code.get_py_string_const(member.name, identifier=True)
+            nameconst_cname = code.get_py_string_cexpr(member.name, identifier=True)
             code.putln("%s; if (unlikely(!member)) goto bad;" % (
                 member.type.to_py_call_code('s.%s' % member.cname, 'member', member.type)))
             code.putln("if (unlikely(PyDict_SetItem(res, %s, member) < 0)) goto bad;" % nameconst_cname)

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -14,16 +14,11 @@ typedef struct {
     int ag_running_async;
 } __pyx_PyAsyncGenObject;
 
-static PyTypeObject *__pyx__PyAsyncGenWrappedValueType = 0;
-static PyTypeObject *__pyx__PyAsyncGenASendType = 0;
-static PyTypeObject *__pyx__PyAsyncGenAThrowType = 0;
-static PyTypeObject *__pyx_AsyncGenType = 0;
-
-#define __Pyx_AsyncGen_CheckExact(obj) __Pyx_IS_TYPE(obj, __pyx_AsyncGenType)
+#define __Pyx_AsyncGen_CheckExact(obj) __Pyx_IS_TYPE(obj, __Pyx_CGlobal(AsyncGenType))
 #define __pyx_PyAsyncGenASend_CheckExact(o) \
-                    __Pyx_IS_TYPE(o, __pyx__PyAsyncGenASendType)
+                    __Pyx_IS_TYPE(o, __Pyx_CGlobal(AsyncGenASendType))
 #define __pyx_PyAsyncGenAThrow_CheckExact(o) \
-                    __Pyx_IS_TYPE(o, __pyx__PyAsyncGenAThrowType)
+                    __Pyx_IS_TYPE(o, __Pyx_CGlobal(AsyncGenAThrowType))
 
 static PyObject *__Pyx_async_gen_anext(PyObject *o);
 static CYTHON_INLINE PyObject *__Pyx_async_gen_asend_iternext(PyObject *o);
@@ -35,17 +30,8 @@ static PyObject *__Pyx__PyAsyncGenValueWrapperNew(PyObject *val);
 
 
 static __pyx_CoroutineObject *__Pyx_AsyncGen_New(
-            __pyx_coroutine_body_t body, PyObject *code, PyObject *closure,
-            PyObject *name, PyObject *qualname, PyObject *module_name) {
-    __pyx_PyAsyncGenObject *gen = PyObject_GC_New(__pyx_PyAsyncGenObject, __pyx_AsyncGenType);
-    if (unlikely(!gen))
-        return NULL;
-    gen->ag_finalizer = NULL;
-    gen->ag_closed = 0;
-    gen->ag_hooks_inited = 0;
-    gen->ag_running_async = 0;
-    return __Pyx__Coroutine_NewInit((__pyx_CoroutineObject*)gen, body, code, closure, name, qualname, module_name);
-}
+    __pyx_coroutine_body_t body, PyObject *code, PyObject *closure,
+    PyObject *name, PyObject *qualname, PyObject *module_name); /*proto*/
 
 static int __pyx_AsyncGen_init(PyObject *module);
 static void __Pyx_PyAsyncGen_Fini(void);
@@ -170,6 +156,20 @@ typedef struct {
 #define _PyAsyncGen_MAXFREELIST 80
 #endif
 
+static __pyx_CoroutineObject *__Pyx_AsyncGen_New(
+    __pyx_coroutine_body_t body, PyObject *code, PyObject *closure,
+    PyObject *name, PyObject *qualname, PyObject *module_name)
+{
+    __pyx_PyAsyncGenObject *gen = PyObject_GC_New(__pyx_PyAsyncGenObject, __Pyx_CGlobal(AsyncGenType));
+    if (unlikely(!gen))
+        return NULL;
+    gen->ag_finalizer = NULL;
+    gen->ag_closed = 0;
+    gen->ag_hooks_inited = 0;
+    gen->ag_running_async = 0;
+    return __Pyx__Coroutine_NewInit((__pyx_CoroutineObject*)gen, body, code, closure, name, qualname, module_name);
+}
+
 // Freelists boost performance 6-10%; they also reduce memory
 // fragmentation, as _PyAsyncGenWrappedValue and PyAsyncGenASend
 // are short-living objects that are instantiated for every
@@ -182,7 +182,7 @@ static __pyx_PyAsyncGenASend *__Pyx_ag_asend_freelist[_PyAsyncGen_MAXFREELIST];
 static int __Pyx_ag_asend_freelist_free = 0;
 
 #define __pyx__PyAsyncGenWrappedValue_CheckExact(o) \
-                    __Pyx_IS_TYPE(o, __pyx__PyAsyncGenWrappedValueType)
+                    __Pyx_IS_TYPE(o, __Pyx_CGlobal(AsyncGenWrappedValueType))
 
 
 static int
@@ -482,7 +482,7 @@ __Pyx_PyAsyncGen_ClearFreeLists(void)
     while (__Pyx_ag_asend_freelist_free) {
         __pyx_PyAsyncGenASend *o;
         o = __Pyx_ag_asend_freelist[--__Pyx_ag_asend_freelist_free];
-        assert(__Pyx_IS_TYPE(o, __pyx__PyAsyncGenASendType));
+        assert(__Pyx_IS_TYPE(o, __Pyx_CGlobal(AsyncGenASendType)));
         __Pyx_PyHeapTypeObject_GC_Del(o);
     }
 
@@ -744,7 +744,7 @@ __Pyx_async_gen_asend_new(__pyx_PyAsyncGenObject *gen, PyObject *sendval)
         o = __Pyx_ag_asend_freelist[__Pyx_ag_asend_freelist_free];
         _Py_NewReference((PyObject *)o);
     } else {
-        o = PyObject_GC_New(__pyx_PyAsyncGenASend, __pyx__PyAsyncGenASendType);
+        o = PyObject_GC_New(__pyx_PyAsyncGenASend, __Pyx_CGlobal(AsyncGenASendType));
         if (unlikely(o == NULL)) {
             return NULL;
         }
@@ -883,7 +883,7 @@ __Pyx__PyAsyncGenValueWrapperNew(PyObject *val)
         assert(__pyx__PyAsyncGenWrappedValue_CheckExact(o));
         _Py_NewReference((PyObject*)o);
     } else {
-        o = PyObject_GC_New(__pyx__PyAsyncGenWrappedValue, __pyx__PyAsyncGenWrappedValueType);
+        o = PyObject_GC_New(__pyx__PyAsyncGenWrappedValue, __Pyx_CGlobal(AsyncGenWrappedValueType));
         if (unlikely(!o)) {
             Py_DECREF(val);
             return NULL;
@@ -1211,7 +1211,7 @@ static PyObject *
 __Pyx_async_gen_athrow_new(__pyx_PyAsyncGenObject *gen, PyObject *args)
 {
     __pyx_PyAsyncGenAThrow *o;
-    o = PyObject_GC_New(__pyx_PyAsyncGenAThrow, __pyx__PyAsyncGenAThrowType);
+    o = PyObject_GC_New(__pyx_PyAsyncGenAThrow, __Pyx_CGlobal(AsyncGenAThrowType));
     if (unlikely(o == NULL)) {
         return NULL;
     }
@@ -1228,43 +1228,48 @@ __Pyx_async_gen_athrow_new(__pyx_PyAsyncGenObject *gen, PyObject *args)
 /* ---------- global type sharing ------------ */
 
 static int __pyx_AsyncGen_init(PyObject *module) {
+    PyTypeObject *type;
 #if CYTHON_USE_TYPE_SPECS
-    __pyx_AsyncGenType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_AsyncGenType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_AsyncGenType_spec, NULL);
 #else
     (void) module;
     // on Windows, C-API functions can't be used in slots statically
     __pyx_AsyncGenType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
-    __pyx_AsyncGenType = __Pyx_FetchCommonType(&__pyx_AsyncGenType_type);
+    type = __Pyx_FetchCommonType(&__pyx_AsyncGenType_type);
 #endif
-    if (unlikely(!__pyx_AsyncGenType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(AsyncGenType) = type;
 
 #if CYTHON_USE_TYPE_SPECS
-    __pyx__PyAsyncGenAThrowType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenAThrowType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenAThrowType_spec, NULL);
 #else
     __pyx__PyAsyncGenAThrowType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
-    __pyx__PyAsyncGenAThrowType = __Pyx_FetchCommonType(&__pyx__PyAsyncGenAThrowType_type);
+    type = __Pyx_FetchCommonType(&__pyx__PyAsyncGenAThrowType_type);
 #endif
-    if (unlikely(!__pyx__PyAsyncGenAThrowType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(AsyncGenAThrowType) = type;
 
 #if CYTHON_USE_TYPE_SPECS
-    __pyx__PyAsyncGenWrappedValueType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenWrappedValueType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenWrappedValueType_spec, NULL);
 #else
     __pyx__PyAsyncGenWrappedValueType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
-    __pyx__PyAsyncGenWrappedValueType = __Pyx_FetchCommonType(&__pyx__PyAsyncGenWrappedValueType_type);
+    type = __Pyx_FetchCommonType(&__pyx__PyAsyncGenWrappedValueType_type);
 #endif
-    if (unlikely(!__pyx__PyAsyncGenWrappedValueType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(AsyncGenWrappedValueType) = type;
 
 #if CYTHON_USE_TYPE_SPECS
-    __pyx__PyAsyncGenASendType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenASendType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx__PyAsyncGenASendType_spec, NULL);
 #else
     __pyx__PyAsyncGenASendType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
-    __pyx__PyAsyncGenASendType = __Pyx_FetchCommonType(&__pyx__PyAsyncGenASendType_type);
+    type = __Pyx_FetchCommonType(&__pyx__PyAsyncGenASendType_type);
 #endif
-    if (unlikely(!__pyx__PyAsyncGenASendType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(AsyncGenASendType) = type;
 
     return 0;
 }

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -442,15 +442,13 @@ static CYTHON_INLINE void __Pyx_Coroutine_ResetFrameBackpointer(__Pyx_ExcInfoStr
 //////////////////// Coroutine.proto ////////////////////
 
 #define __Pyx_Coroutine_USED
-static PyTypeObject *__pyx_CoroutineType = 0;
-static PyTypeObject *__pyx_CoroutineAwaitType = 0;
-#define __Pyx_Coroutine_CheckExact(obj) __Pyx_IS_TYPE(obj, __pyx_CoroutineType)
+#define __Pyx_Coroutine_CheckExact(obj) __Pyx_IS_TYPE(obj, __Pyx_CGlobal(CoroutineType))
 // __Pyx_Coroutine_Check(obj): see override for IterableCoroutine below
 #define __Pyx_Coroutine_Check(obj) __Pyx_Coroutine_CheckExact(obj)
-#define __Pyx_CoroutineAwait_CheckExact(obj) __Pyx_IS_TYPE(obj, __pyx_CoroutineAwaitType)
+#define __Pyx_CoroutineAwait_CheckExact(obj) __Pyx_IS_TYPE(obj, __Pyx_CGlobal(CoroutineAwaitType))
 
 #define __Pyx_Coroutine_New(body, code, closure, name, qualname, module_name)  \
-    __Pyx__Coroutine_New(__pyx_CoroutineType, body, code, closure, name, qualname, module_name)
+    __Pyx__Coroutine_New(__Pyx_CGlobal(CoroutineType), body, code, closure, name, qualname, module_name)
 
 static int __pyx_Coroutine_init(PyObject *module); /*proto*/
 static PyObject *__Pyx__Coroutine_await(PyObject *coroutine); /*proto*/
@@ -467,11 +465,10 @@ static PyObject *__Pyx_CoroutineAwait_Throw(__pyx_CoroutineAwaitObject *self, Py
 //////////////////// Generator.proto ////////////////////
 
 #define __Pyx_Generator_USED
-static PyTypeObject *__pyx_GeneratorType = 0;
-#define __Pyx_Generator_CheckExact(obj) __Pyx_IS_TYPE(obj, __pyx_GeneratorType)
+#define __Pyx_Generator_CheckExact(obj) __Pyx_IS_TYPE(obj, __Pyx_CGlobal(GeneratorType))
 
 #define __Pyx_Generator_New(body, code, closure, name, qualname, module_name)  \
-    __Pyx__Coroutine_New(__pyx_GeneratorType, body, code, closure, name, qualname, module_name)
+    __Pyx__Coroutine_New(__Pyx_CGlobal(GeneratorType), body, code, closure, name, qualname, module_name)
 
 static PyObject *__Pyx_Generator_Next(PyObject *self);
 static int __pyx_Generator_init(PyObject *module); /*proto*/
@@ -1560,7 +1557,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 
 #if PY_VERSION_HEX < 0x030500B1 || defined(__Pyx_IterableCoroutine_USED) || CYTHON_USE_ASYNC_SLOTS
 static CYTHON_INLINE PyObject *__Pyx__Coroutine_await(PyObject *coroutine) {
-    __pyx_CoroutineAwaitObject *await = PyObject_GC_New(__pyx_CoroutineAwaitObject, __pyx_CoroutineAwaitType);
+    __pyx_CoroutineAwaitObject *await = PyObject_GC_New(__pyx_CoroutineAwaitObject, __Pyx_CGlobal(CoroutineAwaitType));
     if (unlikely(!await)) return NULL;
     Py_INCREF(coroutine);
     await->coroutine = coroutine;
@@ -1747,16 +1744,18 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #endif /* CYTHON_USE_TYPE_SPECS */
 
 static int __pyx_Coroutine_init(PyObject *module) {
+    PyTypeObject *type;
     // on Windows, C-API functions can't be used in slots statically
 #if CYTHON_USE_TYPE_SPECS
-    __pyx_CoroutineType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CoroutineType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CoroutineType_spec, NULL);
 #else
     (void) module;
     __pyx_CoroutineType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
-    __pyx_CoroutineType = __Pyx_FetchCommonType(&__pyx_CoroutineType_type);
+    type = __Pyx_FetchCommonType(&__pyx_CoroutineType_type);
 #endif
-    if (unlikely(!__pyx_CoroutineType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(CoroutineType) = type;
 
 #ifdef __Pyx_IterableCoroutine_USED
     if (unlikely(__pyx_IterableCoroutine_init(module) == -1))
@@ -1764,12 +1763,13 @@ static int __pyx_Coroutine_init(PyObject *module) {
 #endif
 
 #if CYTHON_USE_TYPE_SPECS
-    __pyx_CoroutineAwaitType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CoroutineAwaitType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CoroutineAwaitType_spec, NULL);
 #else
-    __pyx_CoroutineAwaitType = __Pyx_FetchCommonType(&__pyx_CoroutineAwaitType_type);
+    type = __Pyx_FetchCommonType(&__pyx_CoroutineAwaitType_type);
 #endif
-    if (unlikely(!__pyx_CoroutineAwaitType))
+    if (unlikely(!type))
         return -1;
+    __Pyx_CGlobal(CoroutineAwaitType) = type;
     return 0;
 }
 
@@ -2043,18 +2043,20 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #endif /* CYTHON_USE_TYPE_SPECS */
 
 static int __pyx_Generator_init(PyObject *module) {
+    PyTypeObject *type;
 #if CYTHON_USE_TYPE_SPECS
-    __pyx_GeneratorType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_GeneratorType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_GeneratorType_spec, NULL);
 #else
     (void) module;
     // on Windows, C-API functions can't be used in slots statically
     __pyx_GeneratorType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
     __pyx_GeneratorType_type.tp_iter = PyObject_SelfIter;
-    __pyx_GeneratorType = __Pyx_FetchCommonType(&__pyx_GeneratorType_type);
+    type = __Pyx_FetchCommonType(&__pyx_GeneratorType_type);
 #endif
-    if (unlikely(!__pyx_GeneratorType)) {
+    if (unlikely(!type)) {
         return -1;
     }
+    __Pyx_CGlobal(GeneratorType) = type;
     return 0;
 }
 
@@ -2134,14 +2136,14 @@ static PyObject* __Pyx_Coroutine_patch_module(PyObject* module, const char* py_c
     globals = PyDict_New();  if (unlikely(!globals)) goto ignore;
     result = PyDict_SetItemString(globals, "_cython_coroutine_type",
     #ifdef __Pyx_Coroutine_USED
-        (PyObject*)__pyx_CoroutineType);
+        (PyObject*)__Pyx_CGlobal(CoroutineType));
     #else
         Py_None);
     #endif
     if (unlikely(result < 0)) goto ignore;
     result = PyDict_SetItemString(globals, "_cython_generator_type",
     #ifdef __Pyx_Generator_USED
-        (PyObject*)__pyx_GeneratorType);
+        (PyObject*)__Pyx_CGlobal(GeneratorType));
     #else
         Py_None);
     #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -63,13 +63,9 @@ typedef struct {
     PyObject *func_annotations; /* function annotations dict */
 } __pyx_CyFunctionObject;
 
-#if !CYTHON_USE_MODULE_STATE
-static PyTypeObject *__pyx_CyFunctionType = 0;
-#endif
-
-#define __Pyx_CyFunction_Check(obj)  __Pyx_TypeCheck(obj, __pyx_CyFunctionType)
-#define __Pyx_IsCyOrPyCFunction(obj)  __Pyx_TypeCheck2(obj, __pyx_CyFunctionType, &PyCFunction_Type)
-#define __Pyx_CyFunction_CheckExact(obj)  __Pyx_IS_TYPE(obj, __pyx_CyFunctionType)
+#define __Pyx_CyFunction_Check(obj)  __Pyx_TypeCheck(obj, __Pyx_CGlobal(CyFunctionType))
+#define __Pyx_IsCyOrPyCFunction(obj)  __Pyx_TypeCheck2(obj, __Pyx_CGlobal(CyFunctionType), &PyCFunction_Type)
+#define __Pyx_CyFunction_CheckExact(obj)  __Pyx_IS_TYPE(obj, __Pyx_CGlobal(CyFunctionType))
 
 static PyObject *__Pyx_CyFunction_Init(__pyx_CyFunctionObject* op, PyMethodDef *ml,
                                       int flags, PyObject* qualname,
@@ -996,15 +992,17 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 
 
 static int __pyx_CyFunction_init(PyObject *module) {
+    PyTypeObject *type;
 #if CYTHON_USE_TYPE_SPECS
-    __pyx_CyFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CyFunctionType_spec, NULL);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CyFunctionType_spec, NULL);
 #else
     (void) module;
-    __pyx_CyFunctionType = __Pyx_FetchCommonType(&__pyx_CyFunctionType_type);
+    type = __Pyx_FetchCommonType(&__pyx_CyFunctionType_type);
 #endif
-    if (unlikely(__pyx_CyFunctionType == NULL)) {
+    if (unlikely(type == NULL)) {
         return -1;
     }
+    __Pyx_CGlobal(CyFunctionType) = type;
     return 0;
 }
 
@@ -1053,7 +1051,7 @@ static PyObject *__Pyx_CyFunction_New(PyMethodDef *ml,
 static PyObject *__Pyx_CyFunction_New(PyMethodDef *ml, int flags, PyObject* qualname,
                                       PyObject *closure, PyObject *module, PyObject* globals, PyObject* code) {
     PyObject *op = __Pyx_CyFunction_Init(
-        PyObject_GC_New(__pyx_CyFunctionObject, __pyx_CyFunctionType),
+        PyObject_GC_New(__pyx_CyFunctionObject, __Pyx_CGlobal(CyFunctionType)),
         ml, flags, qualname, closure, module, globals, code
     );
     if (likely(op)) {
@@ -1104,9 +1102,6 @@ static PyObject *__pyx_FusedFunction_New(PyMethodDef *ml, int flags,
                                          PyObject *code);
 
 static int __pyx_FusedFunction_clear(__pyx_FusedFunctionObject *self);
-#if !CYTHON_USE_MODULE_STATE
-static PyTypeObject *__pyx_FusedFunctionType = NULL;
-#endif
 static int __pyx_FusedFunction_init(PyObject *module);
 
 #define __Pyx_FusedFunction_USED
@@ -1122,7 +1117,7 @@ __pyx_FusedFunction_New(PyMethodDef *ml, int flags,
 {
     PyObject *op = __Pyx_CyFunction_Init(
         // __pyx_CyFunctionObject is correct below since that's the cast that we want.
-        PyObject_GC_New(__pyx_CyFunctionObject, __pyx_FusedFunctionType),
+        PyObject_GC_New(__pyx_CyFunctionObject, __Pyx_CGlobal(FusedFunctionType)),
         ml, flags, qualname, closure, module, globals, code
     );
     if (likely(op)) {
@@ -1510,22 +1505,25 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #endif
 
 static int __pyx_FusedFunction_init(PyObject *module) {
+    PyTypeObject *cyfunction_type = __Pyx_CGlobal(CyFunctionType);
+    PyTypeObject *type;
 #if CYTHON_USE_TYPE_SPECS
-    PyObject *bases = PyTuple_Pack(1, __pyx_CyFunctionType);
+    PyObject *bases = PyTuple_Pack(1, (PyObject*)cyfunction_type);
     if (unlikely(!bases)) {
         return -1;
     }
-    __pyx_FusedFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_FusedFunctionType_spec, bases);
+    type = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_FusedFunctionType_spec, bases);
     Py_DECREF(bases);
 #else
     (void) module;
     // Set base from __Pyx_FetchCommonTypeFromSpec, in case it's different from the local static value.
-    __pyx_FusedFunctionType_type.tp_base = __pyx_CyFunctionType;
-    __pyx_FusedFunctionType = __Pyx_FetchCommonType(&__pyx_FusedFunctionType_type);
+    __pyx_FusedFunctionType_type.tp_base = cyfunction_type;
+    type = __Pyx_FetchCommonType(&__pyx_FusedFunctionType_type);
 #endif
-    if (unlikely(__pyx_FusedFunctionType == NULL)) {
+    if (unlikely(type == NULL)) {
         return -1;
     }
+    __Pyx_CGlobal(FusedFunctionType) = type;
     return 0;
 }
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1187,8 +1187,14 @@ static CYTHON_INLINE float __PYX_NAN() {
 
 /////////////// UtilityFunctionPredeclarations.proto ///////////////
 
-typedef struct {PyObject **p; const char *s; const Py_ssize_t n; const char* encoding;
-                const char is_unicode; const char is_str; const char intern; } __Pyx_StringTabEntry; /*proto*/
+typedef struct {
+    const char *s;
+    const Py_ssize_t n;
+    const char* encoding;
+    const char is_unicode;
+    const char is_str;
+    const char intern;
+} __Pyx_StringTabEntry;
 
 /////////////// ForceInitThreads.proto ///////////////
 //@proto_block: utility_code_proto_before_types


### PR DESCRIPTION
This is a request for comments for addressing #3689 and to get some early review feedback, before I go off and translate everything to this style.

There's 2 preparation cleanups in this PR, the real work addressing the issue is in the third commit.
- Always create a struct for the module state. For the proof of concept the struct will only include the couple variables from `generate_module_preamble` without limited mode enabled.
- Add `__Pyx_Globals()` macro that returns a pointer to the module state. Without limited mode enabled, we will create 1 global static variable and have the macro return the address of that.
- Wrap some `Naming.xxx` things in a `Global` struct, so that using them in a string-context (`__str__`) they return a `__Pyx_Globals()->xxx` expression, but also add a `field_name` field so that we can access just the `xxx` name in the few context that need it, without changing most other users in the codebase.