### PR TITLE
remove unreachable warning in old_build_ext

### DIFF
--- a/Cython/Distutils/old_build_ext.py
+++ b/Cython/Distutils/old_build_ext.py
@@ -8,7 +8,6 @@ Note that this module is deprecated.  Use cythonize() instead.
 
 __revision__ = "$Id:$"
 
-import inspect
 import sys
 import os
 from distutils.errors import DistutilsPlatformError
@@ -16,32 +15,11 @@ from distutils.dep_util import newer, newer_group
 from distutils import log
 from distutils.command import build_ext as _build_ext
 from distutils import sysconfig
-import warnings
-
 
 try:
     from __builtin__ import basestring
 except ImportError:
     basestring = str
-
-
-def _check_stack(path):
-    try:
-        for frame in inspect.getouterframes(inspect.currentframe(), 0):
-            if path in frame[1].replace(os.sep, '/'):
-                return True
-    except Exception:
-        pass
-    return False
-
-
-if (not _check_stack('setuptools/extensions.py')
-        and not _check_stack('pyximport/pyxbuild.py')
-        and not _check_stack('Cython/Distutils/build_ext.py')):
-    warnings.warn(
-        "Cython.Distutils.old_build_ext does not properly handle dependencies "
-        "and is deprecated.")
-
 
 extension_name_re = _build_ext.extension_name_re
 


### PR DESCRIPTION
this warning is impossible because `Cython.Distutils` imports
`Cython.Distutils.build_ext` which in turn imports
`Cython.Distutils.old_build_ext` and the warning does not fire when
`Cython.Distutils.build_ext` is in the parent stack frames.

I found this particular piece of code to be contributing almost 5%
of the startup cost of an application I contribute to.  The problem is
due to the use of `inspect.getouterframes(...)`.  This eventually calls
`inspect.getmodule` which does a `sys.modules.copy()` which is very slow
for lots of modules.

Here's an example piece of code which demonstrates the performance issue:

```bash
set -euxo pipefail

rm -rf foo tmpvenv out.svg

virtualenv tempvenv
tempvenv/bin/pip install -e .

mkdir foo
cat > foo/__main__.py <<EOF
import pkgutil
import foo

for _, name, _ in pkgutil.iter_modules(foo.__path__, f'{foo.__name__}.'):
    __import__(name)

import Cython.Distutils
EOF

set +x
touch foo/__init__.py foo/a{0..10000}.py
set -x

time tempvenv/bin/python -m foo
```

while this seems a bit out there, there's far more than 10k modules in the
code base I was dealing with.

before my change this was taking ~5 seconds.  after my change it takes ~2.