### PR TITLE
Workaround for missing tstate->use_tracing in Python 3.10

### DIFF
--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -33,6 +33,12 @@
   #define CYTHON_PROFILE_REUSE_FRAME 0
 #endif
 
+#if PY_VERSION_HEX < 0x031000B1
+  #define __Pyx_tstate_use_tracing  tstate->use_tracing
+#else
+  #define __Pyx_tstate_use_tracing  tstate->cframe->use_tracing
+#endif
+
 #if CYTHON_PROFILE || CYTHON_TRACE
 
   #include "compile.h"
@@ -50,7 +56,7 @@
   #define __Pyx_TraceDeclarations                                     \
   static PyCodeObject *$frame_code_cname = NULL;                      \
   CYTHON_FRAME_MODIFIER PyFrameObject *$frame_cname = NULL;           \
-  int __Pyx_use_tracing = 0;
+  int __Pyx_tstate_use_tracing = 0;
 
   #define __Pyx_TraceFrameInit(codeobj)                               \
   if (codeobj) $frame_code_cname = (PyCodeObject*) codeobj;
@@ -62,39 +68,39 @@
           PyThreadState *tstate;                                                         \
           PyGILState_STATE state = PyGILState_Ensure();                                  \
           tstate = __Pyx_PyThreadState_Current;                                          \
