### PR TITLE
Suppress warnings about constant expressions on MSVC

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1143,7 +1143,9 @@ class GlobalState(object):
         'cleanup_globals',
         'cleanup_module',
         'main_method',
+        'utility_code_pragmas',  # silence some irrelevant warnings in utility code
         'utility_code_def',
+        'utility_code_pragmas_end',  # clean-up the utility_code_pragmas
         'end'
     ]
 
@@ -1239,6 +1241,18 @@ class GlobalState(object):
         code = self.parts['utility_code_def']
         util = TempitaUtilityCode.load_cached("TypeConversions", "TypeConversion.c")
         code.put(util.format_code(util.impl))
+        code.putln("")
+
+        #
+        # utility code pragmas
+        #
+        code = self.parts['utility_code_pragmas']
+        util = UtilityCode.load_cached("UtilityCodePragmas", "ModuleSetupCode.c")
+        code.putln(util.format_code(util.impl))
+        code.putln("")
+        code = self.parts['utility_code_pragmas_end']
+        util = UtilityCode.load_cached("UtilityCodePragmasEnd", "ModuleSetupCode.c")
+        code.putln(util.format_code(util.impl))
         code.putln("")
 
     def __getitem__(self, key):

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1800,7 +1800,7 @@ static void __Pyx_FastGilFuncInit(void) {
 ///////////////////// UtilityCodePragmas /////////////////////////
 
 #if _MSC_VER
-#warning( push )
+#pragma warning( push )
 #pragma warning( disable : 4127 )
 // conditional expression is constant
 // Cython uses constant conditional expressions a lot in inline functions, so this warning is not useful

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1796,3 +1796,18 @@ static void __Pyx_FastGilFuncInit(void) {
 }
 
 #endif
+
+///////////////////// UtilityCodePragmas /////////////////////////
+
+#if _MSC_VER
+#warning( push )
+#pragma warning( disable : 4127 )
+// conditional expression is constant
+// Cython uses constant conditional expressions a lot in inline functions, so this warning is not useful
+#endif
+
+///////////////////// UtilityCodePragmasEnd //////////////////////
+
+#if _MSV_VER
+#pragma warning( pop )  /* undo whatever Cython has done to warnings */
+#endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1801,9 +1801,11 @@ static void __Pyx_FastGilFuncInit(void) {
 
 #if _MSC_VER
 #pragma warning( push )
+/* Warning 4127: conditional expression is constant
+ * Cython uses constant conditional expressions to allow in inline functions to be optimized at
+ * compile-time, so this warning is not useful
+ */
 #pragma warning( disable : 4127 )
-// conditional expression is constant
-// Cython uses constant conditional expressions a lot in inline functions, so this warning is not useful
 #endif
 
 ///////////////////// UtilityCodePragmasEnd //////////////////////


### PR DESCRIPTION
Adds utility code sections designed to be able to toggle warnings for the duration of the utility code.

Hopefully supersedes #4165

@maxbachmann Opinions? Does this achieve what you want? (I need to reboot to get to MSVC so it isn't quick for me to test)