### PR TITLE
Preferred Element.iter() to Element.getiterator().

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -429,7 +429,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             except ImportError:
                 import xml.etree.ElementTree as ET
             coverage_xml = ET.parse(coverage_xml_filename).getroot()
-            for el in coverage_xml.getiterator():
+            if hasattr(coverage_xml, 'iter'):
+                iterator = coverage_xml.iter()  # Python 2.7 & 3.2+
+            else:
+                iterator = coverage_xml.getiterator()
+            for el in iterator:
                 el.tail = None  # save some memory
         else:
             coverage_xml = None


### PR DESCRIPTION
`xml.etree.ElementTree.Element.getiterator()` was deprecated in Python [2.7](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator) & [3.2](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator) and removed in Python [3.9](https://docs.python.org/3.9/whatsnew/3.9.html#removed).

This fixes the same issue as #3864, but targets the `0.29.x` branch which still supports Python 2.6.