### PR TITLE
Add doc support for cpdef enum

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1546,17 +1546,23 @@ class CEnumDefNode(StatNode):
     #  in_pxd             boolean
     #  create_wrapper     boolean
     #  entry              Entry
+    #  doc                EncodedString or None    Doc string
 
     child_attrs = ["items", "underlying_type"]
+    doc = None
 
     def declare(self, env):
+        doc = None
+        if Options.docstrings:
+            doc = embed_position(self.pos, self.doc)
+
         self.entry = env.declare_enum(
             self.name, self.pos,
             cname=self.cname,
             scoped=self.scoped,
             typedef_flag=self.typedef_flag,
             visibility=self.visibility, api=self.api,
-            create_wrapper=self.create_wrapper)
+            create_wrapper=self.create_wrapper, doc=doc)
 
     def analyse_declarations(self, env):
         scope = None

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3168,11 +3168,13 @@ def p_c_enum_definition(s, pos, ctx):
     s.expect(':')
     items = []
 
+    doc = None
     if s.sy != 'NEWLINE':
         p_c_enum_line(s, ctx, items)
     else:
         s.next()  # 'NEWLINE'
         s.expect_indent()
+        doc = p_doc_string(s)
 
         while s.sy not in ('DEDENT', 'EOF'):
             p_c_enum_line(s, ctx, items)
@@ -3188,7 +3190,7 @@ def p_c_enum_definition(s, pos, ctx):
         underlying_type=underlying_type,
         typedef_flag=ctx.typedef_flag, visibility=ctx.visibility,
         create_wrapper=ctx.overridable,
-        api=ctx.api, in_pxd=ctx.level == 'module_pxd')
+        api=ctx.api, in_pxd=ctx.level == 'module_pxd', doc=doc)
 
 def p_c_enum_line(s, ctx, items):
     if s.sy != 'pass':

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4139,6 +4139,7 @@ def is_optional_template_param(type):
 
 class CEnumType(CIntLike, CType):
     #  name           string
+    #  doc            string or None which then defaults to "An enumeration."
     #  cname          string or None
     #  typedef_flag   boolean
     #  values         [string], populated during declaration analysis
@@ -4147,8 +4148,12 @@ class CEnumType(CIntLike, CType):
     signed = 1
     rank = -1  # Ranks below any integer type
 
-    def __init__(self, name, cname, typedef_flag, namespace=None):
+    def __init__(self, name, cname, typedef_flag, namespace=None, doc=None):
         self.name = name
+        if doc is None:
+            self.doc = "An enumeration."
+        else:
+            self.doc = doc
         self.cname = cname
         self.values = []
         self.typedef_flag = typedef_flag
@@ -4190,7 +4195,8 @@ class CEnumType(CIntLike, CType):
         env.use_utility_code(CythonUtilityCode.load(
             "EnumType", "CpdefEnums.pyx",
             context={"name": self.name,
-                     "items": tuple(self.values)},
+                     "items": tuple(self.values),
+                     "enum_doc": self.doc},
             outer_module_scope=env.global_scope()))
 
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4024,12 +4024,14 @@ class CppClassType(CType):
 
 class CppScopedEnumType(CType):
     # name    string
+    # doc     string or None
     # cname   string
 
     is_cpp_enum = True
 
-    def __init__(self, name, cname, underlying_type, namespace=None):
+    def __init__(self, name, cname, underlying_type, namespace=None, doc=None):
         self.name = name
+        self.doc = doc
         self.cname = cname
         self.values = []
         self.underlying_type = underlying_type
@@ -4084,6 +4086,7 @@ class CppScopedEnumType(CType):
                 "cname": self.cname.split("::")[-1],
                 "items": tuple(self.values),
                 "underlying_type": self.underlying_type.empty_declaration_code(),
+                "enum_doc": self.doc,
             },
             outer_module_scope=env.global_scope())
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4139,7 +4139,7 @@ def is_optional_template_param(type):
 
 class CEnumType(CIntLike, CType):
     #  name           string
-    #  doc            string or None which then defaults to "An enumeration."
+    #  doc            string or None
     #  cname          string or None
     #  typedef_flag   boolean
     #  values         [string], populated during declaration analysis
@@ -4150,10 +4150,7 @@ class CEnumType(CIntLike, CType):
 
     def __init__(self, name, cname, typedef_flag, namespace=None, doc=None):
         self.name = name
-        if doc is None:
-            self.doc = "An enumeration."
-        else:
-            self.doc = doc
+        self.doc = doc
         self.cname = cname
         self.values = []
         self.typedef_flag = typedef_flag
