### PR TITLE
update incorrect version support comment

### DIFF
--- a/Cython/Includes/cpython/pycapsule.pxd
+++ b/Cython/Includes/cpython/pycapsule.pxd
@@ -1,5 +1,5 @@
 
-# available since Python 3.1!
+# available since Python 2.7!
 
 
 cdef extern from "Python.h":


### PR DESCRIPTION
Capsules are already supported in Python 2.7: https://docs.python.org/2.7/c-api/capsule.html