### PR TITLE
Check for dodgy multiple inheritance of cdef class

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -118,9 +118,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
     #  scope                The module scope.
     #  compilation_source   A CompilationSource (see Main)
     #  directives           Top-level compiler directives
+    #  user_code_starts_at  Index for element in body - used to insert utility code before the user code
 
     child_attrs = ["body"]
     directives = None
+    user_code_starts_at = 0
 
     def merge_in(self, tree, scope, merge_scope=False):
         # Merges in the contents of another tree, and possibly scope. With the
@@ -136,10 +138,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # merged in nodes should keep their original compiler directives
             # (for example inline cdef functions)
             tree = Nodes.CompilerDirectivesNode(tree.pos, body=tree, directives=scope.directives)
+        # Utility code is inserted before user code (but is inserted in the order it is defined)
+        # This makes sense because the user code depends on the utility code, so potentially relies
+        # on it being fully executed
         if isinstance(tree, Nodes.StatListNode):
-            self.body.stats.extend(tree.stats)
+            self.body.stats[self.user_code_starts_at:self.user_code_starts_at] = tree.stats
+            self.user_code_starts_at += len(tree.stats)
         else:
-            self.body.stats.append(tree)
+            self.body.stats.insert(self.user_code_starts_at, tree)
+            self.user_code_starts_at += 1
 
         self.scope.utility_code_list.extend(scope.utility_code_list)
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2911,6 +2911,7 @@ class DefNode(FuncDefNode):
     requires_classobj = False
     defaults_struct = None  # Dynamic kwrds structure name
     doc = None
+    generated_by_cython = False
 
     fused_py_func = False
     specialized_cpdefs = None
@@ -3033,7 +3034,7 @@ class DefNode(FuncDefNode):
         if env.is_py_class_scope or env.is_c_class_scope:
             if self.name == '__new__' and env.is_py_class_scope:
                 self.is_staticmethod = True
-            elif self.name == '__init_subclass__' and env.is_c_class_scope:
+            elif self.name == '__init_subclass__' and env.is_c_class_scope and not self.generated_by_cython:
                 error(self.pos, "'__init_subclass__' is not supported by extension class")
             elif self.name in IMPLICIT_CLASSMETHODS and not self.is_classmethod:
                 self.is_classmethod = True

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1978,8 +1978,7 @@ if VALUE is not None:
         # for cdef classes - the ban is mainly because it not called when inherited by other cdef classes,
         #    (which is not a problem for this validation function)
         func.stats[0].generated_by_cython = True
-        directives = dict(node.scope.directives)
-        directives['binding'] = True
+        directives = Options.copy_inherited_directives(node.scope.directives, binding=True)
         func = Nodes.CompilerDirectivesNode(func.pos, body=func, directives=directives)
         func.analyse_declarations(node.scope)
         self.enter_scope(node, node.scope)  # functions should be visited in the class scope

--- a/tests/errors/cdef_multiple_inheritance_subclassing_check.pyx
+++ b/tests/errors/cdef_multiple_inheritance_subclassing_check.pyx
@@ -4,8 +4,9 @@
 # In some circumstances it's possible to multiply inherit Python classes
 # from cdef classes in ways that cause __cinit__ and __dealloc__ not to
 # be called.
-# On Python 3.6+ it's possible to validate this
-import sys
+
+# The tests work on Python<3.6 because Cython itself calls __init_subclass__.
+# If they were written using exec then they would be fail there.
 
 cdef class BaseA:
     cdef int x
@@ -30,28 +31,13 @@ cdef class Y:
 class BaseC(BaseA):
         pass
 
-
-if sys.version_info >= (3, 6):
-    __doc__ = """
-        >>> test_BaseC_A()  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-            ...
-        TypeError: Invalid inheritance from cdef class A: ...
-
-        >>> test_X_Y() # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-            ...
-        TypeError: Invalid inheritance from cdef class Y: ...
-
-        >>> test_Y_X() # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-            ...
-        TypeError: Invalid inheritance from cdef class X: ...
-    """
-
-
 def test_BaseC_A():
