### PR TITLE
Fix reference counting in cyfunction.is_coroutine

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -366,6 +366,7 @@ __Pyx_CyFunction_get_is_coroutine(__pyx_CyFunctionObject *op, CYTHON_UNUSED void
 #if PY_VERSION_HEX >= 0x03050000
     if (is_coroutine) {
         PyObject *module, *fromlist, *marker = PYIDENT("_is_coroutine");
+        Py_INCREF(marker);
         fromlist = PyList_New(1);
         if (unlikely(!fromlist)) return NULL;
         PyList_SET_ITEM(fromlist, 0, marker);


### PR DESCRIPTION
I haven't created a test for this since the timing of the
segmentation fault isn't 100% reliable on my PC (so it's hard
to make a reproducible failure) and you can't easily get to
Cython's cached "marker" to check the reference counts. Happy
to create a test with a good way of doing so

Fixes https://github.com/cython/cython/issues/4182