### PR TITLE
Error message on invalid argument count to range

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -826,7 +826,7 @@ class IterationTransform(Visitor.EnvTransform):
             step_pos = range_function.pos
             step_value = 1
             step = ExprNodes.IntNode(step_pos, value='1', constant_result=1)
-        else:
+        elif len(args) == 3:
             step = args[2]
             step_pos = step.pos
             if not isinstance(step.constant_result, _py_int_types):
@@ -838,6 +838,8 @@ class IterationTransform(Visitor.EnvTransform):
                 return node
             step = ExprNodes.IntNode(step_pos, value=str(step_value),
                                      constant_result=step_value)
+        else:
+            return node
 
         if len(args) == 1:
             bound1 = ExprNodes.IntNode(range_function.pos, value='0',

--- a/tests/run/for_in_iter.py
+++ b/tests/run/for_in_iter.py
@@ -162,3 +162,22 @@ def for_in_gen(N):
     """
     for i in range(N):
         yield i
+
+def test_range_args(arg):
+    """
+    >>> test_range_args([1])
+    [0]
+    >>> test_range_args([1, 2])
+    [1]
+    >>> test_range_args([1, 2,  -1])
+    []
+    >>> test_range_args([1, 2, 1])
+    [1]
+    >>> test_two_args([1, 2, 1, 1])     # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    """
+    results = []
+    for i in range(*arg):
+        results.append(i)
+    return results


### PR DESCRIPTION
This is an updated version of the previous PR. The issue right now is that
```cython
for i in range(1,2,3,4):
    pass
```
generates the same optimized C code as 
```cython
for i in range(1,2,3):
    pass
```
This PR makes this a runtime error.

As a note e.g. the reversed optimizations throws errors when wrong argument counts are provided:
https://github.com/cython/cython/blob/1d37d3a7ad23b72ba4f6e0768a29634ae0cf394a/Cython/Compiler/Optimize.py#L312-L322
I assume this should be runtime errors as well.