### PR TITLE
[RFC] Enable overloaded extern static methods (GH #1851)

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7013,11 +7013,10 @@ class AttributeNode(ExprNode):
                         ubcm_entry = entry
                     else:
                         ubcm_entry = self._create_ubcm_entry(entry, env)
-                        if entry.overloaded_alternatives:
-                            ubcm_entry.overloaded_alternatives = [
-                                self._create_ubcm_entry(overloaded_alternative, env) for overloaded_alternative in
-                                entry.overloaded_alternatives
-                            ]
+                        ubcm_entry.overloaded_alternatives = [
+                            self._create_ubcm_entry(overloaded_alternative, env) for overloaded_alternative in
+                            entry.overloaded_alternatives
+                        ]
                     return self.as_name_node(env, ubcm_entry, target=False)
             elif type.is_enum or type.is_cpp_enum:
                 if self.attribute in type.values:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7012,9 +7012,9 @@ class AttributeNode(ExprNode):
                             return None
                         ubcm_entry = entry
                     else:
-                        ubcm_entry = self._create_ubcm_entry(type, entry, env)
+                        ubcm_entry = self._create_unbound_cmethod_entry(type, entry, env)
                         ubcm_entry.overloaded_alternatives = [
-                            self._create_ubcm_entry(type, overloaded_alternative, env)
+                            self._create_unbound_cmethod_entry(type, overloaded_alternative, env)
                             for overloaded_alternative in entry.overloaded_alternatives
                         ]
                     return self.as_name_node(env, ubcm_entry, target=False)
@@ -7029,7 +7029,7 @@ class AttributeNode(ExprNode):
                     error(self.pos, "%s not a known value of %s" % (self.attribute, type))
         return None
 
-    def _create_ubcm_entry(self, type, entry, env):
+    def _create_unbound_cmethod_entry(self, type, entry, env):
         # Create a temporary entry describing the unbound C method in `entry`
         # as an ordinary function.
         if entry.func_cname and entry.type.op_arg_struct is None:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7014,7 +7014,7 @@ class AttributeNode(ExprNode):
                     else:
                         ubcm_entry = self._create_ubcm_entry(type, entry, env)
                         ubcm_entry.overloaded_alternatives = [
-                            self._create_ubcm_entry(overloaded_alternative, env)
+                            self._create_ubcm_entry(type, overloaded_alternative, env)
                             for overloaded_alternative in entry.overloaded_alternatives
                         ]
                     return self.as_name_node(env, ubcm_entry, target=False)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7012,35 +7012,10 @@ class AttributeNode(ExprNode):
                             return None
                         ubcm_entry = entry
                     else:
-                        # Create a temporary entry describing the C method
-                        # as an ordinary function.
-                        def create_ubcm_entry(entry):
-                            if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
-                                cname = entry.func_cname
-                                if entry.type.is_static_method or (
-                                        env.parent_scope and env.parent_scope.is_cpp_class_scope):
-                                    ctype = entry.type
-                                elif type.is_cpp_class:
-                                    error(self.pos, "%s not a static member of %s" % (entry.name, type))
-                                    ctype = PyrexTypes.error_type
-                                else:
-                                    # Fix self type.
-                                    ctype = copy.copy(entry.type)
-                                    ctype.args = ctype.args[:]
-                                    ctype.args[0] = PyrexTypes.CFuncTypeArg('self', type, 'self', None)
-                            else:
-                                cname = "%s->%s" % (type.vtabptr_cname, entry.cname)
-                                ctype = entry.type
-                            ubcm_entry = Symtab.Entry(entry.name, cname, ctype)
-                            ubcm_entry.is_cfunction = 1
-                            ubcm_entry.func_cname = entry.func_cname
-                            ubcm_entry.is_unbound_cmethod = 1
-                            ubcm_entry.scope = entry.scope
-                            return ubcm_entry
-                        ubcm_entry = create_ubcm_entry(entry)
+                        ubcm_entry = self._create_ubcm_entry(entry, env)
                         if entry.overloaded_alternatives:
                             ubcm_entry.overloaded_alternatives = [
-                                create_ubcm_entry(overloaded_alternative) for overloaded_alternative in
+                                self._create_ubcm_entry(overloaded_alternative, env) for overloaded_alternative in
                                 entry.overloaded_alternatives
                             ]
                     return self.as_name_node(env, ubcm_entry, target=False)
@@ -7054,6 +7029,32 @@ class AttributeNode(ExprNode):
                 else:
                     error(self.pos, "%s not a known value of %s" % (self.attribute, type))
         return None
+
+    def _create_ubcm_entry(self, entry, env):
+        # Create a temporary entry describing the unbound C method in `entry`
+        # as an ordinary function.
+        if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
+            cname = entry.func_cname
+            if entry.type.is_static_method or (
+                    env.parent_scope and env.parent_scope.is_cpp_class_scope):
+                ctype = entry.type
+            elif type.is_cpp_class:
+                error(self.pos, "%s not a static member of %s" % (entry.name, type))
+                ctype = PyrexTypes.error_type
+            else:
+                # Fix self type.
+                ctype = copy.copy(entry.type)
+                ctype.args = ctype.args[:]
+                ctype.args[0] = PyrexTypes.CFuncTypeArg('self', type, 'self', None)
+        else:
+            cname = "%s->%s" % (type.vtabptr_cname, entry.cname)
+            ctype = entry.type
+        ubcm_entry = Symtab.Entry(entry.name, cname, ctype)
+        ubcm_entry.is_cfunction = 1
+        ubcm_entry.func_cname = entry.func_cname
+        ubcm_entry.is_unbound_cmethod = 1
+        ubcm_entry.scope = entry.scope
+        return ubcm_entry
 
     def analyse_as_type(self, env):
         module_scope = self.obj.analyse_as_module(env)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7032,7 +7032,7 @@ class AttributeNode(ExprNode):
     def _create_ubcm_entry(self, type, entry, env):
         # Create a temporary entry describing the unbound C method in `entry`
         # as an ordinary function.
-        if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
+        if entry.func_cname and entry.type.op_arg_struct is not None:
             cname = entry.func_cname
             if entry.type.is_static_method or (
                     env.parent_scope and env.parent_scope.is_cpp_class_scope):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7014,27 +7014,35 @@ class AttributeNode(ExprNode):
                     else:
                         # Create a temporary entry describing the C method
                         # as an ordinary function.
-                        if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
-                            cname = entry.func_cname
-                            if entry.type.is_static_method or (
-                                    env.parent_scope and env.parent_scope.is_cpp_class_scope):
-                                ctype = entry.type
-                            elif type.is_cpp_class:
-                                error(self.pos, "%s not a static member of %s" % (entry.name, type))
-                                ctype = PyrexTypes.error_type
+                        def create_ubcm_entry(entry):
+                            if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):
+                                cname = entry.func_cname
+                                if entry.type.is_static_method or (
+                                        env.parent_scope and env.parent_scope.is_cpp_class_scope):
+                                    ctype = entry.type
+                                elif type.is_cpp_class:
+                                    error(self.pos, "%s not a static member of %s" % (entry.name, type))
+                                    ctype = PyrexTypes.error_type
+                                else:
+                                    # Fix self type.
+                                    ctype = copy.copy(entry.type)
+                                    ctype.args = ctype.args[:]
+                                    ctype.args[0] = PyrexTypes.CFuncTypeArg('self', type, 'self', None)
                             else:
-                                # Fix self type.
-                                ctype = copy.copy(entry.type)
-                                ctype.args = ctype.args[:]
-                                ctype.args[0] = PyrexTypes.CFuncTypeArg('self', type, 'self', None)
-                        else:
-                            cname = "%s->%s" % (type.vtabptr_cname, entry.cname)
-                            ctype = entry.type
-                        ubcm_entry = Symtab.Entry(entry.name, cname, ctype)
-                        ubcm_entry.is_cfunction = 1
-                        ubcm_entry.func_cname = entry.func_cname
-                        ubcm_entry.is_unbound_cmethod = 1
-                        ubcm_entry.scope = entry.scope
+                                cname = "%s->%s" % (type.vtabptr_cname, entry.cname)
+                                ctype = entry.type
+                            ubcm_entry = Symtab.Entry(entry.name, cname, ctype)
+                            ubcm_entry.is_cfunction = 1
+                            ubcm_entry.func_cname = entry.func_cname
+                            ubcm_entry.is_unbound_cmethod = 1
+                            ubcm_entry.scope = entry.scope
+                            return ubcm_entry
+                        ubcm_entry = create_ubcm_entry(entry)
+                        if entry.overloaded_alternatives:
+                            ubcm_entry.overloaded_alternatives = [
+                                create_ubcm_entry(overloaded_alternative) for overloaded_alternative in
+                                entry.overloaded_alternatives
+                            ]
                     return self.as_name_node(env, ubcm_entry, target=False)
             elif type.is_enum or type.is_cpp_enum:
                 if self.attribute in type.values:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7032,7 +7032,7 @@ class AttributeNode(ExprNode):
     def _create_ubcm_entry(self, type, entry, env):
         # Create a temporary entry describing the unbound C method in `entry`
         # as an ordinary function.
