### PR TITLE
Add small pointer guide in 'Interfacing with External C Code' chapter

### DIFF
--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -233,8 +233,10 @@ For example::
     cdef extern from "<my_lib.h>":
         cdef void increase_by_one(int *my_var)
 
-This function requires a pointer to an integer. In order to get the address from an existing
-variable use the ``&`` operator::
+This function takes a pointer to an integer as argument.  Knowing the address of the
+integer allows the function to modify the value in place, so that the caller can see
+the changes afterwards.  In order to get the address from an existing variable,
+use the ``&`` operator::
 
     cdef int some_int = 42
     cdef int *some_int_pointer = &some_int

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -243,6 +243,7 @@ use the ``&`` operator::
     increase_by_one(some_int_pointer)
     # Or without creating the extra variable
     increase_by_one(&some_int)
+    print(some_int)  # prints 44 (== 42+1+1)
 
 If you want to manipulate the variable the pointer points to, you can access it by
 referencing its first element like you would in python ``my_pointer[0]``. For example::

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -223,6 +223,35 @@ See also use of :ref:`external_extension_types`.
 Note that in all the cases below, you refer to the type in Cython code simply
 as :c:type:`Foo`, not ``struct Foo``.
 
+Pointers
+--------
+When interacting with a C-api there may be functions that require pointers as arguments.
+Pointers are variables that contain a memory address to another variable.
+
+For example::
+
+    cdef extern from "<my_lib.h>":
+        cdef void increase_by_one(int *my_var)
+
+This function requires a pointer to an integer. In order to get the address from an existing
+variable use the ``&`` sign::
+
+    cdef int some_int = 42
+    cdef int * some_int_pointer = &some_int
+    increase_by_one(some_int_pointer)
+    # Or without creating the extra variable
+    increase_by_one(&some_int)
+
+If you want to manipulate the variable the pointer points to, you can access pointer by
+referencing its first element like you would in python ``my_pointer[0]``. For example::
+
+    cdef void increase_by_one(int *my_var):
+        my_var[0] += 1
+
+For a pointer 101 you can read `this tutorial at tutorialspoint
+<https://www.tutorialspoint.com/cprogramming/c_pointers.htm>`_. For differences between
+Cython and C syntax for manipulating pointers checkout :ref:`statements_and_expressions`.
+
 Accessing Python/C API routines
 ---------------------------------
 

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -234,23 +234,23 @@ For example::
         cdef void increase_by_one(int *my_var)
 
 This function requires a pointer to an integer. In order to get the address from an existing
-variable use the ``&`` sign::
+variable use the ``&`` operator::
 
     cdef int some_int = 42
-    cdef int * some_int_pointer = &some_int
+    cdef int *some_int_pointer = &some_int
     increase_by_one(some_int_pointer)
     # Or without creating the extra variable
     increase_by_one(&some_int)
 
-If you want to manipulate the variable the pointer points to, you can access pointer by
+If you want to manipulate the variable the pointer points to, you can access it by
 referencing its first element like you would in python ``my_pointer[0]``. For example::
 
     cdef void increase_by_one(int *my_var):
         my_var[0] += 1
 
-For a pointer 101 you can read `this tutorial at tutorialspoint
+For a deeper introduction to pointers, you can read `this tutorial at tutorialspoint
 <https://www.tutorialspoint.com/cprogramming/c_pointers.htm>`_. For differences between
-Cython and C syntax for manipulating pointers checkout :ref:`statements_and_expressions`.
+Cython and C syntax for manipulating pointers, see :ref:`statements_and_expressions`.
 
 Accessing Python/C API routines
 ---------------------------------


### PR DESCRIPTION
This is the point where I got stuck when creating bindings for a C-library. Luckily I got help in the comments: https://github.com/cython/cython/issues/3388#issuecomment-683672261. Later I found that there was some (minimal) documentation on `&`. I added a small sub-chapter to 'Interfacing with External C Code' to help noivce users who want to access external C-libraries that use functions with pointers. I linked to the cython documentation on differences with C pointer syntax.

Background information. I have been creating [bindings](https://github.com/rhpvorderman/python-isal) for the [isa-l](https://github.com/intel/isa-l.git) library. This required me to look at `zlibmodule.c` (from cpython) quite a lot. Both isa-l as `zlibmodule.c` contain a lot of pointers and pointer manipulation, so it would have been nice to know this info beforehand. Nevertheless Cython has saved me a lot of headaches, so I figured it would be nice to add the stuff I learned to the documentation to smoothen the experience for other novice users. Lots of thanks to all Cython developers for creating Cython!