### PR TITLE
Handle constant folding for LanguageLevel 2 on Python 3

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4424,6 +4424,8 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                 string_node.unicode_value = encoded_string(
                     string_node.unicode_value * multiplier,
                     string_node.unicode_value.encoding)
+            if not string_node.value.is_unicode:
+                build_string = bytes_literal
         elif isinstance(string_node, ExprNodes.UnicodeNode):
             if string_node.bytes_value is not None:
                 string_node.bytes_value = bytes_literal(


### PR DESCRIPTION
Ensure that when StrNode is a BytesLiteral, that we don't coerce it to unicode.
Before when using Python 3 as the Compiler and targeting LanguageLevel 2, an expression like `'-'*5` would be optimized into `"b'-----'"` instead of `'-----'`.

Fixes https://github.com/cython/cython/issues/3951