### PR TITLE
Introduce pure python mode in language basics documentation

### DIFF
--- a/docs/examples/quickstart/cythonize/integrate_cy.pyx
+++ b/docs/examples/quickstart/cythonize/integrate_cy.pyx
@@ -2,6 +2,8 @@ def f(double x):
     return x ** 2 - x
 
 
+
+
 def integrate_f(double a, double b, int N):
     cdef int i
     cdef double s, dx

--- a/docs/examples/quickstart/cythonize/integrate_cy.pyx
+++ b/docs/examples/quickstart/cythonize/integrate_cy.pyx
@@ -2,8 +2,6 @@ def f(double x):
     return x ** 2 - x
 
 
-
-
 def integrate_f(double a, double b, int N):
     cdef int i
     cdef double s, dx

--- a/docs/examples/userguide/extension_types/shrubbery.py
+++ b/docs/examples/userguide/extension_types/shrubbery.py
@@ -1,0 +1,15 @@
+from __future__ import print_function
+import cython
+
+@cython.cclass
+class Shrubbery:
+    width: cython.int
+    height: cython.int
+
+    def __init__(self, w, h):
+        self.width = w
+        self.height = h
+
+    def describe(self):
+        print("This shrubbery is", self.width,
+              "by", self.height, "cubits.")

--- a/docs/examples/userguide/extension_types/shrubbery.py
+++ b/docs/examples/userguide/extension_types/shrubbery.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import cython
 
 @cython.cclass
 class Shrubbery:

--- a/docs/examples/userguide/extension_types/shrubbery.pyx
+++ b/docs/examples/userguide/extension_types/shrubbery.pyx
@@ -2,8 +2,8 @@ from __future__ import print_function
 
 
 cdef class Shrubbery:
-    cdef int width, height
-
+    cdef int width
+    cdef int height
 
     def __init__(self, w, h):
         self.width = w

--- a/docs/examples/userguide/extension_types/shrubbery.pyx
+++ b/docs/examples/userguide/extension_types/shrubbery.pyx
@@ -1,7 +1,9 @@
 from __future__ import print_function
 
+
 cdef class Shrubbery:
     cdef int width, height
+
 
     def __init__(self, w, h):
         self.width = w

--- a/docs/examples/userguide/language_basics/casting_python.pxd
+++ b/docs/examples/userguide/language_basics/casting_python.pxd
@@ -1,0 +1,2 @@
+cdef extern from *:
+    ctypedef Py_ssize_t Py_intptr_t

--- a/docs/examples/userguide/language_basics/casting_python.py
+++ b/docs/examples/userguide/language_basics/casting_python.py
@@ -7,7 +7,7 @@ def main():
     # Note that the variables below are automatically inferred
     # as the correct pointer type that is assigned to them.
     # They do not need to be typed explicitly.
-    
+
     ptr = cython.cast(cython.p_void, python_string)
     adress_in_c = cython.cast(Py_intptr_t, ptr)
     address_from_void = adress_in_c        # address_from_void is a python int

--- a/docs/examples/userguide/language_basics/casting_python.py
+++ b/docs/examples/userguide/language_basics/casting_python.py
@@ -1,4 +1,3 @@
-import cython
 from cython.cimports.cpython.ref import PyObject
 
 def main():

--- a/docs/examples/userguide/language_basics/casting_python.py
+++ b/docs/examples/userguide/language_basics/casting_python.py
@@ -4,12 +4,16 @@ def main():
 
     python_string = "foo"
 
-    ptr: p_void = cython.cast(cython.p_void, python_string)
-    adress_in_c: Py_intptr_t= cython.cast(Py_intptr_t, ptr)
+    # Note that the variables below are automatically inferred
+    # as the correct pointer type that is assigned to them.
+    # They do not need to be typed explicitly.
+    
+    ptr = cython.cast(cython.p_void, python_string)
+    adress_in_c = cython.cast(Py_intptr_t, ptr)
     address_from_void = adress_in_c        # address_from_void is a python int
 
-    ptr2: cython.pointer(PyObject) = cython.cast(cython.pointer(PyObject), python_string)
-    address_in_c2: Py_intptr_t= cython.cast(Py_intptr_t, ptr2)
+    ptr2 = cython.cast(cython.pointer(PyObject), python_string)
+    address_in_c2 = cython.cast(Py_intptr_t, ptr2)
     address_from_PyObject = address_in_c2  # address_from_PyObject is a python int
 
     assert address_from_void == address_from_PyObject == id(python_string)

--- a/docs/examples/userguide/language_basics/casting_python.py
+++ b/docs/examples/userguide/language_basics/casting_python.py
@@ -1,0 +1,19 @@
+import cython
+from cython.cimports.cpython.ref import PyObject
+
+def main():
+
+    python_string = "foo"
+
+    ptr: p_void = cython.cast(cython.p_void, python_string)
+    adress_in_c: Py_intptr_t= cython.cast(Py_intptr_t, ptr)
+    address_from_void = adress_in_c        # address_from_void is a python int
+
+    ptr2: cython.pointer(PyObject) = cython.cast(cython.pointer(PyObject), python_string)
+    address_in_c2: Py_intptr_t= cython.cast(Py_intptr_t, ptr2)
+    address_from_PyObject = address_in_c2  # address_from_PyObject is a python int
+
+    assert address_from_void == address_from_PyObject == id(python_string)
+
+    print(cython.cast(object, ptr))                     # Prints "foo"
+    print(cython.cast(object, ptr2))                    # prints "foo"

--- a/docs/examples/userguide/language_basics/open_file.py
+++ b/docs/examples/userguide/language_basics/open_file.py
@@ -1,10 +1,10 @@
-import cython
 from cython.cimports.libc.stdio import FILE, fopen
 from cython.cimports.libc.stdlib import malloc, free
 from cython.cimports.cpython.exc import PyErr_SetFromErrnoWithFilenameObject
 
 def open_file():
     p: cython.pointer(FILE) = fopen("spam.txt", "r")
+
     if p is cython.NULL:
         PyErr_SetFromErrnoWithFilenameObject(OSError, "spam.txt")
     ...

--- a/docs/examples/userguide/language_basics/open_file.py
+++ b/docs/examples/userguide/language_basics/open_file.py
@@ -11,7 +11,8 @@ def open_file():
 
 
 def allocating_memory(number=10):
-    my_array: cython.p_double = cython.cast(p_double, malloc(number * cython.sizeof(double)))
+    # Note that the type of the variable "my_array" is automatically inferred from the assignment.
+    my_array = cython.cast(p_double, malloc(number * cython.sizeof(double)))
     if not my_array:  # same as 'is NULL' above
         raise MemoryError()
     ...

--- a/docs/examples/userguide/language_basics/open_file.py
+++ b/docs/examples/userguide/language_basics/open_file.py
@@ -1,0 +1,18 @@
+import cython
+from cython.cimports.libc.stdio import FILE, fopen
+from cython.cimports.libc.stdlib import malloc, free
+from cython.cimports.cpython.exc import PyErr_SetFromErrnoWithFilenameObject
+
+def open_file():
+    p: cython.pointer(FILE) = fopen("spam.txt", "r")
+    if p is cython.NULL:
+        PyErr_SetFromErrnoWithFilenameObject(OSError, "spam.txt")
+    ...
+
+
+def allocating_memory(number=10):
+    my_array: cython.p_double = cython.cast(p_double, malloc(number * cython.sizeof(double)))
+    if not my_array:  # same as 'is NULL' above
+        raise MemoryError()
+    ...
+    free(my_array)

--- a/docs/examples/userguide/language_basics/open_file.py
+++ b/docs/examples/userguide/language_basics/open_file.py
@@ -3,7 +3,7 @@ from cython.cimports.libc.stdlib import malloc, free
 from cython.cimports.cpython.exc import PyErr_SetFromErrnoWithFilenameObject
 
 def open_file():
-    p: cython.pointer(FILE) = fopen("spam.txt", "r")
+    p = fopen("spam.txt", "r")   # The type of "p" is "FILE*", as returned by fopen().
 
     if p is cython.NULL:
         PyErr_SetFromErrnoWithFilenameObject(OSError, "spam.txt")

--- a/docs/examples/userguide/language_basics/optional_subclassing.py
+++ b/docs/examples/userguide/language_basics/optional_subclassing.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import cython
+
+@cython.cclass
+class A:
+    @cython.cfunc
+    def foo(self):
+        print("A")
+
+@cython.cclass
+class B(A):
+    @cython.cfunc
+    def foo(self, x=None):
+        print("B", x)
+
+@cython.cclass
+class C(B):
+    @cython.ccall
+    def foo(self, x=True, k:cython.int = 3):
+        print("C", x, k)

--- a/docs/examples/userguide/language_basics/optional_subclassing.py
+++ b/docs/examples/userguide/language_basics/optional_subclassing.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import cython
 
 @cython.cclass
 class A:

