### PR TITLE
Changes to the "Error return values" section around exception handling

### DIFF
--- a/docs/examples/userguide/language_basics/exception_example.pyx
+++ b/docs/examples/userguide/language_basics/exception_example.pyx
@@ -1,0 +1,113 @@
+# >>> c.a_cpdef_wo_py_retval()
+# Exception: a_cpdef_wo_py_retval: This Exception will cause a return of 0
+# Exception ignored in: 'cython_exception_example.a_cpdef_wo_py_retval'
+# Traceback (most recent call last):
+#   File "<stdin>", line 1, in <module>
+# Exception: a_cpdef_wo_py_retval: This Exception will cause a return of 0
+# 0
+
+cpdef int a_cpdef_wo_py_retval():
+	# NB: defined as cpdef
+	# This function returns an int which is not a Python
+	# object. Hence the function has no way of signalling
+	# an Exception, and will return a default Exception
+	# indicator of 0 instead.
+	raise Exception(
+		'a_cpdef_wo_py_retval: This Exception '
+		'will cause a return of 0')
+	# As the return type is int, the 
+	# Exception will cause a return of the default value 0
+	pass
+	print('Not running any longer, you will not see this...')
+	return 1  # will not return 1 here, has already returned 0
+
+cdef int a_cdef_wo_py_retval():
+	# NB: defined as cdef, to show the behaviour is
+	# identical to cpdef
+	# This function returns an int which is not a Python
+	# object. Hence the function has no way of signalling
+	# an Exception, and will return a default Exception
+	# indicator of 0 instead.
+	raise Exception(
+		'a_cdef_wo_py_retval: This Exception '
+		'will cause a return of 0')
+	# As return type is int, the 
+	# Exception will cause a return of default value 0
+	pass
+	print('Not running any longer, you will not see this...')
+	return 1  # will not return 1 here, has already returned 0
+
+# >>> c.a_cpdef_w_py_retval()
+# Traceback (most recent call last):
+#   File "<stdin>", line 1, in <module>
+#   File "cython_exception_example.pyx", line 48, in cython_exception_example.a_cpdef_w_py_retval
+#     cpdef a_cpdef_w_py_retval():
+#   File "cython_exception_example.pyx", line 51, in cython_exception_example.a_cpdef_w_py_retval
+#     raise Exception('This exception will bubble up to caller')
+# Exception: This exception will bubble up to caller
+# >>>
+
+cpdef a_cpdef_w_py_retval():
+	# NB: no return type -> returning a Python object
+	# This Exception will bubble up to caller
+	raise Exception('This exception will bubble up to caller')
+	print('Not running any longer, you will not see this...')
+	return 1  # will not return 1 here, Exception has been raised
+
+cdef a_cdef_w_py_retval():
+	# NB: no return type -> returning a Python object
+	# This Exception will bubble up to caller
+	raise Exception('This exception will bubble up to caller')
+	print('Not running any longer, you will not see this...')
+	return 1  # will not return 1 here, Exception has been raised
+
+
+# >>> c.a_cpfdef_wo_py_retval_wrapped_cpdef()
+# Traceback (most recent call last):
+#   File "cython_exception_example.pyx", line 51, in cython_exception_example.a_cpdef_w_py_retval
+#     # This Exception will bubble up to caller
+# Exception: This exception will bubble up to caller
+# Exception ignored in: 'cython_exception_example.a_cpfdef_wo_py_retval_wrapped_cpdef'
+# Traceback (most recent call last):
+#   File "cython_exception_example.pyx", line 51, in cython_exception_example.a_cpdef_w_py_retval
+#     # This Exception will bubble up to caller
+# Exception: This exception will bubble up to caller
+# 0
+cpdef int a_cpfdef_wo_py_retval_wrapped_cpdef():
+	# Example of when an Exception of a wrapped cpdef
+	# becomes effectively ignored because this function
+	# does not return a Python type
+	val = a_cpdef_w_py_retval()
+	# ^ Exception is raised in a_cpdef_w_py_retval(),
+	# which is detected here,
+	# but because the current function does not return
+	# a Python object, it will not bubble up any further
+	# Instead we will return 0 here ("ignoring" it)
+	pass  # keep for better stack trace
+	print('Not running any longer, you will not see this...')
+	return 1  # Nope: has already returned 0
+
+# >>> c.a_cpfdef_wo_py_retval_wrapped_cdef()
+# Traceback (most recent call last):
+#   File "cython_exception_example.pyx", line 58, in cython_exception_example.a_cdef_w_py_retval
+#     # This Exception will bubble up to caller
+# Exception: This exception will bubble up to caller
+# Exception ignored in: 'cython_exception_example.a_cpfdef_wo_py_retval_wrapped_cdef'
+# Traceback (most recent call last):
+#   File "cython_exception_example.pyx", line 58, in cython_exception_example.a_cdef_w_py_retval
+#     # This Exception will bubble up to caller
+# Exception: This exception will bubble up to caller
+# 0
+cpdef int a_cpfdef_wo_py_retval_wrapped_cdef():
+	# Example of when an Exception of a wrapped cdef
+	# becomes effectively ignored because this function
+	# does not return a Python type
+	val = a_cdef_w_py_retval()
+	# ^ Exception is raised in a_cdef_w_py_retval(),
+	# which is detected here,
+	# but because the current function does not return
+	# a Python object, it will not bubble up any further
+	# Instead we will return 0 here ("ignoring" it)
+	pass  # keep for better stack trace
+	print('Not running any longer, you will not see this...')
+	return 1  # Nope: has already returned 0

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -366,14 +366,22 @@ of :ref:`error_return_values`.
 Error return values
 -------------------
 
