### PR TITLE
[ENH] Add operator= to shared_ptr for assignments to base classes

### DIFF
--- a/Cython/Includes/libcpp/memory.pxd
+++ b/Cython/Includes/libcpp/memory.pxd
@@ -59,6 +59,7 @@ cdef extern from "<memory>" namespace "std" nogil:
         shared_ptr(shared_ptr[T]&, T*)
         shared_ptr(unique_ptr[T]&)
         #shared_ptr(weak_ptr[T]&) # Not Supported
+        T& operator=[Y](const shared_ptr[Y]& ptr)
 
         # Modifiers
         void reset()

--- a/Cython/Includes/libcpp/memory.pxd
+++ b/Cython/Includes/libcpp/memory.pxd
@@ -59,7 +59,7 @@ cdef extern from "<memory>" namespace "std" nogil:
         shared_ptr(shared_ptr[T]&, T*)
         shared_ptr(unique_ptr[T]&)
         #shared_ptr(weak_ptr[T]&) # Not Supported
-        T& operator=[Y](const shared_ptr[Y]& ptr)
+        shared_ptr[T]& operator=[Y](const shared_ptr[Y]& ptr)
 
         # Modifiers
         void reset()

--- a/tests/run/cpp_smart_ptr.pyx
+++ b/tests/run/cpp_smart_ptr.pyx
@@ -81,6 +81,15 @@ cdef cppclass C(B):
 
 cdef shared_ptr[A] holding_subclass = shared_ptr[A](new C())
 
+
+def test_assignment_to_base_class():
+    """
+    >>> test_assignment_to_base_class()
+    """
+    cdef shared_ptr[C] derived = shared_ptr[C](new C())
+    cdef shared_ptr[A] base = derived
+
+
 def test_dynamic_pointer_cast():
     """
     >>> test_dynamic_pointer_cast()


### PR DESCRIPTION
As discussed in [this StackOverflow answer](https://stackoverflow.com/a/67631211/5085211), having the `operator=` around enables us to assign `shared_ptr[Derived]` to `shared_ptr[Base]`.

Now admittedly, as the question will suggest, I'm new to C++ Cython and in particular I would be unable to see what pitfalls this might have, but it does work as intended in my particular use case.