--- a/docs/examples/userguide/language_basics/optional_subclassing.pyx
+++ b/docs/examples/userguide/language_basics/optional_subclassing.pyx
@@ -1,13 +1,19 @@
 from __future__ import print_function
 
+
 cdef class A:
+
     cdef foo(self):
         print("A")
 
+
 cdef class B(A):
+
     cdef foo(self, x=None):
         print("B", x)
 
+
 cdef class C(B):
+
     cpdef foo(self, x=True, int k=3):
         print("C", x, k)

--- a/docs/examples/userguide/language_basics/override.py
+++ b/docs/examples/userguide/language_basics/override.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+import cython
+
+@cython.cclass
+class A:
+    @cython.cfunc
+    def foo(self):
+        print("A")
+
+@cython.cclass
+class B(A):
+    @cython.ccall
+    def foo(self):
+        print("B")
+
+class C(B):  # NOTE: no cclass decorator
+    def foo(self):
+        print("C")

--- a/docs/examples/userguide/language_basics/override.py
+++ b/docs/examples/userguide/language_basics/override.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import cython
 
 @cython.cclass
 class A:

--- a/docs/examples/userguide/language_basics/override.pyx
+++ b/docs/examples/userguide/language_basics/override.pyx
@@ -1,10 +1,14 @@
 from __future__ import print_function
 
+
 cdef class A:
+
     cdef foo(self):
         print("A")
 
+
 cdef class B(A):
+
     cpdef foo(self):
         print("B")
 

--- a/docs/examples/userguide/language_basics/parameter_refcount.py
+++ b/docs/examples/userguide/language_basics/parameter_refcount.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+
+from cython.cimports.cpython.ref import PyObject
+
+import sys
+
+python_dict = {"abc": 123}
+python_dict_refcount = sys.getrefcount(python_dict)
+
+@cython.cfunc
+def owned_reference(obj: object):
+    refcount = sys.getrefcount(python_dict)
+    print('Inside owned_reference: {refcount}'.format(refcount=refcount))
+
+@cython.cfunc
+def borrowed_reference(obj: cython.pointer(PyObject)):
+    refcount = obj.ob_refcnt
+    print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
+
+def main():
+    print('Initial refcount: {refcount}'.format(refcount=python_dict_refcount))
+    owned_reference(python_dict)
+    borrowed_reference(cython.cast(cython.pointer(PyObject), python_dict))

--- a/docs/examples/userguide/language_basics/parameter_refcount.pyx
+++ b/docs/examples/userguide/language_basics/parameter_refcount.pyx
@@ -7,13 +7,16 @@ import sys
 python_dict = {"abc": 123}
 python_dict_refcount = sys.getrefcount(python_dict)
 
+
 cdef owned_reference(object obj):
     refcount = sys.getrefcount(python_dict)
     print('Inside owned_reference: {refcount}'.format(refcount=refcount))
 
+
 cdef borrowed_reference(PyObject * obj):
     refcount = obj.ob_refcnt
     print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
+
 
 print('Initial refcount: {refcount}'.format(refcount=python_dict_refcount))
 owned_reference(python_dict)

--- a/docs/examples/userguide/language_basics/struct_union_enum.py
+++ b/docs/examples/userguide/language_basics/struct_union_enum.py
@@ -1,0 +1,6 @@
+import cython
+
+Grail = cython.struct(age=cython.int, volume=cython.float)
+Food = cython.struct(spam=cython.p_char, eggs=cython.p_float)
+
+# Enum is not supported by pure python mode

--- a/docs/examples/userguide/language_basics/struct_union_enum.py
+++ b/docs/examples/userguide/language_basics/struct_union_enum.py
@@ -1,4 +1,4 @@
 import cython
 
 Grail = cython.struct(age=cython.int, volume=cython.float)
-Food = cython.struct(spam=cython.p_char, eggs=cython.p_float)
+Food = cython.union(spam=cython.p_char, eggs=cython.p_float)

--- a/docs/examples/userguide/language_basics/struct_union_enum.py
+++ b/docs/examples/userguide/language_basics/struct_union_enum.py
@@ -1,4 +1,7 @@
-import cython
+Grail = cython.struct(
+    age=cython.int,
+    volume=cython.float)
 
-Grail = cython.struct(age=cython.int, volume=cython.float)
-Food = cython.union(spam=cython.p_char, eggs=cython.p_float)
+Food = cython.union(
+    spam=cython.p_char,
+    eggs=cython.p_float)

--- a/docs/examples/userguide/language_basics/struct_union_enum.py
+++ b/docs/examples/userguide/language_basics/struct_union_enum.py
@@ -2,5 +2,3 @@ import cython
 
 Grail = cython.struct(age=cython.int, volume=cython.float)
 Food = cython.struct(spam=cython.p_char, eggs=cython.p_float)
-
-# Enum is not supported by pure python mode

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -119,7 +119,22 @@ and C :keyword:`struct`, :keyword:`union` or :keyword:`enum` types:
 
                 cdef struct Grail *gp # WRONG
 
-            There is also a ``ctypedef`` statement for giving names to types, e.g.::
+.. note::
+    There is also a ``ctypedef`` statement for giving names to types, e.g.
+
+    .. tabs::
+
+        .. group-tab:: Pure Python
+
+            .. code-block:: python
+
+                 ULong = cython.typedef(cython.ulong)
+
+                 IntPtr = cython.typedef(cython.p_int)
+
+        .. group-tab:: Cython
+
+            .. code-block:: cython
 
                 ctypedef unsigned long ULong
 
@@ -321,8 +336,8 @@ using normal C declaration syntax. For example,
 
         .. code-block:: python
 
-         def chips(t: (cython.long, cython.long, cython.double)) -> (cython.int, cython.float)
-            ...
+            def chips(t: (cython.long, cython.long, cython.double)) -> (cython.int, cython.float):
+                ...
 
     .. group-tab:: Cython
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -47,9 +47,13 @@ the use of ‘early binding’ programming techniques.
 C variable and type definitions
 ===============================
 
-C variables can be declared by using the :keyword:`cdef` statement, by annotating
-variable by special cython type or using function ``declare()``. Statement :keyword:`cdef`
-and function ``declare()`` can declare either local or
+C variables can be declared by 
+
+* using the Cython language :keyword:`cdef` statement,
+* annotating variable by special cython type or
+* using function ``declare()``.
+
+Statement :keyword:`cdef` and function ``declare()`` can declare either local or
 module-level variables, but annotated version currently supports only local variables:
 
 .. tabs::

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -49,12 +49,16 @@ C variable and type definitions
 
 C variables can be declared by 
 
-* using the Cython language :keyword:`cdef` statement,
-* annotating variable by special cython type or
-* using function ``declare()``.
+* using the Cython specific :keyword:`cdef` statement,
+* using PEP-484/526 type annotations with C data types or
+* using the function ``cython.declare()``.
 
-Statement :keyword:`cdef` and function ``declare()`` can declare either local or
-module-level variables, but annotated version currently supports only local variables:
+The :keyword:`cdef` statement and ``declare()`` can define function-local and
+module-level variables, but type annotations only affect local variables.
+This is because type annotations are not Cython specific, so Cython keeps
+the variables in the module dict (as Python values) instead of making them
+module internal C variables. Use ``declare()`` in Python code to explicitly
+define global C variables.
 
 .. tabs::
 
@@ -202,9 +206,10 @@ values for False/True) and ``Py_ssize_t`` for (signed) sizes of Python
 containers.
 
 Pointer types are constructed as in C when using Cython syntax, by appending a ``*`` to the base type
-they point to, e.g. ``int**`` for a pointer to a pointer to a C int. In Pure python mode, pointer types
+they point to, e.g. ``int**`` for a pointer to a pointer to a C int. In Pure python mode, simple pointer types
 use a naming scheme with "p"s instead, separated from the type name with an underscore, e.g. ``cython.pp_int`` for a pointer to
-a pointer to a C int. Further pointer types can be constructed with the ``cython.pointer()`` function.
+a pointer to a C int.  Further pointer types can be constructed with the ``cython.pointer()`` function,
+e.g. ``cython.pointer(cython.int)``.
 
 
 Arrays use the normal C array syntax, e.g. ``int[10]``, and the size must be known
@@ -241,7 +246,8 @@ For declared builtin types, Cython uses internally a C variable of type ``PyObje
     typing in ``.pyx`` files and instead interpreted as C ``int``, ``long``, and ``float``
     respectively, as statically typing variables with these Python
     types has zero advantages. On the other hand, annotating in Pure Python with
-    ``int``, ``long``, and ``float`` python types will be interpreted as ``object`` type.
+    ``int``, ``long``, and ``float`` Python types will be interpreted as
+    Python object types.
 
 Cython provides an accelerated and typed equivalent of a Python tuple, the ``ctuple``.
 A ``ctuple`` is assembled from any valid C types. For example
