### PR TITLE
Add most of the C++17 numeric functions to libcpp.numeric

### DIFF
--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -21,3 +21,41 @@ cdef extern from "<numeric>" namespace "std" nogil:
 
     void partial_sum[InputIt, OutputIt, BinaryOperation](InputIt in_first, InputIt in_last, OutputIt out_first,
                                                          BinaryOperation op)
+
+    
+    T reduce[InputIt, T](InputIt first, InputIt last, T init)
+    T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init)
+    T reduce[InputIt, T, BinaryOp](InputIt first, InputIt last, T init, BinaryOp binary_op)
+    T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryOp binary_op)
+
+    T transform_reduce[InputIt1, InputIt2, T](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init)
+    T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
+    T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](InputIt first, InputIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
+    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init)
+    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
+    T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
+
+    OutputIt adjacent_difference[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
+    ForwardIt2 adjacent_difference[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
+    OutputIt adjacent_difference[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation op)
+    ForwardIt2 adjacent_difference[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation op)
+
+    OutputIt inclusive_scan[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
+    ForwardtIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op)
+    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, T init)
+    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, T init)
+
+    OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, OutputIt d_first, T init)
+    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init)
+    OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op)
+    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init, BinaryOperation binary_op)
+
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op)
+    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op)
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
+    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
+
+    OutputIt transform_exclusive_scan[InputIt, OutputIt, T, BinaryOperation, UnaryOperation](InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op, UnaryOperation unary_op)
+    ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init, BinaryOperation binary_op, UnaryOperation unary_op)

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -78,9 +78,10 @@ cdef extern from "<numeric>" namespace "std" nogil:
         InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, 
         T init)
 
-    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](
-        ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
-        BinaryOperation binary_op, T init)
+    # 
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](
+    #     ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+    #     BinaryOperation binary_op, T init)
 
     OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, 
         OutputIt d_first, T init)

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -24,116 +24,100 @@ cdef extern from "<numeric>" namespace "std" nogil:
 
     
     T reduce[InputIt, T](InputIt first, InputIt last, T init)
-    #T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init)
-    T reduce[InputIt, T, BinaryOp](InputIt first, InputIt last, T init, BinaryOp binary_op)
-    T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, ForwardIt first, 
-                                                      ForwardIt last, T init, BinaryOp binary_op)
 
-    T transform_reduce[InputIt1, InputIt2, T](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init)
-    T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](InputIt1 first1, 
-                                                                                    InputIt1 last1, 
-                                                                                    InputIt2 first2, 
-                                                                                    T init, 
-                                                                                    BinaryReductionOp reduce, 
-                                                                                    BinaryTransformOp transform)
-    T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](InputIt first, InputIt last, 
-                                                                        T init, BinaryReductionOp reduce, 
-                                                                        UnaryTransformOp transform)
-    #T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, 
-    #                                                               ForwardIt1 first1, 
-    #                                                               ForwardIt1 last1, 
-    #                                                               ForwardIt2 first2, T init)
-    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](ExecutionPolicy&& policy, 
-                                                                                                         ForwardIt1 first1, 
-                                                                                                         ForwardIt1 last1, 
-                                                                                                         ForwardIt2 first2, 
-                                                                                                         T init, 
-                                                                                                         BinaryReductionOp reduce, 
-                                                                                                         BinaryTransformOp transform)
-    #T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, 
-    #                                                                                       ForwardIt first, 
-    #                                                                                       ForwardIt last, 
-    #                                                                                       T init, 
-    #                                                                                       BinaryReductionOp reduce, 
-    #                                                                                       UnaryTransformOp transform)
+    # ambiguous with next overload
+    #T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, 
+    #    ForwardIt first, ForwardIt last, T init)
+
+    T reduce[InputIt, T, BinaryOp](InputIt first, InputIt last, T init, BinaryOp binary_op)
+
+    T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, 
+        ForwardIt first, ForwardIt last, T init, BinaryOp binary_op)
+
+    T transform_reduce[InputIt1, InputIt2, T](InputIt1 first1, InputIt1 last1, 
+        InputIt2 first2, T init)
+
+    T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](
+        InputIt1 first1, InputIt1 last1, InputIt2 first2, T init, 
+        BinaryReductionOp reduce, BinaryTransformOp transform)
+
+    T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](
+        InputIt first, InputIt last, T init, BinaryReductionOp reduce, 
+        UnaryTransformOp transform)
+
+    # ambiguous with previous overload
+    #T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](
+    #    ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, 
+    #    ForwardIt2 first2, T init)
+
+    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](
+        ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init, 
+        BinaryReductionOp reduce, BinaryTransformOp transform)
+
+    # ambiguous with second overload
+    #T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](
+    #    ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryReductionOp reduce, 
+    #    UnaryTransformOp transform)
 
     OutputIt inclusive_scan[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
-    # ambiguous with next overload
-    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, 
-    #                                                                    ForwardIt1 first, 
-    #                                                                    ForwardIt1 last, 
-    #                                                                    ForwardIt2 d_first)
-    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, 
-                                                                OutputIt d_first, BinaryOperation binary_op)
-    # ambiguous with next overload
-    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, 
-    #                                                                                     ForwardIt1 first, 
-    #                                                                                     ForwardIt1 last, 
-    #                                                                                     ForwardIt2 d_first, 
-    #                                                                                     BinaryOperation binary_op)
-    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](InputIt first, InputIt last, 
-                                                                   OutputIt d_first, 
-                                                                   BinaryOperation binary_op, 
-                                                                   T init)
-    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](ExecutionPolicy&& policy, 
-                                                                                           ForwardIt1 first, 
-                                                                                           ForwardIt1 last, 
-                                                                                           ForwardIt2 d_first, 
-                                                                                           BinaryOperation binary_op, 
-                                                                                           T init)
 
-    OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, OutputIt d_first, T init)
     # ambiguous with next overload
