### PR TITLE
Allow releasing gil in nogil functions

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2358,10 +2358,11 @@ class CCodeWriter(object):
         "Release the GIL, corresponds to `put_acquire_gil`."
         self.use_fast_gil_utility_code()
         self.putln("#ifdef WITH_THREAD")
-        self.putln("PyThreadState *_save = NULL;")
+        self.putln("PyThreadState *_save;")
+        self.putln("_save = NULL;")
         if unknown_gil_state:
             # we don't *know* that we don't have the GIL (since we may be inside a nogil function,
-            # and Py_UNBLOCK_THREADS
+            # and Py_UNBLOCK_THREADS is unsafe without the GIL)
             self.putln("if (PyGILState_Check()) {")
         self.putln("Py_UNBLOCK_THREADS")
         if unknown_gil_state:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8325,9 +8325,12 @@ class GILStatNode(NogilTryFinallyStatNode):
     #  'with gil' or 'with nogil' statement
     #
     #   state   string   'gil' or 'nogil'
+    #   scope_gil_state_known  bool  For nogil functions this can be False, since they can also be run with gil
+    #                           set to False by GilCheck transform
 
     child_attrs = ["condition"] + NogilTryFinallyStatNode.child_attrs
     state_temp = None
+    scope_gil_state_known = True
 
     def __init__(self, pos, state, body, condition=None):
         self.state = state
@@ -8390,7 +8393,7 @@ class GILStatNode(NogilTryFinallyStatNode):
             code.put_ensure_gil(variable=variable)
             code.funcstate.gil_owned = True
         else:
-            code.put_release_gil(variable=variable)
+            code.put_release_gil(variable=variable, unknown_gil_state=not self.scope_gil_state_known)
             code.funcstate.gil_owned = False
 
         TryFinallyStatNode.generate_execution_code(self, code)
@@ -8407,10 +8410,13 @@ class GILExitNode(StatNode):
     Used as the 'finally' block in a GILStatNode
 
     state   string   'gil' or 'nogil'
