### PR TITLE
Allow default value for memory view

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9488,21 +9488,15 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
         if default_args or default_kwargs:
             if self.defaults_struct is None:
                 if default_args:
-                    defaults_tuple = TupleNode(
-                        self.pos,
-                        args=[
-                            arg.default
-                            for arg in default_args
-                        ]
-                    )
+                    defaults_tuple = TupleNode(self.pos, args=[
+                        arg.default for arg in default_args])
                     self.defaults_tuple = defaults_tuple.analyse_types(env).coerce_to_pyobject(env)
                 if default_kwargs:
                     defaults_kwdict = DictNode(self.pos, key_value_pairs=[
                         DictItemNode(
                             arg.pos,
                             key=IdentifierStringNode(arg.pos, value=arg.name),
-                            value=arg.default
-                        )
+                            value=arg.default)
                         for arg in default_kwargs])
                     self.defaults_kwdict = defaults_kwdict.analyse_types(env)
             elif not self.specialized_cpdefs:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9493,7 +9493,7 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
                     defaults_tuple = TupleNode(
                         self.pos,
                         args=[
-                            arg.default.arg if hasattr(arg.default, "arg") else arg.default
+                            arg.default
                             for arg in default_args
                         ]
                     )
@@ -9503,7 +9503,8 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
                         DictItemNode(
                             arg.pos,
                             key=IdentifierStringNode(arg.pos, value=arg.name),
-                            value=arg.default.arg if hasattr(arg.default, "arg") else arg.default)
+                            value=arg.default
+                        )
                         for arg in default_kwargs])
                     self.defaults_kwdict = defaults_kwdict.analyse_types(env)
             elif not self.specialized_cpdefs:
@@ -13195,6 +13196,9 @@ class CoercionNode(ExprNode):
             file, line, col = self.pos
             code.annotate((file, line, col-1), AnnotationItem(
                 style='coerce', tag='coerce', text='[%s] to [%s]' % (self.arg.type, self.type)))
+
+    def analyse_types(self, env):
+        return self
 
 
 class CoerceToMemViewSliceNode(CoercionNode):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9488,8 +9488,6 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
         if default_args or default_kwargs:
             if self.defaults_struct is None:
                 if default_args:
-                    # If the default argument has a children named arg, pass it down to the TupleNode.
-                    # See issue #4313.
                     defaults_tuple = TupleNode(
                         self.pos,
                         args=[

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9488,15 +9488,22 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
         if default_args or default_kwargs:
             if self.defaults_struct is None:
                 if default_args:
-                    defaults_tuple = TupleNode(self.pos, args=[
-                        arg.default for arg in default_args])
+                    # If the default argument has a children named arg, pass it down to the TupleNode.
+                    # See issue #4313.
+                    defaults_tuple = TupleNode(
+                        self.pos,
+                        args=[
+                            arg.default.arg if hasattr(arg.default, "arg") else arg.default
+                            for arg in default_args
+                        ]
+                    )
                     self.defaults_tuple = defaults_tuple.analyse_types(env).coerce_to_pyobject(env)
                 if default_kwargs:
                     defaults_kwdict = DictNode(self.pos, key_value_pairs=[
                         DictItemNode(
                             arg.pos,
                             key=IdentifierStringNode(arg.pos, value=arg.name),
-                            value=arg.default)
+                            value=arg.default.arg if hasattr(arg.default, "arg") else arg.default)
                         for arg in default_kwargs])
                     self.defaults_kwdict = defaults_kwdict.analyse_types(env)
             elif not self.specialized_cpdefs:

--- a/tests/run/cyfunction_defaults.pyx
+++ b/tests/run/cyfunction_defaults.pyx
@@ -271,6 +271,8 @@ cdef class C:
         pass
     cpdef f9(self, a, int[:] s = None):
         pass
+    def f10(self, a, /, b=1, *, int[:] c=None):
+        pass
 
 
 def check_defaults_on_methods_for_introspection():
@@ -302,5 +304,9 @@ def check_defaults_on_methods_for_introspection():
     >>> C.f9.__defaults__
     (None,)
     >>> C.f9.__kwdefaults__
+    >>> C.f10.__defaults__
+    (1,)
+    >>> C.f10.__kwdefaults__
+    {'c': None}
     """
     pass

--- a/tests/run/cyfunction_defaults.pyx
+++ b/tests/run/cyfunction_defaults.pyx
@@ -269,6 +269,8 @@ cdef class C:
         pass
     cpdef f8(self, a, list s = [15]):
         pass
+    cpdef f9(self, a, int[:] s = None):
+        pass
 
 
 def check_defaults_on_methods_for_introspection():
@@ -297,5 +299,8 @@ def check_defaults_on_methods_for_introspection():
     >>> C.f8.__defaults__
     ([15],)
     >>> C.f8.__kwdefaults__
+    >>> C.f9.__defaults__
+    (None,)
+    >>> C.f9.__kwdefaults__
     """
     pass


### PR DESCRIPTION
An attempt at fixing #4313.

- [x] The bug in #4313 is now tested and fixed
- [x] No need for extra doc

Essentially, what I tried to achieve is to pass the default values as a decoration to the `__default__` instead of casting it into the type associated with the argument.
For example, let us take the following example
```cython
class Foo:
    def my_method(self, int[:] foo = None):
        pass
```
My understanding is that Cython tries to cast None into a memory view, which it then fails to cast back into a Python object to populate the `__default__` of `my_method`. One solution is to *not* cast default values and use them as is.

However, since I am not at all an expert into the inner workings of Cython, I am a bit worried I have missed something here and that this PR may cause inconsistencies between the actual default argument (as understood by Cython) and the one found in `__default__`.
