### PR TITLE
DOC: add documentation for total_ordering

### DIFF
--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -165,14 +165,14 @@ which always take `self` as the first argument.
 Rich comparisons
 -----------------
 
-There are two ways to implement comparison methods.
+There are a few ways to implement comparison methods.
 Depending on the application, one way or the other may be better:
 
-* The first way uses the 6 Python
+* Use the 6 Python
   `special methods <https://docs.python.org/3/reference/datamodel.html#basic-customization>`_
   :meth:`__eq__`, :meth:`__lt__`, etc.
   This is new since Cython 0.27 and works exactly as in plain Python classes.
-* The second way uses a single special method :meth:`__richcmp__`.
+* Use a single special method :meth:`__richcmp__`.
   This implements all rich comparison operations in one method.
   The signature is ``def __richcmp__(self, other, int op)``.
   The integer argument ``op`` indicates which operation is to be performed
@@ -193,6 +193,18 @@ Depending on the application, one way or the other may be better:
   +-----+-------+
 
   These constants can be cimported from the ``cpython.object`` module.
+
+* Use a ``cython.total_ordering`` decorator, which is a re-implementation of
+  the `functools.total_ordering
+  <https://docs.python.org/3/library/functools.html#functools.total_ordering>`_
+  decorator. It can only be used on a ``cdef`` class:
+
+  .. code-block:: cython
+
+    @cython.total_ordering
+    cdef class ExtGe:
+        def __ge__(self, other):
+            return False
 
 .. _the__next__method:
 

--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -203,8 +203,15 @@ Depending on the application, one way or the other may be better:
 
     @cython.total_ordering
     cdef class ExtGe:
+        cdef int x
+
         def __ge__(self, other):
-            return False
+            if not isinstance(other, ExtGe):
+                return NotImplemented
+            return self.x >= (<ExtGe>other).x
+
+        def __eq__(self, other):
+            return isinstance(other, ExtGe) and self.x == (<ExtGe>other).x
 
 .. _the__next__method:
 


### PR DESCRIPTION
Continuation of #3626, closes #2090

I couldn't figure out how to make the intersphinx label work. According to https://webknjaz.github.io/intersphinx-untangled/docs.python.org/, which I found via sphinx-doc/sphinx#6659, 
```
:py:function:`functools.total_ordering` 
```

should have worked but it didn't. :shrug: 