### PR TITLE
Changing uses of 'Py_ISSPACE' to 'Py_UNICODE_ISSPACE' to avoid C++ issues #4111

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -784,10 +784,6 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict,
   #define PyObject_Format(obj, fmt)  PyObject_CallMethod(obj, "__format__", "O", fmt)
 #endif
 
-#if CYTHON_COMPILING_IN_PYPY && !defined(Py_ISSPACE)
-  #define Py_ISSPACE(c)  Py_UNICODE_ISSPACE(c)
-#endif
-
 // ("..." % x)  must call PyNumber_Remainder() if x is a string subclass that implements "__rmod__()".
 #define __Pyx_PyString_FormatSafe(a, b)   ((unlikely((a) == Py_None || (PyString_Check(b) && !PyString_CheckExact(b)))) ? PyNumber_Remainder(a, b) : __Pyx_PyString_Format(a, b))
 #define __Pyx_PyUnicode_FormatSafe(a, b)  ((unlikely((a) == Py_None || (PyUnicode_Check(b) && !PyUnicode_CheckExact(b)))) ? PyNumber_Remainder(a, b) : PyUnicode_Format(a, b))

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -904,9 +904,9 @@ static CYTHON_UNUSED double __Pyx__PyBytes_AsDouble(PyObject *obj, const char* s
     char *end;
 
     // strip spaces at start and end
-    while (Py_ISSPACE(*start))
+    while (Py_UNICODE_ISSPACE(*start))
         start++;
-    while (start < last - 1 && Py_ISSPACE(last[-1]))
+    while (start < last - 1 && Py_UNICODE_ISSPACE(last[-1]))
         last--;
     length = last - start;
     if (unlikely(length <= 0)) goto fallback;


### PR DESCRIPTION
As discussed in #4111, Cython currently uses the Python macro `Py_ISSPACE`, which exposes an underlying variable from cpython that *is not* marked as `extern "C"` -- this means that when compiling Cython output as C++, you can get link errors due `Py_ISSPACE` using a *name-mangled* symbol.

This PR corrects this issue by updating Cython to use `Py_UNICODE_ISSPACE`, which is correctly guarded for C++ uses.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>