-If you don't do anything special, a function declared with :keyword:`cdef` that
-does not return a Python object has no way of reporting Python exceptions to
-its caller. If an exception is detected in such a function, a warning message
-is printed and the exception is ignored.
+If you don't change the default behaviour, a function declared with :keyword:`cdef` or 
+:keyword:`cpdef` that does not return a Python object can not report its
+exception to the caller in an ordinary way, so a default value of ``0``/``False``
+will be immediately returned. If the caller is a Cython function, it will be
+detected as an exception and can be handled appropriately by the calling
+Cython function, but if the caller is a Python function it will only see a
+return value of ``0``/``False``.
 
-If you want a C function that does not return a Python object to be able to
-propagate exceptions to its caller, you need to declare an exception value for
-it. Here is an example::
+See the below example for the default behaviour:
+
+.. literalinclude:: ../../examples/userguide/language_basics/exception_example.pyx
+
+If you want to change the default value returned to indicate an exception for a
+:keyword:`cdef` or :keyword:`cpdef` function that does not return a 
+a Python object, you need to
+declare an exception value for it. Here is an example::
 
     cdef int spam() except -1:
         ...
@@ -383,10 +391,8 @@ immediately return with the value ``-1``. Furthermore, whenever a call to spam
 returns ``-1``, an exception will be assumed to have occurred and will be
 propagated.
 
-When you declare an exception value for a function, you should never
-explicitly or implicitly return that value. In particular, if the exceptional return value
-is a ``False`` value, then you should ensure the function will never terminate via an implicit
-or empty return.
+When you declare an exception value for a function using the above syntax,
+you should never explicitly or implicitly return that value. 
 
 If all possible return values are legal and you
 can't reserve one entirely for signalling errors, you can use an alternative


### PR DESCRIPTION
* The docs were stating that the error return value issue for non Python object returning functions did only apply to cdef functions, but cpdef functions are also treated like this.
* It was unclear what was meant by "ignoring" an exception, clarified that it triggers a return
* The default value for returning (0/False) was missing
* There was no warning of receiving the results of a Cython exception in Python
* Exception Example: Added examples to show the default error return behaviour, and to highlight some of the issues faced
