### PR TITLE
Add Code Coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,9 @@ jobs:
     runs-on: ubuntu-18.04
 
     env:
-      BACKEND: c
+      BACKEND: cpp
       OS_NAME: ubuntu-18.04
       PYTHON_VERSION: 3.9
-      USE_CCACHE: 1
-      CCACHE_SLOPPINESS: "pch_defines,time_macros"
-      CCACHE_COMPRESS: 1
-      CCACHE_MAXSIZE: "200M"
 
     steps:
       - name: Checkout repo
@@ -174,12 +170,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-
-      - name: Cache [ccache]
-        uses: pat-s/always-upload-cache@v2.1.3
-        with:
-          path: ~/.ccache
-          key: ${{ runner.os }}-ccache-code_quality-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run Coverage
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         run: exit; #bash ./Tools/ci-run.sh
         
       - name: Run Coverage
-        #if: ${{ env.coverage == 1 }}
+        if: ${{ matrix.COVERAGE == 1 }}
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
-        run: echo ${{ matrix.coverage }} #bash ./Tools/ci-run.sh
+        run: echo ${{ matrix.env.COVERAGE }} #bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,11 @@ jobs:
 
       - name: Cache [ccache]
         uses: pat-s/always-upload-cache@v2.1.3
-        if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-static_analysis-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run Coverage
+        continue-on-error: true
         env: { COVERAGE: 1 }
         run: bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-ccache-${{ github.workflow }}-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
+          key: ${{ runner.os }}-ccache-code_quality-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run Coverage
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,4 +184,10 @@ jobs:
       - name: Run Coverage
         continue-on-error: true
         env: { COVERAGE: 1 }
-        run: bash ./Tools/ci-run.sh
+        run: bash ./Tools/ci-run.sh; ls
+        
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v2
+          with:
+            path: coverage-report-html  
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
             backend: "c,cpp"
             env: { TEST_CODE_STYLE: 1 }
             extra_hash: "-codestyle"
+          - os: ubuntu-18.04
+            python-version: 3.7
+            backend: "c,cpp"
+            env: { COVERAGE: 1 }
+            extra_hash: "-coverage"  
           # Limited API
           - os: ubuntu-18.04
             python-version: 3.6
@@ -146,4 +151,4 @@ jobs:
       - name: Run CI
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
-        run: bash ./Tools/ci-run.sh
+        run: exit; #bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,13 +149,44 @@ jobs:
           key: ${{ runner.os }}-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run CI
-        if: env.coverage != 1
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
         run: exit; #bash ./Tools/ci-run.sh
         
+
+  static_analysis:
+    strategy:
+      # Allows for matrix sub-jobs to fail without canceling the rest
+      fail-fast: false
+    runs-on: ubuntu-18.04
+
+    env:
+      BACKEND: c
+      OS_NAME: ubuntu-18.04
+      PYTHON_VERSION: 3.9
+      USE_CCACHE: 1
+      CCACHE_SLOPPINESS: "pch_defines,time_macros"
+      CCACHE_COMPRESS: 1
+      CCACHE_MAXSIZE: "200M"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Cache [ccache]
+        uses: pat-s/always-upload-cache@v2.1.3
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-static_analysis-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
+
       - name: Run Coverage
-        if: ${{ matrix.COVERAGE == 1 }}
-        continue-on-error: ${{ matrix.allowed_failure || false }}
-        env: ${{ matrix.env }}
-        run: echo ${{ matrix.env.COVERAGE }} #bash ./Tools/ci-run.sh
+        env: COVERAGE=1
+        run: bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ jobs:
             backend: "c,cpp"
             env: { TEST_CODE_STYLE: 1 }
             extra_hash: "-codestyle"
-          - os: ubuntu-18.04
-            python-version: 3.7
-            backend: "c,cpp"
-            env: { COVERAGE: 1 }
-            extra_hash: "-coverage"  
           # Limited API
           - os: ubuntu-18.04
             python-version: 3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,6 @@ jobs:
         
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v2
-          with:
-            path: coverage-report-html  
+        with:
+          path: coverage-report-html  
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         run: exit; #bash ./Tools/ci-run.sh
         
       - name: Run Coverage
-        if: env.coverage == 1
+        if: ${{ env.coverage == 1 }}
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
         run: bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,13 @@ jobs:
           key: ${{ runner.os }}-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run CI
+        if: env.coverage != 1
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
         run: exit; #bash ./Tools/ci-run.sh
+        
+      - name: Run Coverage
+        if: env.coverage == 1
+        continue-on-error: ${{ matrix.allowed_failure || false }}
+        env: ${{ matrix.env }}
+        run: bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         run: exit; #bash ./Tools/ci-run.sh
         
       - name: Run Coverage
