### PR TITLE
fix call to run_distutils

### DIFF
--- a/Cython/Debugger/Tests/TestLibCython.py
+++ b/Cython/Debugger/Tests/TestLibCython.py
@@ -132,10 +132,11 @@ class DebuggerTestCase(unittest.TestCase):
                 )
 
                 cython_compile_testcase.run_distutils(
+                    test_directory=opts['test_directory'],
+                    module=opts['module'],
+                    workdir=opts['test_directory'],
                     incdir=None,
-                    workdir=self.tempdir,
                     extra_extension_args={'extra_objects':['cfuncs.o']},
-                    **opts
                 )
             finally:
                 optimization_disabler.restore_state()


### PR DESCRIPTION
more #4249 problems, this time with run_distutils. Make it a bit more verbose so it is clear how the differently-named arguments map to each other.