### PR TITLE
Add missing min/max, comparison and permutation operations of C++ algorithm library

### DIFF
--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -244,9 +244,18 @@ cdef extern from "<algorithm>" namespace "std" nogil:
 
     # Minimum/maximum operations
     Iter min_element[Iter](Iter first, Iter last) except +
+    Iter min_element[Iter, Compare](Iter first, Iter last, Compare comp) except +
     Iter min_element[ExecutionPolicy, Iter](ExecutionPolicy&& policy, Iter first, Iter last) except +
     Iter max_element[Iter](Iter first, Iter last) except +
+    Iter max_element[Iter, Compare](Iter first, Iter last, Compare comp) except +
     Iter max_element[ExecutionPolicy, Iter](ExecutionPolicy&& policy, Iter first, Iter last) except +
+    pair[T, T] minmax[T](const T& a, const T& b) except +
+    pair[T, T] minmax[T, Compare](const T& a, const T& b, Compare comp) except +
+    pair[Iter, Iter] minmax_element[Iter](Iter first, Iter last) except +
+    pair[Iter, Iter] minmax_element[Iter, Compare](Iter first, Iter last, Compare comp) except +
+    pair[Iter, Iter] minmax_element[ExecutionPolicy, Iter](ExecutionPolicy&& policy, Iter first, Iter last) except +
+    const T& clamp[T](const T& v, const T& lo, const T& hi) except +
+    const T& clamp[T, Compare](const T& v, const T& lo, const T& hi, Compare comp) except +
 
     # Comparison operations
 

--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -270,3 +270,14 @@ cdef extern from "<algorithm>" namespace "std" nogil:
     bool lexicographical_compare[InputIt1, InputIt2, Compare](InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Compare comp) except +
 
     # Permutation operations
+    bool is_permutation[ForwardIt1, ForwardIt2](ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2) except +
+    bool is_permutation[ForwardIt1, ForwardIt2, BinaryPred](ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, BinaryPred p) except +
+    # ambiguous with previous overload
+    #bool is_permutation[ForwardIt1, ForwardIt2](ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, ForwardIt2 last2) except +
+    bool is_permutation[ForwardIt1, ForwardIt2, BinaryPred](ForwardIt1 first1, ForwardIt1 last1, ForwardIt2 first2, ForwardIt2 last2, BinaryPred p) except +
+    bool next_permutation[BidirIt](BidirIt first, BidirIt last) except +
+    bool next_permutation[BidirIt, Compare](BidirIt first, BidirIt last, Compare comp) except +
+    bool prev_permutation[BidirIt](BidirIt first, BidirIt last) except +
+    bool prev_permutation[BidirIt, Compare](BidirIt first, BidirIt last, Compare comp) except +
+
+

--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -258,6 +258,15 @@ cdef extern from "<algorithm>" namespace "std" nogil:
     const T& clamp[T, Compare](const T& v, const T& lo, const T& hi, Compare comp) except +
 
     # Comparison operations
+    bool equal[InputIt1, InputIt2](InputIt1 first1, InputIt1 last1, InputIt2 first2) except +
+    bool equal[InputIt1, InputIt2, BinPred](InputIt1 first1, InputIt1 last1, InputIt2 first2, BinPred pred) except +
+    # ambiguous with previous overload
+    #bool equal[InputIt1, InputIt2](InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2) except +
+    bool equal[InputIt1, InputIt2, BinPred](InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, BinPred pred) except +
+    
+    bool lexicographical_compare[InputIt1, InputIt2](InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2) except +
+    # ambiguous with next overload
+    #bool lexicographical_compare[InputIt1, InputIt2, ExecutionPolicy](ExecutionPolicy&& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2) except +
+    bool lexicographical_compare[InputIt1, InputIt2, Compare](InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Compare comp) except +
 
     # Permutation operations
-

--- a/tests/macos_cpp_bugs.txt
+++ b/tests/macos_cpp_bugs.txt
@@ -7,3 +7,5 @@ cpp_classes_def
 cpp_smart_ptr
 cpp_stl_conversion
 cpp_stl_function
+cpp_stl_algo_comparison_ops
+cpp_stl_algo_permutation_ops

