### PR TITLE
Avoid calling PyUnicode_FromUnicode() in Py3

### DIFF
--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -561,7 +561,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyUnicode_Substring(
     else if (stop > length)
         stop = length;
     if (stop <= start)
-        return PyUnicode_FromUnicode(NULL, 0);
+        return __Pyx_NewRef($empty_unicode);
 #if CYTHON_PEP393_ENABLED
     return PyUnicode_FromKindAndData(PyUnicode_KIND(text),
         PyUnicode_1BYTE_DATA(text) + start*PyUnicode_KIND(text), stop-start);


### PR DESCRIPTION
Update __Pyx_PyUnicode_Substring().

Closes https://github.com/cython/cython/pull/3677