### PR TITLE
Use std::move in c++ during yield context switch.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9899,6 +9899,8 @@ class YieldExprNode(ExprNode):
             save_cname = code.funcstate.closure_temps.allocate_temp(type)
             saved.append((cname, save_cname, type))
             if type.is_cpp_class:
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("MoveIfSupported", "CppSupport.cpp"))
                 cname = "__PYX_STD_MOVE_IF_SUPPORTED(%s)" % cname
             else:
                 code.put_xgiveref(cname, type)
@@ -9934,6 +9936,8 @@ class YieldExprNode(ExprNode):
         for cname, save_cname, type in saved:
             save_cname = "%s->%s" % (Naming.cur_scope_cname, save_cname)
             if type.is_cpp_class:
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("MoveIfSupported", "CppSupport.cpp"))
                 save_cname = "__PYX_STD_MOVE_IF_SUPPORTED(%s)" % save_cname
             code.putln('%s = %s;' % (cname, save_cname))
             if type.is_pyobject:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9936,8 +9936,6 @@ class YieldExprNode(ExprNode):
         for cname, save_cname, type in saved:
             save_cname = "%s->%s" % (Naming.cur_scope_cname, save_cname)
             if type.is_cpp_class:
-                code.globalstate.use_utility_code(
-                    UtilityCode.load_cached("MoveIfSupported", "CppSupport.cpp"))
                 save_cname = "__PYX_STD_MOVE_IF_SUPPORTED(%s)" % save_cname
             code.putln('%s = %s;' % (cname, save_cname))
             if type.is_pyobject:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9898,9 +9898,10 @@ class YieldExprNode(ExprNode):
         for cname, type, manage_ref in code.funcstate.temps_in_use():
             save_cname = code.funcstate.closure_temps.allocate_temp(type)
             saved.append((cname, save_cname, type))
-            code.put_xgiveref(cname, type)
             if type.is_cpp_class:
                 cname = "__PYX_STD_MOVE_IF_SUPPORTED(%s)" % cname
+            else:
+                code.put_xgiveref(cname, type)
             code.putln('%s->%s = %s;' % (Naming.cur_scope_cname, save_cname, cname))
 
         code.put_xgiveref(Naming.retval_cname, py_object_type)

--- a/runtests.py
+++ b/runtests.py
@@ -2072,7 +2072,7 @@ def main():
             args.append(arg)
 
     from optparse import OptionParser
-    parser = OptionParser()
+    parser = OptionParser(usage="usage: %prog [options] [selector ...]")
     parser.add_option("--no-cleanup", dest="cleanup_workdir",
                       action="store_false", default=True,
                       help="do not delete the generated C files (allows passing --no-cython on next run)")

--- a/tests/compile/cpp_temp_assignment.pyx
+++ b/tests/compile/cpp_temp_assignment.pyx
@@ -1,21 +1,15 @@
-# tag: cpp
+# tag: cpp,cpp11
 # mode: compile
 
 cdef extern from *:
     """
     class NoAssignIterator {
         public:
-        #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
             explicit NoAssignIterator(int pos) : pos_(pos) {}
             NoAssignIterator(NoAssignIterator&) = delete;
             NoAssignIterator(NoAssignIterator&&) {}
             NoAssignIterator& operator=(NoAssignIterator&) = delete;
             NoAssignIterator& operator=(NoAssignIterator&&) { return *this; }
-        #else
-            // the test becomes meaningless
-            // (but just declare something to ensure it passes)
-            explicit NoAssignIterator(int pos) : pos_(pos) {}
-        #endif
             // Default constructor of temp variable is needed by Cython
             // as of 3.0a6.
             NoAssignIterator() : pos_(0) {}
@@ -32,13 +26,7 @@ cdef extern from *:
     };
     class NoAssign {
         public:
-        #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
             NoAssign() {}
-        #else
-            // the test becomes meaningless
-            // (but just declare something to ensure it passes)
-            NoAssign() {}
-        #endif
             NoAssign(NoAssign&) = delete;
             NoAssign(NoAssign&&) {}
             NoAssign& operator=(NoAssign&) = delete;

--- a/tests/compile/cpp_temp_assignment.pyx
+++ b/tests/compile/cpp_temp_assignment.pyx
@@ -5,7 +5,7 @@ cdef extern from *:
     """
     class NoAssignIterator {
         public:
-        #if __cplusplus >= 201103L
+        #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
             explicit NoAssignIterator(int pos) : pos_(pos) {}
             NoAssignIterator(NoAssignIterator&) = delete;
             NoAssignIterator(NoAssignIterator&&) {}
@@ -32,7 +32,7 @@ cdef extern from *:
     };
     class NoAssign {
         public:
-        #if __cplusplus >= 201103L
+        #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
             NoAssign() {}
         #else
             // the test becomes meaningless


### PR DESCRIPTION
When compiling pyarrow with cython 3.0 we get an error about the copy
constructor of an object has been deleted on the generated context switch code.

This PR fixes it.

I'd like to add a unit test, but would need some input on which folder
or file under tests is a good place for it.