### PR TITLE
Avoid unnecessary binding of fused functions

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1227,6 +1227,15 @@ __pyx_FusedFunction_descr_get(PyObject *self, PyObject *obj, PyObject *type)
     if (obj == Py_None)
         obj = NULL;
 
+    if (func->func.flags & __Pyx_CYFUNCTION_CLASSMETHOD)
+        obj = type;
+
+    if (obj == NULL) {
+        // We aren't actually binding to anything, save the effort of rebinding
+        Py_INCREF(self);
+        return self;
+    }
+
     meth = (__pyx_FusedFunctionObject *) __pyx_FusedFunction_New(
                     ((PyCFunctionObject *) func)->m_ml,
                     ((__pyx_CyFunctionObject *) func)->flags,
@@ -1266,9 +1275,6 @@ __pyx_FusedFunction_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 
     Py_XINCREF(func->func.defaults_tuple);
     meth->func.defaults_tuple = func->func.defaults_tuple;
-
-    if (func->func.flags & __Pyx_CYFUNCTION_CLASSMETHOD)
-        obj = type;
 
     Py_XINCREF(obj);
     meth->self = obj;

--- a/tests/run/fused_bound_functions.py
+++ b/tests/run/fused_bound_functions.py
@@ -36,6 +36,10 @@ def regular_func(x):
 def regular_func_0():
     return
 
+@classmethod
+def fused_classmethod_free(cls, x: IntOrFloat):
+    return (cls.__name__, type(x).__name__)
+
 @cython.cclass
 class Cdef:
     __doc__ = """
@@ -66,6 +70,16 @@ class Cdef:
     # Looking up a class attribute doesn't go through all of __get__
     >>> Cdef.fused_in_class is Cdef.fused_in_class
     True
+
+    # looking up a classmethod does go through __get__ though
+    >>> Cdef.fused_classmethod is Cdef.fused_classmethod
+    False
+    >>> Cdef.fused_classmethod_free is Cdef.fused_classmethod_free
+    False
+    >>> Cdef.fused_classmethod(1)
+    ('Cdef', 'int')
+    >>> Cdef.fused_classmethod_free(1)
+    ('Cdef', 'int')
     """.format(typeofCdef = 'Python object' if cython.compiled else 'Cdef')
 
     if cython.compiled:
@@ -82,17 +96,28 @@ class Cdef:
     >>> c.fused_func_0['float']()  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     TypeError: (Exception looks quite different in Python2 and 3 so no way to match both)
+
+    >>> Cdef.fused_classmethod['float'] is Cdef.fused_classmethod['float']
+    False
+    >>> Cdef.fused_classmethod_free['float'] is Cdef.fused_classmethod_free['float']
+    False
     """
     fused_func = fused_func
     fused_func_0 = fused_func_0
     regular_func = regular_func
     regular_func_0 = regular_func_0
 
+    fused_classmethod_free = fused_classmethod_free
+
     def fused_in_class(self, x: MyFusedClass):
         return (type(x).__name__, cython.typeof(x))
 
     def regular_in_class(self):
         return type(self).__name__
+
+    @classmethod
+    def fused_classmethod(cls, x: IntOrFloat):
+        return (cls.__name__, type(x).__name__)
 
 class Regular(object):
     __doc__ = """
@@ -115,6 +140,20 @@ class Regular(object):
     >>> c.regular_func_0()  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: regular_func_0() takes ... arguments ...1... given...
+
+    # Looking up a class attribute doesn't go through all of __get__
+    >>> Regular.fused_func is Regular.fused_func
+    True
+
+    # looking up a classmethod does go __get__ though
+    >>> Regular.fused_classmethod is Regular.fused_classmethod
+    False
+    >>> Regular.fused_classmethod_free is Regular.fused_classmethod_free
+    False
+    >>> Regular.fused_classmethod(1)
+    ('Regular', 'int')
+    >>> Regular.fused_classmethod_free(1)
+    ('Regular', 'int')
     """.format(typeofRegular = "Python object" if cython.compiled else 'Regular')
     if cython.compiled:
         __doc__ += """
@@ -130,15 +169,22 @@ class Regular(object):
     >>> Regular.fused_func_0['float']()
     ('float', 'float')
 
-    # Looking up a class attribute doesn't go through all of __get__
-    >>> Regular.fused_func is Regular.fused_func
-    True
+    >>> Regular.fused_classmethod['float'] is Regular.fused_classmethod['float']
+    False
+    >>> Regular.fused_classmethod_free['float'] is Regular.fused_classmethod_free['float']
+    False
     """
 
     fused_func = fused_func
     fused_func_0 = fused_func_0
     regular_func = regular_func
     regular_func_0 = regular_func_0
+
+    fused_classmethod_free = fused_classmethod_free
+
+    @classmethod
+    def fused_classmethod(cls, x: IntOrFloat):
+        return (cls.__name__, type(x).__name__)
 
 import sys
 if sys.version_info[0] > 2:

--- a/tests/run/fused_bound_functions.py
+++ b/tests/run/fused_bound_functions.py
@@ -62,6 +62,10 @@ class Cdef:
     >>> c.regular_func_0()  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: regular_func_0() takes ... arguments ...1... given...
+
+    # Looking up a class attribute doesn't go through all of __get__
+    >>> Cdef.fused_in_class is Cdef.fused_in_class
+    True
     """.format(typeofCdef = 'Python object' if cython.compiled else 'Cdef')
 
     if cython.compiled:
@@ -125,6 +129,10 @@ class Regular(object):
     TypeError: (Exception looks quite different in Python2 and 3 so no way to match both)
     >>> Regular.fused_func_0['float']()
     ('float', 'float')
+
+    # Looking up a class attribute doesn't go through all of __get__
+    >>> Regular.fused_func is Regular.fused_func
+    True
     """
 
     fused_func = fused_func


### PR DESCRIPTION
Fused methods use `__get__` to bind them to a class instance. However, there's no need to do the full binding process when just looking up a class attribute.

The main consequence is that for:

```
class C:
    def f(self, FusedType x):
        pass
```

`C.f is C.f` now returns True. This saves a bit of computation and also makes them pickleable by name (provided they're not in a closure or anything like that...)