### PR TITLE
Support namespace packages inside regular packages

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -156,9 +156,7 @@ def check_package_dir(dir_path, package_names):
     for dirname in package_names:
         dir_path = os.path.join(dir_path, dirname)
         has_init = contains_init(dir_path)
-        if not namespace and not has_init:
-            return None, False
-        elif has_init:
+        if has_init:
             namespace = False
     return dir_path, namespace
 

--- a/tests/build/cythonize_pep420_namespace.srctree
+++ b/tests/build/cythonize_pep420_namespace.srctree
@@ -11,7 +11,7 @@ setup(
   ext_modules=cythonize([
     Extension("nsp.m1.a", ["nsp/m1/a.pyx"]),
     Extension("nsp.m2.b", ["nsp/m2/b.pyx"]),
-    Extension("nsp.m3.c.d", ["nsp/m3/c/d.pyx"])
+    Extension("nsp.m3.c.d", ["nsp/m3/c/d.pyx"]),
   ]),
 )
 

--- a/tests/build/cythonize_pep420_namespace.srctree
+++ b/tests/build/cythonize_pep420_namespace.srctree
@@ -10,7 +10,8 @@ from distutils.core import setup, Extension
 setup(
   ext_modules=cythonize([
     Extension("nsp.m1.a", ["nsp/m1/a.pyx"]),
-    Extension("nsp.m2.b", ["nsp/m2/b.pyx"])
+    Extension("nsp.m2.b", ["nsp/m2/b.pyx"]),
+    Extension("nsp.m3.c.d", ["nsp/m3/c/d.pyx"])
   ]),
 )
 
@@ -31,14 +32,28 @@ cdef class A:
 ######## nsp/m2/b.pyx ########
 
 from nsp.m1.a cimport A
+from nsp.m3.c.d cimport D
 
 cdef class B(A):
     pass
+
+######## nsp/m3/__init__.py ########
+
+######## nsp/m3/c/d.pyx ########
+
+cdef class D:
+  pass
+
+######## nsp/m3/c/d.pxd ########
+
+cdef class D:
+  pass
 
 ######## runner.py ########
 
 from nsp.m1.a import A
 from nsp.m2.b import B
+from nsp.m3.c.d import D
 
 a = A()
 b = B()


### PR DESCRIPTION
In my understanding the mechanism for cimporting namespace packages that was implemented in #2946 differs from the way the standard CPython PathFinder would find the file to load.
Consider the following structure:

```
a/b/__init__.py
a/b/c/d.py
```
CPython3 allows importing `a.b.c.d`. In my understanding it implicitly creates a namespace package `a.b.c`.
Cython doesn't consider a.b.c a namespace package because `a.b` is a regular package as `a/b/__init__.py` exists.

This patch adds a test exposing the problem as well as an implementation of the following solution: if a directory contains a __init__p{y,xd} file, let's treat all its subdirectories as regular packages as well. This would be closer to what CPython's PathFinder does.