### PR TITLE
Fix move-if-supported for function wrappers

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3478,7 +3478,7 @@ class DefNodeWrapper(FuncDefNode):
         if self.signature.has_dummy_arg:
             args.append(Naming.self_cname)
         for arg in self.args:
-            if arg.hdr_type and arg.type.is_cpp_class:
+            if arg.type.is_cpp_class:
                 # it's safe to move converted C++ types because they aren't
                 # used again afterwards
                 code.globalstate.use_utility_code(


### PR DESCRIPTION
The condition wasn't triggering so code wasn't being tested
(#4163). This is applies to:

```
def f(vector[double] x):
  pass
```
which should now generate:

```
__pyx_v_a = __pyx_convert_vector_from_py_double(values[0]); if (unlikely(PyErr_Occurred())) __PYX_ERR(0, 5, __pyx_L3_error)
...
__pyx_r = __pyx_pf_4cnvt_f(__pyx_self, __PYX_STD_MOVE_IF_SUPPORTED(__pyx_v_a));
```

I haven't included any specific tests because I think it should be
covered by the existing test-suite (now that it works) and it's only
a performance improvement - it doesn't allow any new behaviour.