-    #ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, 
-    #                                                                      ForwardIt1 first, 
-    #                                                                      ForwardIt1 last, 
-    #                                                                      ForwardIt2 d_first, 
-    #                                                                      T init)
-    OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](InputIt first, InputIt last, 
-                                                                   OutputIt d_first, 
-                                                                   T init, 
-                                                                   BinaryOperation binary_op)
-    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](ExecutionPolicy&& policy, 
-                                                                                           ForwardIt1 first, 
-                                                                                           ForwardIt1 last, 
-                                                                                           ForwardIt2 d_first, 
-                                                                                           T init, 
-                                                                                           BinaryOperation binary_op)
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](
+    #    ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, 
+    #    ForwardIt2 d_first)
 
-    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](InputIt first, 
-                                                                                          InputIt last, 
-                                                                                          OutputIt d_first, 
-                                                                                          BinaryOperation binary_op, 
-                                                                                          UnaryOperation unary_op)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](
+        InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op)
+
     # ambiguous with next overload
-    # ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, 
-    #                                                                                                               ForwardIt1 first, 
-    #                                                                                                               ForwardIt1 last, 
-    #                                                                                                               ForwardIt2 d_first, 
-    #                                                                                                               BinaryOperation binary_op, 
-    #                                                                                                               UnaryOperation unary_op)
-    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](InputIt first, 
-                                                                                             InputIt last, 
-                                                                                             OutputIt d_first, 
-                                                                                             BinaryOperation binary_op, 
-                                                                                             UnaryOperation unary_op, 
-                                                                                             T init)
-    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](ExecutionPolicy&& policy, 
-                                                                                                                     ForwardIt1 first, 
-                                                                                                                     ForwardIt1 last, 
-                                                                                                                     ForwardIt2 d_first, 
-                                                                                                                     BinaryOperation binary_op, 
-                                                                                                                     UnaryOperation unary_op, 
-                                                                                                                     T init)
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](
+    #   ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+    #   BinaryOperation binary_op)
 
-    OutputIt transform_exclusive_scan[InputIt, OutputIt, T, BinaryOperation, UnaryOperation](InputIt first, InputIt last, 
-                                                                                             OutputIt d_first, T init, 
-                                                                                             BinaryOperation binary_op, 
-                                                                                             UnaryOperation unary_op)
-    ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, 
-                                                                                                                     ForwardIt1 first, 
-                                                                                                                     ForwardIt1 last, 
-                                                                                                                     ForwardIt2 d_first, 
-                                                                                                                     T init, 
-                                                                                                                     BinaryOperation binary_op,
-                                                                                                                     UnaryOperation unary_op)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](
+        InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, 
+        T init)
+
+    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](
+        ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+        BinaryOperation binary_op, T init)
+
+    OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, 
+        OutputIt d_first, T init)
+
+    # ambiguous with next overload
+    #ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](
+    #    ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, 
+    #    ForwardIt2 d_first, T init)
+
+    OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](
+        InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op)
+
+    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](
+        ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first,
+        T init, BinaryOperation binary_op)
+
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](
+        InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, 
+        UnaryOperation unary_op)
+
+    # ambiguous with next overload
+    # ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](
+    #    ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+    #    BinaryOperation binary_op, UnaryOperation unary_op)
+
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](
+        InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, 
+        UnaryOperation unary_op, T init)
+
+    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](
+        ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+        BinaryOperation binary_op, UnaryOperation unary_op, T init)
+
+    OutputIt transform_exclusive_scan[InputIt, OutputIt, T, BinaryOperation, UnaryOperation](
+        InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op, 
+        UnaryOperation unary_op)
+
+    ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](
+        ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
+        T init, BinaryOperation binary_op, UnaryOperation unary_op)

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -26,35 +26,114 @@ cdef extern from "<numeric>" namespace "std" nogil:
     T reduce[InputIt, T](InputIt first, InputIt last, T init)
     #T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init)
     T reduce[InputIt, T, BinaryOp](InputIt first, InputIt last, T init, BinaryOp binary_op)
-    T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryOp binary_op)
+    T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, ForwardIt first, 
+                                                      ForwardIt last, T init, BinaryOp binary_op)
 
     T transform_reduce[InputIt1, InputIt2, T](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init)
-    T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
-    T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](InputIt first, InputIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
-    #T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init)
-    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
-    #T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
+    T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](InputIt1 first1, 
+                                                                                    InputIt1 last1, 
+                                                                                    InputIt2 first2, 
+                                                                                    T init, 
+                                                                                    BinaryReductionOp reduce, 
+                                                                                    BinaryTransformOp transform)
+    T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](InputIt first, InputIt last, 
+                                                                        T init, BinaryReductionOp reduce, 
+                                                                        UnaryTransformOp transform)
+    #T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, 
+    #                                                               ForwardIt1 first1, 
+    #                                                               ForwardIt1 last1, 
+    #                                                               ForwardIt2 first2, T init)
+    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](ExecutionPolicy&& policy, 
+                                                                                                         ForwardIt1 first1, 
+                                                                                                         ForwardIt1 last1, 
+                                                                                                         ForwardIt2 first2, 
+                                                                                                         T init, 
+                                                                                                         BinaryReductionOp reduce, 
+                                                                                                         BinaryTransformOp transform)
+    #T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, 
+    #                                                                                       ForwardIt first, 
+    #                                                                                       ForwardIt last, 
+    #                                                                                       T init, 
+    #                                                                                       BinaryReductionOp reduce, 
+    #                                                                                       UnaryTransformOp transform)
 
     OutputIt inclusive_scan[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
     # ambiguous with next overload
-    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
-    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op)
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, 
+    #                                                                    ForwardIt1 first, 
+    #                                                                    ForwardIt1 last, 
+    #                                                                    ForwardIt2 d_first)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, 
+                                                                OutputIt d_first, BinaryOperation binary_op)
     # ambiguous with next overload
