### PR TITLE
Don't use symbolic links on Windows, it requires admin account.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -28,12 +28,12 @@ try:
     import platform
     IS_PYPY = platform.python_implementation() == 'PyPy'
     IS_CPYTHON = platform.python_implementation() == 'CPython'
-    CAN_SYMLINK = platform.system() != 'Windows'
 except (ImportError, AttributeError):
     IS_CPYTHON = True
     IS_PYPY = False
-    CAN_SYMLINK = False
+
 IS_PY2 = sys.version_info[0] < 3
+CAN_SYMLINK = sys.platform != 'win32' and hasattr(os, 'symlink')
 
 from io import open as io_open
 try:
@@ -999,13 +999,7 @@ class CythonCompileTestCase(unittest.TestCase):
                         fout.write(preparse_func(fin.read()))
         else:
             # use symlink on Unix, copy on Windows
-            try:
-                if CAN_SYMLINK:
-                    copy = os.symlink
-                else:
-                    copy = shutil.copy
-            except AttributeError:
-                copy = shutil.copy
+            copy = os.symlink if CAN_SYMLINK else shutil.copy
 
         join = os.path.join
         for filename in file_list:

--- a/runtests.py
+++ b/runtests.py
@@ -28,9 +28,11 @@ try:
     import platform
     IS_PYPY = platform.python_implementation() == 'PyPy'
     IS_CPYTHON = platform.python_implementation() == 'CPython'
+    CAN_SYMLINK = platform.system() != 'Windows'
 except (ImportError, AttributeError):
     IS_CPYTHON = True
     IS_PYPY = False
+    CAN_SYMLINK = False
 IS_PY2 = sys.version_info[0] < 3
 
 from io import open as io_open
@@ -998,7 +1000,10 @@ class CythonCompileTestCase(unittest.TestCase):
         else:
             # use symlink on Unix, copy on Windows
             try:
-                copy = os.symlink
+                if CAN_SYMLINK:
+                    copy = os.symlink
+                else:
+                    copy = shutil.copy
             except AttributeError:
                 copy = shutil.copy
 


### PR DESCRIPTION
Running ` python runtests.py -vv --debug cpdef_enums` on Windows with Python 3.7 I get the following error.

```
======================================================================
ERROR: runTest (__main__.CythonRunTestCase)
compiling (c/cy2) and running cpdef_enums
----------------------------------------------------------------------
Traceback (most recent call last):
  File "runtests.py", line 1306, in run
    ext_so_path = self.runCompileTest()
  File "runtests.py", line 975, in runCompileTest
    self.test_directory, self.expect_errors, self.expect_warnings, self.annotate)
  File "runtests.py", line 1240, in compile
    so_path = self.run_distutils(test_directory, module, workdir, incdir)
  File "runtests.py", line 1112, in run_distutils
    self.copy_files(test_directory, workdir, related_files)
  File "runtests.py", line 1009, in copy_files
    copy(file_path, join(target_directory, filename))
OSError: symbolic link privilege not held
```

Currently it creates symbolic links only if `os.symlink` exists, seemingly under the assumption that on Windows it doesn't exist. But according to the [docs](https://docs.python.org/3/library/os.html#os.symlink), it actually does exist except:

```
On newer versions of Windows 10, unprivileged accounts can create symlinks if Developer Mode is enabled. When Developer Mode is not available/enabled, the SeCreateSymbolicLinkPrivilege privilege is required, or the process must be run as an administrator.

OSError is raised when the function is called by an unprivileged user.
```