### PR TITLE
Docs: Use cython.cast() instead of cast() in examples of language basics documentation

### DIFF
--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -916,7 +916,7 @@ Cython uses ``"<"`` and ``">"``.  In pure python mode, the ``cython.cast()`` fun
             def main():
                 p: cython.p_char
                 q: cython.p_float
-                p = cast(cython.p_char, q)
+                p = cython.cast(cython.p_char, q)
 
         When casting a C value to a Python object type or vice versa,
         Cython will attempt a coercion. Simple examples are casts like ``cast(int, pyobj_value)``,
@@ -1043,7 +1043,7 @@ direct equivalent in Python.
                   p: cython.p_char
                   q: cython.p_float
 
-                  p = cast(cython.p_char, q)
+                  p = cython.cast(cython.p_char, q)
 
       .. group-tab:: Cython
 


### PR DESCRIPTION
In the header of documentation it is mentioned that user should import cython in order to execute examples. But in examples function `cast()` is called directly. This PR is changing that to `cython.cast()` in order to conform the header text.