### PR TITLE
Provide fault-tolerant parsing (GH-3303)

### DIFF
--- a/Cython/Compiler/Scanning.pxd
+++ b/Cython/Compiler/Scanning.pxd
@@ -36,6 +36,7 @@ cdef class PyrexScanner(Scanner):
     cdef readonly bint async_enabled
     cdef public sy
     cdef public systring
+    cdef public bint fault_tolerant
 
     cdef long current_level(self)
     #cpdef commentline(self, text)

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -302,7 +302,7 @@ class PyrexScanner(Scanner):
     #  compile_time_expr  boolean  In a compile-time expression context
 
     def __init__(self, file, filename, parent_scanner=None,
-                 scope=None, context=None, source_encoding=None, parse_comments=True, initial_pos=None):
+                 scope=None, context=None, source_encoding=None, parse_comments=True, initial_pos=None, fault_tolerant=False):
         Scanner.__init__(self, get_lexicon(), file, filename, initial_pos)
 
         if filename.is_python_file():
@@ -341,6 +341,8 @@ class PyrexScanner(Scanner):
         self.begin('INDENT')
         self.sy = ''
         self.next()
+
+        self.fault_tolerant = fault_tolerant
 
     def normalize_ident(self, text):
         try:
@@ -478,6 +480,8 @@ class PyrexScanner(Scanner):
         self.queue.insert(0, (token, value))
 
     def error(self, message, pos=None, fatal=True):
+        if self.fault_tolerant:
+            fatal = False
         if pos is None:
             pos = self.position()
         if self.sy == 'INDENT':

--- a/Cython/Compiler/Tests/TestTreeFragment.py
+++ b/Cython/Compiler/Tests/TestTreeFragment.py
@@ -2,6 +2,7 @@ from Cython.TestUtils import CythonTest
 from Cython.Compiler.TreeFragment import *
 from Cython.Compiler.Nodes import *
 from Cython.Compiler.UtilNodes import *
+from Cython.Compiler.Errors import local_errors
 import Cython.Compiler.Naming as Naming
 
 class TestTreeFragments(CythonTest):
@@ -58,6 +59,63 @@ class TestTreeFragments(CythonTest):
         self.assertTrue(isinstance(s[0].expr, TempRefNode))
         self.assertTrue(isinstance(s[1].rhs, TempRefNode))
         self.assertTrue(s[0].expr.handle is s[1].rhs.handle)
+
+    def test_parse_fault_tolerant_complete(self):
+        code = u'''
+def method():
+    pass
+
+def method2():
+    error_here =
+
+def method3():
+    error_here.
+
+def method4():
+    without_error = 10
+
+def method5():
+    error_here =
+'''
+        with local_errors() as errors:
+            stats = parse_from_strings("test_name", code, fault_tolerant=True).body.stats
+        self.assertEquals(len(stats), 5)
+        self.assertIsInstance(stats[0], DefNode)
+        self.assertEqual(str(stats[0].name), "method")
+        self.assertIsInstance(stats[0].body, PassStatNode)
+        self.assertIsInstance(stats[1], DefNode)
+        self.assertEqual(str(stats[1].name), "method2")
+        self.assertIsInstance(stats[1].body, PassStatNode)
+        self.assertIsInstance(stats[2], DefNode)
+        self.assertEqual(str(stats[2].name), "method3")
+        self.assertIsInstance(stats[2].body, ExprStatNode)
+        self.assertIsInstance(stats[3], DefNode)
+        self.assertEqual(str(stats[3].name), "method4")
+        self.assertIsInstance(stats[3].body, SingleAssignmentNode)
+        self.assertIsInstance(stats[4], DefNode)
+        self.assertEqual(str(stats[4].name), "method5")
+        self.assertIsInstance(stats[4].body, PassStatNode)
+        self.assertEquals(len(errors), 5)
+        self.assertEqual(
+            "CompileError((<StringSourceDescriptor:test_name>, 6, 16), 'Expected an identifier or literal')",
+            repr(errors[0])
+        )
+        self.assertEqual(
+            "CompileError((<StringSourceDescriptor:test_name>, 6, 4), \"Internal Error: 'NoneType' object has no attribute 'pos'\")",
+            repr(errors[1])
+        )
+        self.assertEqual(
+            "CompileError((<StringSourceDescriptor:test_name>, 9, 15), 'Expected an identifier')",
+            repr(errors[2])
+        )
+        self.assertEqual(
+            "CompileError((<StringSourceDescriptor:test_name>, 15, 16), 'Expected an identifier or literal')",
+            repr(errors[3])
+        )
+        self.assertEqual(
+            "CompileError((<StringSourceDescriptor:test_name>, 15, 4), \"Internal Error: 'NoneType' object has no attribute 'pos'\")",
+            repr(errors[4])
+        )
 
 if __name__ == "__main__":
     import unittest

--- a/Cython/Compiler/TreeFragment.py
+++ b/Cython/Compiler/TreeFragment.py
@@ -39,7 +39,7 @@ class StringParseContext(Main.Context):
 
 
 def parse_from_strings(name, code, pxds=None, level=None, initial_pos=None,
-                       context=None, allow_struct_enum_decorator=False):
+                       context=None, allow_struct_enum_decorator=False, fault_tolerant=False):
     """
     Utility method to parse a (unicode) string of code. This is mostly
     used for internal Cython compiler purposes (creating code snippets
@@ -72,7 +72,7 @@ def parse_from_strings(name, code, pxds=None, level=None, initial_pos=None,
     buf = StringIO(code)
 
     scanner = PyrexScanner(buf, code_source, source_encoding = encoding,
-                     scope = scope, context = context, initial_pos = initial_pos)
+                     scope = scope, context = context, initial_pos = initial_pos, fault_tolerant=fault_tolerant)
     ctx = Parsing.Ctx(allow_struct_enum_decorator=allow_struct_enum_decorator)
 
     if level is None:


### PR DESCRIPTION
This provides a way to have fault tolerant parsing in cython (so, third-party tools such as IDEs can use it for parsing code that's being written).

Note that it has a catch-all exceptions which turns internal errors into compile errors as just setting the `fatal=False` on `error` doesn't fix all cases.

It should be possible to fix specific issues in the future so that internal errors aren't generated, but in practice, it's hard to catch all errors, so, even if some of those would be fixed I think that the catch-all should still be there.