--- a/tests/run/cpp_stl_algo_comparison_ops.pyx
+++ b/tests/run/cpp_stl_algo_comparison_ops.pyx
@@ -1,0 +1,67 @@
+# mode: run
+# tag: cpp, werror, cpp14, no-cpp-locals
+
+from libcpp cimport bool
+from libcpp.algorithm cimport equal, lexicographical_compare
+from libcpp.vector cimport vector
+
+cdef bool compare(int a, int b):
+    return a == b
+
+cdef bool less_than(char a, char b):
+    return a < b
+
+def test_equal(vector[int] v1, vector[int] v2):
+    """
+    Test equal.
+
+    >>> test_equal([1, 2, 3, 4], [1, 2, 3, 4])
+    True
+    >>> test_equal([1, 2, 3, 4], [9, 2, 3, 4])
+    False
+    """
+    return equal(v1.begin(), v1.end(), v2.begin())
+
+def test_equal_with_bin_pred(vector[int] v1, vector[int] v2):
+    """
+    Test equal with binary predicate.
+
+    >>> test_equal_with_bin_pred([1, 2, 3, 4], [1, 2, 3, 4])
+    True
+    >>> test_equal_with_bin_pred([1, 2, 3, 4], [9, 2, 3, 4])
+    False
+    """
+    return equal(v1.begin(), v1.end(), v2.begin(), compare)
+
+def test_equal_with_second_range_and_bin_pred(vector[int] v1, vector[int] v2):
+    """
+    Test equal with second range and binary predicate.
+
+    >>> test_equal_with_second_range_and_bin_pred([1, 2, 3, 4], [1, 2, 3, 4])
+    True
+    >>> test_equal_with_second_range_and_bin_pred([1, 2, 3, 4], [9, 2, 3, 4])
+    False
+    """
+    return equal(v1.begin(), v1.end(), v2.begin(), v2.end(), compare)
+
+def test_lexicographical_compare(vector[int] v1, vector[int] v2):
+    """
+    Test lexicographical_compare.
+
+    >>> test_lexicographical_compare([1, 2, 3, 4], [5, 6, 7, 8])
+    True
+    >>> test_lexicographical_compare([1, 2, 3, 4], [1, 1, 3, 4])
+    False
+    """
+    return lexicographical_compare(v1.begin(), v1.end(), v2.begin(), v2.end())
+
+def test_lexicographical_compare_with_bin_pred(vector[int] v1, vector[int] v2):
+    """
+    Test lexicographical_compare with binary predicate
+
+    >>> test_lexicographical_compare_with_bin_pred([1, 2, 3, 4], [5, 6, 7, 8])
+    True
+    >>> test_lexicographical_compare_with_bin_pred([1, 2, 3, 4], [1, 1, 3, 4])
+    False
+    """
+    return lexicographical_compare(v1.begin(), v1.end(), v2.begin(), v2.end(), less_than)

--- a/tests/run/cpp_stl_algo_comparison_ops.pyx
+++ b/tests/run/cpp_stl_algo_comparison_ops.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror, cpp14, no-cpp-locals
+# tag: cpp, werror, cpp11, no-cpp-locals
 
 from libcpp cimport bool
 from libcpp.algorithm cimport equal, lexicographical_compare

--- a/tests/run/cpp_stl_algo_comparison_ops.pyx
+++ b/tests/run/cpp_stl_algo_comparison_ops.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror, cpp11, no-cpp-locals
+# tag: cpp, werror, cpp17, no-cpp-locals
 
 from libcpp cimport bool
 from libcpp.algorithm cimport equal, lexicographical_compare