-    # will fail with an exception - test in module __doc__
+    """
+    >>> test_BaseC_A()  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: Invalid inheritance from cdef class A: ...
+    """
     class C(BaseC, A):
         pass
 
@@ -70,14 +56,24 @@ def test_A_BaseC():
     C()
 
 def test_X_Y():
-    # will fail with an exception - test in module __doc__
+    """
+    >>> test_X_Y() # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: Invalid inheritance from cdef class Y: ...
+    """
     class C(X, Y):
         pass
 
     C()
 
 def test_Y_X():
-    # will fail with an exception - test in module __doc__
+    """
+    >>> test_Y_X()  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: Invalid inheritance from cdef class X: ...
+    """
     class C(Y, X):
         pass
 

--- a/tests/errors/cdef_multiple_inheritance_subclassing_check.pyx
+++ b/tests/errors/cdef_multiple_inheritance_subclassing_check.pyx
@@ -1,0 +1,84 @@
+# mode: run
+
+# https://github.com/cython/cython/issues/4350
+# In some circumstances it's possible to multiply inherit Python classes
+# from cdef classes in ways that cause __cinit__ and __dealloc__ not to
+# be called.
+# On Python 3.6+ it's possible to validate this
+import sys
+
+cdef class BaseA:
+    cdef int x
+
+    def __cinit__(self):
+        print "BaseA.__cinit__"
+
+cdef class A(BaseA):
+    # layout compatible with (and derived from) A
+    def __cinit__(self):
+        print "A.__cinit__"
+
+cdef class X:
+    def __cinit__(self):
+        print "X.__cinit__"
+
+cdef class Y:
+    # layout compatible with X
+    def __cinit__(self):
+        print "Y.__cinit__"
+
+class BaseC(BaseA):
+        pass
+
+
+if sys.version_info >= (3, 6):
+    __doc__ = """
+        >>> test_BaseC_A()  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        TypeError: Invalid inheritance from cdef class A: ...
+
+        >>> test_X_Y() # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        TypeError: Invalid inheritance from cdef class Y: ...
+
+        >>> test_Y_X() # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        TypeError: Invalid inheritance from cdef class X: ...
+    """
+
+
+def test_BaseC_A():
+    # will fail with an exception - test in module __doc__
+    class C(BaseC, A):
+        pass
+
+    C()
+
+def test_A_BaseC():
+    """
+    Should work so we just test the constructors are right
+    >>> test_A_BaseC()
+    BaseA.__cinit__
+    A.__cinit__
+    """
+    class C(A, BaseC):
+        pass
+
+    C()
+
+def test_X_Y():
+    # will fail with an exception - test in module __doc__
+    class C(X, Y):
+        pass
+
+    C()
+
+def test_Y_X():
+    # will fail with an exception - test in module __doc__
+    class C(Y, X):
+        pass
+
+    C()

--- a/tests/run/cdef_multiple_inheritance_errors.srctree
+++ b/tests/run/cdef_multiple_inheritance_errors.srctree
@@ -21,7 +21,11 @@ cdef class Foo(Base, Obj):
 ######## wrongbase.pyx ########
 
 cdef class Base:
-    pass
+    # On some version of Python the __init_subclass__ base check gets there first and
+    # thus emits a different error message. Assigning an empty lambda to it
+    # avoids that. Which error is produced isn't that important, except that it's
+    # hard to make a consistent check
+    __init_subclass__ = lambda *args, **kwds: None
 
 Str = type("")
 


### PR DESCRIPTION
Closes https://github.com/cython/cython/issues/4350 (by raising
a runtime error on the cases that will fail).

Some notes:

* The check works all the time in Cython code, but in Python code,
it only works on Python 3.6+. I think that's OK for something
that's designed to help users not to shoot themselves in the
foot rather than a core feature. Supporting earlier versions
would probably be more intrusive.

* The test case is in "errors" rather than "run" even though its
checking for runtime errors. I decided that was the most
suitable place, but maybe I'm wrong...

* It's interesting that Python is more lenient on multiple
inheritence of cdef classes that Cython would be if "C" were
defined as cdef classes

* Some of these errors could be detected at compile-time in
principle too. This seems like a lot of effort given that we'll
need the runtime check anyway. Thus I haven't done it.