### PR TITLE
Fix GCC -Wsign-conversion warning

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -768,7 +768,7 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
             base = base->tp_base;
         }
     }
-    base_vtables = (void**) malloc(sizeof(void*) * (base_depth + 1));
+    base_vtables = (void**) malloc(sizeof(void*) * (size_t)(base_depth + 1));
     base_vtables[0] = unknown;
     // Could do MRO resolution of individual methods in the future, assuming
     // compatible vtables, but for now simply require a common vtable base.


### PR DESCRIPTION
Fixes the following warning in mpi4py:

```
In file included from src/MPI.c:4:
src/mpi4py.MPI.c: In function ‘__Pyx_MergeVtables’:
src/mpi4py.MPI.c:206412:50: warning: conversion to ‘long unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
206412 |     base_vtables = (void**) malloc(sizeof(void*) * (base_depth + 1));
       |                                                  ^
```