### PR TITLE
Use explicitely cython module in examples

### DIFF
--- a/docs/examples/tutorial/external/keyword_args_call.py
+++ b/docs/examples/tutorial/external/keyword_args_call.py
@@ -1,8 +1,7 @@
-import cython
 from cython.cimports.strstr import strstr
 
 def main():
-    data: p_char = "hfvcakdfagbcffvschvxcdfgccbcfhvgcsnfxjh"
+    data: cython.p_char = "hfvcakdfagbcffvschvxcdfgccbcfhvgcsnfxjh"
 
-    pos: p_char = strstr(needle='akd', haystack=data)
+    pos = strstr(needle='akd', haystack=data)
     print(pos is not cython.NULL)

--- a/docs/examples/tutorial/external/keyword_args_call.pyx
+++ b/docs/examples/tutorial/external/keyword_args_call.pyx
@@ -1,7 +1,6 @@
 cdef extern from "string.h":
     char* strstr(const char *haystack, const char *needle)
 
-
 cdef char* data = "hfvcakdfagbcffvschvxcdfgccbcfhvgcsnfxjh"
 
 cdef char* pos = strstr(needle='akd', haystack=data)


### PR DESCRIPTION
In header of each documentation is said:

> To make good use of the latter, including C data types, etc., you need the special cython module, which you can import with

> import cython

> in the Python module that you want to compile.

I have find out that this is not consistent with example in Calling C functions tutorial where we are using symbols imported directly.