### PR TITLE
Allow type of self argument to be overridden

### DIFF
--- a/tests/run/cdef_class_self_type.pyx
+++ b/tests/run/cdef_class_self_type.pyx
@@ -1,0 +1,132 @@
+# mode: run
+
+# cython: binding=True, annotation_typing=True
+
+# The feature this is testing only really works on Python 3, so many
+# of the tests are hidden behind a version guard in the module __doc__.
+# This is unavoidable and due to the different way Python treats
+# bound/unbound methods between versions 2 and 3
+
+cimport cython
+
+ctypedef fused FooOrInt:
+    Foo
+    int
+
+cdef class Foo:
+    cdef update(self):
+        # a function that'll only be accessible if we know the type
+        pass
+
+    def meth1(self, try_to_run_update=True):
+        """
+        >>> f = Foo()
+        >>> f.meth1()
+        'Foo'
+        >>> Foo.meth1(f)
+        'Foo'
+
+        See module __doc__ for more
+        """
+        if try_to_run_update:
+            self.update()  # no error
+        return cython.typeof(self)
+
+    def meth2(Foo self, try_to_run_update=True):
+        """
+        # specifying the type as Foo should do nothing different
+        >>> f = Foo()
+        >>> f.meth2()
+        'Foo'
+        >>> Foo.meth2(f)
+        'Foo'
+
+        See module __doc__ for more
+        """
+        if try_to_run_update:
+            self.update()  # no error
+        return cython.typeof(self)
+
+    def meth_o(object self):
+        """
+        >>> Foo().meth_o()
+        Couldn't find self.update
+        ('Python object', 'Foo')
+
+        See module __doc__ for more...
+        """
+        try:
+            self.update()
+        except AttributeError:
+            print("Couldn't find self.update")
+        else:
+            print("Called self.update()")
+        return cython.typeof(self), type(self).__name__
+
+    def meth_i(int i):
+        """
+        (passed Foo not int)
+        >>> Foo().meth_i() # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        TypeError:
+
+        See module doc for more
+
+        (passed dict not int)
+        >>> Foo.meth_i({}) # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        TypeError:
+        """
+        return i+1
+
+    def meth_fused(FooOrInt x):
+        """
+        >>> Foo.meth_fused(1)
+        'int'
+        >>> Foo().meth_fused()
+        'Foo'
+        """
+        return cython.typeof(x)
+
+    @cython.locals(i=int)
+    def meth_locals(i):
+        """
+        See module doc for more
+        >>> Foo().meth_locals() # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        TypeError:
+        """
+        return cython.typeof(i)
+
+    def meth_anno(i: cython.int):
+        """
+        See module __doc__ for more
+        >>> Foo().meth_anno() # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        TypeError:
+        """
+        return cython.typeof(i)
+
+import sys
+if sys.version_info[0] > 2:
+    # The vast majority of the tests here will only work on Python 3
+    __doc__ = """
+    >>> Foo.meth1(1, try_to_run_update=False)  # not really safe, but current behaviour is not to detect it
+    'Foo'
+
+    >>> Foo.meth2(1, try_to_run_update=False)  # not really safe, but current behaviour is not to detect it
+    'Foo'
+
+    >>> Foo.meth_i(1)
+    2
+
+    >>> Foo.meth_o({})
+    Called self.update()
+    ('Python object', 'dict')
+
+    >>> Foo.meth_locals(1)
+    'int'
+
+    >>> Foo.meth_anno(1)
+    'int'
+    """


### PR DESCRIPTION
This is a small chunk of https://github.com/cython/cython/pull/3383 (in an effort to break it down into more reasonable pieces and get it working again).

As requested in this comment https://github.com/cython/cython/issues/1274#issuecomment-525230079.

This only works in Python 3 - reflecting the different behaviour of pure Python code:

 ```
class C:
  def f(self):
     pass
C.f(1)
```

---------------------

The main reasons for doing this are
1. In Python 3 it is technically allowed (although it's an odd thing to do)
2. It's a step to supporting arbitrary decorators - as soon as a decorator is applied to a method it can change the `self` argument in all kinds of ways (for example the `classmethod` and `staticmethod` decorators). Allowing the user to override the `self` method would give more flexibility about how decorators could be used in methods of `cdef` classes.

-------------------------

Relevant comments copied over from the older PR (in the interests of being transparent that it wasn't a completely popular idea):

scoder:
> I'm not convinced of this feature yet. I think it's worth a separate discussion. There might be other ways to achieve the original intention, for example.

da-woods:
> Do you mean "you're not convinced it should be possible to override the type of self" or "this way of doing it is probably not the right way"?

scoder:
> I'm not convinced it should be possible to override the type of self. Being able to call a type's method on something that is not the type? How is that not a static method then?

da-woods:
> The main counter-argument is that it is possible in Python 3 where functions and methods are the same thing.
>
> The difference between it and a static method is that in staticmethod always drops the self argument whether you call it with an instance or not, but it is acting very similar to a static method.
>
> I definitely don't think this would be a good thing to do regularly. jdemeyer claimed to have use cases for it so maybe could suggest a good reason? I'd mainly implemented it here because it seemed like a necessary step for the arbitrary decorator support.

--------

I suggest treating this PR as fairly low priority - I don't think it's hugely useful without changes to decorators (to follow)