@@ -344,9 +350,6 @@ using normal C declaration syntax. For example,
 
             cdef int eggs(unsigned long l, float f):
                 ...
-
-
-
 ``ctuples`` may also be used
 
 .. tabs::

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -461,7 +461,15 @@ about object parameters in C functions.
 To create a borrowed reference, specify the parameter type as ``PyObject*``.
 Cython won't perform automatic ``Py_INCREF``, or ``Py_DECREF``, e.g.:
 
-.. literalinclude:: ../../examples/userguide/language_basics/parameter_refcount.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/parameter_refcount.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/parameter_refcount.pyx
 
 will display::
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -79,48 +79,50 @@ and C :keyword:`struct`, :keyword:`union` or :keyword:`enum` types:
 
         .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.py
 
+        .. NOTE:: Currently, Pure Python mode does not support enums.
+
     .. group-tab:: Cython
 
         .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.pyx
 
-See also :ref:`struct-union-enum-styles`
+        See also :ref:`struct-union-enum-styles`
 
-.. note::
+        .. note::
 
-    Structs can be declared as ``cdef packed struct``, which has
-    the same effect as the C directive ``#pragma pack(1)``.
+            Structs can be declared as ``cdef packed struct``, which has
+            the same effect as the C directive ``#pragma pack(1)``.
 
-Declaring an enum as ``cpdef`` will create a :pep:`435`-style Python wrapper::
+        Declaring an enum as ``cpdef`` will create a :pep:`435`-style Python wrapper::
 
-    cpdef enum CheeseState:
-        hard = 1
-        soft = 2
-        runny = 3
+            cpdef enum CheeseState:
+                hard = 1
+                soft = 2
+                runny = 3
 
 
 
-There is currently no special syntax for defining a constant, but you can use
-an anonymous :keyword:`enum` declaration for this purpose, for example,::
+        There is currently no special syntax for defining a constant, but you can use
+        an anonymous :keyword:`enum` declaration for this purpose, for example,::
 
-    cdef enum:
-        tons_of_spam = 3
+            cdef enum:
+                tons_of_spam = 3
 
-.. note::
-    the words ``struct``, ``union`` and ``enum`` are used only when
-    defining a type, not when referring to it. For example, to declare a variable
-    pointing to a ``Grail`` you would write::
+        .. note::
+            the words ``struct``, ``union`` and ``enum`` are used only when
+            defining a type, not when referring to it. For example, to declare a variable
+            pointing to a ``Grail`` you would write::
 
-        cdef Grail *gp
+                cdef Grail *gp
 
-    and not::
+            and not::
 
-        cdef struct Grail *gp # WRONG
+                cdef struct Grail *gp # WRONG
 
-    There is also a ``ctypedef`` statement for giving names to types, e.g.::
+            There is also a ``ctypedef`` statement for giving names to types, e.g.::
 
-        ctypedef unsigned long ULong
+                ctypedef unsigned long ULong
 
-        ctypedef int* IntPtr
+                ctypedef int* IntPtr
 
 
 It is also possible to declare functions with :keyword:`cdef`, making them c functions.

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -86,7 +86,7 @@ Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported
 
         .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.py
 
-        .. NOTE:: Currently, Pure Python mode does not support enums.
+        .. note:: Currently, Pure Python mode does not support enums.
 
     .. group-tab:: Cython
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -78,7 +78,7 @@ module-level variables, but annotated version currently supports only local vari
             cdef int i, j, k
             cdef float f, g[42], *h
 
-Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported:
+Moreover, C :keyword:`struct`, :keyword:`union` and :keyword:`enum` are supported:
 
 .. tabs::
 
@@ -115,17 +115,18 @@ Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported
         .. note::
             the words ``struct``, ``union`` and ``enum`` are used only when
             defining a type, not when referring to it. For example, to declare a variable
-            pointing to a ``Grail`` you would write::
+            pointing to a ``Grail`` struct, you would write::
 
                 cdef Grail *gp
 
             and not::
 
-                cdef struct Grail *gp # WRONG
+                cdef struct Grail *gp  # WRONG
 
 .. note::
 
-    There is also support for giving names to types by ``ctypedef`` statement or ``typedef()`` function, e.g.
+    There is also support for giving names to types using the
+    ``ctypedef`` statement or the ``cython.typedef()`` function, e.g.
 
     .. tabs::
 
@@ -133,9 +134,9 @@ Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported
 
             .. code-block:: python
 
-                 ULong = typedef(cython.ulong)
+                 ULong = cython.typedef(cython.ulong)
 
-                 IntPtr = typedef(cython.p_int)
+                 IntPtr = cython.typedef(cython.p_int)
 
         .. group-tab:: Cython
 
@@ -146,7 +147,7 @@ Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported
                 ctypedef int* IntPtr
 
 
-It is also possible to create c function by declaring functions with :keyword:`cdef` or by decorating function with ``@cfunc``:
+You can create a C function by declaring it with :keyword:`cdef` or by decorating a Python function with ``@cfunc``:
 
 .. tabs::
 
