### PR TITLE
Set is_cython_module on annotations correctly

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -929,6 +929,13 @@ class InterpretCompilerDirectives(CythonTransform):
                 # before they have a chance to cause compile-errors
         return node
 
+    def visit_AnnotationNode(self, node):
+        # for most transforms annotations are left unvisited (because they're unevaluated)
+        # however, it is important to pick up compiler directives from them
+        if node.expr:
+            self.visitchildren(node.expr)
+        return node
+
     def visit_NewExprNode(self, node):
         self.visit(node.cppclass)
         self.visitchildren(node)

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -3,6 +3,7 @@
 
 cimport cython
 from cython cimport typeof
+from cpython.ref cimport PyObject
 
 
 def old_dict_syntax(a: list, b: "int" = 2, c: {'ctype': 'long int'} = 3, d: {'type': 'float'} = 4) -> list:
@@ -266,20 +267,32 @@ cdef class ClassAttribute:
     cls_attr : float = 1.
 
 
+@cython.cfunc
+def take_ptr(obj: cython.pointer(PyObject)):
+    pass
+
+def call_take_ptr():
+    """
+    >>> call_take_ptr()  # really just a compile-test
+    """
+    python_dict = {"abc": 123}
+    take_ptr(cython.cast(cython.pointer(PyObject), python_dict))
+
+
 _WARNINGS = """
-8:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
-8:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
-8:56: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
-8:77: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
-8:85: Python type declaration in signature annotation does not refer to a Python type
-8:85: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
-242:44: Unknown type declaration in annotation, ignoring
-249:29: Ambiguous types in annotation, ignoring
-266:15: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
+9:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
+9:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
+9:56: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
+9:77: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
+9:85: Python type declaration in signature annotation does not refer to a Python type
+9:85: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
+243:44: Unknown type declaration in annotation, ignoring
+250:29: Ambiguous types in annotation, ignoring
+267:15: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
 # BUG:
-46:6: 'pytypes_cpdef' redeclared
-120:0: 'struct_io' redeclared
-149:0: 'struct_convert' redeclared
-168:0: 'exception_default' redeclared
-199:0: 'exception_default_uint' redeclared
+47:6: 'pytypes_cpdef' redeclared
+121:0: 'struct_io' redeclared
+150:0: 'struct_convert' redeclared
+169:0: 'exception_default' redeclared
+200:0: 'exception_default_uint' redeclared
 """


### PR DESCRIPTION
Fixes #4243 (and probably a bunch more annotation bugs)

AnnotationNode doesn't have any child_attrs/subexprs because
it mostly doesn't want to be analyzed (it's just transformed to
an evaluable string). However this means that InterpretCompilerDirectives
wasn't visiting its children to set is_cython_module and so the
typing was failing. I've special-cased InterpretCompilerDirectives
to visit AnnotationNode fully.