### PR TITLE
Add more cpp_locals tests

### DIFF
--- a/tests/errors/w_uninitialized_cpp.pyx
+++ b/tests/errors/w_uninitialized_cpp.pyx
@@ -1,7 +1,6 @@
 # cython: warn.maybe_uninitialized=True
 # mode: error
-# tag: cpp, werror, no-cpp-locals
-# FIXME - no-cpp-locals should work
+# tag: cpp, werror
 
 from cython.operator import typeid
 

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -1,7 +1,5 @@
 # mode: run
 # tag: cpp, werror
-# tag: no-cpp-locals
-# FIXME - cpp_locals should work but doesn't
 
 from __future__ import division
 

--- a/tests/run/fused_cpp.pyx
+++ b/tests/run/fused_cpp.pyx
@@ -1,5 +1,4 @@
-# tag: cpp, no-cpp-locals
-# FIXME (or at least investigate) - cpp_locals should probably work
+# tag: cpp
 
 cimport cython
 from libcpp.vector cimport vector


### PR DESCRIPTION
Closes #4266.

It looks like I'd inadvertently fixed the remaining bugs in #4266, but I hadn't realized it. This PR just re-enables the tests for them