### PR TITLE
Added return value in __Pyx_UnicodeContainsUCS4

### DIFF
--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -176,6 +176,15 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(PyObject* unicode, Py_UCS4 ch
 
     }
 #endif
+    /* This should only happen if the user has manually created a non-PEP393 string
+     * (i.e. it's very unlikely)
+     * __Pyx_UnicodeContainsUCS4 is not checked for errors so returning a non-match is
+     * the only option, with a warning to try to be helpful
+     */
+    PyErr_WarnEx(PyExc_UnicodeWarning,
+                    "Unicode string in 'in' comparison with Py_UCS4 character had unexpected format "
+                    "(most likely you created a unicode string with a PyUnicode_WCHAR_KIND)", 1);
+    return 0;
 }
 
 


### PR DESCRIPTION
https://github.com/cython/cython/issues/3925

This is a corner-case mostly to silence C warnings. It can happen
with strings created manually (i.e. not by Cython) using the deprecated
C-API on Python 3.9+

I haven't added a test since it seems quite hard to construct a
string that fails it