### PR TITLE
Improved documentation for annotation typing

### DIFF
--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -13,7 +13,7 @@ To go beyond that, Cython provides language constructs to add static typing
 and cythonic functionalities to a Python module to make it run much faster
 when compiled, while still allowing it to be interpreted.
 This is accomplished via an augmenting ``.pxd`` file, via Python
-type :ref:`annotations` (following
+type :ref:`pep484_type_annotations` (following
 `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ and
 `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_), and/or
 via special functions and decorators available after importing the magic
@@ -273,12 +273,13 @@ can be augmented with the following :file:`.pxd` file :file:`dostuff.pxd`:
 The :func:`cython.declare()` function can be used to specify types for global
 variables in the augmenting :file:`.pxd` file.
 
-.. _annotations:
+.. _pep484_type_annotations:
 
-Annotations
------------
+PEP-484 type annotations
+------------------------
 
-Python annotations can be used to declare argument types, as shown in the
+Python `type hints <https://www.python.org/dev/peps/pep-0484>`_
+can be used to declare argument types, as shown in the
 following example.  To avoid conflicts with other kinds of annotation
 usages, this can be disabled with the directive ``annotation_typing=False``.
 
@@ -310,11 +311,13 @@ declare types of variables in a Python 3.6 compatible way as follows:
 
 There is currently no way to express the visibility of object attributes.
 
-Cython does not support the full range of annotations described by PEP-0526.
-For example it does not understand features from the ``typing`` module such 
-as ``Optional[]`` or typed containers such as ``List[str]``. Such annotations
-typically do not provide information that is useful to Cython in generating
-efficient C code.
+Cython does not support the full range of annotations described by PEP-484.
+For example it does not currently understand features from the ``typing`` module
+such  as ``Optional[]`` or typed containers such as ``List[str]``. This is partly
+because some of these type hints are not relevant for the compilation to
+efficient C code. In other cases, however, where the generated C code could
+benefit from these type hints but does not currently, help is welcome to
+improve the type analysis in Cython.
 
 
 Tips and Tricks

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -13,7 +13,7 @@ To go beyond that, Cython provides language constructs to add static typing
 and cythonic functionalities to a Python module to make it run much faster
 when compiled, while still allowing it to be interpreted.
 This is accomplished via an augmenting ``.pxd`` file, via Python
-type annotations (following
+type :ref:`annotations` (following
 `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ and
 `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_), and/or
 via special functions and decorators available after importing the magic
@@ -158,35 +158,6 @@ Static typing
   If exception propagation is disabled, any Python exceptions that are raised
   inside of the function will be printed and ignored.
 
-* Python annotations can be used to declare argument types, as shown in the
-  following example.  To avoid conflicts with other kinds of annotation
-  usages, this can be disabled with the directive ``annotation_typing=False``.
-
-  .. literalinclude:: ../../examples/tutorial/pure/annotations.py
-
-  This can be combined with the ``@cython.exceptval()`` decorator for non-Python
-  return types:
-
-  .. literalinclude:: ../../examples/tutorial/pure/exceptval.py
-
-  Note that the default exception handling behaviour when returning C numeric types
-  is to check for ``-1``, and if that was returned, check Python's error indicator
-  for an exception.  This means, if no ``@exceptval`` decorator is provided, and the
-  return type is a numeric type, then the default with type annotations is
-  ``@exceptval(-1, check=True)``, in order to make sure that exceptions are correctly
-  and efficiently reported to the caller.  Exception propagation can be disabled
-  explicitly with ``@exceptval(check=False)``, in which case any Python exceptions
-  raised inside of the function will be printed and ignored.
-
-  Since version 0.27, Cython also supports the variable annotations defined
-  in `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_. This allows to
-  declare types of variables in a Python 3.6 compatible way as follows:
-
-  .. literalinclude:: ../../examples/tutorial/pure/pep_526.py
-
-  There is currently no way to express the visibility of object attributes.
-
-
 C types
 ^^^^^^^
 
@@ -301,6 +272,49 @@ can be augmented with the following :file:`.pxd` file :file:`dostuff.pxd`:
 
 The :func:`cython.declare()` function can be used to specify types for global
 variables in the augmenting :file:`.pxd` file.
+
+.. _annotations:
+
+Annotations
+-----------
+
+Python annotations can be used to declare argument types, as shown in the
+following example.  To avoid conflicts with other kinds of annotation
+usages, this can be disabled with the directive ``annotation_typing=False``.
+
+  .. literalinclude:: ../../examples/tutorial/pure/annotations.py
+
+Note the use of ``cython.int`` rather than ``int`` - Cython does not translate
+an ``int`` annotation to a C integer by default since the behaviour can be
+quite different with respect to overflow and division.
+
+Annotations can be combined with the ``@cython.exceptval()`` decorator for non-Python
+return types:
+
+  .. literalinclude:: ../../examples/tutorial/pure/exceptval.py
+
+Note that the default exception handling behaviour when returning C numeric types
+is to check for ``-1``, and if that was returned, check Python's error indicator
+for an exception.  This means, if no ``@exceptval`` decorator is provided, and the
+return type is a numeric type, then the default with type annotations is
+``@exceptval(-1, check=True)``, in order to make sure that exceptions are correctly
+and efficiently reported to the caller.  Exception propagation can be disabled
+explicitly with ``@exceptval(check=False)``, in which case any Python exceptions
+raised inside of the function will be printed and ignored.
+
+Since version 0.27, Cython also supports the variable annotations defined
+in `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_. This allows to
+declare types of variables in a Python 3.6 compatible way as follows:
+
+.. literalinclude:: ../../examples/tutorial/pure/pep_526.py
+
+There is currently no way to express the visibility of object attributes.
+
+Cython does not support the full range of annotations described by PEP-0526.
+For example it does not understand features from the ``typing`` module such 
+as ``Optional[]`` or typed containers such as ``List[str]``. Such annotations
+typically do not provide information that is useful to Cython in generating
+efficient C code.
 
 
 Tips and Tricks


### PR DESCRIPTION
Mainly by moving it to a separate section to make it easier
to find, however also added a small amount of extra information
about some of the obvious limitations