### PR TITLE
Use Py_TYPE() and Py_REFCNT() macros

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -333,7 +333,7 @@ static long __Pyx__PyObject_Ord(PyObject* c) {
     } else {
         // FIXME: support character buffers - but CPython doesn't support them either
         PyErr_Format(PyExc_TypeError,
-            "ord() expected string of length 1, but %.200s found", c->ob_type->tp_name);
+            "ord() expected string of length 1, but %.200s found", Py_TYPE(c)->tp_name);
         return (long)(Py_UCS4)-1;
     }
     PyErr_Format(PyExc_TypeError,

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1135,7 +1135,7 @@ __pyx_FusedFunction_call(PyObject *func, PyObject *args, PyObject *kw)
             PyErr_Format(PyExc_TypeError,
                          "First argument should be of type %.200s, got %.200s.",
                          ((PyTypeObject *) binding_func->type)->tp_name,
-                         self->ob_type->tp_name);
+                         Py_TYPE(self)->tp_name);
             goto bad;
         } else if (unlikely(is_instance == -1)) {
             goto bad;

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1040,7 +1040,7 @@ static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
 /////////////// CallableCheck.proto ///////////////
 
 #if CYTHON_USE_TYPE_SLOTS && PY_MAJOR_VERSION >= 3
-#define __Pyx_PyCallable_Check(obj)   ((obj)->ob_type->tp_call != NULL)
+#define __Pyx_PyCallable_Check(obj)   (Py_TYPE(obj)->tp_call != NULL)
 #else
 #define __Pyx_PyCallable_Check(obj)   PyCallable_Check(obj)
 #endif
@@ -1913,7 +1913,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_Call(PyObject *func, PyObject *arg
 #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE PyObject* __Pyx_PyObject_Call(PyObject *func, PyObject *arg, PyObject *kw) {
     PyObject *result;
-    ternaryfunc call = func->ob_type->tp_call;
+    ternaryfunc call = Py_TYPE(func)->tp_call;
 
     if (unlikely(!call))
         return PyObject_Call(func, arg, kw);


### PR DESCRIPTION
Don't access directly PyObject.ob_type and PyObject.ob_refcnt
members.