### PR TITLE
Don't break when probing type of cimported module

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6214,7 +6214,7 @@ class PyMethodCallNode(SimpleCallNode):
             # not an attribute itself, but might have been assigned from one (e.g. bound method)
             for assignment in self.function.cf_state:
                 value = assignment.rhs
-                if value and value.is_attribute and value.obj.type.is_pyobject:
+                if value and value.is_attribute and value.obj.type and value.obj.type.is_pyobject:
                     if attribute_is_likely_method(value):
                         likely_method = 'likely'
                         break

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6938,7 +6938,11 @@ class AttributeNode(ExprNode):
         # FIXME: this is way too redundant with analyse_types()
         node = self.analyse_as_cimported_attribute_node(env, target=False)
         if node is not None:
-            return node.entry.type
+            if node.entry.type and node.entry.type.is_cfunction:
+                # special-case - function converted to pointer
+                return PyrexTypes.CPtrType(node.entry.type)
+            else:
+                return node.entry.type
         node = self.analyse_as_type_attribute(env)
         if node is not None:
             return node.entry.type

--- a/tests/run/cimport.srctree
+++ b/tests/run/cimport.srctree
@@ -51,11 +51,16 @@ print(A, foo(10))
 
 cimport other
 
+cdef call_fooptr(int (*fptr)(int)):
+    return fptr(10)
+
 def call_other_foo():
     x = other.foo  # GH4000 - failed because other was untyped
-    return x(10)
+    return call_fooptr(x) # check that x is correctly resolved as a function pointer
+    
 
-print(other.A, other.foo(10), call_other_foo()) 
+
+print(other.A, other.foo(10), call_other_foo())
 
 from pkg cimport sub
 cdef sub.my_int a = 100

--- a/tests/run/cimport.srctree
+++ b/tests/run/cimport.srctree
@@ -41,6 +41,8 @@ ctypedef int my_int
 
 ######## a.pyx ########
 
+
+
 from other cimport (
     A,
     foo,
@@ -48,7 +50,12 @@ from other cimport (
 print(A, foo(10))
 
 cimport other
-print(other.A, other.foo(10))
+
+def call_other_foo():
+    x = other.foo  # GH4000 - failed because other was untyped
+    return x(10)
+
+print(other.A, other.foo(10), call_other_foo()) 
 
 from pkg cimport sub
 cdef sub.my_int a = 100


### PR DESCRIPTION
(which is None). Fixes #4000