-        if entry.func_cname and entry.type.op_arg_struct is not None:
+        if entry.func_cname and entry.type.op_arg_struct is None:
             cname = entry.func_cname
             if entry.type.is_static_method or (
                     env.parent_scope and env.parent_scope.is_cpp_class_scope):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7014,8 +7014,8 @@ class AttributeNode(ExprNode):
                     else:
                         ubcm_entry = self._create_ubcm_entry(entry, env)
                         ubcm_entry.overloaded_alternatives = [
-                            self._create_ubcm_entry(overloaded_alternative, env) for overloaded_alternative in
-                            entry.overloaded_alternatives
+                            self._create_ubcm_entry(overloaded_alternative, env)
+                            for overloaded_alternative in entry.overloaded_alternatives
                         ]
                     return self.as_name_node(env, ubcm_entry, target=False)
             elif type.is_enum or type.is_cpp_enum:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7012,7 +7012,7 @@ class AttributeNode(ExprNode):
                             return None
                         ubcm_entry = entry
                     else:
-                        ubcm_entry = self._create_ubcm_entry(entry, env)
+                        ubcm_entry = self._create_ubcm_entry(type, entry, env)
                         ubcm_entry.overloaded_alternatives = [
                             self._create_ubcm_entry(overloaded_alternative, env)
                             for overloaded_alternative in entry.overloaded_alternatives
@@ -7029,7 +7029,7 @@ class AttributeNode(ExprNode):
                     error(self.pos, "%s not a known value of %s" % (self.attribute, type))
         return None
 
-    def _create_ubcm_entry(self, entry, env):
+    def _create_ubcm_entry(self, type, entry, env):
         # Create a temporary entry describing the unbound C method in `entry`
         # as an ordinary function.
         if entry.func_cname and not hasattr(entry.type, 'op_arg_struct'):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2848,7 +2848,6 @@ class CFuncType(CType):
     cached_specialized_types = None
     from_fused = False
     is_const_method = False
-    op_arg_struct = None
 
     subtypes = ['return_type', 'args']
 
@@ -2871,6 +2870,7 @@ class CFuncType(CType):
         self.is_static_method = is_static_method
         self.templates = templates
         self.is_strict_signature = is_strict_signature
+        self.op_arg_struct = None
 
     def __repr__(self):
         arg_reprs = list(map(repr, self.args))

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2841,12 +2841,14 @@ class CFuncType(CType):
     #                               (used for optimisation overrides)
     #  is_const_method  boolean
     #  is_static_method boolean
+    #  op_arg_struct    CPtrType   Pointer to optional argument struct
 
     is_cfunction = 1
     original_sig = None
     cached_specialized_types = None
     from_fused = False
     is_const_method = False
+    op_arg_struct = None
 
     subtypes = ['return_type', 'args']
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2848,6 +2848,7 @@ class CFuncType(CType):
     cached_specialized_types = None
     from_fused = False
     is_const_method = False
+    op_arg_struct = None
 
     subtypes = ['return_type', 'args']
 
@@ -2870,7 +2871,6 @@ class CFuncType(CType):
         self.is_static_method = is_static_method
         self.templates = templates
         self.is_strict_signature = is_strict_signature
-        self.op_arg_struct = None
 
     def __repr__(self):
         arg_reprs = list(map(repr, self.args))

--- a/tests/run/cpp_static_method_overload.pyx
+++ b/tests/run/cpp_static_method_overload.pyx
@@ -1,0 +1,49 @@
+# mode: run
+# tag: cpp, cpp11
+
+cdef extern from *:
+    """
+    struct Foo
+    {
+
+      static const char* bar(int x, int y) {
+        return "second";
+      }
+
+      static const char* bar(int x) {
+        return "first";
+      }
+
+      const char* baz(int x, int y) {
+        return "second";
+      }
+
+      const char* baz(int x) {
+        return "first";
+      }
+    };
+    """
+    cppclass Foo:
+        @staticmethod
+        const char* bar(int x)
+
+        @staticmethod
+        const char* bar(int x, int y)
+
+        const char* baz(int x)
+        const char* baz(int x, int y)
+
+def test_normal_method_overload():
+    """
+    >>> test_normal_method_overload()
+    """
+    cdef Foo f
+    assert f.baz(1) == b"first"
+    assert f.baz(1, 2) == b"second"
+
+def test_static_method_overload():
+    """
+    >>> test_static_method_overload()
+    """
+    assert Foo.bar(1) == b"first"
+    assert Foo.bar(1, 2) == b"second"

--- a/tests/run/cpp_static_method_overload.pyx
+++ b/tests/run/cpp_static_method_overload.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, cpp11
+# tag: cpp
 
 cdef extern from *:
     """


### PR DESCRIPTION
Closes #1851

Not sure if the approach I'm taking here is the best, but I tracked the issue down to overloads not being properly accounted for in `AttributeNode.analyse_as_type_attribute`.