### PR TITLE
Allow creation of wrappers for cdef functions with memoryviews

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -697,9 +697,8 @@ class MemoryViewSliceType(PyrexType):
         # XXX: we put these guards in for now...
         assert not dll_linkage
         from . import MemoryView
-        for_display = for_display or pyrex
         base_code = StringEncoding.EncodedString(
-                        (str(self)) if for_display else MemoryView.memviewslice_cname)
+                        (str(self)) if pyrex or for_display else MemoryView.memviewslice_cname)
         return self.base_declaration_code(
                 base_code,
                 entity_code)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -698,7 +698,7 @@ class MemoryViewSliceType(PyrexType):
         assert not dll_linkage
         from . import MemoryView
         base_code = StringEncoding.EncodedString(
-            (str(self)) if pyrex or for_display else MemoryView.memviewslice_cname)
+            str(self) if pyrex or for_display else MemoryView.memviewslice_cname)
         return self.base_declaration_code(
                 base_code,
                 entity_code)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -697,6 +697,7 @@ class MemoryViewSliceType(PyrexType):
         # XXX: we put these guards in for now...
         assert not dll_linkage
         from . import MemoryView
+        for_display = for_display or pyrex
         base_code = StringEncoding.EncodedString(
                         (str(self)) if for_display else MemoryView.memviewslice_cname)
         return self.base_declaration_code(
@@ -3225,7 +3226,7 @@ class CFuncType(CType):
         if not self.can_coerce_to_pyobject(env):
             return False
         from .UtilityCode import CythonUtilityCode
-        safe_typename = re.sub('[^a-zA-Z0-9]', '__', self.declaration_code("", pyrex=1))
+        safe_typename = type_identifier_from_str(self.declaration_code("", pyrex=1))
         to_py_function = "__Pyx_CFunc_%s_to_py" % safe_typename
 
         for arg in self.args:
@@ -4956,6 +4957,9 @@ def type_list_identifier(types):
 _type_identifier_cache = {}
 def type_identifier(type):
     decl = type.empty_declaration_code()
+    return type_identifier_from_str(decl)
+
+def type_identifier_from_str(decl):
     safe = _type_identifier_cache.get(decl)
     if safe is None:
         safe = decl

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -698,7 +698,7 @@ class MemoryViewSliceType(PyrexType):
         assert not dll_linkage
         from . import MemoryView
         base_code = StringEncoding.EncodedString(
-                        (str(self)) if pyrex or for_display else MemoryView.memviewslice_cname)
+            (str(self)) if pyrex or for_display else MemoryView.memviewslice_cname)
         return self.base_declaration_code(
                 base_code,
                 entity_code)
@@ -3225,7 +3225,7 @@ class CFuncType(CType):
         if not self.can_coerce_to_pyobject(env):
             return False
         from .UtilityCode import CythonUtilityCode
-        safe_typename = type_identifier_from_str(self.declaration_code("", pyrex=1))
+        safe_typename = type_identifier_from_declaration(self.declaration_code("", pyrex=1))
         to_py_function = "__Pyx_CFunc_%s_to_py" % safe_typename
 
         for arg in self.args:
@@ -4953,12 +4953,12 @@ def typecast(to_type, from_type, expr_code):
 def type_list_identifier(types):
     return cap_length('__and_'.join(type_identifier(type) for type in types))
 
-_type_identifier_cache = {}
 def type_identifier(type):
     decl = type.empty_declaration_code()
-    return type_identifier_from_str(decl)
+    return type_identifier_from_declaration(decl)
 
-def type_identifier_from_str(decl):
+_type_identifier_cache = {}
+def type_identifier_from_declaration(decl):
     safe = _type_identifier_cache.get(decl)
     if safe is None:
         safe = decl

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -695,7 +695,6 @@ class MemoryViewSliceType(PyrexType):
     def declaration_code(self, entity_code,
             for_display = 0, dll_linkage = None, pyrex = 0):
         # XXX: we put these guards in for now...
-        assert not pyrex
         assert not dll_linkage
         from . import MemoryView
         base_code = StringEncoding.EncodedString(

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -34,8 +34,6 @@ cdef passmvs(float[:,::1] mvs, object foo):
     mvs = array((10,10), itemsize=sizeof(float), format='f')
     foo = init_obj()
 
-cdef object passmvs_wrapper = passmvs  # also test if wrapper can be generated for cdef functions
-
 cdef object returnobj():
     cdef obj = object()
     return obj

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -34,6 +34,8 @@ cdef passmvs(float[:,::1] mvs, object foo):
     mvs = array((10,10), itemsize=sizeof(float), format='f')
     foo = init_obj()
 
+cdef object passmvs_wrapper = passmvs  # also test if wrapper can be generated for cdef functions
+
 cdef object returnobj():
     cdef obj = object()
     return obj

--- a/tests/run/cfunc_convert.pyx
+++ b/tests/run/cfunc_convert.pyx
@@ -249,7 +249,6 @@ cdef void memoryview_func_f(int [::1,:] x):
     x[0,0] = 4
 
 
-
 def test_memview_wrapping():
     """
     We're mainly concerned that the code compiles without the names clashing

--- a/tests/run/cfunc_convert.pyx
+++ b/tests/run/cfunc_convert.pyx
@@ -229,3 +229,52 @@ def test_cdef_class_params(a, b):
     TypeError: Argument 'b' has incorrect type (expected cfunc_convert.B, got cfunc_convert.A)
     """
     return (<object>test_cdef_class_params_cfunc)(a, b)
+
+cdef void memoryview_func_a(double [:] x):
+    x[0] = 1
+
+cdef void memoryview_func_b(double [::1] x):
+    x[0] = 2
+
+cdef void memoryview_func_c(int [:] x):
+    x[0] = 1
+
+cdef void memoryview_func_d(int [:] x):
+    x[0] = 2
+
+cdef void memoryview_func_e(int [:,::1] x):
+    x[0,0] = 4
+
+cdef void memoryview_func_f(int [::1,:] x):
+    x[0,0] = 4
+
+
+
+def test_memview_wrapping():
+    """
+    We're mainly concerned that the code compiles without the names clashing
+    >>> test_memview_wrapping()
+    1.0
+    2.0
+    1
+    2
+    """
+    cdef a = memoryview_func_a
+    cdef b = memoryview_func_b
+    cdef c = memoryview_func_c
+    cdef d = memoryview_func_d
+    cdef e = memoryview_func_e
+    cdef f = memoryview_func_f
+    cdef double[1] double_arr = [0]
+    cdef int[1] int_arr = [0]
+
+    a(<double[:1]>double_arr)
+    print(double_arr[0])
+    b(<double[:1:1]>double_arr)
+    print(double_arr[0])
+    c(<int[:1]>int_arr)
+    print(int_arr[0])
+    d(<int[:1:1]>int_arr)
+    print(int_arr[0])
+    # don't call e and f because it's harder without needing extra dependencies
+    # it's mostly a compile test for them


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/3843

Final smaller part of https://github.com/cython/cython/pull/3845

--------

The most notable change here is that I made the cfunc wrappers use the name escaping mechanism that was already in `PyrexTypes.type_identifier`. This seemed more satisfactory than just replacing unknown characters with `_` (as was the status quo), and it's a tested mechanism used elsewhere in the code.