### PR TITLE
allow defaults for cpdef functions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9380,7 +9380,7 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
         must_use_constants = env.is_c_class_scope or (self.def_node.is_wrapper and env.is_module_scope)
 
         for arg in self.def_node.args:
-            if arg.default and not must_use_constants:
+            if arg.default:  # and not must_use_constants:
                 if not arg.default.is_literal:
                     arg.is_dynamic = True
                     if arg.type.is_pyobject:

--- a/tests/run/py34_signature.pyx
+++ b/tests/run/py34_signature.pyx
@@ -106,7 +106,7 @@ cpdef cp2(a, b=True):
     """
     >>> def py_cp2(a, b=True): pass
 
-    #>>> signatures_match(cp2, py_cp2)
+    >>> signatures_match(cp2, py_cp2)
     """
 
 
@@ -115,5 +115,5 @@ cpdef cp3(a=1, b=True):
     """
     >>> def py_cp3(a=1, b=True): pass
 
-    #>>> signatures_match(cp3, py_cp3)
+    >>> signatures_match(cp3, py_cp3)
     """


### PR DESCRIPTION
fixes the tests added for ~gh-1834~ gh-1864, but does this break something else?

Edited to fix the issue number