### PR TITLE
Fix missing utility code for complex annotations

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -13857,6 +13857,9 @@ class AnnotationNode(ExprNode):
             warning(annotation.pos,
                     "Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.",
                     level=1)
+        elif arg_type is not None and arg_type.is_complex:
+            # creating utility code needs to be special-cased for complex types
+            arg_type.create_declaration_utility_code(env)
         if arg_type is not None:
             if explicit_pytype and not explicit_ctype and not arg_type.is_pyobject:
                 warning(annotation.pos,

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1783,6 +1783,9 @@ class FuncDefNode(StatNode, BlockNode):
             error(type_node.pos, "Previous declaration here")
         else:
             arg.type = other_type
+            if arg.type.is_complex:
+                # utility code for complex types is special-cased and also important to ensure that it's run
+                arg.type.create_declaration_utility_code(env)
         return arg
 
     def need_gil_acquisition(self, lenv):

--- a/tests/compile/complex_annotations.pyx
+++ b/tests/compile/complex_annotations.pyx
@@ -1,0 +1,7 @@
+# mode: compile
+
+# Complex numbers defined in annotations weren't having their utility code imported directly
+# leading to compile-errors that the type wasn't defined. The test is intentionally minimal since
+# anything more thorough ends up creating the utility code
+cdef f(x: complex):
+    pass

--- a/tests/compile/complex_decorators.pyx
+++ b/tests/compile/complex_decorators.pyx
@@ -1,0 +1,10 @@
+# mode: compile
+
+cimport cython
+
+# Complex numbers defined in "cython.locals" weren't having their utility code imported directly
+# leading to compile-errors that the type wasn't defined. The test is intentionally minimal since
+# anything more thorough ends up creating the utility code
+@cython.locals(x=complex)
+cdef f(x):
+    pass


### PR DESCRIPTION
Generating utility-code for complex types is special-cased, but
it wasn't when they were generated in annotations.

Fixes https://github.com/cython/cython/issues/3949