### PR TITLE
[RFC] Fix const in nested template arg

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2700,6 +2700,10 @@ def looking_at_expr(s):
             s.next()
             is_type = s.sy == ']'
             s.put_back(*saved)
+            if not is_type:  # could be template type
+                s.next()
+                is_type = not looking_at_expr(s)
+                s.put_back(*saved)
 
         dotted_path.reverse()
         for p in dotted_path:

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2698,12 +2698,8 @@ def looking_at_expr(s):
             s.put_back(*saved)
         elif s.sy == '[':
             s.next()
-            is_type = s.sy == ']'
+            is_type = s.sy == ']' or not looking_at_expr(s)  # could be a nested template type
             s.put_back(*saved)
-            if not is_type:  # could be template type
-                s.next()
-                is_type = not looking_at_expr(s)
-                s.put_back(*saved)
 
         dotted_path.reverse()
         for p in dotted_path:

--- a/tests/compile/cpp_templates_nested.pyx
+++ b/tests/compile/cpp_templates_nested.pyx
@@ -1,0 +1,18 @@
+# tag: cpp
+# mode: compile
+
+from libcpp.vector cimport vector
+
+cdef extern from *:
+    cdef cppclass Foo[T]:
+        pass
+
+    cdef cppclass Bar:
+        pass
+
+cdef vector[vector[int]] a
+cdef vector[vector[const int]] b
+cdef vector[vector[vector[int]]] c
+cdef vector[vector[vector[const int]]] d
+cdef Foo[Foo[Bar]] e
+cdef Foo[Foo[const Bar]] f


### PR DESCRIPTION
Fixes #1355 

As noted in https://github.com/cython/cython/issues/3885, declarations such as the following currently fail:

```
cdef vector[vector[const int]] x
```

When the parser sees `cdef vector[...]`, it calls `looking_at_expr` [here](https://github.com/cython/cython/issues/3885) to figure out if `...` is an expression. Currently, that returns `True`. The approach taken here is to ensure it returns `False` so that `...` is parsed correctly as a _type_. I hope this the right way to go about it.