### PR TITLE
Explicit black text colour for line readability in reports

### DIFF
--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -87,7 +87,7 @@ class AnnotationCCodeWriter(CCodeWriter):
         body.cython { font-family: courier; font-size: 12; }
 
         .cython.tag  {  }
-        .cython.line { margin: 0em }
+        .cython.line { color: #000000; margin: 0em }
         .cython.code { font-size: 9; color: #444444; display: none; margin: 0px 0px 0px 8px; border-left: 8px none; }
 
         .cython.line .run { background-color: #B0FFB0; }


### PR DESCRIPTION
Hi,

Just a quick fix for a common omission: the HTML report generated during compilation styles the line background colour, but does not do so for the text on top of it.  I guess most people have their browser set to black text on white background so don't notice, but mine is white on black—the report ends up somewhat difficult to read with white text on a white/yellow background!

Hopefully this PR is all that's needed? Let me know if there are any problems. 