### PR TITLE
Capturing and redirecting stdout/stderr for %%cython-magic

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -383,8 +383,8 @@ class CythonMagics(Magics):
 
         def print_compiler_output(stdout, stderr, where):
             # On windows, errors are printed to stdout, we redirect both to sys.stderr.
-            print_captured(stdout, where, "Content of stdout:\n")
-            print_captured(stderr, where, "Content of stderr:\n")
+            print_captured(stdout, where, u"Content of stdout:\n")
+            print_captured(stderr, where, u"Content of stderr:\n")
 
         get_stderr = get_stdout = None
         try:

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -130,7 +130,7 @@ def prepare_captured(captured):
     return captured_bytes.decode('latin-1')
 
 
-def print_captured(captured, output, header_line):
+def print_captured(captured, output, header_line=None):
     captured = prepare_captured(captured)
     if captured:
         if header_line:

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -366,10 +366,10 @@ class CythonMagics(Magics):
             if args.pgo:
                 self._profile_pgo_wrapper(extension, lib_dir)
 
-        def print_compiler_output(stdout, stderr):
+        def print_compiler_output(stdout, stderr, where):
             # On windows, errors are printed to stdout, we redirect both to sys.stderr.
-            print_captured(stdout, sys.stdout, "Content of stdout:\n")
-            print_captured(stderr, sys.stdout, "Content of stderr:\n")
+            print_captured(stdout, where, "Content of stdout:\n")
+            print_captured(stderr, where, "Content of stderr:\n")
 
         get_stderr = get_stdout = None
         try:
@@ -379,11 +379,11 @@ class CythonMagics(Magics):
                         extension, lib_dir, pgo_step_name='use' if args.pgo else None, quiet=args.quiet)
         except (distutils.errors.CompileError, distutils.errors.LinkError):
             # Build failed, print error message from compiler/linker
-            print_compiler_output(get_stdout, get_stderr)
+            print_compiler_output(get_stdout, get_stderr, sys.stderr)
             return None
 
         # Build seems ok, but we might still want to show any warnings that occurred
-        print_compiler_output(get_stdout, get_stderr)
+        print_compiler_output(get_stdout, get_stderr, sys.stdout)
 
         module = imp.load_dynamic(module_name, module_path)
         self._import_all(module)

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -55,7 +55,6 @@ import time
 import copy
 import distutils.log
 import textwrap
-from collections import OrderedDict
 
 IO_ENCODING = sys.getfilesystemencoding()
 IS_PY2 = sys.version_info[0] < 3
@@ -110,18 +109,12 @@ else:
 
 def get_encoding_candidates():
     candidates = [sys.getdefaultencoding()]
-    try:
-        candidates.extend([sys.stdout.encoding, sys.stdin.encoding])
-    except AttributeError:
-        pass
-    try:
-        candidates.extend([sys.__stdout__.encoding, sys.__stdin__.encoding])
-    except AttributeError:
-        pass
-    unique_candidates = OrderedDict.fromkeys(candidates)
-    # encoding might be None (i.e. somebody redirects stdout):
-    unique_candidates.pop(None, None)
-    return list(unique_candidates)
+    for stream in (sys.stdout, sys.stdin, sys.__stdout__, sys.__stdin__):
+        encoding = getattr(stream, 'encoding', None)
+        # encoding might be None (e.g. somebody redirects stdout):
+        if encoding is not None and encoding not in candidates:
+            candidates.append(encoding)
+    return candidates
 
 
 def prepare_captured(captured):

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -107,17 +107,29 @@ else:
         return name
 
 
+def get_encoding_candidates():
+    candidates = {sys.getdefaultencoding()}
+    try:
+        candidates.update([sys.stdout.encoding, sys.stdin.encoding])
+    except AttributeError:
+        pass
+    try:
+        candidates.update([sys.__stdout__.encoding, sys.__stdin__.encoding])
+    except AttributeError:
+        pass
+    candidates.discard(None)
+    return candidates
+
+
 def prepare_captured(captured):
     captured_bytes = captured and captured().strip()
     if not captured_bytes:
         return None
-    tried = {None}
-    for encoding in [sys.getdefaultencoding(), sys.stdout.encoding, sys.stdin.encoding]:
+    for encoding in get_encoding_candidates():
         try:
-            if encoding not in tried:
-                return captured_bytes.decode(encoding)
+            return captured_bytes.decode(encoding)
         except UnicodeDecodeError:
-            tried.add(encoding)
+            pass
     # last resort: print at least the readable ascii parts correctly.
     return captured_bytes.decode('latin-1')
 

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -55,6 +55,7 @@ import time
 import copy
 import distutils.log
 import textwrap
