### PR TITLE
String constant folding (with test)

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4424,8 +4424,7 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                 string_node.unicode_value = encoded_string(
                     string_node.unicode_value * multiplier,
                     string_node.unicode_value.encoding)
-            if not string_node.value.is_unicode:
-                build_string = bytes_literal
+            build_string = encoded_string if string_node.value.is_unicode else bytes_literal
         elif isinstance(string_node, ExprNodes.UnicodeNode):
             if string_node.bytes_value is not None:
                 string_node.bytes_value = bytes_literal(
@@ -4433,9 +4432,14 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                     string_node.bytes_value.encoding)
         else:
             assert False, "unknown string node type: %s" % type(string_node)
-        string_node.constant_result = string_node.value = build_string(
+        string_node.value = build_string(
             string_node.value * multiplier,
             string_node.value.encoding)
+        # follow constant-folding and use unicode_value in preference
+        if isinstance(string_node, ExprNodes.StringNode) and string_node.unicode_value is not None:
+            string_node.constant_result = string_node.unicode_value
+        else:
+            string_node.constant_result = string_node.value
         return string_node
 
     def _calculate_constant_seq(self, node, sequence_node, factor):

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4424,6 +4424,8 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                 string_node.unicode_value = encoded_string(
                     string_node.unicode_value * multiplier,
                     string_node.unicode_value.encoding)
+            if not string_node.value.is_unicode:
+                build_string = bytes_literal
         elif isinstance(string_node, ExprNodes.UnicodeNode):
             if string_node.bytes_value is not None:
                 string_node.bytes_value = bytes_literal(

--- a/Cython/Compiler/TreePath.py
+++ b/Cython/Compiler/TreePath.py
@@ -10,6 +10,12 @@ from __future__ import absolute_import
 
 import re
 import operator
+import sys
+
+if sys.version_info[0] >= 3:
+    _unicode = str
+else:
+    _unicode = unicode
 
 path_tokenizer = re.compile(
     r"("
@@ -167,7 +173,7 @@ def handle_attribute(next, token):
                     continue
                 if attr_value == value:
                     yield attr_value
-                elif (isinstance(attr_value, bytes) and isinstance(value, str) and
+                elif (isinstance(attr_value, bytes) and isinstance(value, _unicode) and
                         attr_value == value.encode()):
                     # allow a bytes-to-string comparison too
                     yield attr_value

--- a/Cython/Compiler/TreePath.py
+++ b/Cython/Compiler/TreePath.py
@@ -168,7 +168,7 @@ def handle_attribute(next, token):
                 if attr_value == value:
                     yield attr_value
                 elif (isinstance(attr_value, bytes) and isinstance(value, str) and
-                        attr_value.decode("utf-8") == value):
+                        attr_value == value.encode()):
                     # allow a bytes-to-string comparison too
                     yield attr_value
 

--- a/Cython/Compiler/TreePath.py
+++ b/Cython/Compiler/TreePath.py
@@ -167,6 +167,11 @@ def handle_attribute(next, token):
                     continue
                 if attr_value == value:
                     yield attr_value
+                elif (isinstance(attr_value, bytes) and isinstance(value, str) and
+                        attr_value.decode("utf-8") == value):
+                    # allow a bytes-to-string comparison too
+                    yield attr_value
+
     return select
 
 

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -834,7 +834,7 @@ class PrintTree(TreeVisitor):
                 result += "(name=\"%s\")" % node.name
             elif isinstance(node, ExprNodes.AttributeNode):
                 result += "(type=%s, attribute=\"%s\")" % (repr(node.type), node.attribute)
-            elif isinstance(node, ExprNodes.ConstNode):
+            elif isinstance(node, (ExprNodes.ConstNode, ExprNodes.StringNode)):
                 result += "(type=%s, value=\"%s\")" % (repr(node.type), node.value)
             elif isinstance(node, ExprNodes.ExprNode):
                 t = node.type

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -834,8 +834,8 @@ class PrintTree(TreeVisitor):
                 result += "(name=\"%s\")" % node.name
             elif isinstance(node, ExprNodes.AttributeNode):
                 result += "(type=%s, attribute=\"%s\")" % (repr(node.type), node.attribute)
-            elif isinstance(node, (ExprNodes.ConstNode, ExprNodes.StringNode)):
-                result += "(type=%s, value=\"%s\")" % (repr(node.type), node.value)
+            elif isinstance(node, (ExprNodes.ConstNode, ExprNodes.PyConstNode)):
+                result += "(type=%s, value=%r)" % (repr(node.type), node.value)
             elif isinstance(node, ExprNodes.ExprNode):
                 t = node.type
                 result += "(type=%s)" % repr(t)

--- a/tests/run/cstringmul.pyx
+++ b/tests/run/cstringmul.pyx
@@ -31,3 +31,15 @@ grail_long = 700 * "tomato"
 uspam = u"eggs" * 4
 ugrail = 7 * u"tomato"
 ugrail_long = 700 * u"tomato"
+
+cimport cython
+
+@cython.test_assert_path_exists("//StringNode[@value = '-----']")
+#@cython.test_assert_path_exists("//StringNode[@unicode_value = '-----']")
+def gh3951():
+    """
+    Bug occurs with language_level=2 and affects StringNode.value
+    >>> gh3951()
+    '-----'
+    """
+    return "-"*5

--- a/tests/run/cstringmul.pyx
+++ b/tests/run/cstringmul.pyx
@@ -35,7 +35,7 @@ ugrail_long = 700 * u"tomato"
 cimport cython
 
 @cython.test_assert_path_exists("//StringNode[@value = '-----']")
-#@cython.test_assert_path_exists("//StringNode[@unicode_value = '-----']")
+@cython.test_assert_path_exists("//StringNode[@unicode_value = '-----']")
 def gh3951():
     """
     Bug occurs with language_level=2 and affects StringNode.value


### PR DESCRIPTION
This just finishes off https://github.com/cython/cython/pull/3952 by adding a test-case.

It's surprisingly hard to create a test-case for this. I had to allow bytes-to-string comparisons in the TreePath code (allowing bytes constants might be another possibility I think). I've confirmed that it fails on the current master and passes with the patch.