### PR TITLE
Warn when cyfunction.__[kw]defaults__ is changed

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -280,7 +280,7 @@ __Pyx_CyFunction_set_defaults(__pyx_CyFunctionObject *op, PyObject* value, CYTHO
         return -1;
     }
     PyErr_WarnEx(PyExc_RuntimeWarning, "changes to cyfunction.__defaults__ will not "
-                 "affect the values used in function calls", 1);
+                 "currently affect the values used in function calls", 1);
     Py_INCREF(value);
     __Pyx_Py_XDECREF_SET(op->defaults_tuple, value);
     return 0;
@@ -312,7 +312,7 @@ __Pyx_CyFunction_set_kwdefaults(__pyx_CyFunctionObject *op, PyObject* value, CYT
         return -1;
     }
     PyErr_WarnEx(PyExc_RuntimeWarning, "changes to cyfunction.__kwdefaults__ will not "
-                 "affect the values used in function calls", 1);
+                 "currently affect the values used in function calls", 1);
     Py_INCREF(value);
     __Pyx_Py_XDECREF_SET(op->defaults_kwdict, value);
     return 0;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -279,6 +279,8 @@ __Pyx_CyFunction_set_defaults(__pyx_CyFunctionObject *op, PyObject* value, CYTHO
                         "__defaults__ must be set to a tuple object");
         return -1;
     }
+    PyErr_WarnEx(PyExc_RuntimeWarning, "changes to cyfunction.__defaults__ will not "
+                 "affect the values used in function calls", 1);
     Py_INCREF(value);
     __Pyx_Py_XDECREF_SET(op->defaults_tuple, value);
     return 0;
@@ -309,6 +311,8 @@ __Pyx_CyFunction_set_kwdefaults(__pyx_CyFunctionObject *op, PyObject* value, CYT
                         "__kwdefaults__ must be set to a dict object");
         return -1;
     }
+    PyErr_WarnEx(PyExc_RuntimeWarning, "changes to cyfunction.__kwdefaults__ will not "
+                 "affect the values used in function calls", 1);
     Py_INCREF(value);
     __Pyx_Py_XDECREF_SET(op->defaults_kwdict, value);
     return 0;


### PR DESCRIPTION
Cython can't make use of these new defaults so it seems sensible
to alert the user (even if we're choosing to allow the assignment
for compatibility reasons).

I know the warning mechanism is somewhat heavy. I think this is
OK because it's unlikely that users will be repeatedly assigning
to these attributes in a time-critical loop.

Doesn't fix #2650, but hopefully alerts users to it.