### PR TITLE
skip debugger libcython tests on pypy

### DIFF
--- a/Cython/Debugger/Tests/test_libcython_in_gdb.py
+++ b/Cython/Debugger/Tests/test_libcython_in_gdb.py
@@ -31,6 +31,9 @@ from ...Utils import add_metaclass
 # for some reason sys.argv is missing in gdb
 sys.argv = ['gdb']
 
+def setupModule():
+    if hasattr(sys, 'pypy_version_info'):
+        raise unittest.SkipTest("Cannot run these tests on PyPy")
 
 def print_on_call_decorator(func):
     @functools.wraps(func)


### PR DESCRIPTION
These tests probe PyObject internals and cannot succeed on PyPy.