-    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op)
-    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, T init)
-    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, T init)
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, 
+    #                                                                                     ForwardIt1 first, 
+    #                                                                                     ForwardIt1 last, 
+    #                                                                                     ForwardIt2 d_first, 
+    #                                                                                     BinaryOperation binary_op)
+    OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](InputIt first, InputIt last, 
+                                                                   OutputIt d_first, 
+                                                                   BinaryOperation binary_op, 
+                                                                   T init)
+    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](ExecutionPolicy&& policy, 
+                                                                                           ForwardIt1 first, 
+                                                                                           ForwardIt1 last, 
+                                                                                           ForwardIt2 d_first, 
+                                                                                           BinaryOperation binary_op, 
+                                                                                           T init)
 
     OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, OutputIt d_first, T init)
     # ambiguous with next overload
-    #ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init)
-    OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op)
-    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init, BinaryOperation binary_op)
+    #ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, 
+    #                                                                      ForwardIt1 first, 
+    #                                                                      ForwardIt1 last, 
+    #                                                                      ForwardIt2 d_first, 
+    #                                                                      T init)
+    OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](InputIt first, InputIt last, 
+                                                                   OutputIt d_first, 
+                                                                   T init, 
+                                                                   BinaryOperation binary_op)
+    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](ExecutionPolicy&& policy, 
+                                                                                           ForwardIt1 first, 
+                                                                                           ForwardIt1 last, 
+                                                                                           ForwardIt2 d_first, 
+                                                                                           T init, 
+                                                                                           BinaryOperation binary_op)
 
-    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op)
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](InputIt first, 
+                                                                                          InputIt last, 
+                                                                                          OutputIt d_first, 
+                                                                                          BinaryOperation binary_op, 
+                                                                                          UnaryOperation unary_op)
     # ambiguous with next overload
-    # ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op)
-    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
-    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
+    # ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, 
+    #                                                                                                               ForwardIt1 first, 
+    #                                                                                                               ForwardIt1 last, 
+    #                                                                                                               ForwardIt2 d_first, 
+    #                                                                                                               BinaryOperation binary_op, 
+    #                                                                                                               UnaryOperation unary_op)
+    OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](InputIt first, 
+                                                                                             InputIt last, 
+                                                                                             OutputIt d_first, 
+                                                                                             BinaryOperation binary_op, 
+                                                                                             UnaryOperation unary_op, 
+                                                                                             T init)
+    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](ExecutionPolicy&& policy, 
+                                                                                                                     ForwardIt1 first, 
+                                                                                                                     ForwardIt1 last, 
+                                                                                                                     ForwardIt2 d_first, 
+                                                                                                                     BinaryOperation binary_op, 
+                                                                                                                     UnaryOperation unary_op, 
+                                                                                                                     T init)
 
-    OutputIt transform_exclusive_scan[InputIt, OutputIt, T, BinaryOperation, UnaryOperation](InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op, UnaryOperation unary_op)
-    ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init, BinaryOperation binary_op, UnaryOperation unary_op)
+    OutputIt transform_exclusive_scan[InputIt, OutputIt, T, BinaryOperation, UnaryOperation](InputIt first, InputIt last, 
+                                                                                             OutputIt d_first, T init, 
+                                                                                             BinaryOperation binary_op, 
+                                                                                             UnaryOperation unary_op)
+    ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, 
+                                                                                                                     ForwardIt1 first, 
+                                                                                                                     ForwardIt1 last, 
+                                                                                                                     ForwardIt2 d_first, 
+                                                                                                                     T init, 
+                                                                                                                     BinaryOperation binary_op,
+                                                                                                                     UnaryOperation unary_op)

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -24,36 +24,35 @@ cdef extern from "<numeric>" namespace "std" nogil:
 
     
     T reduce[InputIt, T](InputIt first, InputIt last, T init)
-    T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init)
+    #T reduce[ExecutionPolicy, ForwardIt, T](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init)
     T reduce[InputIt, T, BinaryOp](InputIt first, InputIt last, T init, BinaryOp binary_op)
     T reduce[ExecutionPolicy, ForwardIt, T, BinaryOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryOp binary_op)
 
     T transform_reduce[InputIt1, InputIt2, T](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init)
     T transform_reduce[InputIt1, InputIt2, T, BinaryReductionOp, BinaryTransformOp](InputIt1 first1, InputIt1 last1, InputIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
     T transform_reduce[InputIt, T, BinaryReductionOp, UnaryTransformOp](InputIt first, InputIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
-    T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init)
+    #T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init)
     T transform_reduce[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryReductionOp, BinaryTransformOp](ExecutionPolicy&& policy, ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, T init, BinaryReductionOp reduce, BinaryTransformOp transform)
-    T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
-
-    OutputIt adjacent_difference[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
-    ForwardIt2 adjacent_difference[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
-    OutputIt adjacent_difference[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation op)
-    ForwardIt2 adjacent_difference[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation op)
+    #T transform_reduce[ExecutionPolicy, ForwardIt, T, BinaryReductionOp, UnaryTransformOp](ExecutionPolicy&& policy, ForwardIt first, ForwardIt last, T init, BinaryReductionOp reduce, UnaryTransformOp transform)
 
     OutputIt inclusive_scan[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first)
-    ForwardtIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
+    # ambiguous with next overload
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first)
     OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op)
-    ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op)
+    # ambiguous with next overload
+    # ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op)
     OutputIt inclusive_scan[InputIt, OutputIt, BinaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, T init)
     ForwardIt2 inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, T init)
 
     OutputIt exclusive_scan[InputIt, OutputIt, T](InputIt first, InputIt last, OutputIt d_first, T init)
-    ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init)
+    # ambiguous with next overload
+    #ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init)
     OutputIt exclusive_scan[InputIt, OutputIt, T, BinaryOperation](InputIt first, InputIt last, OutputIt d_first, T init, BinaryOperation binary_op)
     ForwardIt2 exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, T init, BinaryOperation binary_op)
 
     OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op)
