### PR TITLE
Add Python 3.10 classifier

### DIFF
--- a/.github/workflows/wheel-manylinux.yml
+++ b/.github/workflows/wheel-manylinux.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Build Linux wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux1_i686
       with:
-        python-versions: 'cp27-cp27m cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp39-cp39'
+        python-versions: 'cp27-cp27m cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -70,7 +70,7 @@ jobs:
     - name: Build Linux wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux1_x86_64
       with:
-        python-versions: 'cp27-cp27m cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        python-versions: 'cp27-cp27m cp27-cp27mu cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -92,7 +92,7 @@ jobs:
     - name: Build Linux wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2014_i686
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -114,7 +114,7 @@ jobs:
     - name: Build Linux wheels
       uses: RalfG/python-wheels-manylinux-build@v0.3.4-manylinux2014_x86_64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ def run_build():
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Programming Language :: C",


### PR DESCRIPTION
I've been looking at PyPI (e.g. [0.29.24](https://pypi.org/project/Cython/0.29.24/#files) or [3.0.0a9](https://pypi.org/project/Cython/3.0.0a9/#files)), and am puzzled why I don't see any binary wheels for Python 3.10. It seems the classifier is missing.

And if Python 3.10 is supported (I can't immediately tell if it is), please backport to the `0.29.x` branch.