### PR TITLE
Add "import_array()" to the Numpy tutorial

### DIFF
--- a/docs/examples/tutorial/numpy/convolve2.pyx
+++ b/docs/examples/tutorial/numpy/convolve2.pyx
@@ -9,6 +9,12 @@ import numpy as np
 # currently part of the Cython distribution).
 cimport numpy as np
 
+# It's necessary to call "import_array" if you use any part of the
+# numpy PyArray_* API. From Cython 3, accessing attributes like
+# ".shape" on a typed Numpy array use this API. Therefore we recommend
+# always calling "import_array" whenever you "cimport numpy"
+np.import_array()
+
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.


### PR DESCRIPTION
Arguably it's unnecessary if the auto-call works correctly, but
if we're still advising users to do it themselves then it probably
should be in the docs.