### PR TITLE
Conversion of C++ containers with optional templates

### DIFF
--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -11,6 +11,10 @@ from libcpp.pair cimport pair
 from libcpp.vector cimport vector
 from libcpp.list cimport list as cpp_list
 
+cdef extern from "<memory>" namespace "std":
+    cdef cppclass allocator[T]:
+        pass
+
 py_set = set
 py_xrange = xrange
 py_unicode = unicode
@@ -95,6 +99,22 @@ def test_int_vector(o):
     OverflowError: ...
     """
     cdef vector[int] v = o
+    return v
+
+def test_int_vector_allocator(o):
+    """
+    >>> test_int_vector_allocator([1, 2, 3])
+    [1, 2, 3]
+    >>> test_int_vector_allocator((1, 10, 100))
+    [1, 10, 100]
+    >>> test_int_vector_allocator(py_xrange(1,10,2))
+    [1, 3, 5, 7, 9]
+    >>> test_int_vector_allocator([10**20])       #doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    OverflowError: ...
+    """
+    cdef vector[int, allocator[int]] v = o
     return v
 
 cdef vector[int] takes_vector(vector[int] x):
@@ -210,6 +230,30 @@ def test_unordered_set(o):
    cdef unordered_set[long] s = o
    return s
 
+cdef extern from *:
+    """
+    struct CustomHash {
+        template <typename T>
+        size_t operator()(T o) const {
+            return o;
+        }
+    };
+    """
+    cdef cppclass CustomHash:
+        pass
+
+def test_unordered_set_hash(o):
+   """
+   >>> sorted(test_unordered_set_hash([1, 2, 3]))
+   [1, 2, 3]
+   >>> sorted(test_unordered_set_hash([1, 2, 3, 3]))
+   [1, 2, 3]
+   >>> type(test_unordered_set_hash([])) is py_set
+   True
+   """
+   cdef unordered_set[long, CustomHash] s = o
+   return s
+
 def test_map(o):
     """
     >>> test_map({1: 1.0, 2: 0.5, 3: 0.25})
@@ -220,13 +264,24 @@ def test_map(o):
 
 def test_unordered_map(o):
    """
-   >>> d = test_map({1: 1.0, 2: 0.5, 3: 0.25})
+   >>> d = test_unordered_map({1: 1.0, 2: 0.5, 3: 0.25})
    >>> sorted(d)
    [1, 2, 3]
    >>> (d[1], d[2], d[3])
    (1.0, 0.5, 0.25)
    """
    cdef unordered_map[int, double] m = o
+   return m
+
+def test_unordered_map_hash(o):
+   """
+   >>> d = test_unordered_map_hash({1: 1.0, 2: 0.5, 3: 0.25})
+   >>> sorted(d)
+   [1, 2, 3]
+   >>> (d[1], d[2], d[3])
+   (1.0, 0.5, 0.25)
+   """
+   cdef unordered_map[int, double, CustomHash] m = o
    return m
 
 def test_nested(o):


### PR DESCRIPTION
e.g. with the allocator specified, or with a hash function or predicate etc. It needs to generate a separate version of the conversion code for each variation of the container.

Fixes #4166