### PR TITLE
use PyContextVar_Get backport until PyPy 7.3.6

### DIFF
--- a/Cython/Includes/cpython/contextvars.pxd
+++ b/Cython/Includes/cpython/contextvars.pxd
@@ -2,10 +2,10 @@ from cpython.object cimport PyObject
 from cpython.ref cimport Py_XDECREF
 
 cdef extern from "Python.h":
-    # Defining PyContextVar_Get() below to always return the default value for Py<3.7
+    # Defining PyContextVar_Get() below to always return the default value for Py<3.7 and PyPy<7.3.6
     # to make the inline functions sort-of work.
     """
-    #if PY_VERSION_HEX < 0x030700b1 && !defined(PyContextVar_Get)
+    #if (PY_VERSION_HEX < 0x030700b1 || (CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM < 0x07030600)) && !defined(PyContextVar_Get)
     #define PyContextVar_Get(var, d, v) \
         ((d) ? \
             ((void)(var), Py_INCREF(d), (v)[0] = (d), 0) : \


### PR DESCRIPTION
PyContextVar_Get  was added to PyPy 7.3.6 (https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/pypy/doc/release-v7.3.6.rst)