### PR TITLE
Glossary was broken

### DIFF
--- a/docs/src/userguide/glossary.rst
+++ b/docs/src/userguide/glossary.rst
@@ -1,7 +1,7 @@
-.. glossary::
-
 Glossary
 ========
+
+.. glossary::
 
    Extension type
       "Extension type" can refer to either a Cython class defined with ``cdef class`` or more generally to any Python type that is ultimately implemented as a native C struct (including the built-in types like `int` or `dict`).

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -11,7 +11,7 @@ Overview
 
 Cython has native support for most of the C++ language.  Specifically:
 
-* C++ objects can be :term:`dynamically allocated<Dynamic allocation>` with ``new`` and ``del`` keywords.
+* C++ objects can be :term:`dynamically allocated<Dynamic allocation or Heap allocation>` with ``new`` and ``del`` keywords.
 * C++ objects can be :term:`stack-allocated<Stack allocation>`.
 * C++ classes can be declared with the new keyword ``cppclass``.
 * Templated classes and functions are supported.


### PR DESCRIPTION
It looks like putting the title between `.. glossary::` and the
entries messed it up