### PR TITLE
Don't test for frozenset singleton on Python 3.10

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -461,8 +461,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyFrozenSet_New(PyObject* it) {
         result = PyFrozenSet_New(it);
         if (unlikely(!result))
             return NULL;
-        if (likely(PySet_GET_SIZE(result)) ||
-            (PY_VERSION_HEX >= 0x031000A1))
+        if ((PY_VERSION_HEX >= 0x031000A1) || likely(PySet_GET_SIZE(result)))
             return result;
         // empty frozenset is a singleton (on Python <3.10)
         // seems wasteful, but CPython does the same

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -461,9 +461,10 @@ static CYTHON_INLINE PyObject* __Pyx_PyFrozenSet_New(PyObject* it) {
         result = PyFrozenSet_New(it);
         if (unlikely(!result))
             return NULL;
-        if (likely(PySet_GET_SIZE(result)))
+        if (likely(PySet_GET_SIZE(result)) ||
+            (PY_VERSION_HEX >= 0x031000A1))
             return result;
-        // empty frozenset is a singleton
+        // empty frozenset is a singleton (on Python <3.10)
         // seems wasteful, but CPython does the same
         Py_DECREF(result);
 #endif

--- a/tests/run/set.pyx
+++ b/tests/run/set.pyx
@@ -417,7 +417,8 @@ def test_empty_frozenset():
     True
     >>> len(s)
     0
-    >>> s is frozenset()   # singleton!
+    >>> import sys
+    >>> sys.version_info >= (3, 10) or s is frozenset()   # singleton (in Python < 3.10)!
     True
     """
     return frozenset()
@@ -430,7 +431,8 @@ def test_empty_frozenset():
 )
 def test_singleton_empty_frozenset():
     """
-    >>> test_singleton_empty_frozenset()  # from CPython's test_set.py
+    >>> import sys
+    >>> test_singleton_empty_frozenset() if sys.version_info < (3, 10) else 1  # from CPython's test_set.py
     1
     """
     f = frozenset()
@@ -438,7 +440,7 @@ def test_singleton_empty_frozenset():
            frozenset(), frozenset([]), frozenset(()), frozenset(''),
            frozenset(range(0)), frozenset(frozenset()),
            frozenset(f), f]
-    return len(set(map(id, efs)))
+    return len(set(map(id, efs)))  # note, only a singleton in Python <3.10
 
 
 def sorted(it):


### PR DESCRIPTION
part of #3919.

Wants backporting to 0.29.x