@@ -167,9 +168,10 @@ It is also possible to create c function by declaring functions with :keyword:`c
 
 You can read more about them in :ref:`python_functions_vs_c_functions`.
 
-Cython is supporting special type of classes known as :ref:`extension-types`. Those will
+Classes can be declared as :ref:`extension-types`.  Those will
 have a behavior very close to python classes, but are faster because they use a ``struct``
-internally to store attributes. They are declared by :keyword:`cdef` keyword or by ``@cclass`` decorator.
+internally to store attributes.
+They are declared with the :keyword:`cdef` keyword or the ``@cclass`` class decorator.
 
 Here is a simple example:
 
@@ -191,18 +193,18 @@ You can read more about them in :ref:`extension-types`.
 Types
 -----
 
-Cython language uses the normal C syntax for C types, including pointers.  It provides
+The Cython language uses the normal C syntax for C types, including pointers.  It provides
 all the standard C types, namely ``char``, ``short``, ``int``, ``long``,
 ``long long`` as well as their ``unsigned`` versions,
-e.g. ``unsigned int`` in Cython laguage and ``uint`` in Pure Python.
+e.g. ``unsigned int`` (``cython.uint`` in Python code).
 The special ``bint`` type is used for C boolean values (``int`` with 0/non-0
 values for False/True) and ``Py_ssize_t`` for (signed) sizes of Python
 containers.
 
-Pointer types are constructed as in C in Cython language, by appending a ``*`` to the base type
+Pointer types are constructed as in C when using Cython syntax, by appending a ``*`` to the base type
 they point to, e.g. ``int**`` for a pointer to a pointer to a C int. In Pure python mode, pointer types
-are constructed by needed number of "p" s and then "_", e.g. ``pp_int`` for a pointer to
-a pointer to a C int. Further pointer types can be constructed with ``pointer()`` function.
+use a naming scheme with "p"s instead, separated from the type name with an underscore, e.g. ``cython.pp_int`` for a pointer to
+a pointer to a C int. Further pointer types can be constructed with the ``cython.pointer()`` function.
 
 
 Arrays use the normal C array syntax, e.g. ``int[10]``, and the size must be known
@@ -236,10 +238,10 @@ which is the main reason for declaring builtin types in the first place.
 For declared builtin types, Cython uses internally a C variable of type ``PyObject*``.
 
 .. Note:: The Python types ``int``, ``long``, and ``float`` are not available for static
-    typing in Cython language and instead interpreted as C ``int``, ``long``, and ``float``
+    typing in ``.pyx`` files and instead interpreted as C ``int``, ``long``, and ``float``
     respectively, as statically typing variables with these Python
     types has zero advantages. On the other hand, annotating in Pure Python with
-    ``int``, ``long``, and ``float`` python types will be interpreted as ``PyObject*`` type.
+    ``int``, ``long``, and ``float`` python types will be interpreted as ``object`` type.
 
 Cython provides an accelerated and typed equivalent of a Python tuple, the ``ctuple``.
 A ``ctuple`` is assembled from any valid C types. For example
@@ -270,7 +272,7 @@ and is typically what one wants).
 If you want to use these numeric Python types simply omit the
 type declaration and let them be objects.
 
-It is also possible to declare :ref:`extension-types` (declared with ``cdef class`` or by ``@cclass`` decorator).
+It is also possible to declare :ref:`extension-types` (declared with ``cdef class`` or the ``@cclass`` decorator).
 This does allow subclasses. This typing is mostly used to access
 ``cdef``/``@cfunc`` methods and attributes of the extension type.
 The C code uses a variable which is a pointer to a structure of the
@@ -283,7 +285,7 @@ Grouping multiple C declarations
 If you have a series of declarations that all begin with :keyword:`cdef`, you
 can group them into a :keyword:`cdef` block like this:
 
-.. note:: This is supported only by Cython language.
+.. note:: This is supported only in Cython's ``cdef`` syntax.
 
 .. literalinclude:: ../../examples/userguide/language_basics/cdef_block.pyx
 
@@ -297,10 +299,10 @@ Python functions vs. C functions
 
 There are two kinds of function definition in Cython:
 
-Python functions are defined using the ``def`` statement, as in Python. They take
+Python functions are defined using the :keyword:`def` statement, as in Python. They take
 :term:`Python objects<Python object>` as parameters and return Python objects.
 
-C functions are defined using the new :keyword:`cdef` statement in Cython language or by ``@cfunc`` decorator. They take
+C functions are defined using the :keyword:`cdef` statement in Cython syntax or with the ``@cfunc`` decorator. They take
 either Python objects or C values as parameters, and can return either Python
 objects or C values.
 
@@ -308,12 +310,12 @@ Within a Cython module, Python functions and C functions can call each other
 freely, but only Python functions can be called from outside the module by
 interpreted Python code. So, any functions that you want to "export" from your
 Cython module must be declared as Python functions using ``def``.
-There is also a hybrid function, declared by :keyword:`cpdef` in Cython language or by ``@ccall`` decorator. A hybrid function
-can be called from anywhere, but uses the faster C calling conventions
-when being called from other Cython code. A hybrid function can also be overridden
+There is also a hybrid function, declared with :keyword:`cpdef` in ``.pyx`` files or with the ``@ccall`` decorator.  These functions
+can be called from anywhere, but use the faster C calling convention
+when being called from other Cython code. They can also be overridden
 by a Python method on a subclass or an instance attribute, even when called from Cython.
 If this happens, most performance gains are of course lost and even if it does not,
-there is a tiny overhead in calling a hybfid method from Cython compared to
+there is a tiny overhead in calling such a method from Cython compared to
 calling a C method.
 
 Parameters of either type of function can be declared to have C data types,
@@ -401,7 +403,8 @@ with string attributes if they are to be used after the function returns.
 C functions, on the other hand, can have parameters of any type, since they're
 passed in directly using a normal C function call.
 
-C Functions declared using :keyword:`cdef` or ``@cfunc`` decorator with Python object return type, like Python functions, will return a :keyword:`None`
+C Functions declared using :keyword:`cdef` or the ``@cfunc`` decorator with a
+Python object return type, like Python functions, will return a :keyword:`None`
 value when execution leaves the function body without an explicit return value. This is in
 contrast to C/C++, which leaves the return value undefined. 
 In the case of non-Python object return types, the equivalent of zero is returned, for example, 0 for ``int``, :keyword:`False` for ``bint`` and :keyword:`NULL` for pointer types.
@@ -472,7 +475,7 @@ object as the explicit return type of a function, e.g.::
         ...
 
 .. note:: Currently, Cython contains a bug not allowing returning ``object`` in
-    pure python from C function.
+    pure python from a C function.
 
 In the interests of clarity, it is probably a good idea to always be explicit
 about object parameters in C functions.
@@ -502,7 +505,7 @@ will display::
 Optional Arguments
 ------------------
 
-Unlike C, it is possible to use optional arguments in C and hybrid functions.
+Unlike C, it is possible to use optional arguments in C and ``cpdef``/``@ccall`` functions.
 There are differences though whether you declare them in a ``.pyx``/``.py``
 file or the corresponding ``.pxd`` file.
 
@@ -583,7 +586,7 @@ through defined error return values.  For functions that return a Python object
 error return value.
 
 While this is always the case for C functions, functions
-defined as C functions or hybryd functions can return arbitrary C types,
+defined as C functions or ``cpdef``/``@ccall`` functions can return arbitrary C types,
 which do not have such a well-defined error return value.  Thus, if an
 exception is detected in such a function, a warning message is printed,
 the exception is ignored, and the function returns immediately without
@@ -686,7 +689,7 @@ An external C++ function that may raise an exception can be declared with::
 
     cdef int spam() except +
 
-.. note:: Pure python mode does not have equivalent to `except +`.
+.. note:: These declarations are not used in Python code, only in ``.pxd``  and ``.pyx`` files.
 
 See :ref:`wrapping-cplusplus` for more details.
 
@@ -704,7 +707,7 @@ Some things to note:
 
       int (*grail)(int, char*) except -1
 
-  .. note:: Pointer to function is currently not supported by pure python mode.
+  .. note:: Pointers to functions are currently not supported by pure Python mode.
 
 * You don't need to (and shouldn't) declare exception values for functions
   which return Python objects. Remember that a function with no declared
@@ -746,7 +749,7 @@ Overriding in extension types
 -----------------------------
 
 
-Hybrid methods can override C methods:
+``cpdef``/``@ccall`` methods can override C methods:
 
 .. tabs::
 
@@ -759,7 +762,7 @@ Hybrid methods can override C methods:
         .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
 
 When subclassing an extension type with a Python class,
-C methods can override hybrid methods but not C methods:
+Python methods can override ``cpdef``/``@ccall`` methods but not plain C methods:
 
 .. tabs::
 
@@ -859,7 +862,7 @@ leaving ``s`` dangling. Since this code could not possibly work, Cython refuses 
 compile it.
 
 The solution is to assign the result of the concatenation to a Python
-variable, and then obtain the pointer to char from that, i.e.
+variable, and then obtain the ``char*`` from that, i.e.
 
 .. tabs::
 
@@ -893,8 +896,8 @@ be careful what you do.
 Type Casting
 ------------
 
-Cython language supports type casting in a simmilar way as C. Where C uses ``"("`` and ``")"``,
-Cython uses ``"<"`` and ``">"``. In pure python mode, ``cast()`` function is used. For example:
+The Cython language supports type casting in a similar way as C. Where C uses ``"("`` and ``")"``,
+Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` function is used.  For example:
 
 .. tabs::
 
@@ -908,8 +911,8 @@ Cython uses ``"<"`` and ``">"``. In pure python mode, ``cast()`` function is use
                 p = cast(cython.p_char, q)
 
         When casting a C value to a Python object type or vice versa,
-        Cython will attempt a coercion. Simple examples are casts like ``cast(int, pyobj)``,
-        which converts a Python number to a plain C ``int`` value, or ``cast(bytes, charptr)``,
+        Cython will attempt a coercion. Simple examples are casts like ``cast(int, pyobj_value)``,
+        which converts a Python number to a plain C ``int`` value, or ``cast(bytes, charptr_value)``,
         which copies a C ``char*`` string into a new Python bytes object.
 
          .. note:: Cython will not prevent a redundant cast, but emits a warning for it.
@@ -932,8 +935,8 @@ Cython uses ``"<"`` and ``">"``. In pure python mode, ``cast()`` function is use
             p = <char*>q
 
         When casting a C value to a Python object type or vice versa,
-        Cython will attempt a coercion. Simple examples are casts like ``<int>pyobj``,
-        which converts a Python number to a plain C ``int`` value, or ``<bytes>charptr``,
+        Cython will attempt a coercion. Simple examples are casts like ``<int>pyobj_value``,
+        which converts a Python number to a plain C ``int`` value, or ``<bytes>charptr_value``,
         which copies a C ``char*`` string into a new Python bytes object.
 
          .. note:: Cython will not prevent a redundant cast, but emits a warning for it.
@@ -955,7 +958,7 @@ Cython uses ``"<"`` and ``">"``. In pure python mode, ``cast()`` function is use
         .. literalinclude:: ../../examples/userguide/language_basics/casting_python.py
             :caption: casting_python.py
 
-        Casting to ``cast(object, ...)`` creates an owned reference. Cython will automatically
+        Casting with ``cast(object, ...)`` creates an owned reference. Cython will automatically
         perform a ``Py_INCREF`` and ``Py_DECREF`` operation. Casting to
         ``cast(pointer(PyObject), ...)`` creates a borrowed reference, leaving the refcount unchanged.
 
@@ -978,7 +981,7 @@ Checked Type Casts
 A cast like ``<MyExtensionType>x`` or ``cast(MyExtensionType, x)`` will cast ``x`` to the class
 ``MyExtensionType`` without any checking at all.
 
-To have a cast checked, use the syntax like: ``<MyExtensionType?>x`` in Cython language
+To have a cast checked, use ``<MyExtensionType?>x`` in Cython syntax
 or ``cast(MyExtensionType, x, typecheck=True)``.
 In this case, Cython will apply a runtime check that raises a ``TypeError``
 if ``x`` is not an instance of ``MyExtensionType``.
@@ -1011,13 +1014,14 @@ direct equivalent in Python.
 
 * An integer literal is treated as a C constant, and will
   be truncated to whatever size your C compiler thinks appropriate.
-  To get a Python integer (of arbitrary precision) cast immediately to
+  To get a Python integer (of arbitrary precision), cast immediately to
   an object (e.g. ``<object>100000000000000000000`` or ``cast(object, 100000000000000000000)``). The ``L``, ``LL``,
