### PR TITLE
Always use "new" string->float conversions

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2195,6 +2195,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
                         args=[func_arg],
                         py_name='float',
                         is_temp=node.is_temp,
+                        utility_code = UtilityCode.load_cached("pynumber_float", "TypeConversion.c"),
                         result_is_used=node.result_is_used,
                     ).coerce_to(node.type, self.current_env())
         return node

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -713,7 +713,6 @@ static double __Pyx_SlowPyString_AsDouble(PyObject *obj) {
 
 static const char* __Pyx__PyBytes_AsDouble_Copy(const char* start, char* buffer, Py_ssize_t length) {
     Py_ssize_t i;
-    char *digit = buffer;
     for (i=0; i < length; i++) {
         if (start[i] != '_') *buffer++ = start[i];
     }

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -466,16 +466,16 @@ static CYTHON_INLINE PyObject * __Pyx_PyInt_FromSize_t(size_t ival) {
 
 /////////////// pynumber_float.proto ///////////////
 
-static CYTHON_INLINE PyObject* __Pyx_PyNumber_Float(PyObject* obj); /* proto */
+static CYTHON_INLINE PyObject* __Pyx__PyNumber_Float(PyObject* obj); /* proto */
+#define __Pyx_PyNumber_Float(x) (PyFloat_CheckExact(x) ? __Pyx_NewRef(x) : __Pyx__PyNumber_Float(x))
 
 /////////////// pynumber_float ///////////////
 //@requires: Optimize.c::pybytes_as_double
 //@requires: Optimize.c::pyunicode_as_double
 
-static CYTHON_INLINE PyObject* __Pyx_PyNumber_Float(PyObject* obj) {
-    if (PyFloat_CheckExact(obj)) {
-        return __Pyx_NewRef(obj);
-    } else if (PyUnicode_CheckExact(obj)) {
+static CYTHON_INLINE PyObject* __Pyx__PyNumber_Float(PyObject* obj) {
+    // obj is PyFloat is handled in the calling macro
+    if (PyUnicode_CheckExact(obj)) {
         return PyFloat_FromDouble(__Pyx_PyUnicode_AsDouble(obj));
     } else if (PyBytes_CheckExact(obj)) {
         return PyFloat_FromDouble(__Pyx_PyBytes_AsDouble(obj));


### PR DESCRIPTION
This ensures that `float("1_2_3")` conversions (with underscored numbers) are handled correctly
whether or not the argument type is known.

Fixes https://github.com/cython/cython/issues/3958 (and thus the
currently broken builtin_float test)

--------------

I suspect a similar inconsistency may apply with integer conversions too - that isn't looked at here.