### PR TITLE
Warning message on cpdef variables (0.29.x)

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1380,6 +1380,9 @@ class CVarDefNode(StatNode):
                     self.entry.type.create_to_py_utility_code(env)
                     self.entry.create_wrapper = True
             else:
+                if self.overridable:
+                    warning(self.pos, "cpdef variables will not be supported in Cython 3; "
+                            "currently they are no different from cdef variables", 2)
                 if self.directive_locals:
                     error(self.pos, "Decorators can only be followed by functions")
                 self.entry = dest_scope.declare_var(

--- a/tests/errors/cpdef_vars.pyx
+++ b/tests/errors/cpdef_vars.pyx
@@ -1,0 +1,18 @@
+# tag: warnings
+
+cpdef str a = "123"
+cpdef b = 2
+
+cdef class C:
+    cpdef float c
+
+def func():
+    cpdef d=C()
+    return d
+
+_WARNINGS = """
+3:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+4:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+7:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+10:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+"""


### PR DESCRIPTION
Allowing these gives people the false impression that they
do something meaningful. "Fixes" https://github.com/cython/cython/issues/3959

0.29.x version of https://github.com/cython/cython/pull/3963/files, with a warning instead of an error.