### PR TITLE
Fix platform_adaptation on windows

### DIFF
--- a/docs/examples/userguide/external_C_code/platform_adaptation.pyx
+++ b/docs/examples/userguide/external_C_code/platform_adaptation.pyx
@@ -1,9 +1,8 @@
 cdef extern from *:
     """
     #if defined(_WIN32) || defined(MS_WINDOWS) || defined(_MSC_VER)
-      #define WIN32_LEAN_AND_MEAN
-      #include <windows.h>
-      #define myapp_sleep(m)  Sleep(m)
+      #include "stdlib.h"
+      #define myapp_sleep(m)  _sleep(m)
     #else
       #include <unistd.h>
       #define myapp_sleep(m)  ((void) usleep((m) * 1000))


### PR DESCRIPTION
For reasons I don't full understand, including "windows.h" seems to break everything. There's an alternative sleep function in stdlib.h so I've used that instead since it makes the point just as well