### PR TITLE
Only #define PY_SSIZE_T_CLEAN if it is not already #defined

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -705,7 +705,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln("END: Cython Metadata */")
             code.putln("")
 
+        code.putln("#ifndef PY_SSIZE_T_CLEAN")
         code.putln("#define PY_SSIZE_T_CLEAN")
+        code.putln("#endif /* PY_SSIZE_T_CLEAN */")
         self._put_setup_code(code, "InitLimitedAPI")
 
         for inc in sorted(env.c_includes.values(), key=IncludeCode.sortkey):


### PR DESCRIPTION
For something I use Cython for, we do not use `setup.py` or anything like that, but add the output of Cython (i.e., the .c files) to our CMakeLists.txt.

However, for the rest of the code in our project, we already have `PY_SSIZE_T_CLEAN` set as a compile-time define (e.g., with `add_definitions(-DPY_SSIZE_T_CLEAN)`. This causes us an issue when we're compiling the output of Cython, as we get a warning (which becomes an error with `-Werror`) related to `PY_SSIZE_T_CLEAN`.

This PR changes Cython such that `PY_SSIZE_T_CLEAN` is only defined in the Cython-generated code, if it is not already defined.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>