-  and ``U`` suffixes have the same meaning in Cython language as in C.
+  and ``U`` suffixes have the same meaning in Cython syntax as in C.
 * There is no ``->`` operator in Cython. Instead of ``p->x``, use ``p.x``
 * There is no unary ``*`` operator in Cython. Instead of ``*p``, use ``p[0]``
-* There is an ``&`` operator in Cython language, with the same semantics as in C. In pure python mode use ``address()`` function.
-* The null C pointer is called ``NULL``, not ``0``. ``NULL`` is a reserved word in Cython language
+* There is an ``&`` operator in Cython, with the same semantics as in C.
+  In pure python mode, use the ``cython.address()`` function instead.
+* The null C pointer is called ``NULL``, not ``0``. ``NULL`` is a reserved word in Cython
   and special object in pure python mode.
 * Type casts are written ``<type>value`` or ``cast(type, value)``, for example,
 
@@ -1122,7 +1126,7 @@ Python and C, and that Cython uses the Python precedences, not the C ones.
 Integer for-loops
 ------------------
 
-.. note:: This syntax is supported only by Cython language.
+.. note:: This syntax is supported only in Cython files and not in Python.
 
 Cython recognises the usual Python for-in-range integer loop pattern::
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -247,7 +247,7 @@ which is the main reason for declaring builtin types in the first place.
 
 For declared builtin types, Cython uses internally a C variable of type ``PyObject*``.
 
-.. Note:: The Python types ``int``, ``long``, and ``float`` are not available for static
+.. note:: The Python types ``int``, ``long``, and ``float`` are not available for static
     typing in ``.pyx`` files and instead interpreted as C ``int``, ``long``, and ``float``
     respectively, as statically typing variables with these Python
     types has zero advantages. On the other hand, annotating in Pure Python with

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -47,8 +47,8 @@ the use of ‘early binding’ programming techniques.
 C variable and type definitions
 ===============================
 
-C variables can be declared by using the :keyword:`cdef` statement or by annotating
-variable by special cython type. Statement :keyword:`cdef` can declare either local or
+C variables can be declared by using the :keyword:`cdef` statement, by annotating
+variable by special cython type or using function ``declare()``. Statement :keyword:`cdef` and function ``declare()`` can declare either local or
 module-level variables, but annotated version currently supports only local variables:
 
 .. tabs::
@@ -57,6 +57,7 @@ module-level variables, but annotated version currently supports only local vari
 
         .. code-block:: python
 
+            global_x = declare(cython.int)
             def main():
                 i: cython.int
                 j: cython.int
@@ -127,9 +128,9 @@ Moreover, C :keyword:`struct`, :keyword:`union` or :keyword:`enum` are supported
 
             .. code-block:: python
 
-                 ULong = cython.typedef(cython.ulong)
+                 ULong = typedef(cython.ulong)
 
-                 IntPtr = cython.typedef(cython.p_int)
+                 IntPtr = typedef(cython.p_int)
 
         .. group-tab:: Cython
 
@@ -148,7 +149,7 @@ It is also possible to create c function by declaring functions with :keyword:`c
 
         .. code-block:: python
 
-            @cython.cfunc
+            @cfunc
             def eggs(l: cython.ulong, f: cython.float) -> cython.int:
                 ...
 
@@ -337,7 +338,7 @@ using normal C declaration syntax. For example,
             def spam(i: cython.int, s: cython.p_char):
                 ...
 
-            @cython.cfunc
+            @cfunc
             def eggs(l: cython.ulong, f: cython.float) -> cython.int:
                 ...
 
@@ -362,7 +363,7 @@ using normal C declaration syntax. For example,
 
         .. code-block:: python
 
-            @cython.cfunc
+            @cfunc
             def chips(t: (cython.long, cython.long, cython.double)) -> (cython.int, cython.float):
                 ...
 
@@ -432,7 +433,7 @@ takes two Python objects as parameters and returns a Python object
 
         .. code-block:: python
 
-            @cython.cfunc
+            @cfunc
             def spamobjs(x, y):
                 ...
 
@@ -463,7 +464,7 @@ as the name of a type, for example,
 
         .. code-block:: python
 
-            @cython.cfunc
+            @cfunc
             def ftang(int: object):
                 ...
 
@@ -523,10 +524,12 @@ When in a ``.pyx``/``.py`` file, the signature is the same as it is in Python it
     .. group-tab:: Pure Python
 
         .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.py
+            :caption: optional_subclassing.py
 
     .. group-tab:: Cython
 
         .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
+            :caption: optional_subclassing.pyx
 
 When in a ``.pxd`` file, the signature is different like this example: ``cdef foo(x=*)``.
 This is because the program calling the function just needs to know what signatures are
@@ -603,7 +606,7 @@ Here is an example
 
         .. code-block:: python
 
-            @cython.exceptval(-1)
+            @exceptval(-1)
             def spam() -> cython.int:
                 ...
 
@@ -638,7 +641,7 @@ form of exception value declaration
 
         .. code-block:: python
 
-            @cython.exceptval(-1, check=True)
+            @exceptval(-1, check=True)
             def spam() -> cython.int:
                 ...
 
@@ -670,7 +673,7 @@ There is also a third form of exception value declaration
 
         .. code-block:: python
 
-            @cython.exceptval(check=True)
+            @exceptval(check=True)
             def spam() -> cython.int:
                 ...
 
@@ -709,6 +712,8 @@ Some things to note:
   example of a pointer-to-function declaration with an exception value::
 
       int (*grail)(int, char*) except -1
+
+  .. note:: Pointer to function is currently not supported by pure python mode.
 
 * You don't need to (and shouldn't) declare exception values for functions
   which return Python objects. Remember that a function with no declared
@@ -750,7 +755,7 @@ Overriding in extension types
 -----------------------------
 
 
-``cpdef`` methods can override ``cdef`` methods:
+Hybrid methods can override C methods:
 
 .. tabs::
 
@@ -909,7 +914,7 @@ Cython uses ``"<"`` and ``">"``. In pure python mode, ``cast()`` function is use
             def main():
                 p: cython.p_char
                 q: cython.p_float
-                p = cython.cast(cython.p_char, q)
+                p = cast(cython.p_char, q)
 
         When casting a C value to a Python object type or vice versa,
         Cython will attempt a coercion. Simple examples are casts like ``cast(int, pyobj)``,
@@ -1034,13 +1039,15 @@ direct equivalent in Python.
               def main():
                   p: cython.p_char
                   q: cython.p_float
-                  p = cython.cast(cython.p_char, q)
+
+                  p = cast(cython.p_char, q)
 
       .. group-tab:: Cython
 
           .. code-block:: cython
 
-              cdef char* p, float* q
+              cdef char* p
+              cdef float* q
 
               p = <char*>q
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -637,10 +637,6 @@ form of exception value declaration
                 ...
 
         The ``check=True`` indicates that the value ``-1`` only signals a possible error.
-        In this
-        case, Cython generates a call to :c:func:`PyErr_Occurred` if the exception value
-        is returned, to make sure it really received an exception and not just a normal
-        result.
 
     .. group-tab:: Cython
 
@@ -650,11 +646,10 @@ form of exception value declaration
                 ...
 
         The ``?`` indicates that the value ``-1`` only signals a possible error.
-        In this
-        case, Cython generates a call to :c:func:`PyErr_Occurred` if the exception value
-        is returned, to make sure it really received an exception and not just a normal
-        result.
 
+In this case, Cython generates a call to :c:func:`PyErr_Occurred` if the exception value
+is returned, to make sure it really received an exception and not just a normal
+result.
 
 There is also a third form of exception value declaration
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -868,7 +868,19 @@ with ``<object>``, or a more specific builtin or extension type
 the object by one, i.e. the cast returns an owned reference.
 Here is an example:
 
-.. literalinclude:: ../../examples/userguide/language_basics/casting_python.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/casting_python.pxd
+            :caption: casting_python.pxd
+        .. literalinclude:: ../../examples/userguide/language_basics/casting_python.py
+            :caption: casting_python.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/casting_python.pyx
+            :caption: casting_python.pyx
 
 The precedence of ``<...>`` is such that ``<type>a.b.c`` is interpreted as ``<type>(a.b.c)``.
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -924,7 +924,7 @@ Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` fun
         To get the address of some Python object, use a cast to a pointer type
         like ``cast(p_void, ...)`` or ``cast(pointer(PyObject), ...)``.
         You can also cast a C pointer back to a Python object reference
-        with ``cast(object, ...)``, or a more specific builtin or extension type
+        with ``cast(object, ...)``, or to a more specific builtin or extension type
         (e.g. ``cast(MyExtType, ptr)``). This will increase the reference count of
         the object by one, i.e. the cast returns an owned reference.
         Here is an example:

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -54,7 +54,8 @@ C variables can be declared by
 * using the function ``cython.declare()``.
 
 The :keyword:`cdef` statement and ``declare()`` can define function-local and
