### PR TITLE
Removed `same_as` from Plex.Actions.Action

### DIFF
--- a/Cython/Plex/Actions.pxd
+++ b/Cython/Plex/Actions.pxd
@@ -5,21 +5,21 @@ cdef class Action:
     cpdef same_as(self, other)
 
 cdef class Return(Action):
-    cdef object value
+    cdef public object value
     cdef perform(self, token_stream, text)
     cpdef same_as(self, other)
 
 cdef class Call(Action):
-    cdef object function
+    cdef public object function
     cdef perform(self, token_stream, text)
     cpdef same_as(self, other)
 
 cdef class Method(Action):
-    cdef str name
-    cdef dict kwargs
+    cdef public str name
+    cdef public dict kwargs
 
 cdef class Begin(Action):
-    cdef object state_name
+    cdef public object state_name
     cdef perform(self, token_stream, text)
     cpdef same_as(self, other)
 

--- a/Cython/Plex/Actions.pxd
+++ b/Cython/Plex/Actions.pxd
@@ -2,26 +2,22 @@
 
 cdef class Action:
     cdef perform(self, token_stream, text)
-    cpdef same_as(self, other)
 
 cdef class Return(Action):
-    cdef public object value
+    cdef object value
     cdef perform(self, token_stream, text)
-    cpdef same_as(self, other)
 
 cdef class Call(Action):
-    cdef public object function
+    cdef object function
     cdef perform(self, token_stream, text)
-    cpdef same_as(self, other)
 
 cdef class Method(Action):
-    cdef public str name
-    cdef public dict kwargs
+    cdef str name
+    cdef dict kwargs
 
 cdef class Begin(Action):
-    cdef public object state_name
+    cdef object state_name
     cdef perform(self, token_stream, text)
-    cpdef same_as(self, other)
 
 cdef class Ignore(Action):
     cdef perform(self, token_stream, text)

--- a/Cython/Plex/Actions.py
+++ b/Cython/Plex/Actions.py
@@ -6,13 +6,9 @@ Python Lexical Analyser
 Actions for use in token specifications
 """
 
-
 class Action(object):
     def perform(self, token_stream, text):
         pass  # abstract
-
-    def same_as(self, other):
-        return self is other
 
     def __copy__(self):
         return self  # immutable, no need to copy
@@ -33,9 +29,6 @@ class Return(Action):
     def perform(self, token_stream, text):
         return self.value
 
-    def same_as(self, other):
-        return isinstance(other, Return) and self.value == other.value
-
     def __repr__(self):
         return "Return(%r)" % self.value
 
@@ -53,9 +46,6 @@ class Call(Action):
 
     def __repr__(self):
         return "Call(%s)" % self.function.__name__
-
-    def same_as(self, other):
-        return isinstance(other, Call) and self.function is other.function
 
 
 class Method(Action):
@@ -79,9 +69,6 @@ class Method(Action):
             if self.kwargs is not None else '')
         return "Method(%s%s%s)" % (self.name, ', ' if kwargs else '', kwargs)
 
-    def same_as(self, other):
-        return isinstance(other, Method) and self.name == other.name and self.kwargs == other.kwargs
-
 
 class Begin(Action):
     """
@@ -98,9 +85,6 @@ class Begin(Action):
 
     def __repr__(self):
         return "Begin(%s)" % self.state_name
-
-    def same_as(self, other):
-        return isinstance(other, Begin) and self.state_name == other.state_name
 
 
 class Ignore(Action):


### PR DESCRIPTION
https://github.com/cython/cython/pull/3846 suggests that the code is broken since it won't be able to access the private attributes of the untyped "other". It looks to be unused since this doesn't cause any errors

--------

This is based on the warnings from https://github.com/cython/cython/pull/3846 that look like legitimate errors. The rest are mostly `cpdef` functions not being accessed as efficiently as possible which is less of a concern.