### PR TITLE
Annotation tests work with non-evaluated annotations

### DIFF
--- a/tests/run/generators_py35.py
+++ b/tests/run/generators_py35.py
@@ -30,7 +30,7 @@ def anno_gen(x: 'int') -> 'float':
     >>> next(gen)
     2.0
     >>> ret, arg = sorted(anno_gen.__annotations__.items())
-    >>> print(ret[0]); print(str(ret[1]).strip("'")) # strip makes it pass with/without PEP563
+    >>> print(ret[0]); print(str(ret[1]).strip("'"))  # strip makes it pass with/without PEP563
     return
     float
     >>> print(arg[0]); print(str(arg[1]).strip("'"))

--- a/tests/run/generators_py35.py
+++ b/tests/run/generators_py35.py
@@ -30,10 +30,10 @@ def anno_gen(x: 'int') -> 'float':
     >>> next(gen)
     2.0
     >>> ret, arg = sorted(anno_gen.__annotations__.items())
-    >>> print(ret[0]); print(ret[1])
+    >>> print(ret[0]); print(str(ret[1]).strip("'")) # strip makes it pass with/without PEP563
     return
     float
-    >>> print(arg[0]); print(arg[1])
+    >>> print(arg[0]); print(str(arg[1]).strip("'"))
     x
     int
     """


### PR DESCRIPTION
I.e. works on Python 3.10+

Backported from 3dc2b9dfc23638fbef2558d619709b5235d5df08

Part fix for #3919