### PR TITLE
Define extern `PyBUF_MAX_NDIM`

### DIFF
--- a/Cython/Includes/cpython/buffer.pxd
+++ b/Cython/Includes/cpython/buffer.pxd
@@ -3,6 +3,9 @@
 cdef extern from "Python.h":
 
     cdef enum:
+        PyBUF_MAX_NDIM
+
+    cdef enum:
         PyBUF_SIMPLE,
         PyBUF_WRITABLE,
         PyBUF_WRITEABLE, # backwards compatibility


### PR DESCRIPTION
Ensure that Cython exposes `PyBUF_MAX_NDIM` from Python as part of `cpython.buffer` to allow access to developers.