### PR TITLE
Allow cythonize to recompile .py file when .pxd file has changed, attempt 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,13 @@ __pycache__
 *venv*/
 
 Cython/Compiler/*.c
+Cython/Compiler/*.pyd
 Cython/Plex/*.c
+Cython/Plex/*.pyd
 Cython/Runtime/refnanny.c
+Cython/Runtime/refnanny.*.pyd
 Cython/Tempita/*.c
+Cython/Tempita/*.pyd
 Cython/*.c
 Cython/*.html
 Cython/*/*.html

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -534,7 +534,7 @@ class DependencyTree(object):
         for include in self.parse_dependencies(filename)[1]:
             include_path = join_path(os.path.dirname(filename), include)
             if not path_exists(include_path):
-                include_path = self.context.find_include_file(include, None)
+                include_path = self.context.find_include_file(include, source_file_path=filename)
             if include_path:
                 if '.' + os.path.sep in include_path:
                     include_path = os.path.normpath(include_path)
@@ -588,17 +588,18 @@ class DependencyTree(object):
                     return None   # FIXME: error?
                 module_path.pop(0)
             relative = '.'.join(package_path + module_path)
-            pxd = self.context.find_pxd_file(relative, None)
+            pxd = self.context.find_pxd_file(relative, source_file_path=filename)
             if pxd:
                 return pxd
         if is_relative:
             return None   # FIXME: error?
-        return self.context.find_pxd_file(module, None)
+        return self.context.find_pxd_file(module, source_file_path=filename)
 
     @cached_method
     def cimported_files(self, filename):
-        if filename[-4:] == '.pyx' and path_exists(filename[:-4] + '.pxd'):
-            pxd_list = [filename[:-4] + '.pxd']
+        filename_root, filename_ext = os.path.splitext(filename)
+        if filename_ext in ('.pyx', '.py') and path_exists(filename_root + '.pxd'):
+            pxd_list = [filename_root + '.pxd']
         else:
             pxd_list = []
         # Cimports generates all possible combinations package.module

