### PR TITLE
Some supplements and fixes in CodeWriter

### DIFF
--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -505,8 +505,10 @@ class StatementWriter(DeclarationWriter):
 
     def visit_DelStatNode(self, node):
         self.startline(u"del ")
-        for arg in node.args:
-            self.visit(arg)
+        for item in node.args[:-1]:
+            self.visit(item)
+            self.put(u", ")
+        self.visit(node.args[-1])
         self.endline()
 
     def visit_GlobalNode(self, node):

--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -7,6 +7,8 @@ is preserved (and it could not be as it is not present in the code tree).
 
 from __future__ import absolute_import, print_function
 
+import copy
+
 from .Compiler.Visitor import TreeVisitor
 from .Compiler.ExprNodes import *
 from .Compiler.Nodes import CNameDeclaratorNode, CSimpleBaseTypeNode
@@ -18,8 +20,9 @@ class LinesResult(object):
         self.s = u""
 
     def __getitem__(self, s):
-        self.s = self.s[s]
-        return self
+        other = copy.deepcopy(self)
+        other.s = other.s[s]
+        return other
 
     def put(self, s):
         self.s += s

--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -448,7 +448,18 @@ class StatementWriter(DeclarationWriter):
         self.startline(u"except")
         if node.pattern is not None:
             self.put(u" ")
-            self.visit(node.pattern[0])
+            if len(node.pattern) == 0:
+                # except () as e
+                self.put(u"()")
+            elif len(node.pattern) == 1:
+                self.visit(node.pattern[0])
+            else:
+                self.put(u"(")
+                for p in node.pattern[:-1]:
+                    self.visit(p)
+                    self.put(u", ")
+                self.visit(node.pattern[-1])
+                self.put(u")")
         if node.target is not None:
             self.put(u" as ")
             self.visit(node.target)
@@ -517,6 +528,9 @@ class StatementWriter(DeclarationWriter):
     def visit_RaiseStatNode(self, node):
         self.startline(u"raise ")
         self.visit(node.exc_type)
+        if node.cause:
+            self.put(u" from ")
+            self.visit(node.cause)
         self.endline()
 
 class ExpressionWriter(TreeVisitor):

--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -19,9 +19,9 @@ class LinesResult(object):
         self.lines = []
         self.s = u""
 
-    def __getitem__(self, s):
+    def __getitem__(self, slices):
         other = copy.deepcopy(self)
-        other.s = other.s[s]
+        other.s = other.s[slices]
         return other
 
     def put(self, s):
@@ -546,7 +546,7 @@ class ExpressionWriter(TreeVisitor):
     def __init__(self, result=None):
         super(ExpressionWriter, self).__init__()
         if result is None:
-            result = u""
+            result = LinesResult()
         self.result = result
         self.precedence = [0]
 
@@ -555,7 +555,7 @@ class ExpressionWriter(TreeVisitor):
         return self.result
 
     def put(self, s):
-        self.result += s
+        self.result.put(s)
 
     def remove(self, s):
         if self.result.endswith(s):

--- a/Cython/Tests/TestCodeWriter.py
+++ b/Cython/Tests/TestCodeWriter.py
@@ -123,6 +123,71 @@ class TestCodeWriter(CythonTest):
                         return 1234
                """)
 
+    def test_assert(self):
+        self.t(u"""
+                    assert a == 10
+                    assert a == 10, 'detail message'
+               """)
+
+    def test_global_node(self):
+        self.t(u"""
+                    global a, b
+               """)
+
+    def test_nonlocal_node(self):
+        self.t(u"""
+                    nonlocal a, b
+               """)
+
+    def test_yield(self):
+        self.t(u"""
+                    yield (1, 2)
+                    yield from [1, 2, 3, 4, 5]
+               """)
+
+    def test_del(self):
+        self.t(u"""
+                    del a
+                    del a[0]
+               """)
+
+    def test_lambda(self):
+        self.t(u"""
+                    lambda x : x + 2
+               """)
+
+    def test_cascaded_cmp_node(self):
+        self.t(u"""
+                    5 < 6 <= 7 > 4 >= 3 > 2 != 1
+               """)
+
+    def test_raise(self):
+        self.t(u"""
+                    raise RuntimeError
+                    raise RuntimeError('detail messages')
+               """)
+
+    def test_general_call(self):
+        self.t(u"""
+                    func(a, b, c=10)
+               """)
+
+    def test_try_except_else_finally(self):
+        self.t(u"""
+                    try:
+                        pass
+                    except:
+                        pass
+                    except IOError as e:
+                        pass
+                    except RuntimeError as e:
+                        pass
+                    else:
+                        pass
+                    finally:
+                        pass
+               """)
+
 if __name__ == "__main__":
     import unittest
     unittest.main()

--- a/Cython/Tests/TestCodeWriter.py
+++ b/Cython/Tests/TestCodeWriter.py
@@ -126,7 +126,7 @@ class TestCodeWriter(CythonTest):
     def test_assert(self):
         self.t(u"""
                     assert a == 10
-                    assert a == 10, 'detail message'
+                    assert a == 10, 'Something detail here'
                """)
 
     def test_global_node(self):
@@ -164,7 +164,9 @@ class TestCodeWriter(CythonTest):
     def test_raise(self):
         self.t(u"""
                     raise RuntimeError
-                    raise RuntimeError('detail messages')
+                    raise RuntimeError('Something bad happened')
+                    raise RuntimeError('Something bad happened') from exc
+                    raise RuntimeError('Something bad happened') from None
                """)
 
     def test_general_call(self):
@@ -181,6 +183,10 @@ class TestCodeWriter(CythonTest):
                     except IOError as e:
                         pass
                     except RuntimeError as e:
+                        pass
+                    except () as e:
+                        pass
+                    except (TypeError, KeyError) as e:
                         pass
                     else:
                         pass

--- a/Cython/Tests/TestCodeWriter.py
+++ b/Cython/Tests/TestCodeWriter.py
@@ -149,6 +149,7 @@ class TestCodeWriter(CythonTest):
         self.t(u"""
                     del a
                     del a[0]
+                    del a, b, c
                """)
 
     def test_lambda(self):


### PR DESCRIPTION
##### Add for `del` expression.
```python
del a
del a[0]
del a, b, c
```

##### Add for `RaiseStatNode` node.
```python
raise RuntimeError
raise RuntimeError('detail messages')
raise RuntimeError('detail messages') from exc
```

##### Fix `visit_TryExceptStatNode` `visit_ExceptClauseNode` `visit_TryFinallyStatNode`
```python
try:
    pass
except:
    pass
except IOError as e:
    pass                    
except RuntimeError as e:
    pass
except (IOError, RuntimeError) as e:
    pass
else:
    pass
finally:
    pass
```

##### Add for `AssertStatNode` node.
```python
assert a == 10
assert a == 10, "detail messages"
```

##### Add for `GlobalNode` and 'NonlocalNode' node.
```python
global a, b
nonlocal a, b
```

##### Add for `visit_LambdaNode`
```python
lambda x : x + 2
```

##### Add for `visit_CascadedCmpNode`
```python
>>> 5 < 6 <= 7 > 4 >= 3 > 2 != 1
>>> True
```

##### Fix `LinesResult `, used by`remove` method, which use an undefined method named `endswith`.