### PR TITLE
Warn users about failed cdef class lookups

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7192,6 +7192,10 @@ class AttributeNode(ExprNode):
         if not env.directives['warn.should_be_ctyped']:
             return
 
+        if self.obj.type is not py_object_type:
+            # it's typed as *something*
+            return
+
         def entry_matches(tp_scope):
             entry = tp_scope.lookup(self.attribute)
             if entry and (entry.is_cfunction or

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7203,6 +7203,11 @@ class AttributeNode(ExprNode):
         possible_type = None
         # attempt to warn the user if it looks like they should have typed a variable
         if self.obj.is_name and self.obj.entry:
+            if ((self.obj.entry.name == "self" and self.obj.entry.is_arg)
+                    or self.obj.entry.is_self_arg):
+                return  # skip self args by default (using the name is as a test is a bit fuzzy
+                    # but since we're only detecting for warnings it'll do)
+
             for assignment in self.obj.entry.cf_assignments:
                 tp = assignment.rhs.type
                 if not tp or (not tp.is_extension_type) or tp == possible_type:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7189,6 +7189,9 @@ class AttributeNode(ExprNode):
             self.python_attribute_lookup_warnings(env)
 
     def python_attribute_lookup_warnings(self, env):
+        if not env.directives['warn.should_be_ctyped']:
+            return
+
         def entry_matches(tp_scope):
             entry = tp_scope.lookup(self.attribute)
             if entry and (entry.is_cfunction or
@@ -7202,7 +7205,7 @@ class AttributeNode(ExprNode):
         if self.obj.is_name and self.obj.entry:
             for assignment in self.obj.entry.cf_assignments:
                 tp = assignment.rhs.type
-                if (not tp.is_extension_type) or tp == possible_type:
+                if not tp or (not tp.is_extension_type) or tp == possible_type:
                     continue
                 entry = entry_matches(tp.scope)
                 if entry:

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -229,6 +229,7 @@ _directive_defaults = {
     'warn.unused_arg': False,
     'warn.unused_result': False,
     'warn.multiple_declarators': True,
+    'warn.should_be_ctyped': True,
 
 # optimizations
     'optimize.inline_defnode_calls': True,

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -452,7 +452,7 @@ cdef class memoryview:
 
         return obj
 
-    cdef setitem_slice_assignment(self, dst, src):
+    cdef setitem_slice_assignment(self, memoryview dst, memoryview src):
         cdef {{memviewslice_name}} dst_slice
         cdef {{memviewslice_name}} src_slice
         cdef {{memviewslice_name}} msrc = get_slice_from_memview(src, &src_slice)[0]

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -957,7 +957,13 @@ to turn the warning on / off.
 ``warn.multiple_declarators`` (default True)
    Warns about multiple variables declared on the same line with at least one pointer type.
    For example ``cdef double* a, b`` - which, as in C, declares ``a`` as a pointer, ``b`` as
-   a value type, but could be mininterpreted as declaring two pointers.
+   a value type, but could be misinterpreted as declaring two pointers.
+
+``warn.should_be_ctyped`` (default True)
+   Warns when Cython thinks the user is trying to lookup a ``cdef`` attribute of a
+   ``cdef class`` but the variable does not have a specific type set (e.g.
+   ``cdef a = Foo; a.cdef_func_of_foo()``). This can generate false positives so it
+   may be useful to disable it locally (e.g. ``with cython.warn.should_be_ctyped(False):``).
 
 
 .. _how_to_set_directives:

--- a/tests/compile/failed_c_lookup_warnings.pyx
+++ b/tests/compile/failed_c_lookup_warnings.pyx
@@ -3,6 +3,8 @@
 
 # Test detection of obvious cases where the user intended to use a cdef function but failed to type it
 
+cimport cython
+
 cdef class C:
     cdef int val1
     cdef public int val2
@@ -33,24 +35,26 @@ def g():
 
 cdef c = C()
 c.func1()
+with cython.warn.should_be_ctyped(False):
+    c.func1()
 c.func2()
 c.func3()
 c.val1 = 5
 c.val2 = 5
 
 _WARNINGS = """
-18:5: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
-19:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
-21:5: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
-22:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
-28:10: This expression is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of this expression
-29:10: This expression is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of this expression
-31:10: This expression is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of this expression
-32:10: This expression is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of this expression
-35:1: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
-36:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
-38:1: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
-39:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
+20:5: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
+21:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
+23:5: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
+24:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
+30:10: This expression is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of this expression
+31:10: This expression is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of this expression
+33:10: This expression is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of this expression
+34:10: This expression is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of this expression
+37:1: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
+40:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
+42:1: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
+43:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
 # BUG:
-11:10: 'func2' redeclared
+13:10: 'func2' redeclared
 """

--- a/tests/compile/failed_c_lookup_warnings.pyx
+++ b/tests/compile/failed_c_lookup_warnings.pyx
@@ -1,0 +1,56 @@
+# mode: compile
+# tag: warnings
+
+# Test detection of obvious cases where the user intended to use a cdef function but failed to type it
+
+cdef class C:
+    cdef int val1
+    cdef public int val2
+    cdef int func1(self):
+        return 1
+    cpdef int func2(self) except *:
+        return 2
+    def func3(self):
+        return 3
+
+def f():
+    cdef c = C()
+    c.func1()
+    c.func2()
+    c.func3()
+    c.val1 = 5
+    c.val2 = 5
+
+def getC():
+    return C()
+
+def g():
+    getC().func1()
+    getC().func2()
+    getC().func3()
+    getC().val1 = 5
+    getC().val2 = 5
+
+cdef c = C()
+c.func1()
+c.func2()
+c.func3()
+c.val1 = 5
+c.val2 = 5
+
+_WARNINGS = """
+18:5: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
+19:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
+21:5: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
+22:5: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
+28:10: This expression is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of this expression
+29:10: This expression is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of this expression
+31:10: This expression is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of this expression
+32:10: This expression is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of this expression
+35:1: 'c' is typed as a Python object; if you intended to lookup 'C.func1' then you must specify the type of 'c'
+36:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.func2' then you must specify the type of 'c'
+38:1: 'c' is typed as a Python object; if you intended to lookup 'C.val1' then you must specify the type of 'c'
+39:1: 'c' is typed as a Python object; to enable fast C lookup of 'C.val2' then you must specify the type of 'c'
+# BUG:
+11:10: 'func2' redeclared
+"""


### PR DESCRIPTION
One of the most commonly seen user errors is to try to access cdef methods/attributes of a cdef class when Cython doesn't know the type.

This attempts to add warnings to alert the user so that they can hopefully correct it themselves. It obviously isn't (and can't be) comprehensive but does catch the obvious cases.

It's possible that it'll be a bit noisy/over-sensitive. Hopefully the test-suite should give an indication of how many false positives it generates.