-          if (unlikely(tstate->use_tracing) && !tstate->tracing &&                       \
+          if (unlikely(__Pyx_tstate_use_tracing) && !tstate->tracing &&                       \
                   (tstate->c_profilefunc || (CYTHON_TRACE && tstate->c_tracefunc))) {    \
-              __Pyx_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
+              __Pyx_tstate_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
           }                                                                              \
           PyGILState_Release(state);                                                     \
-          if (unlikely(__Pyx_use_tracing < 0)) goto_error;                               \
+          if (unlikely(__Pyx_tstate_use_tracing < 0)) goto_error;                               \
       }                                                                                  \
   } else {                                                                               \
       PyThreadState* tstate = PyThreadState_GET();                                       \
-      if (unlikely(tstate->use_tracing) && !tstate->tracing &&                           \
+      if (unlikely(__Pyx_tstate_use_tracing) && !tstate->tracing &&                           \
               (tstate->c_profilefunc || (CYTHON_TRACE && tstate->c_tracefunc))) {        \
-          __Pyx_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
-          if (unlikely(__Pyx_use_tracing < 0)) goto_error;                               \
+          __Pyx_tstate_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
+          if (unlikely(__Pyx_tstate_use_tracing < 0)) goto_error;                               \
       }                                                                                  \
   }
   #else
   #define __Pyx_TraceCall(funcname, srcfile, firstlineno, nogil, goto_error)             \
   {   PyThreadState* tstate = PyThreadState_GET();                                       \
-      if (unlikely(tstate->use_tracing) && !tstate->tracing &&                           \
+      if (unlikely(__Pyx_tstate_use_tracing) && !tstate->tracing &&                           \
               (tstate->c_profilefunc || (CYTHON_TRACE && tstate->c_tracefunc))) {        \
-          __Pyx_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
-          if (unlikely(__Pyx_use_tracing < 0)) goto_error;                               \
+          __Pyx_tstate_use_tracing = __Pyx_TraceSetupAndCall(&$frame_code_cname, &$frame_cname, tstate, funcname, srcfile, firstlineno);  \
+          if (unlikely(__Pyx_tstate_use_tracing < 0)) goto_error;                               \
       }                                                                                  \
   }
   #endif
 
   #define __Pyx_TraceException()                                                           \
-  if (likely(!__Pyx_use_tracing)); else {                                                  \
+  if (likely(!__Pyx_tstate_use_tracing)); else {                                                  \
       PyThreadState* tstate = __Pyx_PyThreadState_Current;                                 \
-      if (tstate->use_tracing &&                                                           \
+      if (__Pyx_tstate_use_tracing &&                                                           \
               (tstate->c_profilefunc || (CYTHON_TRACE && tstate->c_tracefunc))) {          \
           tstate->tracing++;                                                               \
-          tstate->use_tracing = 0;                                                         \
+          __Pyx_tstate_use_tracing = 0;                                                         \
           PyObject *exc_info = __Pyx_GetExceptionTuple(tstate);                            \
           if (exc_info) {                                                                  \
               if (CYTHON_TRACE && tstate->c_tracefunc)                                     \
@@ -104,7 +110,7 @@
                   tstate->c_profileobj, $frame_cname, PyTrace_EXCEPTION, exc_info);        \
               Py_DECREF(exc_info);                                                         \
           }                                                                                \
-          tstate->use_tracing = 1;                                                         \
+          __Pyx_tstate_use_tracing = 1;                                                         \
           tstate->tracing--;                                                               \
       }                                                                                    \
   }
@@ -113,42 +119,42 @@
       PyObject *type, *value, *traceback;
       __Pyx_ErrFetchInState(tstate, &type, &value, &traceback);
       tstate->tracing++;
-      tstate->use_tracing = 0;
+      __Pyx_tstate_use_tracing = 0;
       if (CYTHON_TRACE && tstate->c_tracefunc)
           tstate->c_tracefunc(tstate->c_traceobj, frame, PyTrace_RETURN, result);
       if (tstate->c_profilefunc)
           tstate->c_profilefunc(tstate->c_profileobj, frame, PyTrace_RETURN, result);
       CYTHON_FRAME_DEL(frame);
-      tstate->use_tracing = 1;
+      __Pyx_tstate_use_tracing = 1;
       tstate->tracing--;
       __Pyx_ErrRestoreInState(tstate, type, value, traceback);
   }
 
   #ifdef WITH_THREAD
   #define __Pyx_TraceReturn(result, nogil)                                                \
-  if (likely(!__Pyx_use_tracing)); else {                                                 \
+  if (likely(!__Pyx_tstate_use_tracing)); else {                                                 \
       if (nogil) {                                                                        \
           if (CYTHON_TRACE_NOGIL) {                                                       \
               PyThreadState *tstate;                                                      \
               PyGILState_STATE state = PyGILState_Ensure();                               \
               tstate = __Pyx_PyThreadState_Current;                                       \
-              if (tstate->use_tracing) {                                                  \
+              if (__Pyx_tstate_use_tracing) {                                                  \
                   __Pyx_call_return_trace_func(tstate, $frame_cname, (PyObject*)result);  \
               }                                                                           \
               PyGILState_Release(state);                                                  \
           }                                                                               \
       } else {                                                                            \
           PyThreadState* tstate = __Pyx_PyThreadState_Current;                            \
-          if (tstate->use_tracing) {                                                      \
+          if (__Pyx_tstate_use_tracing) {                                                      \
               __Pyx_call_return_trace_func(tstate, $frame_cname, (PyObject*)result);      \
           }                                                                               \
       }                                                                                   \
   }
   #else
   #define __Pyx_TraceReturn(result, nogil)                                                \
-  if (likely(!__Pyx_use_tracing)); else {                                                 \
+  if (likely(!__Pyx_tstate_use_tracing)); else {                                                 \
       PyThreadState* tstate = __Pyx_PyThreadState_Current;                                \
-      if (tstate->use_tracing) {                                                          \
+      if (__Pyx_tstate_use_tracing) {                                                          \
           __Pyx_call_return_trace_func(tstate, $frame_cname, (PyObject*)result);          \
       }                                                                                   \
   }
@@ -176,9 +182,9 @@
       __Pyx_ErrFetchInState(tstate, &type, &value, &traceback);
       __Pyx_PyFrame_SetLineNumber(frame, lineno);
       tstate->tracing++;
-      tstate->use_tracing = 0;
+      __Pyx_tstate_use_tracing = 0;
       ret = tstate->c_tracefunc(tstate->c_traceobj, frame, PyTrace_LINE, NULL);
-      tstate->use_tracing = 1;
+      __Pyx_tstate_use_tracing = 1;
       tstate->tracing--;
       if (likely(!ret)) {
           __Pyx_ErrRestoreInState(tstate, type, value, traceback);
@@ -192,14 +198,14 @@
 
   #ifdef WITH_THREAD
   #define __Pyx_TraceLine(lineno, nogil, goto_error)                                       \
-  if (likely(!__Pyx_use_tracing)); else {                                                  \
+  if (likely(!__Pyx_tstate_use_tracing)); else {                                                  \
       if (nogil) {                                                                         \
           if (CYTHON_TRACE_NOGIL) {                                                        \
               int ret = 0;                                                                 \
               PyThreadState *tstate;                                                       \
               PyGILState_STATE state = PyGILState_Ensure();                                \
               tstate = __Pyx_PyThreadState_Current;                                        \
-              if (unlikely(tstate->use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
+              if (unlikely(__Pyx_tstate_use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
                   ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);          \
               }                                                                            \
               PyGILState_Release(state);                                                   \
@@ -207,7 +213,7 @@
           }                                                                                \
       } else {                                                                             \
           PyThreadState* tstate = __Pyx_PyThreadState_Current;                             \
-          if (unlikely(tstate->use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
+          if (unlikely(__Pyx_tstate_use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
               int ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);          \
               if (unlikely(ret)) goto_error;                                               \
           }                                                                                \
@@ -215,9 +221,9 @@
   }
   #else
   #define __Pyx_TraceLine(lineno, nogil, goto_error)                                       \
-  if (likely(!__Pyx_use_tracing)); else {                                                  \
+  if (likely(!__Pyx_tstate_use_tracing)); else {                                                  \
       PyThreadState* tstate = __Pyx_PyThreadState_Current;                                 \
-      if (unlikely(tstate->use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
+      if (unlikely(__Pyx_tstate_use_tracing && tstate->c_tracefunc && $frame_cname->f_trace)) { \
           int ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);              \
           if (unlikely(ret)) goto_error;                                                   \
       }                                                                                    \
@@ -266,7 +272,7 @@ static int __Pyx_TraceSetupAndCall(PyCodeObject** code,
       __Pyx_PyFrame_SetLineNumber(*frame, firstlineno);
     retval = 1;
     tstate->tracing++;
-    tstate->use_tracing = 0;
+    __Pyx_tstate_use_tracing = 0;
     __Pyx_ErrFetchInState(tstate, &type, &value, &traceback);
     #if CYTHON_TRACE
     if (tstate->c_tracefunc)
@@ -274,12 +280,12 @@ static int __Pyx_TraceSetupAndCall(PyCodeObject** code,
     if (retval && tstate->c_profilefunc)
     #endif
         retval = tstate->c_profilefunc(tstate->c_profileobj, *frame, PyTrace_CALL, NULL) == 0;
-    tstate->use_tracing = (tstate->c_profilefunc ||
+    __Pyx_tstate_use_tracing = (tstate->c_profilefunc ||
                            (CYTHON_TRACE && tstate->c_tracefunc));
     tstate->tracing--;
     if (retval) {
         __Pyx_ErrRestoreInState(tstate, type, value, traceback);
-        return tstate->use_tracing && retval;
+        return __Pyx_tstate_use_tracing && retval;
     } else {
         Py_XDECREF(type);
         Py_XDECREF(value);


### PR DESCRIPTION
Related to https://github.com/cython/cython/issues/4153

I'm testing this in Fedora right now. Will report back.

Since I consider this a temporary workaround until proper API is defined, I've opened this PR directly to 0.29.x. 3.x can get a proper fix.