### PR TITLE
Try detecting _MSC_VER for __PYX_STD_MOVE_IF_SUPPORTED

### DIFF
--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -61,7 +61,7 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 
 ////////////// MoveIfSupported.proto //////////////////
 
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER > 1900)
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
   // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
   #include <utility>
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -61,7 +61,8 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 
 ////////////// MoveIfSupported.proto //////////////////
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER > 1900)
+  // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
   #include <utility>
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
 #else


### PR DESCRIPTION
Relates to https://github.com/cython/cython/issues/3789

Right now I'm interested in if this gives any appveyor test failures. I think (but not 100% sure) that these versions should support `std::move`