### PR TITLE
Suppress warnings about constant conditional expressions

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2412,8 +2412,7 @@ class CCodeWriter(object):
         return self.error_goto_if("!%s" % cname, pos)
 
     def error_goto_if_neg(self, cname, pos):
-        # Add extra parentheses to silence clang warnings about constant conditions.
-        return self.error_goto_if("(%s < 0)" % cname, pos)
+        return self.error_goto_if("__PYX_CONST_CONDITION(%s < 0)" % cname, pos)
 
     def error_goto_if_PyErr(self, pos):
         return self.error_goto_if("PyErr_Occurred()", pos)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8158,9 +8158,9 @@ class TryFinallyStatNode(StatNode):
 
         # not using preprocessor here to avoid warnings about
         # unused utility functions and/or temps
-        code.putln("if (PY_MAJOR_VERSION >= 3)"
+        code.putln("if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))"
                    " __Pyx_ExceptionSwap(&%s, &%s, &%s);" % exc_vars[3:])
-        code.putln("if ((PY_MAJOR_VERSION < 3) ||"
+        code.putln("if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION < 3) ||"
                    # if __Pyx_GetException() fails in Py3,
                    # store the newly raised exception instead
                    " unlikely(__Pyx_GetException(&%s, &%s, &%s) < 0)) "
@@ -8185,7 +8185,7 @@ class TryFinallyStatNode(StatNode):
 
         # not using preprocessor here to avoid warnings about
         # unused utility functions and/or temps
-        code.putln("if (PY_MAJOR_VERSION >= 3) {")
+        code.putln("if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3)) {")
         for var in exc_vars[3:]:
             code.put_xgiveref(var, py_object_type)
         code.putln("__Pyx_ExceptionReset(%s, %s, %s);" % exc_vars[3:])
@@ -8211,7 +8211,7 @@ class TryFinallyStatNode(StatNode):
 
         # not using preprocessor here to avoid warnings about
         # unused utility functions and/or temps
-        code.putln("if (PY_MAJOR_VERSION >= 3) {")
+        code.putln("if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3)) {")
         for var in exc_vars[3:]:
             code.put_xgiveref(var, py_object_type)
         code.putln("__Pyx_ExceptionReset(%s, %s, %s);" % exc_vars[3:])

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1453,7 +1453,7 @@ class BuiltinObjectType(PyObjectType):
         if not notnone:
             check += '||((%s) == Py_None)' % arg
         if self.name == 'basestring':
-            name = '(PY_MAJOR_VERSION < 3 ? "basestring" : "str")'
+            name = '(__PYX_CONST_CONDITION(PY_MAJOR_VERSION < 3) ? "basestring" : "str")'
         else:
             name = '"%s"' % self.name
         return check + ' || __Pyx_RaiseUnexpectedTypeError(%s, %s)' % (name, arg)

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -323,7 +323,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_Keys(PyObject* d); /*proto*/
 //////////////////// py_dict_keys ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_Keys(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "keys", d);
     else
         return PyDict_Keys(d);
@@ -336,7 +336,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_Values(PyObject* d); /*proto*/
 //////////////////// py_dict_values ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_Values(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "values", d);
     else
         return PyDict_Values(d);
@@ -349,7 +349,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_Items(PyObject* d); /*proto*/
 //////////////////// py_dict_items ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_Items(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "items", d);
     else
         return PyDict_Items(d);
@@ -362,7 +362,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_IterKeys(PyObject* d); /*proto*/
 //////////////////// py_dict_iterkeys ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_IterKeys(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "keys", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "iterkeys", d);
@@ -375,7 +375,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_IterValues(PyObject* d); /*proto*/
 //////////////////// py_dict_itervalues ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_IterValues(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "values", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "itervalues", d);
@@ -388,7 +388,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_IterItems(PyObject* d); /*proto*/
 //////////////////// py_dict_iteritems ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_IterItems(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "items", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "iteritems", d);
@@ -401,7 +401,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewKeys(PyObject* d); /*proto*/
 //////////////////// py_dict_viewkeys ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewKeys(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "keys", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "viewkeys", d);
@@ -414,7 +414,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewValues(PyObject* d); /*proto*/
 //////////////////// py_dict_viewvalues ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewValues(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "values", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "viewvalues", d);
@@ -427,7 +427,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewItems(PyObject* d); /*proto*/
 //////////////////// py_dict_viewitems ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyDict_ViewItems(PyObject* d) {
-    if (PY_MAJOR_VERSION >= 3)
+    if (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3))
         return CALL_UNBOUND_METHOD(PyDict_Type, "items", d);
     else
         return CALL_UNBOUND_METHOD(PyDict_Type, "viewitems", d);
@@ -461,7 +461,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyFrozenSet_New(PyObject* it) {
         result = PyFrozenSet_New(it);
         if (unlikely(!result))
             return NULL;
-        if ((PY_VERSION_HEX >= 0x031000A1) || likely(PySet_GET_SIZE(result)))
+        if (__PYX_CONST_CONDITION(PY_VERSION_HEX >= 0x031000A1) || likely(PySet_GET_SIZE(result)))
             return result;
         // empty frozenset is a singleton (on Python <3.10)
         // seems wasteful, but CPython does the same

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1997,7 +1997,7 @@ static void __Pyx__ReturnWithStopIteration(PyObject* value) {
     PyObject *exc, *args;
 #if CYTHON_COMPILING_IN_CPYTHON || CYTHON_COMPILING_IN_PYSTON
     __Pyx_PyThreadState_declare
-    if ((PY_VERSION_HEX >= 0x03030000 && PY_VERSION_HEX < 0x030500B1)
+    if (__PYX_CONST_CONDITION(PY_VERSION_HEX >= 0x03030000 && PY_VERSION_HEX < 0x030500B1)
             || unlikely(PyTuple_Check(value) || PyExceptionInstance_Check(value))) {
         args = PyTuple_New(1);
         if (unlikely(!args)) return;
@@ -2123,11 +2123,11 @@ static int __Pyx_patch_abc(void) {
     static int abc_patched = 0;
     if (CYTHON_REGISTER_ABCS && !abc_patched) {
         PyObject *module;
-        module = PyImport_ImportModule((PY_MAJOR_VERSION >= 3) ? "collections.abc" : "collections");
+        module = PyImport_ImportModule((__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3) ? "collections.abc" : "collections"));
         if (unlikely(!module)) {
             PyErr_WriteUnraisable(NULL);
             if (unlikely(PyErr_WarnEx(PyExc_RuntimeWarning,
-                    ((PY_MAJOR_VERSION >= 3) ?
+                    (__PYX_CONST_CONDITION(PY_MAJOR_VERSION >= 3) ?
                         "Cython module failed to register with collections.abc module" :
                         "Cython module failed to register with collections module"), 1) < 0)) {
                 return -1;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -307,6 +307,12 @@
   #define __has_cpp_attribute(x) 0
 #endif
 
+/* This macro can be used to suppress warnings about constant conditional expressions */
+#ifndef __PYX_CONST_CONDITION
+  static int __Pyx_const_condition(int b) { return b; }
+  #define __PYX_CONST_CONDITION(CONDITION) __Pyx_const_condition((int)(CONDITION))
+#endif
+
 // restrict
 #ifndef CYTHON_RESTRICT
   #if defined(__GNUC__)

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2074,13 +2074,13 @@ static CYTHON_INLINE PyObject* __Pyx_CallUnboundCMethod1(__Pyx_CachedCFunction* 
         // Not using #ifdefs for PY_VERSION_HEX to avoid C compiler warnings about unused functions.
         if (flag == METH_O) {
             return (*(cfunc->func))(self, arg);
-        } else if ((PY_VERSION_HEX >= 0x030600B1) && flag == METH_FASTCALL) {
-            if ((PY_VERSION_HEX >= 0x030700A0)) {
+        } else if (__PYX_CONST_CONDITION(PY_VERSION_HEX >= 0x030600B1) && flag == METH_FASTCALL) {
+            if (__PYX_CONST_CONDITION(PY_VERSION_HEX >= 0x030700A0)) {
                 return (*(__Pyx_PyCFunctionFast)(void*)(PyCFunction)cfunc->func)(self, &arg, 1);
             } else {
                 return (*(__Pyx_PyCFunctionFastWithKeywords)(void*)(PyCFunction)cfunc->func)(self, &arg, 1, NULL);
             }
-        } else if ((PY_VERSION_HEX >= 0x030700A0) && flag == (METH_FASTCALL | METH_KEYWORDS)) {
+        } else if (__PYX_CONST_CONDITION(PY_VERSION_HEX >= 0x030700A0 && flag == (METH_FASTCALL | METH_KEYWORDS))) {
             return (*(__Pyx_PyCFunctionFastWithKeywords)(void*)(PyCFunction)cfunc->func)(self, &arg, 1, NULL);
         }
     }

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -335,7 +335,7 @@ if (unlikely(__Pyx_check_sane_{{NAME}}())) {
 /////////////// SizeCheck.proto ///////////////
 
 static int __Pyx_check_sane_{{NAME}}(void) {
-    if (((sizeof({{TYPE}}) <= sizeof(int)) ||
+    if (__PYX_CONST_CONDITION((sizeof({{TYPE}}) <= sizeof(int)) ||
 #ifdef HAVE_LONG_LONG
             (sizeof({{TYPE}}) == sizeof(PY_LONG_LONG)) ||
 #endif
@@ -356,27 +356,27 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
 /////////////// Binop ///////////////
 
 static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}} a, {{TYPE}} b, int *overflow) {
-    if ((sizeof({{TYPE}}) < sizeof(int))) {
+    if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) < sizeof(int))) {
         return __Pyx_{{BINOP}}_no_overflow(a, b, overflow);
     } else if (__PYX_IS_UNSIGNED({{TYPE}})) {
-        if ((sizeof({{TYPE}}) == sizeof(unsigned int))) {
+        if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(unsigned int))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_unsigned_int_checking_overflow(a, b, overflow);
-        } else if ((sizeof({{TYPE}}) == sizeof(unsigned long))) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(unsigned long))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_unsigned_long_checking_overflow(a, b, overflow);
 #ifdef HAVE_LONG_LONG
-        } else if ((sizeof({{TYPE}}) == sizeof(unsigned PY_LONG_LONG))) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(unsigned PY_LONG_LONG))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_unsigned_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {
             abort(); return 0; /* handled elsewhere */
         }
     } else {
-        if ((sizeof({{TYPE}}) == sizeof(int))) {
+        if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(int))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_int_checking_overflow(a, b, overflow);
-        } else if ((sizeof({{TYPE}}) == sizeof(long))) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(long))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_long_checking_overflow(a, b, overflow);
 #ifdef HAVE_LONG_LONG
-        } else if ((sizeof({{TYPE}}) == sizeof(PY_LONG_LONG))) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) == sizeof(PY_LONG_LONG))) {
             return ({{TYPE}}) __Pyx_{{BINOP}}_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -397,7 +397,7 @@ static CYTHON_INLINE Py_ssize_t __Pyx_PyIndex_AsSsize_t(PyObject* b) {
   PyObject *x;
 #if PY_MAJOR_VERSION < 3
   if (likely(PyInt_CheckExact(b))) {
-    if (sizeof(Py_ssize_t) >= sizeof(long))
+    if (__PYX_CONST_CONDITION(sizeof(Py_ssize_t) >= sizeof(long)))
         return PyInt_AS_LONG(b);
     else
         return PyInt_AsSsize_t(b);
@@ -417,7 +417,7 @@ static CYTHON_INLINE Py_ssize_t __Pyx_PyIndex_AsSsize_t(PyObject* b) {
          {{for _size in (2, 3, 4)}}
          {{for _case in (_size, -_size)}}
          case {{_case}}:
-           if (8 * sizeof(Py_ssize_t) > {{_size}} * PyLong_SHIFT) {
+           if (__PYX_CONST_CONDITION(8 * sizeof(Py_ssize_t) > {{_size}} * PyLong_SHIFT)) {
              return {{'-' if _case < 0 else ''}}(Py_ssize_t) {{pylong_join(_size, 'digits', 'size_t')}};
            }
            break;
@@ -437,7 +437,7 @@ static CYTHON_INLINE Py_ssize_t __Pyx_PyIndex_AsSsize_t(PyObject* b) {
 
 
 static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject* o) {
-  if (sizeof(Py_hash_t) == sizeof(Py_ssize_t)) {
+  if (__PYX_CONST_CONDITION(sizeof(Py_hash_t) == sizeof(Py_ssize_t))) {
     return (Py_hash_t) __Pyx_PyIndex_AsSsize_t(o);
 #if PY_MAJOR_VERSION < 3
   } else if (likely(PyInt_CheckExact(o))) {
@@ -724,20 +724,20 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
 #endif
     const int is_unsigned = neg_one > const_zero;
     if (is_unsigned) {
-        if (sizeof({{TYPE}}) < sizeof(long)) {
+        if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) < sizeof(long))) {
             return PyInt_FromLong((long) value);
-        } else if (sizeof({{TYPE}}) <= sizeof(unsigned long)) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(unsigned long))) {
             return PyLong_FromUnsignedLong((unsigned long) value);
 #ifdef HAVE_LONG_LONG
-        } else if (sizeof({{TYPE}}) <= sizeof(unsigned PY_LONG_LONG)) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(unsigned PY_LONG_LONG))) {
             return PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG) value);
 #endif
         }
     } else {
-        if (sizeof({{TYPE}}) <= sizeof(long)) {
+        if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(long))) {
             return PyInt_FromLong((long) value);
 #ifdef HAVE_LONG_LONG
-        } else if (sizeof({{TYPE}}) <= sizeof(PY_LONG_LONG)) {
+        } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(PY_LONG_LONG))) {
             return PyLong_FromLongLong((PY_LONG_LONG) value);
 #endif
         }
@@ -914,12 +914,12 @@ static CYTHON_INLINE PyObject* __Pyx_PyInt_FromDouble(double value) {
 #define __PYX__VERIFY_RETURN_INT(target_type, func_type, func_value, exc) \
     {                                                                     \
         func_type value = func_value;                                     \
-        if (sizeof(target_type) < sizeof(func_type)) {                    \
-            if (unlikely(value != (func_type) (target_type) value)) {     \
-                func_type zero = 0;                                       \
-                if (exc && unlikely(value == (func_type)-1 && PyErr_Occurred()))  \
+        if (__PYX_CONST_CONDITION(sizeof(target_type) < sizeof(func_type))) {  \
+            if (unlikely(__PYX_CONST_CONDITION(value != (func_type) (target_type) value))) { \
+                func_type zero = 0;\
+                if (__PYX_CONST_CONDITION(exc) && unlikely(value == (func_type)-1 && PyErr_Occurred()))  \
                     return (target_type) -1;                              \
-                if (is_unsigned && unlikely(value < zero))                \
+                if (__PYX_CONST_CONDITION(is_unsigned && unlikely(value < zero))) \
                     goto raise_neg_overflow;                              \
                 else                                                      \
                     goto raise_overflow;                                  \
@@ -951,7 +951,7 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
     const int is_unsigned = neg_one > const_zero;
 #if PY_MAJOR_VERSION < 3
     if (likely(PyInt_Check(x))) {
-        if ((sizeof({{TYPE}}) < sizeof(long))) {
+        if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) < sizeof(long))) {
             __PYX_VERIFY_RETURN_INT({{TYPE}}, long, PyInt_AS_LONG(x))
         } else {
             long val = PyInt_AS_LONG(x);
@@ -971,10 +971,10 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
                 case  1: __PYX_VERIFY_RETURN_INT({{TYPE}}, digit, digits[0])
                 {{for _size in (2, 3, 4)}}
                 case {{_size}}:
-                    if ((8 * sizeof({{TYPE}}) > {{_size-1}} * PyLong_SHIFT)) {
-                        if ((8 * sizeof(unsigned long) > {{_size}} * PyLong_SHIFT)) {
+                    if (__PYX_CONST_CONDITION(8 * sizeof({{TYPE}}) > {{_size-1}} * PyLong_SHIFT)) {
+                        if (__PYX_CONST_CONDITION(8 * sizeof(unsigned long) > {{_size}} * PyLong_SHIFT)) {
                             __PYX_VERIFY_RETURN_INT({{TYPE}}, unsigned long, {{pylong_join(_size, 'digits')}})
-                        } else if ((8 * sizeof({{TYPE}}) >= {{_size}} * PyLong_SHIFT)) {
+                        } else if (__PYX_CONST_CONDITION(8 * sizeof({{TYPE}}) >= {{_size}} * PyLong_SHIFT)) {
                             return ({{TYPE}}) {{pylong_join(_size, 'digits', TYPE)}};
                         }
                     }
@@ -996,10 +996,10 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
                     goto raise_neg_overflow;
             }
 #endif
-            if ((sizeof({{TYPE}}) <= sizeof(unsigned long))) {
+            if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(unsigned long))) {
                 __PYX_VERIFY_RETURN_INT_EXC({{TYPE}}, unsigned long, PyLong_AsUnsignedLong(x))
 #ifdef HAVE_LONG_LONG
-            } else if ((sizeof({{TYPE}}) <= sizeof(unsigned PY_LONG_LONG))) {
+            } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(unsigned PY_LONG_LONG))) {
                 __PYX_VERIFY_RETURN_INT_EXC({{TYPE}}, unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong(x))
 #endif
             }
@@ -1014,10 +1014,10 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
                 {{for _size in (2, 3, 4)}}
                 {{for _case in (-_size, _size)}}
                 case {{_case}}:
-                    if ((8 * sizeof({{TYPE}}){{' - 1' if _case < 0 else ''}} > {{_size-1}} * PyLong_SHIFT)) {
-                        if ((8 * sizeof(unsigned long) > {{_size}} * PyLong_SHIFT)) {
+                    if (__PYX_CONST_CONDITION(8 * sizeof({{TYPE}}){{' - 1' if _case < 0 else ''}} > {{_size-1}} * PyLong_SHIFT)) {
+                        if (__PYX_CONST_CONDITION(8 * sizeof(unsigned long) > {{_size}} * PyLong_SHIFT)) {
                             __PYX_VERIFY_RETURN_INT({{TYPE}}, {{'long' if _case < 0 else 'unsigned long'}}, {{'-(long) ' if _case < 0 else ''}}{{pylong_join(_size, 'digits')}})
-                        } else if ((8 * sizeof({{TYPE}}) - 1 > {{_size}} * PyLong_SHIFT)) {
+                        } else if (__PYX_CONST_CONDITION(8 * sizeof({{TYPE}}) - 1 > {{_size}} * PyLong_SHIFT)) {
                             return ({{TYPE}}) ({{'((%s)-1)*' % TYPE if _case < 0 else ''}}{{pylong_join(_size, 'digits', TYPE)}});
                         }
                     }
@@ -1026,10 +1026,10 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
                 {{endfor}}
             }
 #endif
-            if ((sizeof({{TYPE}}) <= sizeof(long))) {
+            if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(long))) {
                 __PYX_VERIFY_RETURN_INT_EXC({{TYPE}}, long, PyLong_AsLong(x))
 #ifdef HAVE_LONG_LONG
-            } else if ((sizeof({{TYPE}}) <= sizeof(PY_LONG_LONG))) {
+            } else if (__PYX_CONST_CONDITION(sizeof({{TYPE}}) <= sizeof(PY_LONG_LONG))) {
                 __PYX_VERIFY_RETURN_INT_EXC({{TYPE}}, PY_LONG_LONG, PyLong_AsLongLong(x))
 #endif
             }


### PR DESCRIPTION
This resolves all occurrences of the msvc warning `C4127: conditional expression is constant` I could find.