### PR TITLE
Fix a few bugs in cpp_locals

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2083,8 +2083,7 @@ class CCodeWriter(object):
         elif entry.type.is_pyobject:
             self.put(" = NULL")
         self.putln(";")
-        if entry.utility_code_definition:
-            self.funcstate.scope.use_utility_code(entry.utility_code_definition)
+        self.funcstate.scope.use_entry_utility_code(entry)
 
     def put_temp_declarations(self, func_context):
         for name, type, manage_ref, static in func_context.temps_allocated:

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2083,6 +2083,8 @@ class CCodeWriter(object):
         elif entry.type.is_pyobject:
             self.put(" = NULL")
         self.putln(";")
+        if entry.utility_code_definition:
+            self.funcstate.scope.use_utility_code(entry.utility_code_definition)
 
     def put_temp_declarations(self, func_context):
         for name, type, manage_ref, static in func_context.temps_allocated:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1281,8 +1281,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 decl = attr_type.cpp_optional_declaration_code(attr.cname)
             else:
                 decl = attr_type.declaration_code(attr.cname)
-            if attr.utility_code_definition:
-                type.scope.use_utility_code(attr.utility_code_definition)
+            type.scope.use_entry_utility_code(attr)
             code.putln("%s;" % decl)
         code.putln(footer)
         if type.objtypedef_cname is not None:
@@ -1373,8 +1372,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln(";")
             if entry.cname != cname:
                 code.putln("#define %s (*%s)" % (entry.cname, cname))
-            if entry.utility_code_definition:
-                env.use_utility_code(entry.utility_code_definition)
+            env.use_entry_utility_code(entry)
 
     def generate_cfunction_declarations(self, env, code, definition):
         for entry in env.cfunc_entries:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -274,7 +274,7 @@ class Entry(object):
         assert self.type.is_cpp_class
         self.is_cpp_optional = True
         assert not self.utility_code  # we're not overwriting anything?
-        self.utility_code = Code.UtilityCode.load_cached("OptionalLocals", "CppSupport.cpp")
+        self.utility_code_definition = Code.UtilityCode.load_cached("OptionalLocals", "CppSupport.cpp")
 
 
 class InnerEntry(Entry):

--- a/tests/run/cpp_optional_temps.pyx
+++ b/tests/run/cpp_optional_temps.pyx
@@ -5,17 +5,36 @@
 
 cimport cython
 
+from libcpp cimport bool as cppbool
+
 cdef extern from *:
-    """
+    r"""
+    static void print_C_destructor();
+
     class C {
         public:
             C() = delete; // look! No default constructor
-            C(int x) : x(x) {}
+            C(int x, bool print_destructor=true) : x(x), print_destructor(print_destructor) {}
+            C(C&& rhs) : x(rhs.x), print_destructor(rhs.print_destructor) {
+                rhs.print_destructor = false; // moved-from instances are deleted silently
+            }
+            C& operator=(C&& rhs) {
+                x=rhs.x;
+                print_destructor=rhs.print_destructor;
+                rhs.print_destructor = false; // moved-from instances are deleted silently
+                return *this;
+            }
+            C(const C& rhs) = default;
+            C& operator=(const C& rhs) = default;
+            ~C() {
+                if (print_destructor) print_C_destructor();
+            }
 
             int getX() const { return x; }
 
         private:
             int x;
+            bool print_destructor;
     };
 
     C make_C(int x) {
@@ -24,26 +43,35 @@ cdef extern from *:
     """
     cdef cppclass C:
         C(int)
+        C(int, cppbool)
         int getX() const
     C make_C(int) except +  # needs a temp to receive
 
-def maybe_assign_infer(assign, value):
+# this function just makes sure the output from the destructor can be captured by doctest
+cdef void print_C_destructor "print_C_destructor" () nogil:
+    print("~C()")
+
+def maybe_assign_infer(assign, value, do_print):
     """
-    >>> maybe_assign_infer(True, 5)
+    >>> maybe_assign_infer(True, 5, True)
     5
-    >>> maybe_assign_infer(False, 0)
+    ~C()
+    >>> maybe_assign_infer(False, 0, True)
     Traceback (most recent call last):
         ...
     UnboundLocalError: local variable 'x' referenced before assignment
+    >>> maybe_assign_infer(False, 0, False)  # no destructor call here
     """
     if assign:
         x = C(value)
-    print(x.getX())
+    if do_print:
+        print(x.getX())
 
 def maybe_assign_cdef(assign, value):
     """
     >>> maybe_assign_cdef(True, 5)
     5
+    ~C()
     >>> maybe_assign_cdef(False, 0)
     Traceback (most recent call last):
         ...
@@ -58,6 +86,7 @@ def maybe_assign_annotation(assign, value):
     """
     >>> maybe_assign_annotation(True, 5)
     5
+    ~C()
     >>> maybe_assign_annotation(False, 0)
     Traceback (most recent call last):
         ...
@@ -72,6 +101,7 @@ def maybe_assign_directive1(assign, value):
     """
     >>> maybe_assign_directive1(True, 5)
     5
+    ~C()
     >>> maybe_assign_directive1(False, 0)
     Traceback (most recent call last):
         ...
@@ -87,6 +117,7 @@ def maybe_assign_directive2(assign, value):
     """
     >>> maybe_assign_directive2(True, 5)
     5
+    ~C()
     >>> maybe_assign_directive2(False, 0)
     Traceback (most recent call last):
         ...
@@ -100,6 +131,7 @@ def maybe_assign_nocheck(assign, value):
     """
     >>> maybe_assign_nocheck(True, 5)
     5
+    ~C()
 
     # unfortunately it's quite difficult to test not assigning because there's a decent chance it'll crash
     """
@@ -113,6 +145,7 @@ def uses_temp(value):
     needs a temp to handle the result of make_C - still doesn't use the default constructor
     >>> uses_temp(10)
     10
+    ~C()
     """
 
     x = make_C(value)
@@ -127,32 +160,47 @@ def call_has_argument():
     >>> call_has_argument()
     50
     """
-    has_argument(C(50))
+    has_argument(C(50, False))
 
 cdef class HoldsC:
     """
-    >>> inst = HoldsC(True)
+    >>> inst = HoldsC(True, False)
     >>> inst.getCX()
     10
-    >>> inst = HoldsC(False)
+    >>> inst = HoldsC(False, False)
     >>> inst.getCX()
     Traceback (most recent call last):
         ...
     AttributeError: C++ attribute 'value' is not initialized
     """
     cdef C value
-    def __cinit__(self, initialize):
+    def __cinit__(self, initialize, print_destructor):
         if initialize:
-            self.value = C(10)
+            self.value = C(10, print_destructor)
 
     def getCX(self):
         return self.value.getX()
+
+def dont_test_on_pypy(f):
+    import sys
+    if not hasattr(sys, "pypy_version_info"):
+        return f
+
+@dont_test_on_pypy  # non-deterministic destruction
+def testHoldsCDestruction(initialize):
+    """
+    >>> testHoldsCDestruction(True)
+    ~C()
+    >>> testHoldsCDestruction(False)  # no destructor
+    """
+    x = HoldsC(initialize, True)
+    del x
 
 cdef C global_var
 
 def initialize_global_var():
     global global_var
-    global_var = C(-1)
+    global_var = C(-1, False)
 
 def read_global_var():
     """

--- a/tests/run/cpp_optional_temps_unused.pyx
+++ b/tests/run/cpp_optional_temps_unused.pyx
@@ -1,0 +1,13 @@
+# mode: run
+# tag: cpp, cpp17
+
+# cython: cpp_locals=True
+
+cdef cppclass C:
+    C()
+
+cdef class PyC:
+    """
+    >>> PyC() and None  # doesn't really do anything, but should run
+    """
+    cdef C  # this limited usage wasn't triggering the creation of utility code


### PR DESCRIPTION
1) Entry utility_code wasn't being imported unless the entry
   was visibly used. The utility code is needed for the definition
   even if unused. I think
   this is what utility_code_definition is for, but I'm not completely
   sure. I also had to add some calls to ensure it's used.
   Not confident that this is solved the right way

2) CppOptionalTempCoercions weren't being moved correctly. Tested by
   printing from the destructor.

3) cdef-class attributes weren't being created or destroyed correctly.
   Tested by printing from the destructor