-    ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op)
+    # ambiguous with next overload
+    # ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op)
     OutputIt transform_inclusive_scan[InputIt, OutputIt, BinaryOperation, UnaryOperation, T](InputIt first, InputIt last, OutputIt d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
     ForwardIt2 transform_inclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, BinaryOperation, UnaryOperation, T](ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, BinaryOperation binary_op, UnaryOperation unary_op, T init)
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -73,7 +73,7 @@ def test_transform_reduce(vector[int] v1, vector[int] v2, int init):
     >>> test_transform_reduce([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(v1.begin(), v2.begin(), v1.end(), 0)
+    return transform_reduce(v1.begin(), v2.begin(), v1.end(), init)
 
 def test_transform_reduce_with_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
     """
@@ -81,7 +81,7 @@ def test_transform_reduce_with_bin_red_op_and_bin_tran_op(vector[int] v1, vector
     >>> test_transform_reduce_with_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(v1.begin(), v2.begin(), v1.end(), 0, add_integers, multiply_integers)
+    return transform_reduce(v1.begin(), v2.begin(), v1.end(), init, add_integers, multiply_integers)
 
 def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, int init):
     """
@@ -89,7 +89,7 @@ def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, int init):
     >>> test_transform_reduce_with_bin_op_and_unary_op([1, 2, 3], 0)
     12
     """
-    return transform_reduce(v1.begin(), v2.begin(), 0, add_integers, multiply_with_2)
+    return transform_reduce(v1.begin(), v2.begin(), init, add_integers, multiply_with_2)
 
 def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int init):
     """
@@ -97,7 +97,7 @@ def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int in
     >>> test_transform_reduce_with_execpolicy([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), 0)
+    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), init)
 
 def test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
     """
@@ -105,7 +105,7 @@ def test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op(vector[int]
     >>> test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), 0, add_integers, multiply_integers)
+    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), init, add_integers, multiply_integers)
 
 def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, int init):
     """
@@ -113,7 +113,7 @@ def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, in
     >>> test_transform_reduce_with_execpolicy_bin_op_and_unary_op([1, 2, 3], 0)
     12
     """
-    return transform_reduce(seq, v1.begin(), v2.begin(), 0, add_integers, multiply_with_2)
+    return transform_reduce(seq, v1.begin(), v2.begin(), init, add_integers, multiply_with_2)
 
 def test_inclusive_scan(vector[int] v):
     """
@@ -162,7 +162,7 @@ def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
     [1, 3, 6, 10]
     """
     cdef vector[int] out
-    inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, 0)
+    inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, init)
     return out
 
 def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init):
@@ -172,7 +172,7 @@ def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init)
     [1, 3, 6, 10]
     """
     cdef vector[int] out
-    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, 0)
+    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, init)
     return out
 
 def test_transform_inclusive_scan(vector[int] v):
@@ -202,7 +202,7 @@ def test_transform_inclusive_scan_with_init(vector[int] v, int init):
     [2, 6, 12, 20 ]
     """
     cdef vector[int] out
-    transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, 0)
+    transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, init)
     return out
 
 def test_transform_inclusive_scan_with_execpolicy_and_init(vector[int] v, int init):
@@ -212,7 +212,7 @@ def test_transform_inclusive_scan_with_execpolicy_and_init(vector[int] v, int in
     [2, 6, 12, 20 ]
     """
     cdef vector[int] out
-    transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, 0)
+    transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, init)
     return out
 
 def test_exclusive_scan(vector[int] v, int init):
@@ -222,7 +222,7 @@ def test_exclusive_scan(vector[int] v, int init):
     [0, 1, 3, 6]
     """
     cdef vector[int] out
-    exclusive_scan(v.begin(), v.end(), out.begin(), 0)
+    exclusive_scan(v.begin(), v.end(), out.begin(), init)
     return out
 
 def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
@@ -232,7 +232,7 @@ def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
     [0, 1, 3, 6]
     """
     cdef vector[int] out
-    exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0)
+    exclusive_scan(seq, v.begin(), v.end(), out.begin(), init)
     return out
 
 def test_exclusive_scan_with_bin_op(vector[int] v, int init):
@@ -242,7 +242,7 @@ def test_exclusive_scan_with_bin_op(vector[int] v, int init):
     [0, 1, 3, 6]
     """
     cdef vector[int] out
-    exclusive_scan(v.begin(), v.end(), out.begin(), 0, add_integers)
+    exclusive_scan(v.begin(), v.end(), out.begin(), init, add_integers)
     return out
 
 def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
@@ -252,7 +252,7 @@ def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
     [0, 1, 3, 6]
     """
     cdef vector[int] out
-    exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers)
+    exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers)
     return out
 
 
@@ -263,7 +263,7 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     [0, 2, 6, 12]
     """
     cdef vector[int] out
-    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers, multiply_with_2)
+    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
 
 def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
@@ -273,7 +273,7 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     [0, 2, 6, 12]
     """
     cdef vector[int] out
-    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers, multiply_with_2)
+    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
 
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -115,6 +115,67 @@ def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, in
     """
     return transform_reduce(seq, v1.begin(), v2.begin(), 0, add_integers, multiply_with_2)
 
+def test_inclusive_scan(vector[int] v):
+    """
+    Test inclusive_scan
+    >>> test_inclusive_scan([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(v.begin(), v.end(), out.begin())
+    return out
+
+def test_inclusive_scan_with_execpolicy(vector[int] v):
+    """
+    Test inclusive_scan with a execution policy
+    >>> test_inclusive_scan_with_execpolicy([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(seq, v.begin(), v.end(), out.begin())
+    return out
+
+def test_inclusive_scan_with_bin_op(vector[int] v):
+    """
+    Test inclusive_scan with a binary operation
+    >>> test_inclusive_scan_with_bin_op([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(v.begin(), v.end(), out.begin(), add_integers)
+    return out
+
+def test_inclusive_scan_with_execpolicy_and_bin_op(vector[int] v):
+    """
+    Test inclusive_scan with a execution policy and a binary operation
+    >>> test_inclusive_scan_with_execpolicy_and_bin_op([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers)
+    return out
+
+def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
+    """
+    Test inclusive_scan with a binary operation and a initial value
+    >>> test_inclusive_scan_with_bin_op_and_init([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, 0)
+    return out
+
+def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init):
+    """
+    Test inclusive_scan with a execution policy, a binary operation and a initial value
+    >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4])
+    [1, 3, 6, 10]
+    """
+    cdef vector[int] out
+    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, 0)
+    return out
+
+
 
 
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -158,7 +158,7 @@ def test_inclusive_scan_with_execpolicy_and_bin_op(vector[int] v):
 def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
     """
     Test inclusive_scan with a binary operation and a initial value
-    >>> test_inclusive_scan_with_bin_op_and_init([1, 2, 3, 4])
+    >>> test_inclusive_scan_with_bin_op_and_init([1, 2, 3, 4], 0)
     [1, 3, 6, 10]
     """
     cdef vector[int] out
@@ -168,11 +168,51 @@ def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
 def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init):
     """
     Test inclusive_scan with a execution policy, a binary operation and a initial value
-    >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4])
+    >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4], 0)
     [1, 3, 6, 10]
     """
     cdef vector[int] out
     inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, 0)
+    return out
+
+def test_exclusive_scan(vector[int] v, int init):
+    """
+    Test exclusive_scan
+    >>> test_exclusive_scan([1, 2, 3, 4], 0)
+    [0 1 3 6]
+    """
+    cdef vector[int] out
+    exclusive_scan(v.begin(), v.end(), out.begin(), 0)
+    return out
+
+def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
+    """
+    Test exclusive_scan with a execution policy
+    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+    [0 1 3 6]
+    """
+    cdef vector[int] out
+    exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0)
+    return out
+
+def test_exclusive_scan_with_bin_op(vector[int] v, int init):
+    """
+    Test exclusive_scan with a binary operation
+    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+    [0 1 3 6]
+    """
+    cdef vector[int] out
+    exclusive_scan(v.begin(), v.end(), out.begin(), 0, add_integers)
+    return out
+
+def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
+    """
+    Test exclusive_scan with a execution policy and a binary operation
+    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+    [0 1 3 6]
+    """
+    cdef vector[int] out
+    exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers)
     return out
 
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -1,9 +1,9 @@
 # mode: run
-# tag: cpp, werror, cpp17, cppexecpolicies, no-cpp-locals
+# tag: cpp, werror, cpp17, cppexecpolicies
 
-from libcpp.numeric cimport reduce, exclusive_scan, inclusive_scan, 
-                            transform_reduce, transform_exclusive_scan, 
-                            transform_inclusive_scan
+from libcpp.numeric cimport (reduce, transform_reduce, inclusive_scan, 
+                             exclusive_scan, transform_inclusive_scan, 
+                             transform_exclusive_scan)
 from libcpp.execution cimport seq
 from libcpp.vector cimport vector
 
@@ -45,16 +45,16 @@ def test_reduce_with_bin_op(vector[int] v, int init):
     """
     return reduce(v.begin(), v.end(), init, subtract_integers)
 
-def test_reduce_with_execpolicy(vector[int] v, int init):
-    """
-    Test reduce with execution policy. 
-     0 + 1 = 1
-     1 + 2 = 3
-     3 + 3 = 6
-    >>> test_reduce_with_execpolicy([1, 2, 3], 0)
-    6
-    """
-    return reduce(seq, v.begin(), v.end(), init)
+# def test_reduce_with_execpolicy(vector[int] v, int init):
+#     """
+#     Test reduce with execution policy. 
+#      0 + 1 = 1
+#      1 + 2 = 3
+#      3 + 3 = 6
+#     >>> test_reduce_with_execpolicy([1, 2, 3], 0)
+#     6
+#     """
+#     return reduce(seq, v.begin(), v.end(), init)
 
 def test_reduce_with_bin_op_and_execpolicy(vector[int] v, int init):
     """
@@ -73,7 +73,7 @@ def test_transform_reduce(vector[int] v1, vector[int] v2, int init):
     >>> test_transform_reduce([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(v1.begin(), v2.begin(), v1.end(), init)
+    return transform_reduce(v1.begin(), v1.end(), v2.begin(), init)
 
 def test_transform_reduce_with_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
     """
@@ -81,23 +81,23 @@ def test_transform_reduce_with_bin_red_op_and_bin_tran_op(vector[int] v1, vector
     >>> test_transform_reduce_with_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(v1.begin(), v2.begin(), v1.end(), init, add_integers, multiply_integers)
+    return transform_reduce(v1.begin(), v1.end(), v2.begin(), init, add_integers, multiply_integers)
 
-def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, int init):
+def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, vector[int] v2, int init):
     """
     Test transform_reduce with a binary reduction and a unary transform operation
-    >>> test_transform_reduce_with_bin_op_and_unary_op([1, 2, 3], 0)
+    >>> test_transform_reduce_with_bin_op_and_unary_op([1, 2, 3], [1, 2, 3], 0)
     12
     """
-    return transform_reduce(v1.begin(), v2.begin(), init, add_integers, multiply_with_2)
+    return transform_reduce(v1.begin(), v1.end(), v2.begin(), init, add_integers, multiply_with_2)
 
-def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int init):
-    """
-    Test transform_reduce with a execution policy
-    >>> test_transform_reduce_with_execpolicy([1, 2, 3], [1, 2, 3], 0)
-    14
-    """
-    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), init)
+# def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int init):
+#     """
+#     Test transform_reduce with a execution policy
+#     >>> test_transform_reduce_with_execpolicy([1, 2, 3], [1, 2, 3], 0)
+#     14
+#     """
+#     return transform_reduce(seq, v1.begin(), v1.end(), v2.begin(), init)
 
 def test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
     """
@@ -105,15 +105,15 @@ def test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op(vector[int]
     >>> test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
     14
     """
-    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), init, add_integers, multiply_integers)
+    return transform_reduce(seq, v1.begin(), v1.end(), v2.begin(), init, add_integers, multiply_integers)
 
-def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, int init):
-    """
-    Test transform_reduce with a execution policy and binary reduction and a unary transform operation
-    >>> test_transform_reduce_with_execpolicy_bin_op_and_unary_op([1, 2, 3], 0)
-    12
-    """
-    return transform_reduce(seq, v1.begin(), v2.begin(), init, add_integers, multiply_with_2)
+# def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, vector[int] v2, int init):
+#     """
+#     Test transform_reduce with a execution policy and binary reduction and a unary transform operation
+#     >>> test_transform_reduce_with_execpolicy_bin_op_and_unary_op([1, 2, 3], [1, 2, 3], 0)
+#     12
+#     """
+#     return transform_reduce(seq, v1.begin(), v1.end(), v2.begin(), init, add_integers, multiply_with_2)
 
 def test_inclusive_scan(vector[int] v):
     """
@@ -121,19 +121,19 @@ def test_inclusive_scan(vector[int] v):
     >>> test_inclusive_scan([1, 2, 3, 4])
     [1, 3, 6, 10]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     inclusive_scan(v.begin(), v.end(), out.begin())
     return out
 
-def test_inclusive_scan_with_execpolicy(vector[int] v):
-    """
-    Test inclusive_scan with a execution policy
-    >>> test_inclusive_scan_with_execpolicy([1, 2, 3, 4])
-    [1, 3, 6, 10]
-    """
-    cdef vector[int] out
-    inclusive_scan(seq, v.begin(), v.end(), out.begin())
-    return out
+# def test_inclusive_scan_with_execpolicy(vector[int] v):
+#     """
+#     Test inclusive_scan with a execution policy
+#     >>> test_inclusive_scan_with_execpolicy([1, 2, 3, 4])
+#     [1, 3, 6, 10]
+#     """
+#     cdef vector[int] out
+#     inclusive_scan(seq, v.begin(), v.end(), out.begin())
+#     return out
 
 def test_inclusive_scan_with_bin_op(vector[int] v):
     """
@@ -141,19 +141,19 @@ def test_inclusive_scan_with_bin_op(vector[int] v):
     >>> test_inclusive_scan_with_bin_op([1, 2, 3, 4])
     [1, 3, 6, 10]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     inclusive_scan(v.begin(), v.end(), out.begin(), add_integers)
     return out
 
-def test_inclusive_scan_with_execpolicy_and_bin_op(vector[int] v):
-    """
-    Test inclusive_scan with a execution policy and a binary operation
-    >>> test_inclusive_scan_with_execpolicy_and_bin_op([1, 2, 3, 4])
-    [1, 3, 6, 10]
-    """
-    cdef vector[int] out
-    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers)
-    return out
+# def test_inclusive_scan_with_execpolicy_and_bin_op(vector[int] v):
+#     """
+#     Test inclusive_scan with a execution policy and a binary operation
+#     >>> test_inclusive_scan_with_execpolicy_and_bin_op([1, 2, 3, 4])
+#     [1, 3, 6, 10]
+#     """
+#     cdef vector[int] out
+#     inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers)
+#     return out
 
 def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
     """
@@ -161,7 +161,7 @@ def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
     >>> test_inclusive_scan_with_bin_op_and_init([1, 2, 3, 4], 0)
     [1, 3, 6, 10]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, init)
     return out
 
@@ -171,7 +171,7 @@ def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init)
     >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4], 0)
     [1, 3, 6, 10]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, init)
     return out
 
@@ -185,15 +185,15 @@ def test_transform_inclusive_scan(vector[int] v):
     transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
     return out
 
-def test_transform_inclusive_scan_with_execpolicy(vector[int] v):
-    """
-    Test transform inclusive_scan with a execution policy
-    >>> test_transform_inclusive_scan_with_execpolicy([1, 2, 3, 4])
-    [2, 6, 12, 20 ]
-    """
-    cdef vector[int] out
-    transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
-    return out
+# def test_transform_inclusive_scan_with_execpolicy(vector[int] v):
+#     """
+#     Test transform inclusive_scan with a execution policy
+#     >>> test_transform_inclusive_scan_with_execpolicy([1, 2, 3, 4])
+#     [2, 6, 12, 20 ]
+#     """
+#     cdef vector[int] out
+#     transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
+#     return out
 
 def test_transform_inclusive_scan_with_init(vector[int] v, int init):
     """
@@ -221,37 +221,37 @@ def test_exclusive_scan(vector[int] v, int init):
     >>> test_exclusive_scan([1, 2, 3, 4], 0)
     [0, 1, 3, 6]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     exclusive_scan(v.begin(), v.end(), out.begin(), init)
     return out
 
-def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
-    """
-    Test exclusive_scan with a execution policy
-    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
-    [0, 1, 3, 6]
-    """
-    cdef vector[int] out
-    exclusive_scan(seq, v.begin(), v.end(), out.begin(), init)
-    return out
+# def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
+#     """
+#     Test exclusive_scan with a execution policy
+#     >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+#     [0, 1, 3, 6]
+#     """
+#     cdef vector[int] out
+#     exclusive_scan(seq, v.begin(), v.end(), out.begin(), init)
+#     return out
 
 def test_exclusive_scan_with_bin_op(vector[int] v, int init):
     """
     Test exclusive_scan with a binary operation
-    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+    >>> test_exclusive_scan_with_bin_op([1, 2, 3, 4], 0)
     [0, 1, 3, 6]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     exclusive_scan(v.begin(), v.end(), out.begin(), init, add_integers)
     return out
 
 def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
     """
     Test exclusive_scan with a execution policy and a binary operation
-    >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
+    >>> test_exclusive_scan_with_execpolicy_and_bin_op([1, 2, 3, 4], 0)
     [0, 1, 3, 6]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers)
     return out
 
@@ -259,10 +259,10 @@ def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
 def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     """
     Test transform_exclusive_scan
-    >>> test_transform_exclusive_scan([1, 2, 3, 4], 0)
+    >>> test_transform_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
     [0, 2, 6, 12]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
 
@@ -272,7 +272,7 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     >>> test_transform_exclusive_scan([1, 2, 3, 4], 0)
     [0, 2, 6, 12]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -1,0 +1,125 @@
+# mode: run
+# tag: cpp, werror, cpp17, cppexecpolicies, no-cpp-locals
+
+from libcpp.numeric cimport reduce, exclusive_scan, inclusive_scan, 
+                            transform_reduce, transform_exclusive_scan, 
+                            transform_inclusive_scan
+from libcpp.execution cimport seq
+from libcpp.vector cimport vector
+
+# Subtracts two integers.
+cdef int subtract_integers(int lhs, int rhs):
+    return lhs - rhs
+
+# Adds two integers.
+cdef int add_integers(int lhs, int rhs):
+    return lhs + rhs
+
+# Multiplies two integers.
+cdef int multiply_integers(int lhs, int rhs):
+    return lhs * rhs
+
+# Multiplies a integer with 2
+cdef int multiply_with_2(int val):
+    return 2*val
+
+def test_reduce(vector[int] v, int init):
+    """
+    Test reduce.
+     0 + 1 = 1
+     1 + 2 = 3
+     3 + 3 = 6
+    >>> test_reduce([1, 2, 3], 0)
+    6
+    """
+    return reduce(v.begin(), v.end(), init)
+
+def test_reduce_with_bin_op(vector[int] v, int init):
+    """
+    Test reduce with a binary operation (subtraction). 
+     0 - 1 = -1
+    -1 - 2 = -3
+    -3 - 3 = -6
+    >>> test_reduce_with_bin_op([1, 2, 3], 0)
+    -6
+    """
+    return reduce(v.begin(), v.end(), init, subtract_integers)
+
+def test_reduce_with_execpolicy(vector[int] v, int init):
+    """
+    Test reduce with execution policy. 
+     0 + 1 = 1
+     1 + 2 = 3
+     3 + 3 = 6
+    >>> test_reduce_with_execpolicy([1, 2, 3], 0)
+    6
+    """
+    return reduce(seq, v.begin(), v.end(), init)
+
+def test_reduce_with_bin_op_and_execpolicy(vector[int] v, int init):
+    """
+    Test reduce with execution policy and a binary operation (subtraction). 
+     0 - 1 = -1
+    -1 - 2 = -3
+    -3 - 3 = -6
+    >>> test_reduce_with_bin_op_and_execpolicy([1, 2, 3], 0)
+    -6
+    """
+    return reduce(seq, v.begin(), v.end(), init, subtract_integers)
+
+def test_transform_reduce(vector[int] v1, vector[int] v2, int init):
+    """
+    Test transform_reduce
+    >>> test_transform_reduce([1, 2, 3], [1, 2, 3], 0)
+    14
+    """
+    return transform_reduce(v1.begin(), v2.begin(), v1.end(), 0)
+
+def test_transform_reduce_with_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
+    """
+    Test transform_reduce with a binary reduce and transform operations
+    >>> test_transform_reduce_with_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
+    14
+    """
+    return transform_reduce(v1.begin(), v2.begin(), v1.end(), 0, add_integers, multiply_integers)
+
+def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, int init):
+    """
+    Test transform_reduce with a binary reduction and a unary transform operation
+    >>> test_transform_reduce_with_bin_op_and_unary_op([1, 2, 3], 0)
+    12
+    """
+    return transform_reduce(v1.begin(), v2.begin(), 0, add_integers, multiply_with_2)
+
+def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int init):
+    """
+    Test transform_reduce with a execution policy
+    >>> test_transform_reduce_with_execpolicy([1, 2, 3], [1, 2, 3], 0)
+    14
+    """
+    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), 0)
+
+def test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op(vector[int] v1, vector[int] v2, int init):
+    """
+    Test transform_reduce with a execution policy and binary reduce and transform operations
+    >>> test_transform_reduce_with_execpolicy_bin_red_op_and_bin_tran_op([1, 2, 3], [1, 2, 3], 0)
+    14
+    """
+    return transform_reduce(seq, v1.begin(), v2.begin(), v1.end(), 0, add_integers, multiply_integers)
+
+def test_transform_reduce_with_execpolicy_bin_op_and_unary_op(vector[int] v1, int init):
+    """
+    Test transform_reduce with a execution policy and binary reduction and a unary transform operation
+    >>> test_transform_reduce_with_execpolicy_bin_op_and_unary_op([1, 2, 3], 0)
+    12
+    """
+    return transform_reduce(seq, v1.begin(), v2.begin(), 0, add_integers, multiply_with_2)
+
+
+
+
+
+
+
+
+

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -89,7 +89,7 @@ def test_transform_reduce_with_bin_op_and_unary_op(vector[int] v1, vector[int] v
     >>> test_transform_reduce_with_bin_op_and_unary_op([1, 2, 3], [1, 2, 3], 0)
     12
     """
-    return transform_reduce(v1.begin(), v1.end(), v2.begin(), init, add_integers, multiply_with_2)
+    return transform_reduce(v1.begin(), v1.end(), init, add_integers, multiply_with_2)
 
 # def test_transform_reduce_with_execpolicy(vector[int] v1, vector[int] v2, int init):
 #     """
@@ -179,9 +179,9 @@ def test_transform_inclusive_scan(vector[int] v):
     """
     Test transform inclusive_scan
     >>> test_transform_inclusive_scan([1, 2, 3, 4])
-    [2, 6, 12, 20 ]
+    [2, 6, 12, 20]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
     return out
 
@@ -199,9 +199,9 @@ def test_transform_inclusive_scan_with_init(vector[int] v, int init):
     """
     Test transform inclusive_scan with an initial value
     >>> test_transform_inclusive_scan_with_init([1, 2, 3, 4], 0)
-    [2, 6, 12, 20 ]
+    [2, 6, 12, 20]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, init)
     return out
 
@@ -209,9 +209,9 @@ def test_transform_inclusive_scan_with_execpolicy_and_init(vector[int] v, int in
     """
     Test transform inclusive_scan with an initial value
     >>> test_transform_inclusive_scan_with_execpolicy_and_init([1, 2, 3, 4], 0)
-    [2, 6, 12, 20 ]
+    [2, 6, 12, 20]
     """
-    cdef vector[int] out
+    cdef vector[int] out = vector[int](v.size())
     transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, init)
     return out
 
@@ -269,7 +269,7 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
 def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     """
     Test transform_exclusive_scan with a execution policy
-    >>> test_transform_exclusive_scan([1, 2, 3, 4], 0)
+    >>> test_transform_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
     [0, 2, 6, 12]
     """
     cdef vector[int] out = vector[int](v.size())

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -275,12 +275,3 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     cdef vector[int] out = vector[int](v.size())
     transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
-
-
-
-
-
-
-
-
-

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -165,15 +165,15 @@ def test_inclusive_scan_with_bin_op_and_init(vector[int] v, int init):
     inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, init)
     return out
 
-def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init):
-    """
-    Test inclusive_scan with a execution policy, a binary operation and a initial value
-    >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4], 0)
-    [1, 3, 6, 10]
-    """
-    cdef vector[int] out = vector[int](v.size())
-    inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, init)
-    return out
+# def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init):
+#     """
+#     Test inclusive_scan with a execution policy, a binary operation and a initial value
+#     >>> test_inclusive_scan_with_execpolicy_bin_op_and_init([1, 2, 3, 4], 0)
+#     [1, 3, 6, 10]
+#     """
+#     cdef vector[int] out = vector[int](v.size())
+#     inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, init)
+#     return out
 
 def test_transform_inclusive_scan(vector[int] v):
     """

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -179,7 +179,7 @@ def test_exclusive_scan(vector[int] v, int init):
     """
     Test exclusive_scan
     >>> test_exclusive_scan([1, 2, 3, 4], 0)
-    [0 1 3 6]
+    [0, 1, 3, 6]
     """
     cdef vector[int] out
     exclusive_scan(v.begin(), v.end(), out.begin(), 0)
@@ -189,7 +189,7 @@ def test_exclusive_scan_with_execpolicy(vector[int] v, int init):
     """
     Test exclusive_scan with a execution policy
     >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
-    [0 1 3 6]
+    [0, 1, 3, 6]
     """
     cdef vector[int] out
     exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0)
@@ -199,7 +199,7 @@ def test_exclusive_scan_with_bin_op(vector[int] v, int init):
     """
     Test exclusive_scan with a binary operation
     >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
-    [0 1 3 6]
+    [0, 1, 3, 6]
     """
     cdef vector[int] out
     exclusive_scan(v.begin(), v.end(), out.begin(), 0, add_integers)
@@ -209,12 +209,11 @@ def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
     """
     Test exclusive_scan with a execution policy and a binary operation
     >>> test_exclusive_scan_with_execpolicy([1, 2, 3, 4], 0)
-    [0 1 3 6]
+    [0, 1, 3, 6]
     """
     cdef vector[int] out
     exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers)
     return out
-
 
 
 

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -175,6 +175,46 @@ def test_inclusive_scan_with_execpolicy_bin_op_and_init(vector[int] v, int init)
     inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, 0)
     return out
 
+def test_transform_inclusive_scan(vector[int] v):
+    """
+    Test transform inclusive_scan
+    >>> test_transform_inclusive_scan([1, 2, 3, 4])
+    [2, 6, 12, 20 ]
+    """
+    cdef vector[int] out
+    transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
+    return out
+
+def test_transform_inclusive_scan_with_execpolicy(vector[int] v):
+    """
+    Test transform inclusive_scan with a execution policy
+    >>> test_transform_inclusive_scan_with_execpolicy([1, 2, 3, 4])
+    [2, 6, 12, 20 ]
+    """
+    cdef vector[int] out
+    transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2)
+    return out
+
+def test_transform_inclusive_scan_with_init(vector[int] v, int init):
+    """
+    Test transform inclusive_scan with an initial value
+    >>> test_transform_inclusive_scan_with_init([1, 2, 3, 4], 0)
+    [2, 6, 12, 20 ]
+    """
+    cdef vector[int] out
+    transform_inclusive_scan(v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, 0)
+    return out
+
+def test_transform_inclusive_scan_with_execpolicy_and_init(vector[int] v, int init):
+    """
+    Test transform inclusive_scan with an initial value
+    >>> test_transform_inclusive_scan_with_execpolicy_and_init([1, 2, 3, 4], 0)
+    [2, 6, 12, 20 ]
+    """
+    cdef vector[int] out
+    transform_inclusive_scan(seq, v.begin(), v.end(), out.begin(), add_integers, multiply_with_2, 0)
+    return out
+
 def test_exclusive_scan(vector[int] v, int init):
     """
     Test exclusive_scan
@@ -214,7 +254,7 @@ def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
     cdef vector[int] out
     exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers)
     return out
-    
+
 
 def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     """

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -214,6 +214,27 @@ def test_exclusive_scan_with_execpolicy_and_bin_op(vector[int] v, int init):
     cdef vector[int] out
     exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers)
     return out
+    
+
+def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
+    """
+    Test transform_exclusive_scan
+    >>> test_transform_exclusive_scan([1, 2, 3, 4], 0)
+    [0, 2, 6, 12]
+    """
+    cdef vector[int] out
+    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers, multiply_with_2)
+    return out
+
+def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
+    """
+    Test transform_exclusive_scan with a execution policy
+    >>> test_transform_exclusive_scan([1, 2, 3, 4], 0)
+    [0, 2, 6, 12]
+    """
+    cdef vector[int] out
+    transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), 0, add_integers, multiply_with_2)
+    return out
 
 
 


### PR DESCRIPTION
Adds most of the C++17 STL functions of the [numeric library](https://en.cppreference.com/w/cpp/header/numeric) to `libcpp.numeric`, i.e.

- `reduce`
- `transform_reduce`
- `inclusive_scan`
- `exclusive_scan`
- `transform_inclusive_scan`
- `transform_exclusive_scan`

Unfortunately, I'm not really aware of an appropriate way to handle the ambiguous overloads in Cython only, so I excluded some of them, see also [my question at the mailing list](https://groups.google.com/g/cython-users/c/hMfR9LmOjGg).