### PR TITLE
Don't let Py-class annotations set a type

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1996,6 +1996,9 @@ class NameNode(AtomicExprNode):
                 or not env.directives['annotation_typing']
             ):
                 atype = None
+            elif env.is_py_class_scope:
+                # For Python class scopes every attribute is a Python object
+                atype = py_object_type
             else:
                 _, atype = annotation.analyse_type_annotation(env)
             if atype is None:

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -165,7 +165,6 @@ _WARNINGS = """
 37:19: Unknown type declaration in annotation, ignoring
 38:12: Unknown type declaration in annotation, ignoring
 39:18: Unknown type declaration in annotation, ignoring
-57:19: Unknown type declaration in annotation, ignoring
 73:11: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
 73:19: Unknown type declaration in annotation, ignoring
 # FIXME: these are sort-of evaluated now, so the warning is misleading

--- a/tests/run/pyclass_annotations_pep526.py
+++ b/tests/run/pyclass_annotations_pep526.py
@@ -11,6 +11,8 @@ try:
 except ImportError:  # Py<=3.5
     ClassVar = {int: int}
 
+class NotAStr:
+    pass
 
 class PyAnnotatedClass:
     """
@@ -38,6 +40,9 @@ class PyAnnotatedClass:
     literal: "int"
     recurse: "PyAnnotatedClass"
     default: bool = False
+    # https://github.com/cython/cython/issues/4196 and https://github.com/cython/cython/issues/4198
+    not_object: float = 0.1  # Shouldn't try to create a c attribute
+    lie_about_type: str = NotAStr  # Shouldn't generate a runtime type-check
 
 
 class PyVanillaClass:


### PR DESCRIPTION
Fixes #4198 and #4196