### PR TITLE
Don't error when exception_check is set to True when return type is PyObject.

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -715,8 +715,13 @@ class CFuncDeclaratorNode(CDeclaratorNode):
         if (return_type.is_pyobject
                 and (self.exception_value or self.exception_check)
                 and self.exception_check != '+'):
-            # Exception clause is silently ignored for functions returning Python object.
-            self.exception_check = False
+            if self.exception_value is None and self.exception_check is True:
+                # Functions in pure python mode defaults to always check return value for exception
+                # (equivalent to except * declaration in Cython language). In this case exception clause
+                # is silently ignored for functions returning Python object.
+                self.exception_check = False
+            else:
+                error(self.pos, "Exception clause not allowed for function returning Python object")
         else:
             if self.exception_value is None and self.exception_check and self.exception_check != '+':
                 # Use an explicit exception return value to speed up exception checks.

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -712,16 +712,16 @@ class CFuncDeclaratorNode(CDeclaratorNode):
             env.add_include_file('new')         # for std::bad_alloc
             env.add_include_file('stdexcept')
             env.add_include_file('typeinfo')    # for std::bad_cast
+        elif return_type.is_pyobject and self.exception_check:
+            # Functions in pure Python mode default to always check return values for exceptions
+            # (equivalent to the "except*" declaration). In this case, the exception clause
+            # is silently ignored for functions returning a Python object.
+            self.exception_check = False
+
         if (return_type.is_pyobject
                 and (self.exception_value or self.exception_check)
                 and self.exception_check != '+'):
-            if self.exception_value is None and self.exception_check is True:
-                # Functions in pure python mode defaults to always check return value for exception
-                # (equivalent to except * declaration in Cython language). In this case exception clause
-                # is silently ignored for functions returning Python object.
-                self.exception_check = False
-            else:
-                error(self.pos, "Exception clause not allowed for function returning Python object")
+            error(self.pos, "Exception clause not allowed for function returning Python object")
         else:
             if self.exception_value is None and self.exception_check and self.exception_check != '+':
                 # Use an explicit exception return value to speed up exception checks.

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -715,7 +715,8 @@ class CFuncDeclaratorNode(CDeclaratorNode):
         if (return_type.is_pyobject
                 and (self.exception_value or self.exception_check)
                 and self.exception_check != '+'):
-            error(self.pos, "Exception clause not allowed for function returning Python object")
+            # Exception clause is silently ignored for functions returning Python object.
+            self.exception_check = False
         else:
             if self.exception_value is None and self.exception_check and self.exception_check != '+':
                 # Use an explicit exception return value to speed up exception checks.

--- a/tests/errors/pure_errors.py
+++ b/tests/errors/pure_errors.py
@@ -50,8 +50,15 @@ def pyfunc(x):  # invalid
     return x + 1
 
 
+@cython.exceptval(-1)
+@cython.cfunc
+def test_cdef_return_object_broken(x: object) -> object:
+    return x
+
+
 _ERRORS = """
 44:22: Calling gil-requiring function not allowed without gil
 45:24: Calling gil-requiring function not allowed without gil
 48:0: Python functions cannot be declared 'nogil'
+53:0: Exception clause not allowed for function returning Python object
 """

--- a/tests/run/pure_py3.py
+++ b/tests/run/pure_py3.py
@@ -85,3 +85,12 @@ def call_cdef_inline(x):
     """
     ret = cdef_inline(x)
     return ret, cython.typeof(ret)
+
+@cython.cfunc
+def test_cdef_return_object(x: object) -> object:
+    """
+    Test support of python object in annotations
+    >>> test_cdef_return_object(3)
+    3
+    """
+    return x

--- a/tests/run/pure_py3.py
+++ b/tests/run/pure_py3.py
@@ -92,5 +92,12 @@ def test_cdef_return_object(x: object) -> object:
     Test support of python object in annotations
     >>> test_cdef_return_object(3)
     3
+    >>> test_cdef_return_object(None)
+    Traceback (most recent call last):
+        ...
+    RuntimeError
     """
-    return x
+    if x:
+        return x
+    else:
+        raise RuntimeError()


### PR DESCRIPTION
This PR fixes issues in pure python mode when Python object is
annotated as returned value - e.g.:
```python
@cython.cfunc
def foo(s) -> str:
```
It raises following exception: `Exception clause not allowed for function returning Python object`.
This exception is raised because Pure python mode defaults `exception_check` to `True`:

https://github.com/cython/cython/blob/09cbf492dfcf1ad022e79660d6aec0be3f444244/Cython/Compiler/ParseTreeTransforms.py#L2508-L2510

I have tried to fix the issue in this place by checking of returned type but I have found it challenging because
during this stage of compilation we don't have annotation parsed. Hence, I decided to ignore the error and just reset
the `exception_check` value because:

Cython language is ignoring `exception_check` when python object is
returned - e.g. following code is compiled successfully:
```cython
cdef object ftang(object i) except *:
    return 5
```

Hence the pure python mode will have the same behavior as cython language. Moreover I was not able to raise the error in cython language.

Fixes #2529 (If I read comments in the issue correctly all other cases were or fixed or other issues were created)
