### PR TITLE
Don't require default constructor for C++ temps

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -183,6 +183,8 @@ class PyrexType(BaseType):
     #  is_struct             boolean     Is a C struct type
     #  is_enum               boolean     Is a C enum type
     #  is_cpp_enum           boolean     Is a C++ scoped enum type
+    #  is_cpp_class          boolean     Is a cppclass
+    #  is_cpp_temp           boolean     Is a temporary handle to a c++ class
     #  is_typedef            boolean     Is a typedef type
     #  is_string             boolean     Is a C char * type
     #  is_pyunicode_ptr      boolean     Is a C PyUNICODE * type
@@ -246,6 +248,7 @@ class PyrexType(BaseType):
     is_cfunction = 0
     is_struct_or_union = 0
     is_cpp_class = 0
+    is_cpp_temp = 0
     is_cpp_string = 0
     is_struct = 0
     is_enum = 0
@@ -4021,6 +4024,27 @@ class CppClassType(CType):
         constructor = self.scope.lookup(u'<init>')
         if constructor is not None and best_match([], constructor.all_alternatives()) is None:
             error(pos, "C++ class must have a nullary constructor to be %s" % msg)
+
+
+class CppTempType(PyrexType):
+    """
+    Used internally to avoid requiring a default constructor for C++ temps
+    """
+    is_cpp_temp = 1
+
+    def __init__(self, base):
+        self.base = base
+
+    def __repr__(self):
+        return "<CppTempType %s>" % repr(self.base.name)
+
+    def __str__(self):
+        return "%s [temp]" % self.base.name
+
+    def declaration_code(self, entity_code,
+            for_display = 0, dll_linkage = None, pyrex = 0):
+        return "__Pyx_CppTemp<%s> %s" % (self.base.empty_declaration_code(), entity_code)
+
 
 class CppScopedEnumType(CType):
     # name    string

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -64,7 +64,10 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER > 1900)
   // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
   #include <utility>
-  #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
+  template<class T>
+  typename std::remove_reference<T>::type&& __PYX_STD_MOVE_IF_SUPPORTED(T&& x) {
+      return std::move(x);
+  }
 #else
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) x
 #endif

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -61,7 +61,8 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 
 ////////////// MoveIfSupported.proto //////////////////
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER > 1900)
+  // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
   #include <utility>
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
 #else


### PR DESCRIPTION
Made C++ temps a special type to avoid default constructor
    
This uses placement new to avoid requiring a default constructor (at the cost of using a little extra space for an "assigned" bool). The pattern is pretty similar to std::optional. This gives a little extra flexibility in terms of the C++ classes that Cython can handle.
    
(built on top of https://github.com/cython/cython/pull/3792 for simplicity, but needn't require that - it only requires a change to some #if lines)

Longer-term it might be possible to support something similar for regular cdef variables, but it'd probably need some extra syntax since I doubt we'd want to change the default behaviour.