+    #   scope_gil_state_known  bool  For nogil functions this can be False, since they can also be run with gil
+    #                           set to False by GilCheck transform
     """
 
     child_attrs = []
     state_temp = None
+    scope_gil_state_known = True
 
     def analyse_expressions(self, env):
         return self
@@ -8424,7 +8430,7 @@ class GILExitNode(StatNode):
         if self.state == 'gil':
             code.put_release_ensured_gil(variable)
         else:
-            code.put_acquire_gil(variable)
+            code.put_acquire_gil(variable, unknown_gil_state=not self.scope_gil_state_known)
 
 
 class EnsureGILNode(GILExitNode):

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -636,6 +636,23 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
 // PyThread_ReInitTLS() is a no-op
 #endif /* TSS (Thread Specific Storage) API */
 
+
+#if PY_MAJOR_VERSION < 3
+#if !CYTHON_COMPILING_IN_PYPY
+    // https://stackoverflow.com/a/25666624
+    static CYTHON_INLINE int PyGILState_Check(void) {
+        PyThreadState * tstate = _PyThreadState_Current;
+        return tstate && (tstate == PyGILState_GetThisThreadState());
+    }
+#else
+    static CYTHON_INLINE int PyGILState_Check(void) {
+        // completely unsatisfactory workaround, but it appears that it doesn't
+        // crash PyPy to try to release the GIL without holding the GIL.
+        return 0;
+    }
+#endif
+#endif
+
 #if CYTHON_COMPILING_IN_CPYTHON || defined(_PyDict_NewPresized)
 #define __Pyx_PyDict_NewPresized(n)  ((n <= 8) ? PyDict_New() : _PyDict_NewPresized(n))
 #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -638,32 +638,32 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
 
 
 #if PY_MAJOR_VERSION < 3
-#if (CYTHON_COMPILING_IN_PYPY
-  #if PYPY_VERSION_NUM < 0x07030600)
-    #if defined(__cplusplus) && __cplusplus >= 201402L
-        [[deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")]]
-    #elif defined(__GNUC__) || defined(__clang__)
-        __attribute__ ((__deprecated__("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")))
-    #elif defined(_MSC_VER)
-        __declspec(deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6"))
-    #endif
-    static CYTHON_INLINE int PyGILState_Check(void) {
-        // PyGILState_Check is used to decided whether to release the GIL when we don't
-        // know what we have it. For PyPy2 it isn't possible to check.
-        // Therefore assume that we don't have the GIL (which causes us not to release it,
-        // but is "safe")
-        return 0;
-    }
+    #if CYTHON_COMPILING_IN_PYPY
+        #if PYPY_VERSION_NUM < 0x07030600
+            #if defined(__cplusplus) && __cplusplus >= 201402L
+                [[deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")]]
+            #elif defined(__GNUC__) || defined(__clang__)
+                __attribute__ ((__deprecated__("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")))
+            #elif defined(_MSC_VER)
+                __declspec(deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6"))
+            #endif
+            static CYTHON_INLINE int PyGILState_Check(void) {
+                // PyGILState_Check is used to decided whether to release the GIL when we don't
+                // know what we have it. For PyPy2 it isn't possible to check.
+                // Therefore assume that we don't have the GIL (which causes us not to release it,
+                // but is "safe")
+                return 0;
+            }
+        #else  // PYPY_VERSION_NUM < 0x07030600
+            // PyPy2 >= 7.3.6 has PyGILState_Check
+        #endif  // PYPY_VERSION_NUM < 0x07030600
     #else
-    // PyPy2 >= 7.3.6 has PyGILState_Check
+        // https://stackoverflow.com/a/25666624
+        static CYTHON_INLINE int PyGILState_Check(void) {
+            PyThreadState * tstate = _PyThreadState_Current;
+            return tstate && (tstate == PyGILState_GetThisThreadState());
+        }
     #endif
-#else
-    // https://stackoverflow.com/a/25666624
-    static CYTHON_INLINE int PyGILState_Check(void) {
-        PyThreadState * tstate = _PyThreadState_Current;
-        return tstate && (tstate == PyGILState_GetThisThreadState());
-    }
-#endif
 #endif
 
 #if CYTHON_COMPILING_IN_CPYTHON || defined(_PyDict_NewPresized)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -638,7 +638,8 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
 
 
 #if PY_MAJOR_VERSION < 3
-#if (CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM < 0x07030600)
+#if (CYTHON_COMPILING_IN_PYPY
+  #if PYPY_VERSION_NUM < 0x07030600)
     #if defined(__cplusplus) && __cplusplus >= 201402L
         [[deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")]]
     #elif defined(__GNUC__) || defined(__clang__)
@@ -653,6 +654,9 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
         // but is "safe")
         return 0;
     }
+    #else
+    // PyPy2 >= 7.3.6 has PyGILState_Check
+    #endif
 #else
     // https://stackoverflow.com/a/25666624
     static CYTHON_INLINE int PyGILState_Check(void) {

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -648,8 +648,8 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
                 __declspec(deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6"))
             #endif
             static CYTHON_INLINE int PyGILState_Check(void) {
-                // PyGILState_Check is used to decided whether to release the GIL when we don't
-                // know what we have it. For PyPy2 it isn't possible to check.
+                // PyGILState_Check is used to decide whether to release the GIL when we don't
+                // know that we have it. For PyPy2 it isn't possible to check.
                 // Therefore assume that we don't have the GIL (which causes us not to release it,
                 // but is "safe")
                 return 0;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -640,11 +640,11 @@ static CYTHON_INLINE void * PyThread_tss_get(Py_tss_t *key) {
 #if PY_MAJOR_VERSION < 3
 #if (CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM < 0x07030600)
     #if defined(__cplusplus) && __cplusplus >= 201402L
-        [[deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2")]]
+        [[deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")]]
     #elif defined(__GNUC__) || defined(__clang__)
-        __attribute__ ((__deprecated__("`with nogil:` inside a nogil function will not release the GIL in PyPy2")))
+        __attribute__ ((__deprecated__("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6")))
     #elif defined(_MSC_VER)
-        __declspec(deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2"))
+        __declspec(deprecated("`with nogil:` inside a nogil function will not release the GIL in PyPy2 < 7.3.6"))
     #endif
     static CYTHON_INLINE int PyGILState_Check(void) {
         // PyGILState_Check is used to decided whether to release the GIL when we don't

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -84,6 +84,7 @@ def test_nogil_exception_propagation():
     with nogil:
         nogil_func()
 
+
 cdef int write_unraisable() nogil:
     with gil:
         raise ValueError()

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -28,6 +28,19 @@ cdef int g(int x) nogil:
         y = x + 42
         return y
 
+cdef void release_gil_in_nogil() nogil:
+    # This should generate valid code with/without the GIL
+    with nogil:
+        pass
+
+def test_release_gil_in_nogil():
+    """
+    >>> test_release_gil_in_nogil()
+    """
+    with nogil:
+        release_gil_in_nogil()
+    release_gil_in_nogil()
+
 cdef int with_gil_func() except -1 with gil:
     raise Exception("error!")
 

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -44,9 +44,29 @@ def test_release_gil_in_nogil():
     """
     with nogil:
         release_gil_in_nogil()
+    with nogil:
         release_gil_in_nogil2()
     release_gil_in_nogil()
     release_gil_in_nogil2()
+
+cdef void get_gil_in_nogil() nogil:
+    with gil:
+        pass
+
+cpdef void get_gil_in_nogil2() nogil:
+    with gil:
+        pass
+
+def test_get_gil_in_nogil():
+    """
+    >>> test_get_gil_in_nogil()
+    """
+    with nogil:
+        get_gil_in_nogil()
+    with nogil:
+        get_gil_in_nogil2()
+    get_gil_in_nogil()
+    get_gil_in_nogil2()
 
 cdef int with_gil_func() except -1 with gil:
     raise Exception("error!")
@@ -63,7 +83,6 @@ def test_nogil_exception_propagation():
     """
     with nogil:
         nogil_func()
-
 
 cdef int write_unraisable() nogil:
     with gil:

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -33,13 +33,20 @@ cdef void release_gil_in_nogil() nogil:
     with nogil:
         pass
 
+cpdef void release_gil_in_nogil2() nogil:
+    # This should generate valid code with/without the GIL
+    with nogil:
+        pass
+
 def test_release_gil_in_nogil():
     """
     >>> test_release_gil_in_nogil()
     """
     with nogil:
         release_gil_in_nogil()
+        release_gil_in_nogil2()
     release_gil_in_nogil()
+    release_gil_in_nogil2()
 
 cdef int with_gil_func() except -1 with gil:
     raise Exception("error!")


### PR DESCRIPTION
Fixes #4137

Also adds a check whether we have the GIL before doing so. This
is important because Py_UNBLOCK_THREADS is documented as unsafe
if we don't hold the GIL. This bit of it is possibly a candidate to be
backported (since the pattern was allowed in Cython 0.29 but
can cause a segfault).