+from collections import OrderedDict
 
 IO_ENCODING = sys.getfilesystemencoding()
 IS_PY2 = sys.version_info[0] < 3
@@ -108,17 +109,19 @@ else:
 
 
 def get_encoding_candidates():
-    candidates = {sys.getdefaultencoding()}
+    candidates = [sys.getdefaultencoding()]
     try:
-        candidates.update([sys.stdout.encoding, sys.stdin.encoding])
+        candidates.extend([sys.stdout.encoding, sys.stdin.encoding])
     except AttributeError:
         pass
     try:
-        candidates.update([sys.__stdout__.encoding, sys.__stdin__.encoding])
+        candidates.extend([sys.__stdout__.encoding, sys.__stdin__.encoding])
     except AttributeError:
         pass
-    candidates.discard(None)
-    return candidates
+    unique_candidates = OrderedDict.fromkeys(candidates)
+    # encoding might be None (i.e. somebody redirects stdout):
+    unique_candidates.pop(None, None)
+    return list(unique_candidates)
 
 
 def prepare_captured(captured):

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -118,7 +118,7 @@ def get_encoding_candidates():
 
 
 def prepare_captured(captured):
-    captured_bytes = captured and captured().strip()
+    captured_bytes = captured.strip()
     if not captured_bytes:
         return None
     for encoding in get_encoding_candidates():
@@ -387,11 +387,11 @@ class CythonMagics(Magics):
                         extension, lib_dir, pgo_step_name='use' if args.pgo else None, quiet=args.quiet)
         except (distutils.errors.CompileError, distutils.errors.LinkError):
             # Build failed, print error message from compiler/linker
-            print_compiler_output(get_stdout, get_stderr, sys.stderr)
+            print_compiler_output(get_stdout(), get_stderr(), sys.stderr)
             return None
 
         # Build seems ok, but we might still want to show any warnings that occurred
-        print_compiler_output(get_stdout, get_stderr, sys.stdout)
+        print_compiler_output(get_stdout(), get_stderr(), sys.stdout)
 
         module = imp.load_dynamic(module_name, module_path)
         self._import_all(module)

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -347,18 +347,18 @@ class CythonMagics(Magics):
             get_stderr = get_stdout = None
             with captured_fd(1, sys.getdefaultencoding()) as get_stdout:
                 with captured_fd(2, sys.getdefaultencoding()) as get_stderr:
-                    self._build_extension(extension, lib_dir, pgo_step_name='use' if args.pgo else None,
-                                  quiet=args.quiet)
+                    self._build_extension(
+                        extension, lib_dir, pgo_step_name='use' if args.pgo else None, quiet=args.quiet)
         except (distutils.errors.CompileError, distutils.errors.LinkError):
             # Build failed, print error message from compiler/linker
             # On windows errors are printed to stdout,
             # we redirect it to sys.stderr
             stdout = get_stdout and get_stdout().strip()
             if stdout:
-                print(stdout, file=sys.stderr)
+                sys.stderr.write(stdout)
             stderr = get_stderr and get_stderr().strip()
             if stderr:
-                print(stderr, file=sys.stderr)
+                sys.stderr.write(stderr)
             return None
 
         module = imp.load_dynamic(module_name, module_path)

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -107,6 +107,26 @@ else:
         return name
 
 
+def prepare_captured(captured):
+    captured_bytes = captured and captured().strip()
+    if captured_bytes:
+        for enc in [sys.getdefaultencoding(), 'latin-1']:
+            try:
+                return captured_bytes.decode(enc)
+            except UnicodeDecodeError:
+                pass
+    # returns as bytes, as it couldn't be decoded
+    return captured_bytes
+
+
+def print_captured(captured, output, header_line):
+    captured = prepare_captured(captured)
+    if captured:
+        if header_line:
+            output.write(header_line)
+        output.write(captured)
+
+
 @magics_class
 class CythonMagics(Magics):
 
@@ -345,21 +365,21 @@ class CythonMagics(Magics):
 
         try:
             get_stderr = get_stdout = None
-            with captured_fd(1, sys.getdefaultencoding()) as get_stdout:
-                with captured_fd(2, sys.getdefaultencoding()) as get_stderr:
+            with captured_fd(1) as get_stdout:
+                with captured_fd(2) as get_stderr:
                     self._build_extension(
                         extension, lib_dir, pgo_step_name='use' if args.pgo else None, quiet=args.quiet)
         except (distutils.errors.CompileError, distutils.errors.LinkError):
             # Build failed, print error message from compiler/linker
             # On windows errors are printed to stdout,
             # we redirect it to sys.stderr