@@ -4196,7 +4193,8 @@ class CEnumType(CIntLike, CType):
             "EnumType", "CpdefEnums.pyx",
             context={"name": self.name,
                      "items": tuple(self.values),
-                     "enum_doc": self.doc},
+                     "enum_doc": self.doc,
+                     },
             outer_module_scope=env.global_scope()))
 
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -694,7 +694,7 @@ class Scope(object):
                 namespace = None
 
             if scoped:
-                type = PyrexTypes.CppScopedEnumType(name, cname, namespace)
+                type = PyrexTypes.CppScopedEnumType(name, cname, namespace, doc=doc)
             else:
                 type = PyrexTypes.CEnumType(name, cname, typedef_flag, namespace, doc=doc)
         else:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -680,7 +680,7 @@ class Scope(object):
                 entry.name, entry.visibility))
 
     def declare_enum(self, name, pos, cname, scoped, typedef_flag,
-            visibility='private', api=0, create_wrapper=0):
+            visibility='private', api=0, create_wrapper=0, doc=None):
         if name:
             if not cname:
                 if (self.in_cinclude or visibility == 'public'
@@ -696,7 +696,7 @@ class Scope(object):
             if scoped:
                 type = PyrexTypes.CppScopedEnumType(name, cname, namespace)
             else:
-                type = PyrexTypes.CEnumType(name, cname, typedef_flag, namespace)
+                type = PyrexTypes.CEnumType(name, cname, typedef_flag, namespace, doc=doc)
         else:
             type = PyrexTypes.c_anon_enum_type
         entry = self.declare_type(name, type, pos, cname = cname,

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -58,7 +58,7 @@ if PY_VERSION_HEX >= 0x03040000:
     {{endfor}}
 else:
     class {{name}}(__Pyx_EnumBase):
-        __doc__ = """{{enum_doc}}"""
+        {{ repr(enum_doc) }}
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}({{item}}, '{{item}}')
     {{endfor}}

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -51,7 +51,7 @@ if PY_VERSION_HEX >= 0x03040000:
         ('{{item}}', {{item}}),
         {{endfor}}
     ]))
-    {{name}}.__doc__ = """{{enum_doc}}"""
+    {{name}}.__doc__ = {{ repr(enum_doc) }}
 
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}.{{item}}

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -82,3 +82,7 @@ else:
     {{for item in items}}
     __Pyx_globals["{{name}}"](<{{underlying_type}}>({{name}}.{{item}}), '{{item}}')
     {{endfor}}
+
+{{if enum_doc is not None}}
+__Pyx_globals["{{name}}"].__doc__ = {{ repr(enum_doc) }}
+{{endif}}

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -52,7 +52,7 @@ if PY_VERSION_HEX >= 0x03040000:
         {{endfor}}
     ]))
     {{if enum_doc is not None}}
-        {{name}}.__doc__ = {{ repr(enum_doc) }}
+    {{name}}.__doc__ = {{ repr(enum_doc) }}
     {{endif}}
 
     {{for item in items}}

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -51,12 +51,14 @@ if PY_VERSION_HEX >= 0x03040000:
         ('{{item}}', {{item}}),
         {{endfor}}
     ]))
+    {{name}}.__doc__ = """{{enum_doc}}"""
+
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}.{{item}}
     {{endfor}}
 else:
     class {{name}}(__Pyx_EnumBase):
-        pass
+        __doc__ = """{{enum_doc}}"""
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}({{item}}, '{{item}}')
     {{endfor}}

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -51,14 +51,16 @@ if PY_VERSION_HEX >= 0x03040000:
         ('{{item}}', {{item}}),
         {{endfor}}
     ]))
-    {{name}}.__doc__ = {{ repr(enum_doc) }}
+    {{if enum_doc is not None}}
+        {{name}}.__doc__ = {{ repr(enum_doc) }}
+    {{endif}}
 
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}.{{item}}
     {{endfor}}
 else:
     class {{name}}(__Pyx_EnumBase):
-        {{ repr(enum_doc) }}
+        {{ repr(enum_doc) if enum_doc is not None else 'pass' }}
     {{for item in items}}
     __Pyx_globals['{{item}}'] = {{name}}({{item}}, '{{item}}')
     {{endfor}}

--- a/tests/run/cpdef_enums.pxd
+++ b/tests/run/cpdef_enums.pxd
@@ -14,16 +14,16 @@ cpdef enum PxdEnum:
 cpdef enum cpdefPxdDocEnum:
     """Home is where...
     """
-    RANK_0 = 11
+    RANK_6 = 159
 
 cpdef enum cpdefPxdDocLineEnum:
     """Home is where..."""
-    RANK_0 = 11
+    RANK_7 = 889
 
 cdef enum PxdSecretEnum:
-    RANK_3 = 5077
+    RANK_8 = 5077
 
 cdef enum cdefPxdDocEnum:
     """the heart is.
     """
