### PR TITLE
WIP, ENH: error if a property decorator and attribute have the same name

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1416,10 +1416,8 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
                 same_name = [n for n in self.scope_node.body.stats 
                              if getattr(n,'name', '') == node.name and n is not node]
                 if len(same_name) > 0:
-                    import pdb;pdb.set_trace()
                     error(decorator_node.pos,
-                          "Duplicate property decorator and other class attribute "
-                          "name '%s'" % node.name)
+                          "property hides existing attribute '%s'" % node.name)
                 return self._add_property(node, node.name, decorator_node)
             else:
                 handler_name = self._map_property_attribute(decorator.attribute)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1410,14 +1410,14 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
                 #
                 #    @property
                 #    def p(self):
-                #        return self.p
+                #        return self.p()
                 #
-                # In a python class this will raise a runtime RecursionError
-                same_name = [n for n in self.scope_node.body.stats 
-                             if getattr(n,'name', '') == node.name and n is not node]
-                if len(same_name) > 0:
+                # In a python class the later definition will override the earlier,
+                # leading to a RecursionError as the property calls itself.
+                if any(n is not node and getattr(n, 'name', '') == node.name
+                                for n in self.scope_node.body.stats):
                     error(decorator_node.pos,
-                          "property hides existing attribute '%s'" % node.name)
+                          "Property hides existing attribute '%s'" % node.name)
                 return self._add_property(node, node.name, decorator_node)
             else:
                 handler_name = self._map_property_attribute(decorator.attribute)

--- a/tests/errors/e_property_override1.pyx
+++ b/tests/errors/e_property_override1.pyx
@@ -10,6 +10,6 @@ cdef class A:
         return self.fortytwo()
 
 _ERRORS = u"""
-8:4: Duplicate property decorator and other class attribute name 'fortytwo'
+8:4: Property hides existing attribute 'fortytwo'
 """
 

--- a/tests/errors/e_property_override1.pyx
+++ b/tests/errors/e_property_override1.pyx
@@ -1,0 +1,15 @@
+# mode: error
+
+cdef class A:
+
+    def fortytwo(self):
+        return 42
+
+    @property
+    def fortytwo(self):
+        return self.fortytwo()
+
+_ERRORS = u"""
+8:4: Duplicate property decorator and other class attribute name 'fortytwo'
+"""
+

--- a/tests/errors/e_property_override2.pyx
+++ b/tests/errors/e_property_override2.pyx
@@ -1,0 +1,15 @@
+# mode: error
+
+cdef class A:
+
+    @property
+    def fortytwo(self):
+        return self.fortytwo()
+
+    def fortytwo(self):
+        return 42
+
+_ERRORS = u"""
+5:4: Duplicate property decorator and other class attribute name 'fortytwo'
+"""
+

--- a/tests/errors/e_property_override2.pyx
+++ b/tests/errors/e_property_override2.pyx
@@ -10,6 +10,6 @@ cdef class A:
         return 42
 
 _ERRORS = u"""
-5:4: Duplicate property decorator and other class attribute name 'fortytwo'
+5:4: Property hides existing attribute 'fortytwo'
 """
 

--- a/tests/run/property_decorator_T3651.py
+++ b/tests/run/property_decorator_T3651.py
@@ -1,0 +1,17 @@
+# mode: run
+# ticket: 3651
+# tag: property, decorator
+
+class Prop(object):
+    """
+    >>> p = Prop()
+    >>> p.p
+    Traceback (most recent call last):
+    RecursionError: ...
+    """
+    def p(self):
+        return 42
+
+    @property
+    def p(self):
+        return self.p()

--- a/tests/run/property_decorator_T3651.py
+++ b/tests/run/property_decorator_T3651.py
@@ -7,11 +7,18 @@ class Prop(object):
     >>> p = Prop()
     >>> p.p
     Traceback (most recent call last):
-    RecursionError: ...
+    RecursionError: recursion while looking up property
     """
+    call_count = 0
+    
     def p(self):
         return 42
 
     @property
     def p(self):
+        self.call_count += 1
+        # Pure python can detect the recursion, cython does not
+        # and will segfault with a stack overflow.
+        if self.call_count > 10:
+            raise RecursionError("recursion while looking up property")
         return self.p()


### PR DESCRIPTION
Error for code like
````
cdef class A:
    def fortytwo(self):
        return 42

    @property
    def fortytwo(self):
        return self.fortytwo()4
```

Still a WIP, the fix is not right.