### PR TITLE
Fixed cpdef_vars test failure on Python 2

### DIFF
--- a/tests/errors/cpdef_vars.pyx
+++ b/tests/errors/cpdef_vars.pyx
@@ -1,3 +1,4 @@
+# mode: compile
 # tag: warnings
 
 cpdef str a = "123"
@@ -11,8 +12,8 @@ def func():
     return d
 
 _WARNINGS = """
-3:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
 4:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
-7:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
-10:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+5:6: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+8:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
+11:10: cpdef variables will not be supported in Cython 3; currently they are no different from cdef variables
 """


### PR DESCRIPTION
Very quick follow up to https://github.com/cython/cython/pull/3972
For some reason the test was failing on Python 2 if I didn't
specify a mode