### PR TITLE
Bug 4096 (Using CFLAGS for compiler defines)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ MANIFEST
 /.idea
 /*.iml
 
+# Visual Studio Code files
+.vscode

--- a/runtests.py
+++ b/runtests.py
@@ -432,6 +432,7 @@ VER_DEP_MODULES = {
 INCLUDE_DIRS = [ d for d in os.getenv('INCLUDE', '').split(os.pathsep) if d ]
 CFLAGS = os.getenv('CFLAGS', '').split()
 CCACHE = os.getenv('CYTHON_RUNTESTS_CCACHE', '').split()
+CDEFS = []
 TEST_SUPPORT_DIR = 'testsupport'
 
 BACKENDS = ['c', 'cpp']
@@ -1052,6 +1053,7 @@ class CythonCompileTestCase(unittest.TestCase):
                 build_extension.compiler = COMPILER
 
             ext_compile_flags = CFLAGS[:]
+            ext_compile_defines = CDEFS[:]
 
             if  build_extension.compiler == 'mingw32':
                 ext_compile_flags.append('-Wno-format')
@@ -1066,6 +1068,7 @@ class CythonCompileTestCase(unittest.TestCase):
                 module,
                 sources=self.source_files(workdir, module, related_files),
                 extra_compile_args=ext_compile_flags,
+                define_macros=ext_compile_defines,
                 **extra_extension_args
                 )
 
@@ -2306,7 +2309,7 @@ def runtests(options, cmd_args, coverage=None):
                              build_in_temp=True,
                              pyxbuild_dir=os.path.join(WORKDIR, "support"))
         sys.path.insert(0, os.path.split(libpath)[0])
-        CFLAGS.append("-DCYTHON_REFNANNY=1")
+        CDEFS.append((CYTHON_REFNANNY, 1))
 
     if xml_output_dir and options.fork:
         # doesn't currently work together

--- a/runtests.py
+++ b/runtests.py
@@ -2309,7 +2309,7 @@ def runtests(options, cmd_args, coverage=None):
                              build_in_temp=True,
                              pyxbuild_dir=os.path.join(WORKDIR, "support"))
         sys.path.insert(0, os.path.split(libpath)[0])
-        CDEFS.append((CYTHON_REFNANNY, 1))
+        CDEFS.append(('CYTHON_REFNANNY', '1'))
 
     if xml_output_dir and options.fork:
         # doesn't currently work together


### PR DESCRIPTION
Creating global CDEFS for holding compiler definitions. Then pass it to the distutils.

Also add .vscode folder to .gitignore

Fixes https://github.com/cython/cython/issues/4096