--- a/tests/run/cpp_stl_algo_minmax_ops.pyx
+++ b/tests/run/cpp_stl_algo_minmax_ops.pyx
@@ -1,0 +1,143 @@
+# mode: run
+# tag: cpp, werror, cpp17, cppexecpolicies
+
+from cython.operator cimport dereference as deref
+
+from libcpp cimport bool
+from libcpp.algorithm cimport (min_element, max_element, minmax, minmax_element, 
+                               clamp)
+from libcpp.vector cimport vector
+from libcpp.pair cimport pair
+from libcpp.execution cimport seq
+
+
+cdef bool less(int a, int b):
+    return a < b
+
+def test_min_element(vector[int] v):
+    """
+    Test min_element.
+
+    >>> test_min_element([0, 1, 2, 3, 4, 5])
+    0
+    """
+    cdef vector[int].iterator it = min_element(v.begin(), v.end())
+    return deref(it)
+
+def test_min_element_with_pred(vector[int] v):
+    """
+    Test min_element with binary predicate.
+
+    >>> test_min_element_with_pred([0, 1, 2, 3, 4, 5])
+    0
+    """
+    cdef vector[int].iterator it = min_element(v.begin(), v.end(), less)
+    return deref(it)
+
+def test_min_element_with_exec(vector[int] v):
+    """
+    Test min_element with execution policy.
+
+    >>> test_min_element_with_exec([0, 1, 2, 3, 4, 5])
+    0
+    """
+    cdef vector[int].iterator it = min_element(seq, v.begin(), v.end())
+    return deref(it)
+
+def test_max_element(vector[int] v):
+    """
+    Test max_element.
+
+    >>> test_max_element([0, 1, 2, 3, 4, 5])
+    5
+    """
+    cdef vector[int].iterator it = max_element(v.begin(), v.end())
+    return deref(it)
+
+def test_max_element_with_pred(vector[int] v):
+    """
+    Test max_element with binary predicate.
+
+    >>> test_max_element_with_pred([0, 1, 2, 3, 4, 5])
+    5
+    """
+    cdef vector[int].iterator it = max_element(v.begin(), v.end(), less)
+    return deref(it)
+
+def test_max_element_with_exec(vector[int] v):
+    """
+    Test max_element with execution policy.
+
+    >>> test_max_element_with_exec([0, 1, 2, 3, 4, 5])
+    5
+    """
+    cdef vector[int].iterator it = max_element(seq, v.begin(), v.end())
+    return deref(it)
+
+def test_minmax(int a, int b):
+    """
+    Test minmax.
+
+    >>> test_minmax(10, 20)
+    [10, 20]
+    """
+    cdef pair[int, int] p = minmax(a, b)
+    return [p.first, p.second]
+
+def test_minmax_with_pred(int a, int b):
+    """
+    Test minmax with binary predicate.
+
+    >>> test_minmax_with_pred(10, 20)
+    [10, 20]
+    """
+    cdef pair[int, int] p = minmax(a, b, less)
+    return [p.first, p.second]
+
+def test_minmax_element(vector[int] v):
+    """
+    Test minmax_element.
+
+    >>> test_minmax_element([0, 1, 2, 3, 4, 5])
+    [0, 5]
+    """
+    cdef pair[vector[int].iterator, vector[int].iterator] p = minmax_element(v.begin(), v.end())
+    return [deref(p.first), deref(p.second)]
+
+def test_minmax_element_with_pred(vector[int] v):
+    """
+    Test minmax_element with binary predicate.
+
+    >>> test_minmax_element_with_pred([0, 1, 2, 3, 4, 5])
+    [0, 5]
+    """
+    cdef pair[vector[int].iterator, vector[int].iterator] p = minmax_element(v.begin(), v.end(), less)
+    return [deref(p.first), deref(p.second)]
+
+def test_minmax_element_with_exec(vector[int] v):
+    """
+    Test minmax_element with execution policy.
+
+    >>> test_minmax_element_with_exec([0, 1, 2, 3, 4, 5])
+    [0, 5]
+    """
+    cdef pair[vector[int].iterator, vector[int].iterator] p = minmax_element(seq, v.begin(), v.end())
+    return [deref(p.first), deref(p.second)]
+
+def test_clamp(int v, int lo, int hi):
+    """
+    Test clamp.
+
+    >>> test_clamp(-129, -128, 255)
+    -128
+    """
+    return clamp(v, lo, hi)
+
+def test_clamp_with_pred(int v, int lo, int hi):
+    """
+    Test clamp with binary predicate
+
+    >>> test_clamp_with_pred(-129, -128, 255)
+    -128
+    """
+    return clamp(v, lo, hi, less)

