### PR TITLE
Allow using nested types of typedefs

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1044,7 +1044,10 @@ class CSimpleBaseTypeNode(CBaseTypeNode):
                 scope = env
                 for item in self.module_path:
                     entry = scope.lookup(item)
-                    if entry is not None and entry.is_cpp_class:
+                    if entry is not None and (
+                        entry.is_cpp_class or
+                        entry.is_type and entry.type.is_cpp_class
+                    ):
                         scope = entry.type.scope
                     else:
                         scope = None

--- a/tests/run/cpp_nested_classes.pyx
+++ b/tests/run/cpp_nested_classes.pyx
@@ -25,7 +25,9 @@ cdef extern from "cpp_nested_classes_support.h":
     cdef cppclass SpecializedTypedClass(TypedClass[double]):
         pass
 
-    ctypedef A AliasA
+
+ctypedef A AliasA1
+ctypedef AliasA1 AliasA2
 
 
 def test_nested_classes():
@@ -53,7 +55,14 @@ def test_typedef_for_nested(py_x):
     """
     >>> test_typedef_for_nested(5)
     """
-    cdef AliasA.my_int x = py_x
+    cdef AliasA1.my_int x = py_x
+    assert A.negate(x) == -py_x
+
+def test_typedef_for_nested_deep(py_x):
+    """
+    >>> test_typedef_for_nested_deep(5)
+    """
+    cdef AliasA2.my_int x = py_x
     assert A.negate(x) == -py_x
 
 def test_typed_nested_typedef(x):

--- a/tests/run/cpp_nested_classes.pyx
+++ b/tests/run/cpp_nested_classes.pyx
@@ -25,6 +25,8 @@ cdef extern from "cpp_nested_classes_support.h":
     cdef cppclass SpecializedTypedClass(TypedClass[double]):
         pass
 
+    ctypedef A AliasA
+
 
 def test_nested_classes():
     """
@@ -45,6 +47,13 @@ def test_nested_typedef(py_x):
     >>> test_nested_typedef(5)
     """
     cdef A.my_int x = py_x
+    assert A.negate(x) == -py_x
+
+def test_typedef_for_nested(py_x):
+    """
+    >>> test_typedef_for_nested(5)
+    """
+    cdef AliasA.my_int x = py_x
     assert A.negate(x) == -py_x
 
 def test_typed_nested_typedef(x):


### PR DESCRIPTION
That fixes the following code:

```
ctypedef unordered_map[string, vector[string]] string_to_strings
cdef string_to_strings.iterator it
```

See for details: https://github.com/cython/cython/issues/2233