### PR TITLE
FIX: change c includes to account for upstream changes

### DIFF
--- a/Cython/Includes/cpython/longintrepr.pxd
+++ b/Cython/Includes/cpython/longintrepr.pxd
@@ -1,5 +1,4 @@
 # Internals of the "long" type (Python 2) or "int" type (Python 3).
-# This is not part of Python's published API.
 
 cdef extern from "Python.h":
     """

--- a/Cython/Includes/cpython/longintrepr.pxd
+++ b/Cython/Includes/cpython/longintrepr.pxd
@@ -1,11 +1,9 @@
 # Internals of the "long" type (Python 2) or "int" type (Python 3).
 # This is not part of Python's published API.
 
-cdef extern from *:
-    """"
-    #if PY_VERSION_HEX >= 0x03000000
-     #include "Python.h"
-    #else
+cdef extern from "Python.h":
+    """
+    #if PY_MAJOR_VERSION < 3
      #include "longintrepr.h"
     #endif
     """

--- a/Cython/Includes/cpython/longintrepr.pxd
+++ b/Cython/Includes/cpython/longintrepr.pxd
@@ -1,7 +1,14 @@
 # Internals of the "long" type (Python 2) or "int" type (Python 3).
 # This is not part of Python's published API.
 
-cdef extern from "longintrepr.h":
+cdef extern from *:
+    """"
+    #if PY_VERSION_HEX >= 0x03000000
+     #include "Python.h"
+    #else
+     #include "longintrepr.h"
+    #endif
+    """
     ctypedef unsigned int digit
     ctypedef int sdigit  # Python >= 2.7 only
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -263,9 +263,7 @@
 #define CYTHON_BACKPORT_VECTORCALL (CYTHON_METH_FASTCALL && PY_VERSION_HEX < 0x030800B1)
 
 #if CYTHON_USE_PYLONG_INTERNALS
-  #if PY_VERSION_HEX >= 0x03000000
-    #include "Python.h"
-  #else
+  #if PY_MAJOR_VERSION < 3
     #include "longintrepr.h"
   #endif
   /* These short defines can easily conflict with other code */

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -263,7 +263,11 @@
 #define CYTHON_BACKPORT_VECTORCALL (CYTHON_METH_FASTCALL && PY_VERSION_HEX < 0x030800B1)
 
 #if CYTHON_USE_PYLONG_INTERNALS
-  #include "longintrepr.h"
+  #if PY_VERSION_HEX >= 0x03000000
+    #include "Python.h"
+  #else
+    #include "longintrepr.h"
+  #endif
   /* These short defines can easily conflict with other code */
   #undef SHIFT
   #undef BASE

--- a/tests/compile/pylong.pyx
+++ b/tests/compile/pylong.pyx
@@ -1,6 +1,13 @@
 # mode: compile
 
-cdef extern from "Python.h":
+cdef extern from *:
+    """"
+    #if PY_VERSION_HEX >= 0x03000000
+     #include "Python.h"
+    #else
+     #include "longintrepr.h"
+    #endif
+    """
     ctypedef struct PyTypeObject:
         pass
 
@@ -8,7 +15,14 @@ cdef extern from "Python.h":
         Py_ssize_t ob_refcnt
         PyTypeObject *ob_type
 
-cdef extern from "longintrepr.h":
+cdef extern from *:
+    """"
+    #if PY_VERSION_HEX >= 0x03000000
+     #include "Python.h"
+    #else
+     #include "longintrepr.h"
+    #endif
+    """
     cdef struct _longobject:
         int ob_refcnt
         PyTypeObject *ob_type

--- a/tests/compile/pylong.pyx
+++ b/tests/compile/pylong.pyx
@@ -1,13 +1,6 @@
 # mode: compile
 
-cdef extern from *:
-    """"
-    #if PY_VERSION_HEX >= 0x03000000
-     #include "Python.h"
-    #else
-     #include "longintrepr.h"
-    #endif
-    """
+cdef extern from "Python.h":
     ctypedef struct PyTypeObject:
         pass
 
@@ -15,11 +8,9 @@ cdef extern from *:
         Py_ssize_t ob_refcnt
         PyTypeObject *ob_type
 
-cdef extern from *:
-    """"
-    #if PY_VERSION_HEX >= 0x03000000
-     #include "Python.h"
-    #else
+cdef extern from "Python.h":
+    """
+    #if PY_MAJOR_VERSION < 3
      #include "longintrepr.h"
     #endif
     """


### PR DESCRIPTION
https://github.com/python/cpython/pull/28968 / 8e5de40f90476249e9a2e5ef135143b5c6a0b512 which is part of implementing https://bugs.python.org/issue35134 moved the header "longintrepr.h" into a sub-folder.  The notes on this change suggested to include "Python.h" instead.