-module-level variables, but type annotations only affect local variables.
+module-level variables as well as attributes in classes, but type annotations only
+affect local variables and attributes and are ignored at the module level.
 This is because type annotations are not Cython specific, so Cython keeps
 the variables in the module dict (as Python values) instead of making them
 module internal C variables. Use ``declare()`` in Python code to explicitly

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -916,7 +916,7 @@ Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` fun
 
         When casting a C value to a Python object type or vice versa,
         Cython will attempt a coercion. Simple examples are casts like ``cast(int, pyobj_value)``,
-        which converts a Python number to a plain C ``int`` value, or ``cast(bytes, charptr_value)``,
+        which convert a Python number to a plain C ``int`` value, or the statement ``cast(bytes, charptr_value)``,
         which copies a C ``char*`` string into a new Python bytes object.
 
          .. note:: Cython will not prevent a redundant cast, but emits a warning for it.

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -224,7 +224,7 @@ A ``ctuple`` is assembled from any valid C types. For example
 
         .. code-block:: python
 
-            bar: (double, int)
+            bar: (cython.double, cython.int)
 
     .. group-tab:: Cython
 
@@ -323,7 +323,7 @@ using normal C declaration syntax. For example,
 
         .. code-block:: python
 
-         def chips(t: (long, long, double)) -> (int, float)
+         def chips(t: (cython.long, cython.long, cython.double)) -> (cython.int, cython.float)
             ...
 
     .. group-tab:: Cython
@@ -486,6 +486,7 @@ This is because the program calling the function just needs to know what signatu
 possible in C, but doesn't need to know the value of the default arguments.:
 
 .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pxd
+    :caption: optional_subclassing.pxd
 
 .. note::
     The number of arguments may increase when subclassing,
@@ -556,7 +557,7 @@ Here is an example
         .. code-block:: python
 
             @cython.exceptval(-1)
-            def spam() -> int:
+            def spam() -> cython.int:
                 ...
 
     .. group-tab:: Cython
@@ -591,7 +592,7 @@ form of exception value declaration
         .. code-block:: python
 
             @cython.exceptval(-1, check=True)
-            def spam() -> int:
+            def spam() -> cython.int:
                 ...
 
     .. group-tab:: Cython
@@ -615,7 +616,7 @@ There is also a third form of exception value declaration
         .. code-block:: python
 
             @cython.exceptval(check=True)
-            def spam() -> int:
+            def spam() -> cython.int:
                 ...
 
     .. group-tab:: Cython

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -48,7 +48,8 @@ C variable and type definitions
 ===============================
 
 C variables can be declared by using the :keyword:`cdef` statement, by annotating
-variable by special cython type or using function ``declare()``. Statement :keyword:`cdef` and function ``declare()`` can declare either local or
+variable by special cython type or using function ``declare()``. Statement :keyword:`cdef`
+and function ``declare()`` can declare either local or
 module-level variables, but annotated version currently supports only local variables:
 
 .. tabs::
@@ -480,6 +481,9 @@ object as the explicit return type of a function, e.g.::
 
     cdef object ftang(object int):
         ...
+
+.. note:: Currently, Cython contains a bug not allowing returning ``object`` in
+    pure python from C function.
 
 In the interests of clarity, it is probably a good idea to always be explicit
 about object parameters in C functions.

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -948,7 +948,7 @@ Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` fun
         To get the address of some Python object, use a cast to a pointer type
         like ``<void*>`` or ``<PyObject*>``.
         You can also cast a C pointer back to a Python object reference
-        with ``<object>``, or a more specific builtin or extension type
+        with ``<object>``, or to a more specific builtin or extension type
         (e.g. ``<MyExtType>ptr``). This will increase the reference count of
         the object by one, i.e. the cast returns an owned reference.
         Here is an example:

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -45,14 +45,43 @@ C variable and type definitions
 ===============================
 
 The :keyword:`cdef` statement is used to declare C variables, either local or
-module-level::
+module-level
 
-    cdef int i, j, k
-    cdef float f, g[42], *h
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            import cython
+
+            i: cython.int
+            j: cython.int
+            k: cython.int
+            f: cython.float
+            g: cython.int[42]
+            h: cython.p_float
+
+
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef int i, j, k
+            cdef float f, g[42], *h
 
 and C :keyword:`struct`, :keyword:`union` or :keyword:`enum` types:
 
-.. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.pyx
 
 See also :ref:`struct-union-enum-styles`
 
@@ -96,10 +125,22 @@ an anonymous :keyword:`enum` declaration for this purpose, for example,::
 
 It is also possible to declare functions with :keyword:`cdef`, making them c functions.
 
-::
+.. tabs::
 
-    cdef int eggs(unsigned long l, float f):
-        ...
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.cfunc
+            def eggs(l: cython.ulong, f: cython.float) -> cython.int:
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef int eggs(unsigned long l, float f):
+                ...
 
 You can read more about them in :ref:`python_functions_vs_c_functions`.
 
@@ -109,7 +150,15 @@ internally to store attributes.
 
 Here is a simple example:
 
-.. literalinclude:: ../../examples/userguide/extension_types/shrubbery.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/extension_types/shrubbery.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/extension_types/shrubbery.pyx
 
 You can read more about them in :ref:`extension-types`.
 
@@ -135,9 +184,21 @@ whereas ``x[0]`` is.
 
 Also, the Python types ``list``, ``dict``, ``tuple``, etc. may be used for
 static typing, as well as any user defined :ref:`extension-types`.
-For example::
+For example
 
-    cdef list foo = []
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            foo: list = []
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef list foo = []
 
 This requires an *exact* match of the class, it does not allow subclasses.
 This allows Cython to optimize code by accessing internals of the builtin class,
@@ -150,9 +211,21 @@ respectively, as statically typing variables with these Python
 types has zero advantages.
 
 Cython provides an accelerated and typed equivalent of a Python tuple, the ``ctuple``.
-A ``ctuple`` is assembled from any valid C types. For example::
+A ``ctuple`` is assembled from any valid C types. For example
 
-    cdef (double, int) bar
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            bar: (double, int)
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef (double, int) bar
 
 They compile down to C-structures and can be used as efficient alternatives to
 Python tuples.
@@ -209,28 +282,77 @@ there is a tiny overhead in calling a :keyword:`cpdef` method from Cython compar
 calling a :keyword:`cdef` method.
 
 Parameters of either type of function can be declared to have C data types,
-using normal C declaration syntax. For example,::
+using normal C declaration syntax. For example,
 
-    def spam(int i, char *s):
-        ...
+.. tabs::
 
-    cdef int eggs(unsigned long l, float f):
-        ...
+    .. group-tab:: Pure Python
 
-``ctuples`` may also be used::
+        .. code-block:: python
 
-    cdef (int, float) chips((long, long, double) t):
-        ...
+            def spam(i: cython.int, s: cython.p_char):
+                ...
+
+            @cython.cfunc
+            def eggs(l: cython.ulong, f: cython.float) -> cython.int:
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            def spam(int i, char *s):
+                ...
+
+            cdef int eggs(unsigned long l, float f):
+                ...
+
+
+
+``ctuples`` may also be used
+
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+         def chips(t: (long, long, double)) -> (int, float)
+            ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef (int, float) chips((long, long, double) t):
+                ...
 
 When a parameter of a Python function is declared to have a C data type, it is
 passed in as a Python object and automatically converted to a C value, if
 possible. In other words, the definition of ``spam`` above is equivalent to
-writing::
+writing
 
-    def spam(python_i, python_s):
-        cdef int i = python_i
-        cdef char* s = python_s
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            def spam(python_i, python_s):
+                i: cython.int = python_i
+                s: cython.p_char = python_s
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            def spam(python_i, python_s):
+                cdef int i = python_i
+                cdef char* s = python_s
+                ...
+
+
 
 Automatic conversion is currently only possible for numeric types,
 string types and structs (composed recursively of any of these types);
@@ -257,10 +379,24 @@ Python objects as parameters and return values
 If no type is specified for a parameter or return value, it is assumed to be a
 Python object. (Note that this is different from the C convention, where it
 would default to int.) For example, the following defines a C function that
-takes two Python objects as parameters and returns a Python object::
+takes two Python objects as parameters and returns a Python object
 
-    cdef spamobjs(x, y):
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.cfunc
+            def spamobjs(x, y):
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef spamobjs(x, y):
+                ...
 
 Reference counting for these objects is performed automatically according to
 the standard Python/C API rules (i.e. borrowed references are taken as
@@ -274,10 +410,24 @@ parameters and a new reference is returned).
 
 The name object can also be used to explicitly declare something as a Python
 object. This can be useful if the name being declared would otherwise be taken
-as the name of a type, for example,::
+as the name of a type, for example,
 
