### PR TITLE
Fix compile error of Coroutine.c

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -810,7 +810,7 @@ PyObject *__Pyx_Coroutine_FinishDelegation(__pyx_CoroutineObject *gen) {
 }
 
 static PyObject *__Pyx_PyGen_Send(PyObject *gen, PyObject *arg) {
-#if PY_VERSION_HEX < 0x030A00A1
+#if PY_VERSION_HEX <= 0x030A00A1
     return _PyGen_Send((PyGenObject*)gen, arg);
 #else
     PyObject *result;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -809,6 +809,29 @@ PyObject *__Pyx_Coroutine_FinishDelegation(__pyx_CoroutineObject *gen) {
     return ret;
 }
 
+static PyObject *__Pyx_PyGen_Send(PyObject *gen, PyObject *arg) {
+#if PY_VERSION_HEX < 0x030A00A1
+    return _PyGen_Send((PyGenObject*)gen, arg);
+#else
+    PyObject *result;
+    // PyIter_Send() asserts non-NULL arg
+    if (PyIter_Send(gen, arg ? arg : Py_None, &result) == PYGEN_RETURN) {
+        if (PyAsyncGen_CheckExact(gen)) {
+            assert(result == Py_None);
+            PyErr_SetNone(PyExc_StopAsyncIteration);
+        }
+        else if (result == Py_None) {
+            PyErr_SetNone(PyExc_StopIteration);
+        }
+        else {
+            _PyGen_SetStopIterationValue(result);
+        }
+        Py_CLEAR(result);
+    }
+    return result;
+#endif
+}
+
 static PyObject *__Pyx_Coroutine_Send(PyObject *self, PyObject *value) {
     PyObject *retval;
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject*) self;
@@ -838,13 +861,13 @@ static PyObject *__Pyx_Coroutine_Send(PyObject *self, PyObject *value) {
         #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x03030000 && (defined(__linux__) || PY_VERSION_HEX >= 0x030600B3)
         // _PyGen_Send() is not exported before Py3.6
         if (PyGen_CheckExact(yf)) {
-            ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
+            ret = __Pyx_PyGen_Send(yf, value == Py_None ? NULL : value);
         } else
         #endif
         #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x03050000 && defined(PyCoro_CheckExact) && (defined(__linux__) || PY_VERSION_HEX >= 0x030600B3)
         // _PyGen_Send() is not exported before Py3.6
         if (PyCoro_CheckExact(yf)) {
-            ret = _PyGen_Send((PyGenObject*)yf, value == Py_None ? NULL : value);
+            ret = __Pyx_PyGen_Send(yf, value == Py_None ? NULL : value);
         } else
         #endif
         {
@@ -939,7 +962,7 @@ static PyObject *__Pyx_Generator_Next(PyObject *self) {
         #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x03030000 && (defined(__linux__) || PY_VERSION_HEX >= 0x030600B3)
         // _PyGen_Send() is not exported before Py3.6
         if (PyGen_CheckExact(yf)) {
-            ret = _PyGen_Send((PyGenObject*)yf, NULL);
+            ret = __Pyx_PyGen_Send(yf, NULL);
         } else
         #endif
         #ifdef __Pyx_Coroutine_USED


### PR DESCRIPTION
A workaround for #3876.
Alomost the same as `gen_send()`  in [cpython/Objects/genobject.c](https://github.com/python/cpython/blob/cfb0f57ff876ab3d04ff144f19eda58844981643/Objects/genobject.c).

Redundant PR, but I suppose this routine is not so hot.
[72acc2c](https://github.com/cython/cython/commit/72acc2cdcbb6fd738fcffe7d193bfc44aefc6474) and [3aa55e6](https://github.com/cython/cython/commit/3aa55e6596df7cc4235dd1c199eafdcd8f17e1b2) say this case is special.