### PR TITLE
Fix deduplication of tuples constaining IdentifierStringNode

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -209,6 +209,11 @@ def make_dedup_key(outer_type, item_nodes):
         # For constants, look at the Python value type if we don't know the concrete Cython type.
         else (node.type, node.constant_result,
               type(node.constant_result) if node.type is py_object_type else None) if node.has_constant_result()
+        # IdentifierStringNode doesn't usually have a "constant_result" set because:
+        #  1. it doesn't usually have unicode_value
+        #  2. it's often created later in the compilation process after ConstantFolding
+        # but should be cacheable
+        else (node.type, node.value, node.unicode_value, "IdentifierStringNode") if isinstance(node, IdentifierStringNode)
         else None  # something we cannot handle => short-circuit below
         for node in item_nodes
     ]

--- a/tests/run/tuple_constants.pyx
+++ b/tests/run/tuple_constants.pyx
@@ -2,6 +2,9 @@
 cimport cython
 
 module_level_tuple = (1,2,3)
+second_module_level_tuple = (1,2,3)  # should be deduplicated to be the same as the first
+string_module_level_tuple = ("1", "2")
+string_module_level_tuple2 = ("1", "2")
 
 def return_module_level_tuple():
     """
@@ -9,6 +12,30 @@ def return_module_level_tuple():
     (1, 2, 3)
     """
     return module_level_tuple
+
+def test_deduplicated_tuples():
+    """
+    >>> test_deduplicated_tuples()
+    """
+    assert (module_level_tuple is second_module_level_tuple)
+    assert (module_level_tuple is (1,2,3))  # also deduplicated with a function tuple
+    assert (string_module_level_tuple is string_module_level_tuple2)
+    assert (string_module_level_tuple is ("1", "2"))
+
+def func1(arg1, arg2):
+    pass
+
+def func2(arg1, arg2):
+    pass
+
+def test_deduplicated_args():
+    """
+    >>> test_deduplicated_args()
+    """
+    # This is a concern because in large modules *a lot* of similar code objects
+    # are generated often with the same argument names. Therefore it's worth ensuring that
+    # they are correctly deduplicated
+    assert func1.__code__.co_varnames is func2.__code__.co_varnames
 
 @cython.test_assert_path_exists("//TupleNode",
                                 "//TupleNode[@is_literal = true]")

--- a/tests/run/tuple_constants.pyx
+++ b/tests/run/tuple_constants.pyx
@@ -35,7 +35,9 @@ def test_deduplicated_args():
     # This is a concern because in large modules *a lot* of similar code objects
     # are generated often with the same argument names. Therefore it's worth ensuring that
     # they are correctly deduplicated
-    assert func1.__code__.co_varnames is func2.__code__.co_varnames
+    import sys
+    if not hasattr(sys, "pypy_version_info"):  # test doesn't work on PyPy (which is probably fair enough)
+        assert func1.__code__.co_varnames is func2.__code__.co_varnames
 
 @cython.test_assert_path_exists("//TupleNode",
                                 "//TupleNode[@is_literal = true]")


### PR DESCRIPTION
I'm hoping to speed up the complication of some of the larger
Cython internal modules (but it's worthwhile even if that fails
I think!). ExprNodes.py was creating hundreds
of tuples containing ("self", "env") for example, because it
wasn't able to match and deduplicate them.