-    cdef ftang(object int):
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.cfunc
+            def ftang(int: object):
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef ftang(object int):
+                ...
 
 declares a parameter called int which is a Python object. You can also use
 object as the explicit return type of a function, e.g.::
@@ -315,7 +465,15 @@ the implementation (in ``.pyx`` files).
 
 When in a ``.pyx`` file, the signature is the same as it is in Python itself:
 
-.. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
 
 When in a ``.pxd`` file, the signature is different like this example: ``cdef foo(x=*)``.
 This is because the program calling the function just needs to know what signatures are
@@ -383,10 +541,24 @@ propagating the exception to its caller.
 
 If you want such a C function to be able to propagate exceptions, you need
 to declare an exception return value for it as a contract with the caller.
-Here is an example::
+Here is an example
 
-    cdef int spam() except -1:
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.exceptval(-1)
+            def spam() -> int:
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef int spam() except -1:
+                ...
 
 With this declaration, whenever an exception occurs inside ``spam``, it will
 immediately return with the value ``-1``.  From the caller's side, whenever
@@ -404,20 +576,47 @@ returns small results.
 
 If all possible return values are legal and you
 can't reserve one entirely for signalling errors, you can use an alternative
-form of exception value declaration::
+form of exception value declaration
 
-    cdef int spam() except? -1:
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.exceptval(-1, check=True)
+            def spam() -> int:
+                ...
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef int spam() except? -1:
+                ...
 
 The "?" indicates that the value ``-1`` only signals a possible error. In this
 case, Cython generates a call to :c:func:`PyErr_Occurred` if the exception value
 is returned, to make sure it really received an exception and not just a normal
 result.
 
-There is also a third form of exception value declaration::
+There is also a third form of exception value declaration
 
-    cdef int spam() except *:
-        ...
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            @cython.exceptval(check=True)
+            def spam() -> int:
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef int spam() except *:
+                ...
 
 This form causes Cython to generate a call to :c:func:`PyErr_Occurred` after
 *every* call to spam, regardless of what value it returns. If you have a
@@ -470,7 +669,15 @@ function or a C function that calls Python/C API routines. To get an exception
 from a non-Python-aware function such as :func:`fopen`, you will have to check the
 return value and raise it yourself, for example:
 
-.. literalinclude:: ../../examples/userguide/language_basics/open_file.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/open_file.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/open_file.pyx
 
 .. _overriding_in_extension_types:
 
@@ -480,13 +687,29 @@ Overriding in extension types
 
 ``cpdef`` methods can override ``cdef`` methods:
 
-.. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/optional_subclassing.pyx
 
 When subclassing an extension type with a Python class,
 ``def`` methods can override ``cpdef`` methods but not ``cdef``
 methods:
 
-.. literalinclude:: ../../examples/userguide/language_basics/override.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/language_basics/override.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/language_basics/override.pyx
 
 If ``C`` above would be an extension type (``cdef class``),
 this would not work correctly.
@@ -548,10 +771,23 @@ as the C string is needed. If you can't guarantee that the Python string will
 live long enough, you will need to copy the C string.
 
 Cython detects and prevents some mistakes of this kind. For instance, if you
-attempt something like::
+attempt something like
 
-    cdef char *s
-    s = pystring1 + pystring2
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            s: cython.p_char
+            s = pystring1 + pystring2
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef char *s
+            s = pystring1 + pystring2
 
 then Cython will produce the error message ``Storing unsafe C derivative of temporary
 Python reference``. The reason is that concatenating the two Python strings
@@ -562,11 +798,25 @@ leaving ``s`` dangling. Since this code could not possibly work, Cython refuses 
 compile it.
 
 The solution is to assign the result of the concatenation to a Python
-variable, and then obtain the ``char*`` from that, i.e.::
+variable, and then obtain the ``char*`` from that, i.e.
 
-    cdef char *s
-    p = pystring1 + pystring2
-    s = p
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            s: cython.p_char
+            p = pystring1 + pystring2
+            s = p
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef char *s
+            p = pystring1 + pystring2
+            s = p
 
 It is then your responsibility to hold the reference p for as long as
 necessary.
@@ -581,11 +831,25 @@ be careful what you do.
 Type Casting
 ------------
 
-Where C uses ``"("`` and ``")"``, Cython uses ``"<"`` and ``">"``. For example::
+Where C uses ``"("`` and ``")"``, Cython uses ``"<"`` and ``">"``. For example
 
-    cdef char *p
-    cdef float *q
-    p = <char*>q
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. code-block:: python
+
+            p: cython.p_char
+            q: cython.p_float
+            p = cython.cast(cython.p_char, q)
+
+    .. group-tab:: Cython
+
+        .. code-block:: cython
+
+            cdef char *p
+            cdef float *q
+            p = <char*>q
 
 When casting a C value to a Python object type or vice versa,
 Cython will attempt a coercion. Simple examples are casts like ``<int>pyobj``,
@@ -657,10 +921,24 @@ direct equivalent in Python.
 * There is no unary ``*`` operator in Cython. Instead of ``*p``, use ``p[0]``
 * There is an ``&`` operator, with the same semantics as in C.
 * The null C pointer is called ``NULL``, not ``0`` (and ``NULL`` is a reserved word).
-* Type casts are written ``<type>value`` , for example,::
+* Type casts are written ``<type>value`` , for example,
 
