### PR TITLE
Port test_exceptions to Python 3.10 (GH-4042)

### DIFF
--- a/tests/run/test_exceptions.pyx
+++ b/tests/run/test_exceptions.pyx
@@ -13,11 +13,16 @@ import pickle
 import weakref
 import errno
 
-from test.support import (TESTFN, captured_stderr, check_impl_detail,
-                          check_warnings, gc_collect,
+from test.support import (captured_stderr, check_impl_detail, gc_collect,
                           # no_tracing, cpython_only,
-                          unlink, import_module, script_helper,
-                          SuppressCrashReport)
+                          script_helper, SuppressCrashReport)
+try:
+    from test.support.os_helper import TESTFN, unlink
+    from test.support.warnings_helper import check_warnings
+    from test.support.import_helper import import_module
+except ImportError:
+    # Python 3.9 and older
+    from test.support import check_warnings
 
 no_tracing = unittest.skip("For nested functions, Cython generates a C call without recursion checks.")
 


### PR DESCRIPTION
The `test.support` has been split into sub-modules. Adapt `test_exceptions` (originally coped from CPython) for these changes.

(cherry picked from commit 43cf17d4a4a68242d17e965e2aa4d10044d137a2)