### PR TITLE
Revert "optimize enumerate with start argument"

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -980,7 +980,7 @@ class ControlFlowAnalysis(CythonTransform):
                 if not entry or entry.is_builtin:
                     if function.name == 'reversed' and len(sequence.args) == 1:
                         sequence = sequence.args[0]
-                    elif function.name == 'enumerate' and len(sequence.args) in (1, 2):
+                    elif function.name == 'enumerate' and len(sequence.args) == 1:
                         if target.is_sequence_constructor and len(target.args) == 2:
                             iterator = sequence.args[0]
                             if iterator.is_name:
@@ -1016,11 +1016,7 @@ class ControlFlowAnalysis(CythonTransform):
             # Python strings, etc., while correctly falling back to an
             # object type when the base type cannot be handled.
 
-            self.mark_assignment(target, ExprNodes.IndexNode(
-                node.pos,
-                base=sequence,
-                index=ExprNodes.IntNode(target.pos, value='PY_SSIZE_T_MAX',
-                                        type=PyrexTypes.c_py_ssize_t_type)))
+            self.mark_assignment(target, node.item)
 
     def visit_AsyncForStatNode(self, node):
         return self.visit_ForInStatNode(node)

--- a/Cython/Compiler/TypeInference.py
+++ b/Cython/Compiler/TypeInference.py
@@ -111,7 +111,7 @@ class MarkParallelAssignments(EnvTransform):
                 if not entry or entry.is_builtin:
                     if function.name == 'reversed' and len(sequence.args) == 1:
                         sequence = sequence.args[0]
-                    elif function.name == 'enumerate' and len(sequence.args) in (1, 2):
+                    elif function.name == 'enumerate' and len(sequence.args) == 1:
                         if target.is_sequence_constructor and len(target.args) == 2:
                             iterator = sequence.args[0]
                             if iterator.is_name:

--- a/tests/run/for_in_string.pyx
+++ b/tests/run/for_in_string.pyx
@@ -1,6 +1,4 @@
-from __future__ import print_function
 cimport cython
-from cython cimport typeof
 
 bytes_abc = b'abc'
 bytes_ABC = b'ABC'
@@ -221,30 +219,6 @@ def for_pyucs4_in_enumerate_unicode(unicode s):
     """
     cdef Py_UCS4 c
     cdef Py_ssize_t i
-    for i, c in enumerate(s):
-        if c == u'C':
-            return i
-    else:
-        return 'X'
-
-@cython.test_assert_path_exists("//ForFromStatNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
-def for_infered_type_in_enumerate_unicode(unicode s):
-    """
-    >>> for_infered_type_in_enumerate_unicode(unicode_abc)
-    Py_ssize_t Py_UCS4
-    'X'
-    >>> for_infered_type_in_enumerate_unicode(unicode_ABC)
-    Py_ssize_t Py_UCS4
-    2
-    >>> for_infered_type_in_enumerate_unicode(unicode_abc_null)
-    Py_ssize_t Py_UCS4
-    'X'
-    >>> for_infered_type_in_enumerate_unicode(unicode_ABC_null)
-    Py_ssize_t Py_UCS4
-    4
-    """
-    print(typeof(i), typeof(c))
     for i, c in enumerate(s):
         if c == u'C':
             return i


### PR DESCRIPTION
This broke C++ map iteration code, which needs a better fix.
See https://github.com/cython/cython/issues/4171
Reverts https://github.com/cython/cython/pull/4077