### PR TITLE
Fix annotations for decorated classes

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -4875,7 +4875,7 @@ class PyClassDefNode(ClassDefNode):
         return cenv
 
     def analyse_declarations(self, env):
-        class_result = self.classobj
+        unwrapped_class_result = class_result = self.classobj
         if self.decorators:
             from .ExprNodes import SimpleCallNode
             for decorator in self.decorators[::-1]:
@@ -4897,7 +4897,7 @@ class PyClassDefNode(ClassDefNode):
         if self.doc_node:
             self.doc_node.analyse_target_declaration(cenv)
         self.body.analyse_declarations(cenv)
-        self.class_result.analyse_annotations(cenv)
+        unwrapped_class_result.analyse_annotations(cenv)
 
     update_bases_functype = PyrexTypes.CFuncType(
         PyrexTypes.py_object_type, [

--- a/runtests.py
+++ b/runtests.py
@@ -443,6 +443,7 @@ VER_DEP_MODULES = {
                                          'run.time_pxd',  # _PyTime_GetSystemClock doesn't exist in 3.4
                                          ]),
     (3,7): (operator.lt, lambda x: x in ['run.pycontextvar',
+                                         'run.pep557_dataclasses',  # dataclasses module
                                          ]),
 }
 

--- a/tests/run/pep557_dataclasses.py
+++ b/tests/run/pep557_dataclasses.py
@@ -1,0 +1,54 @@
+# mode: run
+# tag: pep557, pure3.7
+
+import dataclasses
+from typing import Sequence
+
+
+@dataclasses.dataclass
+class Color:
+    """
+    >>> list(Color.__dataclass_fields__.keys())
+    ['red', 'green', 'blue', 'alpha']
+    >>> Color(1, 2, 3)
+    Color(red=1, green=2, blue=3, alpha=255)
+    >>> Color(1, 2, 3, 4)
+    Color(red=1, green=2, blue=3, alpha=4)
+    >>> Color(green=1, blue=2, red=3, alpha=40)
+    Color(red=3, green=1, blue=2, alpha=40)
+    """
+    red: int
+    green: int
+    blue: int
+    alpha: int = 255
+
+
+@dataclasses.dataclass
+class NamedColor(Color):
+    """
+    >>> list(NamedColor.__dataclass_fields__.keys())
+    ['red', 'green', 'blue', 'alpha', 'names']
+    >>> NamedColor(1, 2, 3)
+    NamedColor(red=1, green=2, blue=3, alpha=255, names=[])
+    >>> NamedColor(1, 2, 3, 4)
+    NamedColor(red=1, green=2, blue=3, alpha=4, names=[])
+    >>> NamedColor(green=1, blue=2, red=3, alpha=40)
+    NamedColor(red=3, green=1, blue=2, alpha=40, names=[])
+    >>> NamedColor(1, 2, 3, names=["blackish", "very dark cyan"])
+    NamedColor(red=1, green=2, blue=3, alpha=255, names=['blackish', 'very dark cyan'])
+    """
+    names: Sequence[str] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class IceCream:
+    """
+    >>> IceCream("vanilla")
+    IceCream(flavour='vanilla', num_toppings=2)
+    >>> IceCream("vanilla") == IceCream("vanilla", num_toppings=3)
+    False
+    >>> IceCream("vanilla") == IceCream("vanilla", num_toppings=2)
+    True
+    """
+    flavour: str
+    num_toppings: int = 2

--- a/tests/run/pep563_annotations.py
+++ b/tests/run/pep563_annotations.py
@@ -24,3 +24,17 @@ def f(a: 1+2==3, b: list, c: this_cant_evaluate, d: "Hello from inside a string"
     True
     """
     pass
+
+
+def empty_decorator(cls):
+    return cls
+
+
+@empty_decorator
+class DecoratedStarship(object):
+    """
+    >>> sorted(DecoratedStarship.__annotations__.items())
+    [('captain', 'str'), ('damage', 'cython.int')]
+    """
+    captain: str = 'Picard'               # instance variable with default
+    damage: cython.int                    # instance variable without default


### PR DESCRIPTION
This patch fixes a problem with using dataclasses in Cython. Using Cython master, the following code:

```py3
# cython: language_level=3

import dataclasses


@dataclasses.dataclass
class Foo:
    bar: int


print(Foo(1))
```

Fails with:

```pytb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "x.py", line 11, in init x
    print(Foo(1))
TypeError: __init__() takes 1 positional argument but 2 were given
```

This is because decorated classes do not have an `__annotations__` attribute. The root cause of this problem is that annotations are looked for after wrapping the class with the decorator(s), and since `SimpleCallNode` does not forward the class' annotations, none are found. This patch fixes the problem by checking for annotations before wrapping the class.