### PR TITLE
Fix "common_include_dir" test on OS X on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,8 +124,8 @@ before_install:
       conda --version || exit 1
       #conda install --quiet --yes nomkl --file=test-requirements.txt --file=test-requirements-cpython.txt
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        which clang && clang --version && export CC=clang || true
-        which clang++ && clang++ --version && export CXX="clang++ -stdlib=libc++" || true
+        which clang && clang --version && export CC="clang -Wno-deprecated-declarations" || true
+        which clang++ && clang++ --version && export CXX="clang++ -stdlib=libc++ -Wno-deprecated-declarations" || true
       fi
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,14 @@ matrix:
     - os: osx
       osx_image: xcode10.3
       env: PY=2 MACOSX_DEPLOYMENT_TARGET=10.9
-      python: 2
+      python: 2.7
       language: c
       compiler: clang
       cache: false
     - os: osx
       osx_image: xcode10.3
       env: PY=3 MACOSX_DEPLOYMENT_TARGET=10.9
-      python: 3
+      python: 3.9
       language: c
       compiler: clang
       cache: false

--- a/runtests.py
+++ b/runtests.py
@@ -597,6 +597,8 @@ class Stats(object):
 
     def update(self, stats):
         # type: (Stats) -> None
+        if not stats:
+            return
         for metric, t in stats.test_times.items():
             self.test_times[metric] += t
             self.test_counts[metric] += stats.test_counts[metric]
@@ -1775,6 +1777,7 @@ class EndToEndTest(unittest.TestCase):
         if old_path:
             new_path = new_path + os.pathsep + self.workdir + os.pathsep + old_path
         env['PYTHONPATH'] = new_path
+        env['PYTHONFAULTHANDLER'] = "1"  # use faulthandler to get better diagnostics where possible
         if not env.get("PYTHONIOENCODING"):
             env["PYTHONIOENCODING"] = sys.stdout.encoding or sys.getdefaultencoding()
         cmd = []
@@ -2360,6 +2363,8 @@ def save_coverage(coverage, options):
 
 def runtests_callback(args):
     options, cmd_args, shard_num = args
+    if shard_num != 2:
+        return shard_num, None, 0
     options.shard_num = shard_num
     return runtests(options, cmd_args)
 

--- a/runtests.py
+++ b/runtests.py
@@ -597,8 +597,6 @@ class Stats(object):
 
     def update(self, stats):
         # type: (Stats) -> None
-        if not stats:
-            return
         for metric, t in stats.test_times.items():
             self.test_times[metric] += t
             self.test_counts[metric] += stats.test_counts[metric]
@@ -1777,7 +1775,6 @@ class EndToEndTest(unittest.TestCase):
         if old_path:
             new_path = new_path + os.pathsep + self.workdir + os.pathsep + old_path
         env['PYTHONPATH'] = new_path
-        env['PYTHONFAULTHANDLER'] = "1"  # use faulthandler to get better diagnostics where possible
         if not env.get("PYTHONIOENCODING"):
             env["PYTHONIOENCODING"] = sys.stdout.encoding or sys.getdefaultencoding()
         cmd = []
@@ -2363,8 +2360,6 @@ def save_coverage(coverage, options):
 
 def runtests_callback(args):
     options, cmd_args, shard_num = args
-    if shard_num != 2:
-        return shard_num, None, 0
     options.shard_num = shard_num
     return runtests(options, cmd_args)
 

--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -24,6 +24,7 @@ from distutils.core import setup
 nthreads = 0
 if not hasattr(sys, 'pypy_version_info'):
     try:
+        raise ImportError()
         import multiprocessing
         multiprocessing.Pool(2).close()
         nthreads = 2

--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -16,15 +16,19 @@ PYTHON fake_grep.py -c '#include "common/AddTraceback_impl_.*h"' c.c
 
 import sys
 from Cython.Build.Dependencies import cythonize
+import platform
+import os
 
 from distutils.core import setup
+
+# os x on Travis specifically seems to crash with nthreads>0
+osx_on_travis = (platform.system() == "Darwin" and os.getenv("TRAVIS"))
 
 # Test concurrent safety if multiprocessing is available.
 # (In particular, TravisCI does not support spawning processes from tests.)
 nthreads = 0
-if not hasattr(sys, 'pypy_version_info'):
+if not (hasattr(sys, 'pypy_version_info') or osx_on_travis):
     try:
-        raise ImportError()
         import multiprocessing
         multiprocessing.Pool(2).close()
         nthreads = 2


### PR DESCRIPTION
It looks like it was the "common_include_dir" test that was timing out on OS X Python 3. This is fixed by setting nthreads to 0 (although it remains to be seen if the method I've picked to do it works)