### PR TITLE
Fix silent cython-magic build failure on jupyter-notebooks

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -345,8 +345,9 @@ class CythonMagics(Magics):
         try:
             self._build_extension(extension, lib_dir, pgo_step_name='use' if args.pgo else None,
                                   quiet=args.quiet)
-        except distutils.errors.CompileError:
+        except (distutils.errors.CompileError, distutils.errors.LinkError):
             # Build failed and printed error message
+            print('Build failed, see logs for more details', file=sys.stderr)
             return None
 
         module = imp.load_dynamic(module_name, module_path)


### PR DESCRIPTION
Fixes #3751 

After #3196, the situation is a little bit annoying when using jupyter-notebooks: jupyter-notebooks don't show C-level stdout/stderr to the user and thus all messages logged by compiler/linker to stderr aren't seen, and to the user it looks as if the run of  the %%cython-cell was successful, but it was not and all symbols aren't defined (or aren't updated).

With this fix, at least "Build failed, see logs for more details" will be shown for jupyter-notebooks. One could try to detect that the cell is run in a jupyiter-notebook and only then this error message (so the behavior stays unchanged for ipython-kernel), but I'm not sure there is an explicit way to do so and workarounds look a little bit too brittle, so alway logging "Build failed, ..." doesn't seem to be too bad.

Furthermore, with this fix, the same behavior as for the  CompileError is ensured also for the LinkError (there are also other possible distutils-errors, but it looks as if they cannot be triggered in a %%cython-cell, but I might be wrong).
