### PR TITLE
[0.29] Fix usage of undefined C-API "_PyGen_Send" in Py3.10 with "PyIter_Send".

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -791,12 +791,12 @@ PyObject *__Pyx_Coroutine_MethodReturn(CYTHON_UNUSED PyObject* gen, PyObject *re
 #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x03030000 && (defined(__linux__) || PY_VERSION_HEX >= 0x030600B3)
 static CYTHON_INLINE
 PyObject *__Pyx_PyGen_Send(PyGenObject *gen, PyObject *arg) {
-#if PY_VERSION_HEX < 0x030A00A1
+#if PY_VERSION_HEX <= 0x030A00A1
     return _PyGen_Send(gen, arg);
 #else
     PyObject *result;
-    // PyGen_Send() asserts non-NULL arg
-    if (PyGen_Send(gen, arg ? arg : Py_None, &result) == PYGEN_RETURN) {
+    // PyIter_Send() asserts non-NULL arg
+    if (PyIter_Send((PyObject*)gen, arg ? arg : Py_None, &result) == PYGEN_RETURN) {
         if (PyAsyncGen_CheckExact(gen)) {
             assert(result == Py_None);
             PyErr_SetNone(PyExc_StopAsyncIteration);


### PR DESCRIPTION
The C-API function applied in previous commit (https://github.com/cython/cython/commit/b37607f46b165e81f7af2b4eec2ae7f76f7717df) is now also obsolete.
This patch works for cython 0.29 and cpython after (https://github.com/python/cpython/commit/1e996c3a3b51e9c6f1f4cea8a6dbcf3bcb865060#diff-d2c90d06d281ca8dd7ac8b90109fc26755f7319dd209b5f9416efdecfa56e289).

issue #3876