--- a/Cython/Build/Tests/TestRecythonize.py
+++ b/Cython/Build/Tests/TestRecythonize.py
@@ -1,0 +1,185 @@
+import shutil
+import os
+import tempfile
+
+import Cython.Build.Dependencies
+import Cython.Utils
+from Cython.TestUtils import CythonTest
+
+
+SAME = "The result of cytonization is the same: "
+INCOR = "Incorrect cythonization: "
+
+
+# assertIn and assertNotIn are not used to validate the generated code
+# as a failure causes an unreadable mess
+class TestRecythonize(CythonTest):
+
+    def setUp(self):
+        CythonTest.setUp(self)
+        self.temp_dir = (
+            tempfile.mkdtemp(
+                prefix='recythonize-test',
+                dir='TEST_TMP' if os.path.isdir('TEST_TMP') else None
+            )
+        )
+        self.src_dir = tempfile.mkdtemp(prefix='src', dir=self.temp_dir)
+        self.dep_tree = Cython.Build.Dependencies.create_dependency_tree()
+
+    def tearDown(self):
+        CythonTest.tearDown(self)
+        shutil.rmtree(self.temp_dir)
+
+    def fresh_cythonize(self, *args, **kwargs):
+        Cython.Utils.clear_function_caches()
+        Cython.Build.Dependencies._dep_tree = None  # discard method caches
+        Cython.Build.Dependencies.cythonize(*args, **kwargs)
+        
+    def refresh_dep_tree(self):
+        Cython.Utils.clear_function_caches()
+        Cython.Utils.clear_method_caches(self.dep_tree)
+        self.dep_tree._transitive_cache.clear()
+
+    def fresh_all_dependencies(self, *args, **kwargs):
+        self.refresh_dep_tree()
+        return self.dep_tree.all_dependencies(*args, **kwargs)
+
+    def recythonize_on_pxd_change(self, ext, creating_pxd):
+        a_pxd = os.path.join(self.src_dir, 'a.pxd')  # will be changed
+        a_source = os.path.join(self.src_dir, 'a' + ext)
+        a_c = os.path.join(self.src_dir, 'a.c')  # change check
+
+        if not creating_pxd:
+            with open(a_pxd, 'w') as f:
+                f.write('cdef int x\n')
+
+        with open(a_source, 'w') as f:
+            f.write('x = 1\n')
+
+        dependencies = self.fresh_all_dependencies(a_source)
+        self.assertIn(a_source, dependencies)
+        if creating_pxd:
+            self.assertEqual(1, len(dependencies))
+        else:
+            self.assertIn(a_pxd, dependencies)
+            self.assertEqual(2, len(dependencies))
+
+        # Create a.c
+        self.fresh_cythonize(a_source)
+
+        with open(a_c) as f:
+            a_c_before = f.read()
+
+        if creating_pxd:
+            self.assertTrue("a_x = 1;" not in a_c_before,
+                            INCOR + '"a_x = 1;" in a_c_before')
+        else:
+            self.assertTrue("a_x = 1;" in a_c_before,
+                            INCOR + '"a_x = 1;" not in a_c_before')
+
+        with open(a_pxd, 'w') as f:
+            f.write('cdef float x\n')
+
+        if creating_pxd:
+            dependencies = self.fresh_all_dependencies(a_source)
+            self.assertIn(a_source, dependencies)
+            self.assertIn(a_pxd, dependencies)
+            self.assertEqual(2, len(dependencies))
+
+        # Change a.c
+        self.fresh_cythonize(a_source)
+
+        with open(a_c) as f:
+            a_c_after = f.read()
+
+        self.assertTrue("a_x = 1;" not in a_c_after,
+                        SAME + '"a_x = 1;" in a_c_after')
+        self.assertTrue("a_x = 1.0;" in a_c_after,
+                        INCOR + '"a_x = 1.0;" not in a_c_after')
+
+    # creating_pxd is not used because cimport requires pxd
+    # to import another script.
+    def recythonize_on_dep_pxd_change(self, ext_a, ext_b):
+        a_pxd = os.path.join(self.src_dir, 'a.pxd')  # will be changed
+        a_source = os.path.join(self.src_dir, 'a' + ext_a)  # dependency
+        a_c = os.path.join(self.src_dir, 'a.c')  # change check
+        b_pxd = os.path.join(self.src_dir, 'b.pxd')  # for cimport
+        b_source = os.path.join(self.src_dir, 'b' + ext_b)  # reason for change
+        b_c = os.path.join(self.src_dir, 'b.c')  # change check
+
+        with open(a_pxd, 'w') as f:
+            f.write('cdef int x\n')
+
+        with open(a_source, 'w') as f:
+            f.write('x = 1\n')
+
+        with open(b_pxd, 'w') as f:
+            f.write('cimport a\n')
+
+        with open(b_source, 'w') as f:
+            f.write('a.x = 2\n')
+
+        dependencies = self.fresh_all_dependencies(b_source)
+        self.assertIn(b_pxd, dependencies)
+        self.assertIn(b_source, dependencies)
+        self.assertIn(a_pxd, dependencies)
+        self.assertEqual(3, len(dependencies))
+
+        # Create a.c and b.c
+        self.fresh_cythonize([a_source, b_source])
+
+        with open(a_c) as f:
+            a_c_before = f.read()
+
+        with open(b_c) as f:
+            b_c_before = f.read()
+
+        self.assertTrue("a_x = 1;" in a_c_before,
+                        INCOR + '"a_x = 1;" not in a_c_before')
+        self.assertTrue("a_x = 2;" in b_c_before,
+                        INCOR + '"a_x = 2;" not in b_c_before')
+
+        with open(a_pxd, 'w') as f:
+            f.write('cdef float x\n')
+
+        # Change a.c and b.c
+        self.fresh_cythonize([a_source, b_source])
+
+        with open(a_c) as f:
+            a_c_after = f.read()
+
+        with open(b_c) as f:
+            b_c_after = f.read()
+
+        self.assertTrue("a_x = 1;" not in a_c_after,
+                        SAME + '"a_x = 1;" in file a.c')
+        self.assertTrue("a_x = 2;" not in b_c_after,
+                        SAME + '"a_x = 2;" in b_c_after')
+        self.assertTrue("a_x = 1.0;" in a_c_after,
+                        INCOR + '"a_x = 1.0;" not in a_c_after')
+        self.assertTrue("a_x = 2.0;" in b_c_after,
+                        INCOR + '"a_x = 2.0;" not in b_c_after')
+
+    def test_recythonize_py_on_pxd_change(self):
+        self.recythonize_on_pxd_change(".py", False)
+
+    def test_recythonize_pyx_on_pxd_change(self):
+        self.recythonize_on_pxd_change(".pyx", False)
+        
+    def test_recythonize_py_on_pxd_creating(self):
+        self.recythonize_on_pxd_change(".py", True)
+
+    def test_recythonize_pyx_on_pxd_creating(self):
+        self.recythonize_on_pxd_change(".pyx", True)
+
+    def test_recythonize_py_py_on_dep_pxd_change(self):
+        self.recythonize_on_dep_pxd_change(".py", ".py")
+
+    def test_recythonize_py_pyx_on_dep_pxd_change(self):
+        self.recythonize_on_dep_pxd_change(".py", ".pyx")
+
+    def test_recythonize_pyx_py_on_dep_pxd_change(self):
+        self.recythonize_on_dep_pxd_change(".pyx", ".py")
+
+    def test_recythonize_pyx_pyx_on_dep_pxd_change(self):
+        self.recythonize_on_dep_pxd_change(".pyx", ".pyx")

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -54,6 +54,21 @@ def cached_function(f):
     return wrapper
 
 
+# or clear_instance_method_caches
+def clear_method_caches(instance):
+    pattern = re.compile(r"__(.+)_cache")
+
+    for attr_name in dir(instance):
+        match = pattern.fullmatch(attr_name)
+        if match is None:
+            continue
+
+        func_name = match.group(1)
+        # additional check that the function exists
+        if getattr(instance, func_name, None) is not None:
+            delattr(instance, attr_name)
+
+
 def cached_method(f):
     cache_name = '__%s_cache' % f.__name__
 


### PR DESCRIPTION
This PR changes #4063 to make the tests work and be more complete.
The correctness of the compiler behavior is checked if:
1) the `pxd` changes when there is a `py` / `pyx` with the same name
2) `pxd` is created (before this was compiled without) when there is a `py` / `pyx` with the same name
3) the `pxd` changes with the same name as the `py` / `pyx` script that was imported for another `py` / `pyx` script (for simplicity, the import takes place in the second `pxd` file)

---

This PR at least serves as a check that all tests are working.