### PR TITLE
_TextTestResult->TextTestResult

### DIFF
--- a/Cython/Tests/xmlrunner.py
+++ b/Cython/Tests/xmlrunner.py
@@ -43,7 +43,7 @@ from __future__ import absolute_import
 import os
 import sys
 import time
-from unittest import TestResult, _TextTestResult, TextTestRunner
+from unittest import TestResult, TextTestResult, TextTestRunner
 import xml.dom.minidom
 try:
     from StringIO import StringIO
@@ -95,7 +95,7 @@ class _TestInfo(object):
             self.err, self.test_method)
 
 
-class _XMLTestResult(_TextTestResult):
+class _XMLTestResult(TextTestResult):
     """A test result class that can express test results in a XML report.
 
     Used by XMLTestRunner.
@@ -103,7 +103,7 @@ class _XMLTestResult(_TextTestResult):
     def __init__(self, stream=sys.stderr, descriptions=1, verbosity=1,
                  elapsed_times=True):
         "Create a new instance of _XMLTestResult."
-        _TextTestResult.__init__(self, stream, descriptions, verbosity)
+        TextTestResult.__init__(self, stream, descriptions, verbosity)
         self.successes = []
         self.callback = None
         self.elapsed_times = elapsed_times
@@ -158,7 +158,7 @@ class _XMLTestResult(_TextTestResult):
     def stopTest(self, test):
         "Called after execute each test method."
         self._restore_standard_output()
-        _TextTestResult.stopTest(self, test)
+        TextTestResult.stopTest(self, test)
         self.stop_time = time.time()
 
         if self.callback and callable(self.callback):

--- a/runtests.py
+++ b/runtests.py
@@ -1624,14 +1624,11 @@ class _FakeClass(object):
     def shortDescription(self):
         return self._shortDescription
 
-try: # Py2.7+ and Py3.2+
-    from unittest.runner import _TextTestResult
-except ImportError:
-    from unittest import _TextTestResult
+from unittest import TextTestResult
 
-class PartialTestResult(_TextTestResult):
+class PartialTestResult(TextTestResult):
     def __init__(self, base_result):
-        _TextTestResult.__init__(
+        TextTestResult.__init__(
             self, self._StringIO(), True,
             base_result.dots + base_result.showAll*2)
 


### PR DESCRIPTION
All the versions we currently test are new enough that the alias is no longer necessary

This is a cherry-pick of a small part of https://github.com/cython/cython/pull/4414