### PR TITLE
Include utilitycode for inline memoryview functions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -13115,12 +13115,11 @@ class CoerceToMemViewSliceNode(CoercionNode):
         CoercionNode.__init__(self, arg)
         self.type = dst_type
         self.is_temp = 1
-        self.env = env
         self.use_managed_ref = True
         self.arg = arg
+        self.type.create_from_py_utility_code(env)
 
     def generate_result_code(self, code):
-        self.type.create_from_py_utility_code(self.env)
         code.putln(self.type.from_py_call_code(
             self.arg.py_result(),
             self.result(),

--- a/tests/memoryview/memoryview_inline_pxd.srctree
+++ b/tests/memoryview/memoryview_inline_pxd.srctree
@@ -1,0 +1,35 @@
+# ticket: 1415
+
+# Utility code from an inline function in a pxd file was not
+# correctly included in a pyx file that cimported it.
+# Do not add more to this test - it is intentionally minimal
+# to avoid including the utility code through other means
+
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import uses_inline; uses_inline.main()"
+
+######## setup.py ########
+
+from distutils.core import setup
+from Cython.Distutils import build_ext
+from Cython.Distutils.extension import Extension
+
+setup(
+    ext_modules = [
+        Extension("uses_inline", ["uses_inline.pyx"]),
+    ],
+    cmdclass={'build_ext': build_ext},
+)
+
+######## has_inline.pxd ########
+
+from libc.stdlib cimport malloc
+cdef inline double[::1] mview(size_t size, double* null):
+    return <double[:size:1]>malloc(size * sizeof(null[0]))
+    
+######## uses_inline.pyx ########
+
+from has_inline cimport mview
+def main():
+    return mview(1, <double*>NULL)
+

--- a/tests/memoryview/memoryview_inline_pxd.srctree
+++ b/tests/memoryview/memoryview_inline_pxd.srctree
@@ -24,12 +24,12 @@ setup(
 ######## has_inline.pxd ########
 
 from libc.stdlib cimport malloc
-cdef inline double[::1] mview(size_t size, double* null):
-    return <double[:size:1]>malloc(size * sizeof(null[0]))
+cdef inline double[::1] mview(size_t size):
+    return <double[:size:1]>malloc(size * sizeof(double))
     
 ######## uses_inline.pyx ########
 
 from has_inline cimport mview
 def main():
-    return mview(1, <double*>NULL)
+    return mview(1)
 


### PR DESCRIPTION
Fixes #1415

The utilitycode was generated at too late a stage, after the
utilitycode from the pxd was merged into the pyx scope.