### PR TITLE
Ban templating C++ classes with reference counted types

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3897,10 +3897,12 @@ class CppClassType(CType):
             return error_type
         has_object_template_param = False
         for value in template_values:
-            if value.is_pyobject:
+            if value.is_pyobject or value.needs_refcounting:
                 has_object_template_param = True
+                type_description = "Python object" if value.is_pyobject else "Reference-counted"
                 error(pos,
-                      "Python object type '%s' cannot be used as a template argument" % value)
+                      "%s type '%s' cannot be used as a template argument" % (
+                          type_description, value))
         if has_object_template_param:
             return error_type
         return self.specialize(dict(zip(self.templates, template_values)))

--- a/tests/errors/cpp_object_template.pyx
+++ b/tests/errors/cpp_object_template.pyx
@@ -12,7 +12,13 @@ def main():
     cdef vector[A] va
     va.push_back(A())
 
+def memview():
+    import array
+    cdef vector[int[:]] vmv
+    vmv.push_back(array.array("i", [1,2,3]))
+
 _ERRORS = u"""
 10:16: Python object type 'Python object' cannot be used as a template argument
 12:16: Python object type 'A' cannot be used as a template argument
+17:16: Reference-counted type 'int[:]' cannot be used as a template argument
 """


### PR DESCRIPTION
Specifically this disallows memoryviews (closing #3085)
but it extends to any future type that Cython has to generate
manual reference counting code for.