### PR TITLE
fix move on msvc

### DIFF
--- a/Cython/Includes/libcpp/utility.pxd
+++ b/Cython/Includes/libcpp/utility.pxd
@@ -17,6 +17,7 @@ cdef extern from "<utility>" namespace "std" nogil:
 cdef extern from * namespace "cython_std" nogil:
     """
     #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
+    // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
     #include <type_traits>
 
     namespace cython_std {

--- a/Cython/Includes/libcpp/utility.pxd
+++ b/Cython/Includes/libcpp/utility.pxd
@@ -16,7 +16,7 @@ cdef extern from "<utility>" namespace "std" nogil:
 
 cdef extern from * namespace "cython_std" nogil:
     """
-    #if __cplusplus > 199711L
+    #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
     #include <type_traits>
 
     namespace cython_std {


### PR DESCRIPTION
@scoder this works around the broken __cplusplus macro in msvc (https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)

The same issue was fixed for the `__PYX_STD_MOVE_IF_SUPPORTED` macro here: https://github.com/cython/cython/pull/3792
