### PR TITLE
Try to fix exception when debugging a module with linetrace enabled

### DIFF
--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -235,7 +235,7 @@
               PyThreadState *tstate;                                                       \
               PyGILState_STATE state = __Pyx_PyGILState_Ensure();                          \
               tstate = __Pyx_PyThreadState_Current;                                        \
-              if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc && $frame_cname->f_trace) { \
+              if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc) {                  \
                   ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);          \
               }                                                                            \
               __Pyx_PyGILState_Release(state);                                             \
@@ -243,7 +243,7 @@
           }                                                                                \
       } else {                                                                             \
           PyThreadState* tstate = __Pyx_PyThreadState_Current;                             \
-          if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc && $frame_cname->f_trace) { \
+          if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc) {                      \
               int ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);          \
               if (unlikely(ret)) goto_error;                                               \
           }                                                                                \
@@ -253,7 +253,7 @@
   #define __Pyx_TraceLine(lineno, nogil, goto_error)                                       \
   if (likely(!__Pyx_use_tracing)); else {                                                  \
       PyThreadState* tstate = __Pyx_PyThreadState_Current;                                 \
-      if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc && $frame_cname->f_trace) { \
+      if (__Pyx_IsTracing(tstate, 0, 0) && tstate->c_tracefunc) {                          \
           int ret = __Pyx_call_line_trace_func(tstate, $frame_cname, lineno);              \
           if (unlikely(ret)) goto_error;                                                   \
       }                                                                                    \
@@ -289,11 +289,6 @@ static int __Pyx_TraceSetupAndCall(PyCodeObject** code,
             0                                /*PyObject *locals*/
         );
         if (*frame == NULL) return 0;
-        if (CYTHON_TRACE && (*frame)->f_trace == NULL) {
-            // this enables "f_lineno" lookup, at least in CPython ...
-            Py_INCREF(Py_None);
-            (*frame)->f_trace = Py_None;
-        }
 #if PY_VERSION_HEX < 0x030400B1
     } else {
         (*frame)->f_tstate = tstate;


### PR DESCRIPTION
With linetrace enabled trying to debug with VS Code (Which uses the pydevd debugger internally), causes a `"TypeError: 'NoneType' object is not callable"` due to mishandling of the `f_trace` member of frame objects.

`f_trace` is an internal member used by `trace_trampoline` to support a Python trace function that returns a different trace function than itself, basically the thread local trace function. Cython is setting it to `None`, but it should (Surprisingly and unlike other PyObject*) be `NULL` or a callable `PyObject` but not `None`. Actually, Cython should just avoid touching the it at all, as it is only used by `trace_trampoline` internally for it's own operation and isn't supposed to be touched by code externally calling the `c_tracefunc` (Which again is a Python implementation detail, FUN!).

Now `f_trace` might have be set to None for some other purpose, but it shouldn't really be touched by Cython...

Fixes #4443