-        if: ${{ env.coverage == 1 }}
+        #if: ${{ env.coverage == 1 }}
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
-        run: bash ./Tools/ci-run.sh
+        run: echo ${{ matrix.coverage }} #bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
           python-version: 3.9
 
       - name: Run Coverage
-        continue-on-error: true
         env: { COVERAGE: 1 }
         run: bash ./Tools/ci-run.sh
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,10 @@ jobs:
       - name: Run CI
         continue-on-error: ${{ matrix.allowed_failure || false }}
         env: ${{ matrix.env }}
-        run: exit; #bash ./Tools/ci-run.sh
+        run: bash ./Tools/ci-run.sh
         
 
-  static_analysis:
+  code_quality:
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
       fail-fast: false
@@ -179,12 +179,12 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.3
         with:
           path: ~/.ccache
-          key: ${{ runner.os }}-static_analysis-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
+          key: ${{ runner.os }}-ccache-${{ github.workflow }}-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run Coverage
         continue-on-error: true
         env: { COVERAGE: 1 }
-        run: bash ./Tools/ci-run.sh; ls
+        run: bash ./Tools/ci-run.sh
         
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,5 +188,5 @@ jobs:
           key: ${{ runner.os }}-static_analysis-${{ hashFiles('**/test-requirements*.txt', '**/ci.yml', '**/ci-run.sh') }}
 
       - name: Run Coverage
-        env: COVERAGE=1
+        env: { COVERAGE: 1 }
         run: bash ./Tools/ci-run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     env:
-      BACKEND: cpp
+      BACKEND: c,cpp
       OS_NAME: ubuntu-18.04
       PYTHON_VERSION: 3.9
 

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -101,7 +101,7 @@ python runtests.py \
   --backends=$BACKEND \
    $LIMITED_API \
    $EXCLUDE \
-   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage --coverage-html"; fi) \
+   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage --coverage-html --cython-only"; fi) \
    $(if [ -z "$TEST_CODE_STYLE" ]; then echo " -j7 "; fi)
 
 EXIT_CODE=$?

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -101,7 +101,7 @@ python runtests.py \
   --backends=$BACKEND \
    $LIMITED_API \
    $EXCLUDE \
-   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage"; fi) \
+   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage-html coverage.html"; fi) \
    $(if [ -z "$TEST_CODE_STYLE" ]; then echo " -j7 "; fi)
 
 EXIT_CODE=$?

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -101,7 +101,7 @@ python runtests.py \
   --backends=$BACKEND \
    $LIMITED_API \
    $EXCLUDE \
-   $(if [ "$COVERAGE" == "1" ]; then echo "--coverage --coverage-html"; fi) \
+   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage --coverage-html"; fi) \
    $(if [ -z "$TEST_CODE_STYLE" ]; then echo " -j7 "; fi)
 
 EXIT_CODE=$?

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -101,7 +101,7 @@ python runtests.py \
   --backends=$BACKEND \
    $LIMITED_API \
    $EXCLUDE \
-   $(if [ "$COVERAGE" == "1" ]; then echo " --coverage-html coverage.html"; fi) \
+   $(if [ "$COVERAGE" == "1" ]; then echo "--coverage --coverage-html"; fi) \
    $(if [ -z "$TEST_CODE_STYLE" ]; then echo " -j7 "; fi)
 
 EXIT_CODE=$?


### PR DESCRIPTION
Github Action: https://github.com/Endle/cython/actions/runs/837909611
It could generate an artifact for code coverage https://github.com/Endle/cython/actions/runs/837909611

However, some tests are failing when enabling coverage
```
File "/home/runner/work/cython/cython/TEST_TMP/1/run/c/line_trace/line_trace.cpython-39-x86_64-linux-gnu.so", line ?, in line_trace.run_trace
Failed example:
    run_trace(py_add, 1, 2)
Exception raised:
    Traceback (most recent call last):
      File "/opt/hostedtoolcache/Python/3.9.4/x64/lib/python3.9/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest line_trace.run_trace[2]>", line 1, in <module>
        run_trace(py_add, 1, 2)
      File "tests/run/line_trace.pyx", line 230, in line_trace.run_trace (line_trace.c:6817)
        try:
      File "tests/run/line_trace.pyx", line 60, in line_trace.trace_trampoline (line_trace.c:3290)
        raise
      File "tests/run/line_trace.pyx", line 54, in line_trace.trace_trampoline (line_trace.c:3189)
        result = callback(frame, what, arg)
    TypeError: Tracer_call() argument 2 must be str, not int

```


I created a new job instead of editing matrix for such reasons  
1. I want to workaround the 30 minute limit.  
2. I think current matrix is already complex enough.
3. We can add more code quality assurance steps, like static analysis mentioned in https://github.com/cython/cython/issues/4097