### PR TITLE
Fix maybe uninitialized `value` in get_value and get_value_no_default.

### DIFF
--- a/Cython/Includes/cpython/contextvars.pxd
+++ b/Cython/Includes/cpython/contextvars.pxd
@@ -114,7 +114,7 @@ cdef inline object get_value(var, default_value=None):
     or the default value of the context variable,
     or None if no such value or default was found.
     """
-    cdef PyObject *value
+    cdef PyObject *value = NULL
     PyContextVar_Get(var, NULL, &value)
     if value is NULL:
         # context variable does not have a default
@@ -132,7 +132,7 @@ cdef inline object get_value_no_default(var, default_value=None):
 
     Ignores the default value of the context variable, if any.
     """
-    cdef PyObject *value
+    cdef PyObject *value = NULL
     PyContextVar_Get(var, <PyObject*>default_value, &value)
     # value of context variable or 'default_value'
     pyvalue = <object>value


### PR DESCRIPTION
ff16389c0da5acc2be1 introduced convenient functions get_value() and get_value_no_default().

Unfortunately, the variable `value` in these functions was not set before usage with PyContextVar_Get().
This triggered some warnings:
```

Error compiling Cython file:
------------------------------------------------------------
...
    """Return a new reference to the value of the context variable,
    or the default value of the context variable,
    or None if no such value or default was found.
    """
    cdef PyObject *value
    PyContextVar_Get(var, NULL, &value)
                                ^
------------------------------------------------------------

Cython/Includes/cpython/contextvars.pxd:118:33: local variable 'value' might be referenced before assignment

Error compiling Cython file:
------------------------------------------------------------
...
    or the provided default value if no such value was found.

    Ignores the default value of the context variable, if any.
    """
    cdef PyObject *value
    PyContextVar_Get(var, <PyObject*>default_value, &value)
                                                    ^
------------------------------------------------------------

Cython/Includes/cpython/contextvars.pxd:136:53: local variable 'value' might be referenced before assignment
```

It can be replicated by simply importing `cpython`:
`echo "cimport cpython" >/tmp/mod.pyx && ./cython.py -Werror -Wextra /tmp/mod.pyx`

The solution is simply to assign NULL to `value` on declaration.