### PR TITLE
removed a default mutable argument pitfall

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -945,7 +945,9 @@ class CythonCompileTestCase(unittest.TestCase):
                  fork=True, language_level=2, warning_errors=False,
                  test_determinism=False,
                  common_utility_dir=None, pythran_dir=None, stats=None, add_cython_import=False,
-                 extra_directives={}):
+                 extra_directives=None):
+        if not extra_directives:
+            extra_directives = {}
         self.test_directory = test_directory
         self.tags = tags
         self.workdir = workdir

--- a/runtests.py
+++ b/runtests.py
@@ -946,7 +946,7 @@ class CythonCompileTestCase(unittest.TestCase):
                  test_determinism=False,
                  common_utility_dir=None, pythran_dir=None, stats=None, add_cython_import=False,
                  extra_directives=None):
-        if not extra_directives:
+        if extra_directives is None:
             extra_directives = {}
         self.test_directory = test_directory
         self.tags = tags


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in method, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument