### PR TITLE
Fixed fused.__self__ tests on PyPy

### DIFF
--- a/tests/run/function_self.py
+++ b/tests/run/function_self.py
@@ -64,8 +64,8 @@ if sys.version_info[0] > 2 or cython.compiled:
     __doc__ += """
     >>> hasattr(C.regular, "__self__")  # __self__==None on pure-python 2
     False
-    # returns None on pure-python 2
 
+    # returns None on pure-python 2
     >>> C.fused.__self__  #doctest: +ELLIPSIS
     Traceback (most recent call last):
         ...


### PR DESCRIPTION
PyPy v7.3.6 looks to have added a helpful "did you mean..." to the AttributeError exception. It's currently tripping up these tests.