### PR TITLE
add windows to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,23 @@ jobs:
             backend: cpp
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
 
-    # This defaults to 360 minutes (6h) which is way too long and if a test gets stuck, it can block other pipelines.
-    # From testing, the runs tend to take ~20 minutes, so a limit of 30 minutes should be enough. This can always be
-    # changed in the future if needed.
-    timeout-minutes: 30
+          # Windows sub-jobs
+          # ==============
+          - os: windows-2019
+            python-version: 3.8
+            backend: c
+            env: {}
+          - os: windows-2019
+            python-version: 3.8
+            backend: cpp
+            env: {}
+
+    # This defaults to 360 minutes (6h) which is way too long and if a test
+    # gets stuck, it can block other pipelines.
+    # From testing, the runs tend to take ~20 minutes and XXX on windows, so a
+    # limit of 30 minutes should be enough. This can always be changed in the
+    # future if needed.
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
 
     env:

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -107,13 +107,17 @@ fi
 
 if [ "$TEST_CODE_STYLE" == "1" ]; then
     make -C docs html || exit 1
-elif [ -n "${PYTHON_VERSION##pypy*}" ]; then
+elif [ -n "${PYTHON_VERSION##pypy*}" -a "${OS_NAME##windows*}" == "" ]; then
   # Run the debugger tests in python-dbg if available (but don't fail, because they currently do fail)
   PYTHON_DBG="python$( python -c 'import sys; print("%d.%d" % sys.version_info[:2])' )-dbg"
   if $PYTHON_DBG -V >&2; then CFLAGS="-O0 -ggdb" $PYTHON_DBG runtests.py -vv --no-code-style Debugger --backends=$BACKEND; fi;
 fi
 
-export CFLAGS="-O0 -ggdb -Wall -Wextra $EXTRA_CFLAGS"
+if [ "${OS_NAME##windows*}" == "" ]; then
+    export CFLAGS="/Od /Wall $EXTRA_CFLAGS"
+else
+    export CFLAGS="-O0 -ggdb -Wall -Wextra $EXTRA_CFLAGS"
+fi
 python runtests.py \
   -vv $STYLE_ARGS \
   -x Debugger \


### PR DESCRIPTION
Add windows to CI:
- add a basic c and cpp job
- use the builtin bash support so no new scripts are needed (yay github actions)
- up the timeout to 60 minutes (da-woods)
- disable debug mode testing (scoder)

On my branch we seem to have exceeded github limits for CI runs, let's see if that happens here too.