### PR TITLE
Disabled embed test from the docs on Py3.4

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -439,6 +439,7 @@ VER_DEP_MODULES = {
                                          'run.pep526_variable_annotations',  # typing module
                                          'run.test_exceptions',  # copied from Py3.7+
                                          'run.time_pxd',  # _PyTime_GetSystemClock doesn't exist in 3.4
+                                         'embedding.embedded',  # From the docs, needs Py_DecodeLocale
                                          ]),
 }
 


### PR DESCRIPTION
It requires Py_DecodeLocale which appears in 3.5. This is causing
it to fail on Windows. It's somehow passing on Linux for reasons
that I don't understand (but it really shouldn't be)