### PR TITLE
Fix a couple of trivial typos

### DIFF
--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -1286,7 +1286,7 @@ constants within a Cython source file.
 
 .. note::
 
-    This feature has very little use cases.  Specifically, is is not a good
+    This feature has very little use cases.  Specifically, it is not a good
     way to adapt code to platform and environment.  Use code generation or
     (preferably) C compile time adaptation for this.  See, for example,
     :ref:`verbatim_c`.

--- a/tests/errors/cpp_bool.pyx
+++ b/tests/errors/cpp_bool.pyx
@@ -5,7 +5,7 @@ from libcpp.string cimport string
 
 cdef foo():
     cdef string field
-    if field:  # field cannot be coerced to book
+    if field:  # field cannot be coerced to bool
         pass
 
 _ERRORS = u"""


### PR DESCRIPTION
One that I added in a recent commit (sorry!) and one pointed out here https://github.com/cython/cython/commit/0574dbceef7b8ee16a9cc94091c3629dfa23133d#r54025763