### PR TITLE
suppress unused param warning on MSVC

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -330,6 +330,8 @@
 #   endif
 # elif defined(__ICC) || (defined(__INTEL_COMPILER) && !defined(_MSC_VER))
 #   define CYTHON_UNUSED __attribute__ ((__unused__))
+# elif defined(_MSC_VER)
+#   define CYTHON_UNUSED __pragma(warning(suppress: 4100 4101))
 # else
 #   define CYTHON_UNUSED
 # endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -331,7 +331,7 @@
 # elif defined(__ICC) || (defined(__INTEL_COMPILER) && !defined(_MSC_VER))
 #   define CYTHON_UNUSED __attribute__ ((__unused__))
 # elif defined(_MSC_VER)
-#   define CYTHON_UNUSED __pragma(warning(suppress: 4100 4101))
+#   define CYTHON_UNUSED __pragma(warning(suppress: 4100 4101 4505))
 # else
 #   define CYTHON_UNUSED
 # endif


### PR DESCRIPTION
This fixes #4057 by suppressing the warnings on MSVC as well