### PR TITLE
tweak 1027db04 for older versions of PyPy

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -78,7 +78,7 @@ static PyObject* __Pyx_PyExec3(PyObject* o, PyObject* globals, PyObject* locals)
                 "code object passed to exec() may not contain free variables");
             goto bad;
         }
-        #if PY_VERSION_HEX < 0x030200B1
+        #if PY_VERSION_HEX < 0x030200B1 || (CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM < 0x07030400)
         result = PyEval_EvalCode((PyCodeObject *)o, globals, locals);
         #else
         result = PyEval_EvalCode(o, globals, locals);


### PR DESCRIPTION
In commit 1027db04fb7c5b, the qualification for PyPy was removed from this `#ifdef`. That will break pypy users for v7.3.3 and earlier (pypy v7.3.4 was released 2021-04-08). This PR replaces that commit with a more nuanced version.

xref #4234