### PR TITLE
Fix C++ bool coercion where no operator bool exists

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1012,11 +1012,11 @@ class ExprNode(Node):
             return self
         elif type.is_pyobject or type.is_int or type.is_ptr or type.is_float:
             return CoerceToBooleanNode(self, env)
-        elif type.is_cpp_class:
+        elif type.is_cpp_class and type.scope and type.scope.lookup("operator bool"):
             return SimpleCallNode(
                 self.pos,
                 function=AttributeNode(
-                    self.pos, obj=self, attribute='operator bool'),
+                    self.pos, obj=self, attribute=StringEncoding.EncodedString('operator bool')),
                 args=[]).analyse_types(env)
         elif type.is_ctuple:
             bool_value = len(type.components) == 0

--- a/tests/errors/cpp_bool.pyx
+++ b/tests/errors/cpp_bool.pyx
@@ -1,0 +1,13 @@
+# tag: cpp
+# mode: error
+
+from libcpp.string cimport string
+
+cdef foo():
+    cdef string field
+    if field:  # field cannot be coerced to book
+        pass
+
+_ERRORS = u"""
+8:7: Type 'string' not acceptable as a boolean
+"""


### PR DESCRIPTION
Fixes #4348

~Note that patch is against 0.29.x and will need merging against master too.~ I've changed it to be patched against master (just so that the tests get run). I think it should be backported though