### PR TITLE
Fix OpenVMS reserved names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ MANIFEST
 
 # Komodo EDIT/IDE project files
 /*.komodoproject
+
+.vscode

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -7,6 +7,13 @@ from __future__ import absolute_import
 import re
 import copy
 import operator
+import sys
+
+is_openvms = (sys.platform == 'OpenVMS')
+openvms_reserved_names = [
+    'readonly',
+    '_align',
+]
 
 try:
     import __builtin__ as builtins
@@ -474,6 +481,8 @@ class Scope(object):
         if not self.in_cinclude and cname and re.match("^_[_A-Z]+$", cname):
             # See https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html#Reserved-Names
             warning(pos, "'%s' is a reserved name in C." % cname, -1)
+        if is_openvms and cname in openvms_reserved_names:
+            cname = cname + '$'
 
         entries = self.entries
         if name and name in entries and not shadow:

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -378,7 +378,38 @@
         #endif
     #endif
 #else
-    #include <stdint.h>
+#ifdef __VMS
+#if __CRTL_VER > 80400000
+#include <stdint.h>
+#else
+typedef signed char             int8_t;
+typedef signed short            int16_t;
+typedef signed int              int32_t;
+typedef signed char             int_least8_t;
+typedef signed short            int_least16_t;
+typedef signed int              int_least32_t;
+typedef signed long long int    int_least64_t;
+typedef signed char             int_fast8_t;
+typedef signed int              int_fast16_t;
+typedef signed int              int_fast32_t;
+typedef signed long long int    int_fast64_t;
+typedef signed long long int    intmax_t;
+typedef unsigned char           uint8_t;
+typedef unsigned short          uint16_t;
+typedef unsigned int            uint32_t;
+typedef unsigned char           uint_least8_t;
+typedef unsigned short          uint_least16_t;
+typedef unsigned int            uint_least32_t;
+typedef unsigned long long int  uint_least64_t;
+typedef unsigned char           uint_fast8_t;
+typedef unsigned int            uint_fast16_t;
+typedef unsigned int            uint_fast32_t;
+typedef unsigned long long int  uint_fast64_t;
+typedef unsigned long long int  uintmax_t;
+#endif
+#else
+#include <stdint.h>
+#endif
     typedef uintptr_t  __pyx_uintptr_t;
 #endif
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -378,36 +378,7 @@
         #endif
     #endif
 #else
-#ifdef __VMS
-#if __CRTL_VER > 80400000
-#include <stdint.h>
-#else
-typedef signed char             int8_t;
-typedef signed short            int16_t;
-typedef signed int              int32_t;
-typedef signed char             int_least8_t;
-typedef signed short            int_least16_t;
-typedef signed int              int_least32_t;
-typedef signed long long int    int_least64_t;
-typedef signed char             int_fast8_t;
-typedef signed int              int_fast16_t;
-typedef signed int              int_fast32_t;
-typedef signed long long int    int_fast64_t;
-typedef signed long long int    intmax_t;
-typedef unsigned char           uint8_t;
-typedef unsigned short          uint16_t;
-typedef unsigned int            uint32_t;
-typedef unsigned char           uint_least8_t;
-typedef unsigned short          uint_least16_t;
-typedef unsigned int            uint_least32_t;
-typedef unsigned long long int  uint_least64_t;
-typedef unsigned char           uint_fast8_t;
-typedef unsigned int            uint_fast16_t;
-typedef unsigned int            uint_fast32_t;
-typedef unsigned long long int  uint_fast64_t;
-typedef unsigned long long int  uintmax_t;
-#endif
-#else
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
     typedef uintptr_t  __pyx_uintptr_t;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -379,7 +379,7 @@
     #endif
 #else
 #ifdef HAVE_STDINT_H
-#include <stdint.h>
+    #include <stdint.h>
 #endif
     typedef uintptr_t  __pyx_uintptr_t;
 #endif


### PR DESCRIPTION
Just add a suffix '$' to the name. The same is done in OpenVMS Python 3.8 port.
Also not all OpenVMS systems (like the other systems too) have STDINT.H file.