### PR TITLE
Flow control and names in finally blocks

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1220,6 +1220,7 @@ class ControlFlowAnalysis(CythonTransform):
         if self.flow.loops:
             self.flow.loops[-1].exceptions.append(descr)
         self.flow.block = body_block
+        body_block.add_child(entry_point)
         self.flow.nextblock()
         self._visit(node.body)
         self.flow.exceptions.pop()

--- a/tests/compile/tryfinally.pyx
+++ b/tests/compile/tryfinally.pyx
@@ -18,4 +18,11 @@ def f(a, b, c, x):
         finally:
             i = 42
 
+def use_name_in_finally(name):
+    # GH3712
+    try:
+        []
+    finally:
+        name()
+
 


### PR DESCRIPTION
Fixes #3712 (hopefully) by reverting a small part of bbef4d7

Should be applied to 0.29.x and 3.0 branches