### PR TITLE
Use distutils in duplicate_utilitycode test

### DIFF
--- a/tests/run/duplicate_utilitycode_from_pyx.srctree
+++ b/tests/run/duplicate_utilitycode_from_pyx.srctree
@@ -17,7 +17,7 @@ cdef class ClassB(ClassA):
 
 ###################### setup.py ###################
 
-from setuptools import setup
+from distutils.core import setup
 from Cython.Build import cythonize
 import Cython.Compiler.Options
 


### PR DESCRIPTION
See https://github.com/conda-forge/cython-feedstock/pull/75#issuecomment-848521485
Avoids unneeded dependency of setuptools for the testsuite