### PR TITLE
Disable time_pxd test in Python 3.4

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -438,6 +438,7 @@ VER_DEP_MODULES = {
                                          'run.mod__spec__',
                                          'run.pep526_variable_annotations',  # typing module
                                          'run.test_exceptions',  # copied from Py3.7+
+                                         'run.time_pxd',  # _PyTime_GetSystemClock doesn't exist in 3.4
                                          ]),
 }
 


### PR DESCRIPTION
It uses features that are unavailable thus always fails

Test was introduced in https://github.com/cython/cython/pull/3767