### PR TITLE
Fixed assorted crashes with fused types

### DIFF
--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -24,6 +24,8 @@ class PyrexError(Exception):
 class PyrexWarning(Exception):
     pass
 
+class CannotSpecialize(PyrexError):
+    pass
 
 def context(position):
     source = position[0]

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -23,7 +23,8 @@ import os.path
 import operator
 
 from .Errors import (
-    error, warning, InternalError, CompileError, report_error, local_errors)
+    error, warning, InternalError, CompileError, report_error, local_errors,
+    CannotSpecialize)
 from .Code import UtilityCode, TempitaUtilityCode
 from . import StringEncoding
 from . import Naming
@@ -2000,11 +2001,13 @@ class NameNode(AtomicExprNode):
             if atype is None:
                 atype = unspecified_type if as_target and env.directives['infer_types'] != False else py_object_type
             if atype.is_fused and env.fused_to_specific:
-                atype = atype.specialize(env.fused_to_specific)
-                if atype is error_type:
+                try:
+                    atype = atype.specialize(env.fused_to_specific)
+                except CannotSpecialize:
                     error(self.pos,
-                      "'%s' cannot be specialized since its type is not a fused argument to this function" %
-                      self.name)
+                          "'%s' cannot be specialized since its type is not a fused argument to this function" %
+                          self.name)
+                    atype = error_type
 
             entry = self.entry = env.declare_var(name, atype, self.pos, is_cdef=not as_target)
         # Even if the entry already exists, make sure we're supplying an annotation if we can.
@@ -10939,10 +10942,11 @@ class SizeofVarNode(SizeofNode):
         if operand_as_type:
             self.arg_type = operand_as_type
             if self.arg_type.is_fused:
-                self.arg_type = self.arg_type.specialize(env.fused_to_specific)
-                if self.arg_type is error_type:
+                try:
+                    self.arg_type = self.arg_type.specialize(env.fused_to_specific)
+                except CannotSpecialize:
                     error(self.operand.pos,
-                      "Type cannot be specialized since it is not a fused argument to this function")
+                          "Type cannot be specialized since it is not a fused argument to this function")
             self.__class__ = SizeofTypeNode
             self.check_type()
         else:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2001,6 +2001,11 @@ class NameNode(AtomicExprNode):
                 atype = unspecified_type if as_target and env.directives['infer_types'] != False else py_object_type
             if atype.is_fused and env.fused_to_specific:
                 atype = atype.specialize(env.fused_to_specific)
+                if atype is error_type:
+                    error(self.pos,
+                      "'%s' cannot be specialized since its type is not a fused argument to this function" %
+                      self.name)
+
             entry = self.entry = env.declare_var(name, atype, self.pos, is_cdef=not as_target)
         # Even if the entry already exists, make sure we're supplying an annotation if we can.
         if annotation and not entry.annotation:
@@ -10935,6 +10940,9 @@ class SizeofVarNode(SizeofNode):
             self.arg_type = operand_as_type
             if self.arg_type.is_fused:
                 self.arg_type = self.arg_type.specialize(env.fused_to_specific)
+                if self.arg_type is error_type:
+                    error(self.operand.pos,
+                      "Type cannot be specialized since it is not a fused argument to this function")
             self.__class__ = SizeofTypeNode
             self.check_type()
         else:

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -140,20 +140,12 @@ class FusedCFuncDefNode(StatListNode):
         for cname, fused_to_specific in permutations:
             copied_node = copy.deepcopy(self.node)
 
-            # unlike for the argument types, specializing the return type can fail, so tentatively
-            # try it here and produce an error message if it fails.
-            # specialize can also go through layers of pointers/const which makes anything other
-            # than "try...except" difficult
-            if copied_node.type.return_type.is_fused:
-                try:
-                    copied_node.type.return_type.specialize(fused_to_specific)
-                except KeyError:
-                    Errors.error(copied_node.pos, "Return type is a fused type that cannot "
-                                 "be determined from the function arguments")
-                    copied_node.type.return_type = PyrexTypes.error_type
-
             # Make the types in our CFuncType specific.
             type = copied_node.type.specialize(fused_to_specific)
+            # unlike for the argument types, specializing the return type can fail, so test it
+            if type.return_type is PyrexTypes.error_type:
+                Errors.error(copied_node.pos, "Return type is a fused type that cannot "
+                                 "be determined from the function arguments")
             entry = copied_node.entry
             type.specialize_entry(entry, cname)
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -519,6 +519,10 @@ class CNameDeclaratorNode(CDeclaratorNode):
 
         if base_type.is_fused and env.fused_to_specific:
             base_type = base_type.specialize(env.fused_to_specific)
+            if base_type is PyrexTypes.error_type:
+                error(self.pos,
+                      "'%s' cannot be specialized since its type is not a fused argument to this function" %
+                      self.name)
 
         self.type = base_type
         return self, base_type
@@ -1208,6 +1212,11 @@ class TemplatedTypeNode(CBaseTypeNode):
 
         if self.type.is_fused and env.fused_to_specific:
             self.type = self.type.specialize(env.fused_to_specific)