--- a/tests/run/cpp_stl_algo_permutation_ops.pyx
+++ b/tests/run/cpp_stl_algo_permutation_ops.pyx
@@ -1,0 +1,103 @@
+# mode: run
+# tag: cpp, werror, cpp14, no-cpp-locals, c_string_type=str
+# cython: c_string_encoding=ascii, c_string_type=str
+
+from libcpp cimport bool
+from libcpp.algorithm cimport is_permutation, next_permutation, prev_permutation
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+
+cdef bool compare(int a, int b):
+    return a == b
+
+cdef bool less_than(char a, char b):
+    return a < b
+
+def test_is_permutation(vector[int] v1, vector[int] v2):
+    """
+    Test is_permutation.
+
+    >>> test_is_permutation([1, 2, 3, 4], [4, 2, 3, 1])
+    True
+    >>> test_is_permutation([1, 2, 3, 4], [4, 4, 2, 5])
+    False
+    """
+    return is_permutation(v1.begin(), v1.end(), v2.begin())
+
+def test_is_permutation_with_bin_pred(vector[int] v1, vector[int] v2):
+    """
+    Test is_permutation with binary predicate
+
+    >>> test_is_permutation_with_bin_pred([1, 2, 3, 4], [4, 2, 3, 1])
+    True
+    >>> test_is_permutation_with_bin_pred([1, 2, 3, 4], [4, 4, 2, 5])
+    False
+    """
+    return is_permutation(v1.begin(), v1.end(), v2.begin(), compare)
+
+def test_is_permutation_with_second_range_and_bin_pred(vector[int] v1, vector[int] v2):
+    """
+    Test is_permutation with second range and binary predicate
+
+    >>> test_is_permutation_with_second_range_and_bin_pred([1, 2, 3, 4], [4, 2, 3, 1])
+    True
+    >>> test_is_permutation_with_second_range_and_bin_pred([1, 2, 3, 4], [4, 4, 2, 5])
+    False
+    """
+    return is_permutation(v1.begin(), v1.end(), v2.begin(), v2.end(), compare)
+
+def test_next_permutation(s_in, s_perm):
+    """
+    Test next_permutation.
+
+    >>> test_next_permutation("aba", "baa")
+    True
+    >>> test_next_permutation("aba", "bab")
+    False
+    """
+    cdef string ss = <char*>s_in
+    cdef string expected = <char*>s_perm
+    next_permutation(ss.begin(), ss.end())
+    return ss == expected
+
+def test_next_permutation_with_bin_pred(s_in, s_perm):
+    """
+    Test next_permutation with binary predicate
+
+    >>> test_next_permutation_with_bin_pred("aba", "baa")
+    True
+    >>> test_next_permutation_with_bin_pred("aba", "bab")
+    False
+    """
+    cdef string ss = <char*>s_in
+    cdef string expected = <char*>s_perm
+    next_permutation(ss.begin(), ss.end(), less_than)
+    return ss == expected
+
+def test_prev_permutation(s_in, s_perm):
+    """
+    Test prev_permutation.
+
+    >>> test_prev_permutation("aba", "aab")
+    True
+    >>> test_prev_permutation("aba", "bab")
+    False
+    """
+    cdef string ss = <char*>s_in
+    cdef string expected = <char*>s_perm
+    prev_permutation(ss.begin(), ss.end())
+    return ss == expected
+
+def test_prev_permutation_with_bin_pred(s_in, s_perm):
+    """
+    Test prev_permutation with binary predicate
+
+    >>> test_prev_permutation_with_bin_pred("aba", "aab")
+    True
+    >>> test_prev_permutation_with_bin_pred("aba", "bab")
+    False
+    """
+    cdef string ss = <char*>s_in
+    cdef string expected = <char*>s_perm
+    prev_permutation(ss.begin(), ss.end(), less_than)
+    return ss == expected

--- a/tests/run/cpp_stl_algo_permutation_ops.pyx
+++ b/tests/run/cpp_stl_algo_permutation_ops.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror, cpp14, no-cpp-locals, c_string_type=str
+# tag: cpp, werror, cpp17, no-cpp-locals, c_string_type=str
 # cython: c_string_encoding=ascii, c_string_type=str
 
 from libcpp cimport bool


### PR DESCRIPTION
Adds most of the missing minimum/maximum operations, comparison operations and permutation operations of the algorithm library (<= C++17):

- `minmax`, `minmax_element` (C++11), `clamp` (C++17) and one missing overload of `min/max_element`.
- `equal`, `lexicographical_compare`
- `is_permutation`, `next_permutation`, `prev_permutation`