-            stdout = get_stdout and get_stdout().strip()
-            if stdout:
-                sys.stderr.write(stdout)
-            stderr = get_stderr and get_stderr().strip()
-            if stderr:
-                sys.stderr.write(stderr)
+            print_captured(get_stdout, sys.stderr, "Content of stdout:\n")
+            print_captured(get_stderr, sys.stderr, "Content of stderr:\n")
             return None
+
+        # Build might be ok, that we should show the warnings (if there are some):
+        print_captured(get_stdout, sys.stdout, "Content of stdout:\n")
+        print_captured(get_stderr, sys.stdout, "Content of stderr:\n")
 
         module = imp.load_dynamic(module_name, module_path)
         self._import_all(module)

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -40,14 +40,14 @@ def capture_output():
              io.TextIOWrapper(io.BytesIO(), encoding=sys.stderr.encoding),
         ]
         sys.stdout, sys.stderr = replacement
-        output = ["", ""]
+        output = []
         yield output
     finally:
         sys.stdout, sys.stderr = backup
         for wrapper in replacement:
             wrapper.seek(0)  # rewind
-        output[0] = replacement[0].read()
-        output[1] = replacement[1].read()
+            output.append(wrapper.read())
+            wrapper.close()
 
 
 code = u"""\

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -49,15 +49,15 @@ def main():
 main()
 """
 
-compile_error_code = u"""\
+compile_error_code = u'''\
 cdef extern from *:
-    \"\"\"
+    """
     xxx a=1;
-    \"\"\"
+    """
     int a;
 def doit():
     return a
-"""
+'''
 
 
 if sys.platform == 'win32':

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -158,13 +158,13 @@ class TestIPythonMagic(CythonTest):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3', compile_error_code)
-        self.assertTrue("error" in captured.stderr)
+        self.assertEqual("error", captured.stderr)
 
     def test_cython_link_error_shown(self):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3 -l=xxxxxxxx', code)
-        self.assertTrue("error" in captured.stderr)
+        self.assertEqual("error", captured.stderr)
 
     @skip_win32('Skip on Windows')
     def test_cython3_pgo(self):

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -158,13 +158,15 @@ class TestIPythonMagic(CythonTest):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3', compile_error_code)
-        self.assertEqual("error", captured.stderr)
+        self.assertTrue("error" in captured.stderr,
+                        msg="captured [" + captured.stderr + "]")
 
     def test_cython_link_error_shown(self):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3 -l=xxxxxxxx', code)
-        self.assertEqual("error", captured.stderr)
+        self.assertTrue("error" in captured.stderr,
+                        msg="captured [" + captured.stderr + "]")
 
     @skip_win32('Skip on Windows')
     def test_cython3_pgo(self):

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -154,13 +154,13 @@ class TestIPythonMagic(CythonTest):
         self.assertEqual(ip.user_ns['g'], 2 // 10)
         self.assertEqual(ip.user_ns['h'], 2 // 10)
 
-    def test_compile_error_shown(self):
+    def test_cython_compile_error_shown(self):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3', compile_error_code)
         self.assertTrue("error" in captured.stderr)
 
-    def test_link_error_shown(self):
+    def test_cython_link_error_shown(self):
         ip = self._ip
         with capture_output() as captured:
             ip.run_cell_magic('cython', '-3 -l=xxxxxxxx', code)


### PR DESCRIPTION
Fixes #3751 as discussed [here](https://github.com/cython/cython/issues/3751#issuecomment-702725848)

Some compilers (MSVC) and linkers write errors to stdout (and not stderr), so we need to catch both and if an error caught, redirect both to sys.stderr.

After fix, for this code:

```
%%cython
cdef extern from *:
    """
    xxxx a;
    """
    int a;
def doit():
    return a
```
Shows error:
```
.../_cython_magic_0c7dc5ea1c624caa7d5b6b78d977eedea31eb934.c:622:5: error: unknown type name ‘xxxx’
     xxxx a;
```
on Linux and
```
_cython_magic_18af9232b2d51cf1c8df01fd5af261c66fd7b162.c
...\_cython_magic_18af9232b2d51cf1c8df01fd5af261c66fd7b162.c(610): error C2061: syntax error: identifier 'a'
...\_cython_magic_18af9232b2d51cf1c8df01fd5af261c66fd7b162.c(610): error C2059: syntax error: ';'
...\_cython_magic_18af9232b2d51cf1c8df01fd5af261c66fd7b162.c(1073): error C2065: 'a': undeclared identifier
```
on Windows (seen in IPython-notebook).