+            if self.type is PyrexTypes.error_type:
+                error(self.pos,
+                      "'%s' cannot be specialized since its type is not a fused argument to this function" %
+                      self.name)
+
 
         return self.type
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -17,7 +17,7 @@ from .Code import UtilityCode, LazyUtilityCode, TempitaUtilityCode
 from . import StringEncoding
 from . import Naming
 
-from .Errors import error, warning
+from .Errors import error, warning, CannotSpecialize
 
 
 class BaseType(object):
@@ -274,6 +274,7 @@ class PyrexType(BaseType):
 
     def specialize(self, values):
         # Returns the concrete type if this is a fused type, or otherwise the type itself.
+        # May raise Errors.CannotSpecialize on failure
         return self
 
     def literal_code(self, value):
@@ -1827,7 +1828,10 @@ class FusedType(CType):
         return 'FusedType(name=%r)' % self.name
 
     def specialize(self, values):
-        return values.get(self, error_type)
+        if self in values:
+            return values[self]
+        else:
+            raise CannotSpecialize()
 
     def get_fused_types(self, result=None, seen=None):
         if result is None:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -274,6 +274,7 @@ class PyrexType(BaseType):
 
     def specialize(self, values):
         # TODO(danilo): Override wherever it makes sense.
+        # Overridden functions should generally return error_type instead of raising an exception
         return self
 
     def literal_code(self, value):
@@ -1827,7 +1828,7 @@ class FusedType(CType):
         return 'FusedType(name=%r)' % self.name
 
     def specialize(self, values):
-        return values[self]
+        return values.get(self, error_type)
 
     def get_fused_types(self, result=None, seen=None):
         if result is None:

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -82,6 +82,10 @@ cdef floating return_type_unfindable1(cython.integral x):
 cpdef floating return_type_unfindable2(cython.integral x):
     return 1.0
 
+cdef void contents_unfindable1(cython.integral x):
+    z: floating = 1  # note: cdef variables also fail with an error but not by the time this test aborts
+    sz = sizeof(floating)
+
 
 _ERRORS = u"""
 11:15: fused_type does not take keyword arguments
@@ -98,6 +102,17 @@ _ERRORS = u"""
 46:9: Fused types not allowed here
 61:0: Invalid use of fused types, type cannot be specialized
 61:29: ambiguous overloaded method
+# Possibly duplicates the errors more often than we want
+79:5: Return type is a fused type that cannot be determined from the function arguments
+79:5: Return type is a fused type that cannot be determined from the function arguments
 79:5: Return type is a fused type that cannot be determined from the function arguments
 82:6: Return type is a fused type that cannot be determined from the function arguments
+82:6: Return type is a fused type that cannot be determined from the function arguments
+82:6: Return type is a fused type that cannot be determined from the function arguments
+86:4: 'z' cannot be specialized since its type is not a fused argument to this function
+86:4: 'z' cannot be specialized since its type is not a fused argument to this function
+86:4: 'z' cannot be specialized since its type is not a fused argument to this function
+87:24: Type cannot be specialized since it is not a fused argument to this function
+87:24: Type cannot be specialized since it is not a fused argument to this function
+87:24: Type cannot be specialized since it is not a fused argument to this function
 """

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -76,6 +76,12 @@ ctypedef fused fused2:
 
 func(x, y)
 
+cdef floating return_type_unfindable1(cython.integral x):
+    return 1.0
+
+cpdef floating return_type_unfindable2(cython.integral x):
+    return 1.0
+
 
 _ERRORS = u"""
 11:15: fused_type does not take keyword arguments
@@ -92,4 +98,6 @@ _ERRORS = u"""
 46:9: Fused types not allowed here
 61:0: Invalid use of fused types, type cannot be specialized
 61:29: ambiguous overloaded method
+79:5: Return type is a fused type that cannot be determined from the function arguments
+82:6: Return type is a fused type that cannot be determined from the function arguments
 """

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -104,10 +104,6 @@ _ERRORS = u"""
 61:29: ambiguous overloaded method
 # Possibly duplicates the errors more often than we want
 79:5: Return type is a fused type that cannot be determined from the function arguments
-79:5: Return type is a fused type that cannot be determined from the function arguments
-79:5: Return type is a fused type that cannot be determined from the function arguments
-82:6: Return type is a fused type that cannot be determined from the function arguments
-82:6: Return type is a fused type that cannot be determined from the function arguments
 82:6: Return type is a fused type that cannot be determined from the function arguments
 86:4: 'z' cannot be specialized since its type is not a fused argument to this function
 86:4: 'z' cannot be specialized since its type is not a fused argument to this function


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/3820 (and probably some other bugs too)

Originally part of https://github.com/cython/cython/pull/3845.

-----------

It's pretty hard to test if a fused type specializes expect by doing it. For example, the specialization may go through a chain of const and pointer types. The I've changed the exception that this produces to make it more identifiable (rather than a generic Python KeyError). I've applied this to `cdef fused_type var`, `var: fused_type = something` and `sizeof(fused_type)` as well as a fused return type. All of these previously caused compiler crashes.