### PR TITLE
Replaced Element.getiterator() with Element.iter().

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -501,7 +501,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             except ImportError:
                 import xml.etree.ElementTree as ET
             coverage_xml = ET.parse(coverage_xml_filename).getroot()
-            for el in coverage_xml.getiterator():
+            for el in coverage_xml.iter():
                 el.tail = None  # save some memory
         else:
             coverage_xml = None


### PR DESCRIPTION
`xml.etree.ElementTree.Element.getiterator()` was deprecated in Python [2.7](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator) & [3.2](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator) and removed in Python [3.9](https://docs.python.org/3.9/whatsnew/3.9.html#removed).

This is currently crashing in the recently released Python 3.9 so I think it also needs to be backported to the 0.29.x releases.