### PR TITLE
Restore error on cdef function arbitrary decorator

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1442,7 +1442,11 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
         if not node.decorators:
             return node
         elif self.scope_type != 'cclass' or self.scope_node.visibility != "extern":
-            error(node.decorators[0].pos, "Cdef functions cannot take arbitrary decorators.")
+            # at the moment cdef functions are very restricted in what decorators they can take
+            # so it's simple to test for the small number of allowed decorators....
+            if not (len(node.decorators) == 1 and node.decorators[0].decorator.is_name and
+                    node.decorators[0].decorator.name == "staticmethod"):
+                error(node.decorators[0].pos, "Cdef functions cannot take arbitrary decorators.")
             return node
 
         ret_node = node

--- a/tests/errors/cdef_func_decorators.pyx
+++ b/tests/errors/cdef_func_decorators.pyx
@@ -1,0 +1,39 @@
+# mode: error
+# tag: decorator
+
+from functools import wraps
+
+@wraps
+cdef cant_be_decoratored():
+    pass
+
+@wraps
+cpdef also_cant_be_decorated():
+    pass
+
+cdef class C:
+    @wraps
+    cdef still_cant_be_decorated(self):
+        pass
+
+    @property
+    cdef property_only_works_for_extern_classes(self):
+        pass
+
+    @wraps
+    cpdef also_still_cant_be_decorated(self):
+        pass
+
+    @wraps
+    @wraps
+    cdef two_is_just_as_bad_as_one(self):
+        pass
+
+_ERRORS = """
+6:0: Cdef functions cannot take arbitrary decorators.
+10:0: Cdef functions cannot take arbitrary decorators.
+15:4: Cdef functions cannot take arbitrary decorators.
+19:4: Cdef functions cannot take arbitrary decorators.
+23:4: Cdef functions cannot take arbitrary decorators.
+27:4: Cdef functions cannot take arbitrary decorators.
+"""


### PR DESCRIPTION
These were lost when cdef properties (for extern types) were
introduced.

"Fixes" #4322 (based on my interpretation of the problem as an
error-reporting issue)