-    RANK_3 = 5077
+    RANK_9 = 2458

--- a/tests/run/cpdef_enums.pxd
+++ b/tests/run/cpdef_enums.pxd
@@ -11,5 +11,19 @@ cpdef enum PxdEnum:
     RANK_1 = 37
     RANK_2 = 389
 
+cpdef enum cpdefPxdDocEnum:
+    """Home is where...
+    """
+    RANK_0 = 11
+
+cpdef enum cpdefPxdDocLineEnum:
+    """Home is where..."""
+    RANK_0 = 11
+
 cdef enum PxdSecretEnum:
+    RANK_3 = 5077
+
+cdef enum cdefPxdDocEnum:
+    """the heart is.
+    """
     RANK_3 = 5077

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -49,9 +49,9 @@ NameError: ...name 'IntEnum' is not defined
 """
 
 >>> PxdEnum.__doc__
-"An enumeration."
+None
 >>> PyxEnum.__doc__
-"An enumeration."
+None
 >>> cpdefPyxDocEnum.__doc__
 "Home is where...\n    "
 >>> cpdefPxdDocEnum.__doc__

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -48,6 +48,10 @@ Traceback (most recent call last):
 NameError: ...name 'IntEnum' is not defined
 """
 
+>>> PxdEnum.__doc__ not in ("Home is where...\n    ", "Home is where...")
+True
+>>> PyxEnum.__doc__ not in ("Home is where...\n    ", "Home is where...")
+True
 >>> cpdefPyxDocEnum.__doc__
 "Home is where...\n    "
 >>> cpdefPxdDocEnum.__doc__

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -48,6 +48,18 @@ Traceback (most recent call last):
 NameError: ...name 'IntEnum' is not defined
 """
 
+>>> PxdEnum.__doc__
+"An enumeration."
+>>> PyxEnum.__doc__
+"An enumeration."
+>>> cpdefPyxDocEnum.__doc__
+"Home is where...\n    "
+>>> cpdefPxdDocEnum.__doc__
+"Home is where...\n    "
+>>> cpdefPyxDocLineEnum.__doc__
+"Home is where..."
+>>> cpdefPxdDocLineEnum.__doc__
+"Home is where..."
 
 cdef extern from *:
     cpdef enum: # ExternPyx
@@ -63,8 +75,22 @@ cpdef enum PyxEnum:
     THREE = 3
     FIVE = 5
 
+cpdef enum cpdefPyxDocEnum:
+    """Home is where...
+    """
+    RANK_0 = 11
+
+cpdef enum cpdefPyxDocLineEnum:
+    """Home is where..."""
+
 cdef enum SecretPyxEnum:
     SEVEN = 7
+
+cdef enum cdefPyxDocEnum:
+    """the heart is.
+    """
+    RANK_3 = 5077
+
 
 def test_as_variable_from_cython():
     """

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -54,19 +54,6 @@ Traceback (most recent call last):
 NameError: ...name 'IntEnum' is not defined
 """
 
->>> PxdEnum.__doc__ not in ("Home is where...\n    ", "Home is where...")
-True
->>> PyxEnum.__doc__ not in ("Home is where...\n    ", "Home is where...")
-True
->>> cpdefPyxDocEnum.__doc__
-"Home is where...\n    "
->>> cpdefPxdDocEnum.__doc__
-"Home is where...\n    "
->>> cpdefPyxDocLineEnum.__doc__
-"Home is where..."
->>> cpdefPxdDocLineEnum.__doc__
-"Home is where..."
-
 cdef extern from *:
     cpdef enum: # ExternPyx
         ONE "1"
@@ -88,6 +75,7 @@ cpdef enum cpdefPyxDocEnum:
 
 cpdef enum cpdefPyxDocLineEnum:
     """Home is where..."""
+    FOURTEEN = 14
 
 cdef enum SecretPyxEnum:
     SEVEN = 7
@@ -121,3 +109,21 @@ def verify_resolution_GH1533():
     """
     THREE = 100
     return int(PyxEnum.THREE)
+
+
+def check_docs():
+    """
+    >>> PxdEnum.__doc__ not in ("Home is where...\\n    ", "Home is where...")
+    True
+    >>> PyxEnum.__doc__ not in ("Home is where...\\n    ", "Home is where...")
+    True
+    >>> cpdefPyxDocEnum.__doc__ == "Home is where...\\n    "
+    True
+    >>> cpdefPxdDocEnum.__doc__ == "Home is where...\\n    "
+    True
+    >>> cpdefPyxDocLineEnum.__doc__
+    'Home is where...'
+    >>> cpdefPxdDocLineEnum.__doc__
+    'Home is where...'
+    """
+    pass

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -11,6 +11,8 @@ True
 True
 >>> FIVE == 5 or FIVE
 True
