### PR TITLE
Fix windows linking error for unicode modules with a dummy function

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1146,7 +1146,7 @@ def fix_windows_unicode_modules(module_list):
     # https://bugs.python.org/issue39432
     if sys.platform != "win32":
         return
-    if sys.version_info < (3, 5):
+    if sys.version_info < (3, 5) or sys.version_info >= (3, 8, 2):
         return
 
     def make_filtered_list(ignored_symbol, old_entries):

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1146,7 +1146,7 @@ def fix_windows_unicode_modules(module_list):
     # https://bugs.python.org/issue39432
     if sys.platform != "win32":
         return
-    if sys.version_info < (3, 5) or sys.version_info >= (3, 8, 2):
+    if sys.version_info < (3, 5):
         return
 
     def make_filtered_list(ignored_symbol, old_entries):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2757,6 +2757,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln("__Pyx_PyMODINIT_FUNC PyInit___init__(void) { return %s(); }" % (
                 self.mod_init_func_cname('PyInit', env)))
             code.putln("#endif")
+        # Hack for a distutils bug - https://bugs.python.org/issue39432
+        # distutils attempts to make visible a slightly wrong PyInitU module name. Just create a dummy
+        # function to keep it quiet
+        wrong_punycode_module_name = self.wrong_punycode_module_name(env.module_name)
+        if wrong_punycode_module_name:
+            code.putln("#if !defined(CYTHON_NO_PYINIT_EXPORT) && (defined(_WIN32) || defined(WIN32) || defined(MS_WINDOWS))")
+            code.putln("void %s(void) {} /* hacky workaround! */" % wrong_punycode_module_name)
+            code.putln("#endif")
         code.putln(header3)
 
         # CPython 3.5+ supports multi-phase module initialisation (gives access to __spec__, __file__, etc.)
@@ -3192,6 +3200,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         except UnicodeEncodeError:
             name = 'U_' + name.encode('punycode').replace(b'-', b'_').decode('ascii')
         return "%s%s" % (prefix, name)
+
+    def wrong_punycode_module_name(self, name):
+        # to work around a distutils bug by also generating an incorrect symbol...
+        try:
+            name.encode("ascii")
+            return None  # workaround is not needed
+        except UnicodeEncodeError:
+            return "PyInitU" + (u"_"+name).encode('punycode').replace(b'-', b'_').decode('ascii')
 
     def mod_init_func_cname(self, prefix, env):
         # from PEP483

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2763,7 +2763,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         wrong_punycode_module_name = self.wrong_punycode_module_name(env.module_name)
         if wrong_punycode_module_name:
             code.putln("#if !defined(CYTHON_NO_PYINIT_EXPORT) && (defined(_WIN32) || defined(WIN32) || defined(MS_WINDOWS))")
-            code.putln("void %s(void) {} /* hacky workaround! */" % wrong_punycode_module_name)
+            code.putln("void %s(void) {} /* workaround for https://bugs.python.org/issue39432 */" % wrong_punycode_module_name)
             code.putln("#endif")
         code.putln(header3)
 


### PR DESCRIPTION
The fix in https://bugs.python.org/issue39432 isn't quite right (`"_name".encode("punycode") != "name".encode("punycode")`) and thus the unicode_imports test is failing on Windows 3.8+. I don't think Python is accepting patches to distutils any more but I'm going to submit one of setuptools in the near future.

For now just apply the hack to all versions >3.5

Link to distutils PR https://github.com/pypa/distutils/pull/38

This creates a dummy function with the alternative name so that the export doesn't fail.