### PR TITLE
Improve "import_array" guard

### DIFF
--- a/Cython/Utility/NumpyImportArray.c
+++ b/Cython/Utility/NumpyImportArray.c
@@ -8,7 +8,7 @@
  * add the line
  *   <void>numpy._import_array
  */
-#ifdef NPY_NDARRAYOBJECT_H /* numpy headers have been included */
+#ifdef NPY_FEATURE_VERSION /* This is a public define that makes us reasonably confident it's "real" Numpy */
 // NO_IMPORT_ARRAY is Numpy's mechanism for indicating that import_array is handled elsewhere
 #if !NO_IMPORT_ARRAY /* https://docs.scipy.org/doc/numpy-1.17.0/reference/c-api.array.html#c.NO_IMPORT_ARRAY  */
 if (unlikely(_import_array() == -1)) {

--- a/tests/run/numpy_import_array_error.srctree
+++ b/tests/run/numpy_import_array_error.srctree
@@ -18,7 +18,7 @@ setup(ext_modules = cythonize('cimport_numpy.pyx'))
 
 cdef extern from *:
     """
-    #define NPY_NDARRAYOBJECT_H
+    #define NPY_FEATURE_VERSION
     static int _import_array(void) {
         PyErr_SetString(PyExc_ValueError, "Oh no!");
         return -1;


### PR DESCRIPTION
Stop using NPY_NDARRAYOBJECT_H since:
a) in principle it's private
b) Numpy has renamed it
and use a public symbol instead.

I think the existing tests are adequate - we just aren't yet testing
against a new enough version of Numpy to have caught it yet

Closes https://github.com/cython/cython/issues/4396 and https://github.com/cython/cython/issues/4394