### PR TITLE
Fix test_formatting_with_enum() on Python 3.10

### DIFF
--- a/tests/run/test_unicode.pyx
+++ b/tests/run/test_unicode.pyx
@@ -1470,18 +1470,18 @@ class UnicodeTest(CommonTest,
         class Str(str, enum.Enum):
             ABC = 'abc'
         # Testing Unicode formatting strings...
-        self.assertEqual("%s, %s" % (Str.ABC, Str.ABC),
+        self.assertEqual("%r, %r" % (Str.ABC, Str.ABC),
                          'Str.ABC, Str.ABC')
-        self.assertEqual("%s, %s, %d, %i, %u, %f, %5.2f" %
+        self.assertEqual("%r, %r, %d, %i, %u, %f, %5.2f" %
                         (Str.ABC, Str.ABC,
                          Int.IDES, Int.IDES, Int.IDES,
                          Float.PI, Float.PI),
                          'Str.ABC, Str.ABC, 15, 15, 15, 3.141593,  3.14')
 
         # formatting jobs delegated from the string implementation:
-        self.assertEqual('...%(foo)s...' % {'foo':Str.ABC},
+        self.assertEqual('...%(foo)r...' % {'foo':Str.ABC},
                          '...Str.ABC...')
-        self.assertEqual('...%(foo)s...' % {'foo':Int.IDES},
+        self.assertEqual('...%(foo)r...' % {'foo':Int.IDES},
                          '...Int.IDES...')
         self.assertEqual('...%(foo)i...' % {'foo':Int.IDES},
                          '...15...')


### PR DESCRIPTION
Fix test_unicode.test_formatting_with_enum() on Python 3.10. In
Python 3.10, str(enum.Enum) now omits the class name: use
repr(enum.Enum) which works on Python 3.4-Python 3.10.

See https://docs.python.org/dev/whatsnew/3.10.html#enum