### PR TITLE
Fix various compiler crashes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1997,6 +1997,11 @@ class NameNode(AtomicExprNode):
             atype = unspecified_type if as_target and env.directives['infer_types'] != False else py_object_type
         if atype.is_fused and env.fused_to_specific:
             atype = atype.specialize(env.fused_to_specific)
+        if as_target and env.is_c_class_scope and not atype.is_pyobject:
+            # TODO: this will need revising slightly for cdef dataclasses when implemented
+            atype = py_object_type
+            warning(self.pos, "Annotation ignored since class-level attributes must be Python objects. "
+                    "Were you trying to set up an instance attribute?", 2)
         self.entry = env.declare_var(name, atype, self.pos, is_cdef=not as_target)
         self.entry.annotation = annotation.expr
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -695,7 +695,6 @@ class MemoryViewSliceType(PyrexType):
     def declaration_code(self, entity_code,
             for_display = 0, dll_linkage = None, pyrex = 0):
         # XXX: we put these guards in for now...
-        assert not pyrex
         assert not dll_linkage
         from . import MemoryView
         base_code = StringEncoding.EncodedString(

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -76,6 +76,12 @@ ctypedef fused fused2:
 
 func(x, y)
 
+cdef floating return_type_unfindable1(cython.integral x):
+    return 1.0
+
+cpdef floating return_type_unfindable2(cython.integral x):
+    return 1.0
+
 
 _ERRORS = u"""
 11:15: fused_type does not take keyword arguments
@@ -92,4 +98,6 @@ _ERRORS = u"""
 46:9: Fused types not allowed here
 61:0: Invalid use of fused types, type cannot be specialized
 61:29: ambiguous overloaded method
+79:5: Return type is a fused type that cannot be determined from the function arguments
+82:6: Return type is a fused type that cannot be determined from the function arguments
 """

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -34,6 +34,8 @@ cdef passmvs(float[:,::1] mvs, object foo):
     mvs = array((10,10), itemsize=sizeof(float), format='f')
     foo = init_obj()
 
+cdef object passmvs_wrapper = passmvs  # also test if wrapper can be generated for cdef functions
+
 cdef object returnobj():
     cdef obj = object()
     return obj

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -262,6 +262,10 @@ def py_float_default(price : float=None, ndigits=4):
     return price, ndigits
 
 
+cdef class ClassAttribute:
+    cls_attr : float = 1.
+
+
 _WARNINGS = """
 8:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 8:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
@@ -271,6 +275,7 @@ _WARNINGS = """
 8:85: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 242:44: Unknown type declaration in annotation, ignoring
 249:29: Ambiguous types in annotation, ignoring
+266:4: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
 # BUG:
 46:6: 'pytypes_cpdef' redeclared
 120:0: 'struct_io' redeclared


### PR DESCRIPTION
This fixes a few recently reported compiler crashes. It should possibly be 3 separate PRs and I can split it up if needed.

Fixes https://github.com/cython/cython/issues/3843 - allow creation of wrapper functions with memoryview arguments
Fixes https://github.com/cython/cython/issues/3820 - report error when return type cannot be deduced from fused arguments
Fixes https://github.com/cython/cython/issues/3830 - don't allow annotation types to set the type of cdef class class-level attributes