-        cdef char* p, float* q
-        p = <char*>q
+  .. tabs::
+
+      .. group-tab:: Pure Python
+
+          .. code-block:: python
+
+              p: cython.p_char
+              q: cython.p_float
+              p = cython.cast(cython.p_char, q)
+
+      .. group-tab:: Cython
+
+          .. code-block:: cython
+
+              cdef char* p, float* q
+              p = <char*>q
 
 Scope rules
 -----------

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -940,7 +940,7 @@ Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` fun
 
         When casting a C value to a Python object type or vice versa,
         Cython will attempt a coercion. Simple examples are casts like ``<int>pyobj_value``,
-        which converts a Python number to a plain C ``int`` value, or ``<bytes>charptr_value``,
+        which convert a Python number to a plain C ``int`` value, or the statement ``<bytes>charptr_value``,
         which copies a C ``char*`` string into a new Python bytes object.
 
          .. note:: Cython will not prevent a redundant cast, but emits a warning for it.

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -397,7 +397,7 @@ with string attributes if they are to be used after the function returns.
 C functions, on the other hand, can have parameters of any type, since they're
 passed in directly using a normal C function call.
 
-C Functions declared using :keyword:`cdef` or ``cfunc`` decorator with Python object return type, like Python functions, will return a :keyword:`None`
+C Functions declared using :keyword:`cdef` or ``@cfunc`` decorator with Python object return type, like Python functions, will return a :keyword:`None`
 value when execution leaves the function body without an explicit return value. This is in
 contrast to C/C++, which leaves the return value undefined. 
 In the case of non-Python object return types, the equivalent of zero is returned, for example, 0 for ``int``, :keyword:`False` for ``bint`` and :keyword:`NULL` for pointer types.

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -610,6 +610,7 @@ Here is an example
 
         .. code-block:: python
 
+            @cfunc
             @exceptval(-1)
             def spam() -> cython.int:
                 ...
@@ -645,6 +646,7 @@ form of exception value declaration
 
         .. code-block:: python
 
+            @cfunc
             @exceptval(-1, check=True)
             def spam() -> cython.int:
                 ...
@@ -677,6 +679,7 @@ There is also a third form of exception value declaration
 
         .. code-block:: python
 
+            @cfunc
             @exceptval(check=True)
             def spam() -> cython.int:
                 ...

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -67,8 +67,9 @@ define global C variables.
 
         .. code-block:: python
 
-            global_x = declare(cython.int)
-            def main():
+            a_global_variable = declare(cython.int)
+
+            def func():
                 i: cython.int
                 j: cython.int
                 k: cython.int
@@ -80,8 +81,11 @@ define global C variables.
 
         .. code-block:: cython
 
-            cdef int i, j, k
-            cdef float f, g[42], *h
+            cdef int a_global_variable
+
+            def func():
+                cdef int i, j, k
+                cdef float f, g[42], *h
 
 Moreover, C :keyword:`struct`, :keyword:`union` and :keyword:`enum` are supported:
 
@@ -91,7 +95,7 @@ Moreover, C :keyword:`struct`, :keyword:`union` and :keyword:`enum` are supporte
 
         .. literalinclude:: ../../examples/userguide/language_basics/struct_union_enum.py
 
-        .. note:: Currently, Pure Python mode does not support enums.
+        .. note:: Currently, Pure Python mode does not support enums. (GitHub issue :issue:`4252`)
 
     .. group-tab:: Cython
 
@@ -160,7 +164,7 @@ You can create a C function by declaring it with :keyword:`cdef` or by decoratin
 
         .. code-block:: python
 
-            @cfunc
+            @cython.cfunc
             def eggs(l: cython.ulong, f: cython.float) -> cython.int:
                 ...
 
@@ -337,7 +341,7 @@ using normal C declaration syntax. For example,
             def spam(i: cython.int, s: cython.p_char):
                 ...
 
-            @cfunc
+            @cython.cfunc
             def eggs(l: cython.ulong, f: cython.float) -> cython.int:
                 ...
 
@@ -359,7 +363,7 @@ using normal C declaration syntax. For example,
 
         .. code-block:: python
 
-            @cfunc
+            @cython.cfunc
             def chips(t: (cython.long, cython.long, cython.double)) -> (cython.int, cython.float):
                 ...
 
@@ -430,7 +434,7 @@ takes two Python objects as parameters and returns a Python object
 
         .. code-block:: python
 
-            @cfunc
+            @cython.cfunc
             def spamobjs(x, y):
                 ...
 
@@ -461,7 +465,7 @@ as the name of a type, for example,
 
         .. code-block:: python
 
-            @cfunc
+            @cython.cfunc
             def ftang(int: object):
                 ...
 
@@ -478,8 +482,8 @@ object as the explicit return type of a function, e.g.::
     cdef object ftang(object int):
         ...
 
-.. note:: Currently, Cython contains a bug not allowing returning ``object`` in
-    pure python from a C function.
+.. note:: Currently, Cython contains a bug not allowing ``object`` as return annotation in
+    pure Python from a C function. (GitHub issue :issue:`2529`)
 
 In the interests of clarity, it is probably a good idea to always be explicit
 about object parameters in C functions.
@@ -606,8 +610,8 @@ Here is an example
 
         .. code-block:: python
 
-            @cfunc
-            @exceptval(-1)
+            @cython.cfunc
+            @cython.exceptval(-1)
             def spam() -> cython.int:
                 ...
 
@@ -642,12 +646,12 @@ form of exception value declaration
 
         .. code-block:: python
 
-            @cfunc
-            @exceptval(-1, check=True)
+            @cython.cfunc
+            @cython.exceptval(-1, check=True)
             def spam() -> cython.int:
                 ...
 
-        The ``check=True`` indicates that the value ``-1`` only signals a possible error.
+        The keyword argument ``check=True`` indicates that the value ``-1`` _may_ signal an error.
 
     .. group-tab:: Cython
 
@@ -656,7 +660,7 @@ form of exception value declaration
             cdef int spam() except? -1:
                 ...
 
-        The ``?`` indicates that the value ``-1`` only signals a possible error.
+        The ``?`` indicates that the value ``-1`` _may_ signal an error.
 
 In this case, Cython generates a call to :c:func:`PyErr_Occurred` if the exception value
 is returned, to make sure it really received an exception and not just a normal
@@ -670,8 +674,8 @@ There is also a third form of exception value declaration
 
         .. code-block:: python
 
-            @cfunc
-            @exceptval(check=True)
+            @cython.cfunc
+            @cython.exceptval(check=True)
             def spam() -> cython.int:
                 ...
 
@@ -711,7 +715,7 @@ Some things to note:
 
       int (*grail)(int, char*) except -1
 
-  .. note:: Pointers to functions are currently not supported by pure Python mode.
+  .. note:: Pointers to functions are currently not supported by pure Python mode. (GitHub issue :issue:`4279`)
 
 * You don't need to (and shouldn't) declare exception values for functions
   which return Python objects. Remember that a function with no declared
@@ -1130,7 +1134,7 @@ Python and C, and that Cython uses the Python precedences, not the C ones.
 Integer for-loops
 ------------------
 
-.. note:: This syntax is supported only in Cython files and not in Python.
+.. note:: This syntax is supported only in Cython files.  Use a normal `for-in-range()` loop instead.
 
 Cython recognises the usual Python for-in-range integer loop pattern::
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -11,6 +11,9 @@
 Language Basics
 *****************
 
+.. include::
+    ../two-syntax-variants-used
+
 .. _declaring_data_types:
 
 Declaring Data Types
@@ -305,6 +308,7 @@ using normal C declaration syntax. For example,
 
             def spam(int i, char *s):
                 ...
+
 
             cdef int eggs(unsigned long l, float f):
                 ...
@@ -612,6 +616,7 @@ There is also a third form of exception value declaration
 
             @cython.exceptval(check=True)
             def spam() -> int:
+                ...
 
     .. group-tab:: Cython
 
@@ -952,6 +957,7 @@ direct equivalent in Python.
           .. code-block:: cython
 
               cdef char* p, float* q
+
               p = <char*>q
 
 Scope rules

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -1182,6 +1182,11 @@ Conditional Compilation
 Some features are available for conditional compilation and compile-time
 constants within a Cython source file.
 
+.. note::
+
+    Cython currently does not support conditional compilation and compile-time
+    definitions in Pure Python mode.
+
 Compile-Time Definitions
 ------------------------
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -187,39 +187,24 @@ You can read more about them in :ref:`extension-types`.
 Types
 -----
 
-.. tabs::
+Cython language uses the normal C syntax for C types, including pointers.  It provides
+all the standard C types, namely ``char``, ``short``, ``int``, ``long``,
+``long long`` as well as their ``unsigned`` versions,
+e.g. ``unsigned int`` in Cython laguage and ``uint`` in Pure Python.
+The special ``bint`` type is used for C boolean values (``int`` with 0/non-0
+values for False/True) and ``Py_ssize_t`` for (signed) sizes of Python
+containers.
 
-    .. group-tab:: Pure Python
+Pointer types are constructed as in C in Cython language, by appending a ``*`` to the base type
+they point to, e.g. ``int**`` for a pointer to a pointer to a C int. In Pure python mode, pointer types
+are constructed by needed number of "p" s and then "_", e.g. ``pp_int`` for a pointer to
+a pointer to a C int. Further pointer types can be constructed with ``pointer()`` function.
 
-        Cython supports annotaions for C types, including pointers.  It provides
-        all the standard C types, namely ``char``, ``short``, ``int``, ``long``,
-        ``long long`` as well as their ``unsigned`` versions, e.g. ``uint``.
-        The special ``bint`` type is used for C boolean values (``int`` with 0/non-0
-        values for False/True) and ``Py_ssize_t`` for (signed) sizes of Python
-        containers.
 
-        Pointer types are constructed by appending a ``p_`` to the base type
-        they point to, e.g. ``pp_int`` for a pointer to a pointer to a C int.
-        Further pointer types can be constructed with ``pointer()`` function.
-        Arrays use the normal C array syntax, e.g. ``int[10]``, and the size must be known
-        at compile time for stack allocated arrays. Cython doesn't support variable length arrays from C99.
-        Note that Cython uses array access for pointer dereferencing.
-
-    .. group-tab:: Cython
-
-        Cython language uses the normal C syntax for C types, including pointers.  It provides
-        all the standard C types, namely ``char``, ``short``, ``int``, ``long``,
-        ``long long`` as well as their ``unsigned`` versions, e.g. ``unsigned int``.
-        The special ``bint`` type is used for C boolean values (``int`` with 0/non-0
-        values for False/True) and ``Py_ssize_t`` for (signed) sizes of Python
-        containers.
-
-        Pointer types are constructed as in C, by appending a ``*`` to the base type
-        they point to, e.g. ``int**`` for a pointer to a pointer to a C int.
-        Arrays use the normal C array syntax, e.g. ``int[10]``, and the size must be known
-        at compile time for stack allocated arrays. Cython doesn't support variable length arrays from C99.
-        Note that Cython uses array access for pointer dereferencing, as ``*x`` is not valid Python syntax,
-        whereas ``x[0]`` is.
+Arrays use the normal C array syntax, e.g. ``int[10]``, and the size must be known
+at compile time for stack allocated arrays. Cython doesn't support variable length arrays from C99.
+Note that Cython uses array access for pointer dereferencing, as ``*x`` is not valid Python syntax,
+whereas ``x[0]`` is.
 
 Also, the Python types ``list``, ``dict``, ``tuple``, etc. may be used for
 static typing, as well as any user defined :ref:`extension-types`.
@@ -702,7 +687,7 @@ An external C++ function that may raise an exception can be declared with::
 
     cdef int spam() except +
 
-.. note:: Pure python mode currently does not have equivalent to `except +`.
+.. note:: Pure python mode does not have equivalent to `except +`.
 
 See :ref:`wrapping-cplusplus` for more details.
 

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -102,8 +102,6 @@ and C :keyword:`struct`, :keyword:`union` or :keyword:`enum` types:
                 soft = 2
                 runny = 3
 
-
-
         There is currently no special syntax for defining a constant, but you can use
         an anonymous :keyword:`enum` declaration for this purpose, for example,::
 


### PR DESCRIPTION
This PR is introducing pure python mode in language basics documentation. It is partial fix of https://github.com/cython/cython/issues/4187