### PR TITLE
Fixes #4143: Can't catch ValueError from float() calls

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -475,12 +475,16 @@ static CYTHON_INLINE PyObject* __Pyx__PyNumber_Float(PyObject* obj); /* proto */
 
 static CYTHON_INLINE PyObject* __Pyx__PyNumber_Float(PyObject* obj) {
     // obj is PyFloat is handled in the calling macro
+    double val;
     if (PyUnicode_CheckExact(obj)) {
-        return PyFloat_FromDouble(__Pyx_PyUnicode_AsDouble(obj));
+        val = __Pyx_PyUnicode_AsDouble(obj);
+        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
     } else if (PyBytes_CheckExact(obj)) {
-        return PyFloat_FromDouble(__Pyx_PyBytes_AsDouble(obj));
+        val = __Pyx_PyBytes_AsDouble(obj);
+        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
     } else if (PyByteArray_CheckExact(obj)) {
-        return PyFloat_FromDouble(__Pyx_PyByteArray_AsDouble(obj));
+        val = __Pyx_PyByteArray_AsDouble(obj);
+        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
     } else {
         return PyNumber_Float(obj);
     }

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -478,13 +478,13 @@ static CYTHON_INLINE PyObject* __Pyx__PyNumber_Float(PyObject* obj) {
     double val;
     if (PyUnicode_CheckExact(obj)) {
         val = __Pyx_PyUnicode_AsDouble(obj);
-        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
+        return unlikely(val == -1 && PyErr_Occurred()) ? NULL : PyFloat_FromDouble(val);
     } else if (PyBytes_CheckExact(obj)) {
         val = __Pyx_PyBytes_AsDouble(obj);
-        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
+        return unlikely(val == -1 && PyErr_Occurred()) ? NULL : PyFloat_FromDouble(val);
     } else if (PyByteArray_CheckExact(obj)) {
         val = __Pyx_PyByteArray_AsDouble(obj);
-        return val == -1 && PyErr_Occurred() ? NULL : PyFloat_FromDouble(val);
+        return unlikely(val == -1 && PyErr_Occurred()) ? NULL : PyFloat_FromDouble(val);
     } else {
         return PyNumber_Float(obj);
     }

--- a/tests/run/builtin_float.py
+++ b/tests/run/builtin_float.py
@@ -234,3 +234,22 @@ def from_unicode_literals():
     (123.0, 123.23, 123.45, 1e+100, 123.23)
     """
     return float(u"123"), float(u"123.23"), float(fix_underscores(u"12_3.4_5")), float(u"1e100"), float(u"123.23\N{PUNCTUATION SPACE}")
+
+
+def catch_valueerror(val):
+    """
+    >>> catch_valueerror("foo")
+    False
+    >>> catch_valueerror(u"foo")
+    False
+    >>> catch_valueerror(b"foo")
+    False
+    >>> catch_valueerror(bytearray(b"foo"))
+    False
+    >>> catch_valueerror("-1")
+    -1.0
+    """
+    try:
+        return float(val)
+    except ValueError:
+        return False


### PR DESCRIPTION
See issue #4143 

The implementation of __Pyx__PyNumber_Float() wasn't checking whether errors occurred on the calls to __Pyx_PyUnicode_AsDouble(), __Pyx_PyBites_AsDouble(), and __Pyx_PyByteArray_AsDouble(). Errors from those functions are now properly propagated to the caller.

I didn't understand the `@cython.test_assert_path_exists` decorators on some of the tests in that file. Please let me know if this new test needs such a decorator.