### PR TITLE
[WIP] Do not allow the test suite to output Cython warnings

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1199,6 +1199,8 @@ class CythonCompileTestCase(unittest.TestCase):
         tostderr = sys.__stderr__.write
         if expected_warnings or (expect_warnings and warnings):
             self._match_output(expected_warnings, warnings, tostderr)
+        elif warnings:
+            self._match_output([], warnings, tostderr)
         if 'cerror' in self.tags['tag']:
             if errors:
                 tostderr("\n=== Expected C compile error ===\n")


### PR DESCRIPTION
… unless they are expected.

See #1699.

This will require some work to fix all tests.