+>>> ELEVEN == 11 or ELEVEN
+True
 >>> SEVEN           # doctest: +ELLIPSIS
 Traceback (most recent call last):
 NameError: ...name 'SEVEN' is not defined
@@ -28,6 +30,10 @@ True
 >>> RANK_1 == 37 or RANK_1
 True
 >>> RANK_2 == 389 or RANK_2
+True
+>>> RANK_6 == 159 or RANK_6
+True
+>>> RANK_7 == 889 or RANK_7
 True
 >>> RANK_3         # doctest: +ELLIPSIS
 Traceback (most recent call last):
@@ -78,7 +84,7 @@ cpdef enum PyxEnum:
 cpdef enum cpdefPyxDocEnum:
     """Home is where...
     """
-    RANK_0 = 11
+    ELEVEN = 11
 
 cpdef enum cpdefPyxDocLineEnum:
     """Home is where..."""
@@ -89,7 +95,7 @@ cdef enum SecretPyxEnum:
 cdef enum cdefPyxDocEnum:
     """the heart is.
     """
-    RANK_3 = 5077
+    FIVE_AND_SEVEN = 5077
 
 
 def test_as_variable_from_cython():

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -48,10 +48,6 @@ Traceback (most recent call last):
 NameError: ...name 'IntEnum' is not defined
 """
 
->>> PxdEnum.__doc__
-None
->>> PyxEnum.__doc__
-None
 >>> cpdefPyxDocEnum.__doc__
 "Home is where...\n    "
 >>> cpdefPxdDocEnum.__doc__

--- a/tests/run/cpdef_scoped_enums.pyx
+++ b/tests/run/cpdef_scoped_enums.pyx
@@ -34,9 +34,9 @@ def test_enum_to_list():
 
 def test_enum_doc():
     """
-    >>> assert Enum2.__doc__ == "Apricots and other fruits.\\n        "
+    >>> Enum2.__doc__ == "Apricots and other fruits.\\n        "
     True
-    >>> assert Enum1.__doc__ != "Apricots and other fruits.\\n        "
+    >>> Enum1.__doc__ != "Apricots and other fruits.\\n        "
     True
     """
     pass

--- a/tests/run/cpdef_scoped_enums.pyx
+++ b/tests/run/cpdef_scoped_enums.pyx
@@ -34,7 +34,9 @@ def test_enum_to_list():
 
 def test_enum_doc():
     """
-    >>> test_enum_doc()
+    >>> assert Enum2.__doc__ == "Apricots and other fruits.\\n        "
+    True
+    >>> assert Enum1.__doc__ != "Apricots and other fruits.\\n        "
+    True
     """
-    assert Enum2.__doc__ == "Apricots and other fruits.\n        "
-    assert Enum1.__doc__ != "Apricots and other fruits.\n        "
+    pass

--- a/tests/run/cpdef_scoped_enums.pyx
+++ b/tests/run/cpdef_scoped_enums.pyx
@@ -7,10 +7,21 @@ cdef extern from *:
         Item1 = 1,
         Item2 = 2
     };
+
+    enum class Enum2 {
+        Item4 = 4,
+        Item5 = 5
+    };
     """
     cpdef enum class Enum1:
         Item1
         Item2
+
+    cpdef enum class Enum2:
+        """Apricots and other fruits.
+        """
+        Item4
+        Item5
 
 
 def test_enum_to_list():
@@ -18,3 +29,12 @@ def test_enum_to_list():
     >>> test_enum_to_list()
     """
     assert list(Enum1) == [1, 2]
+    assert list(Enum2) == [4, 5]
+
+
+def test_enum_doc():
+    """
+    >>> test_enum_doc()
+    """
+    assert Enum2.__doc__ == "Apricots and other fruits.\n        "
+    assert Enum1.__doc__ != "Apricots and other fruits.\n        "


### PR DESCRIPTION
Fixes #3805.

This adds support for "class" level docs when a enum is declared with `cpdef` and the docs should show up under `__doc__` in python. It also supports writing docs for `cdef enum` (and enum from `cpp` I believe) in the same style, but the docs won't be stored anywhere in that case.

The only issue currently is that the enum code is generated from `CpdefEnums.pyx`. What this means is that we manually handle dumping the docstring to the generated code. However, I'm not sure how to handle quote mixing. I.e. I just put triple-quotes around the text, but this would break if the original text e.g. was quoted with triple-single-quotes and has a triple-quote in the text itself. There's probably some standard way of escaping such generic text, but I'm not sure what it is.

Also, I wasn't familiar with cython internal before this, so I may be way of with the changes!?