### PR TITLE
Instruct setuptools and wheel to include the license files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,6 @@ omit = Test*
 universal = 1
 
 [metadata]
-license_file = LICENSE.txt
+license_file =
+    LICENSE.txt
+    COPYING.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,6 @@ omit = Test*
 universal = 1
 
 [metadata]
-license_file =
+license_files =
     LICENSE.txt
     COPYING.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,5 @@ omit = Test*
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
Closes #3854 

See
 - https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 - https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#metadata

When building wheels, ensure `wheel>=0.32.0` (2018-09-29) is used.