### PR TITLE
DOC Add a Performance section for Typed Memoryviews

### DIFF
--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -663,9 +663,7 @@ call functions in C files, see :ref:`using_c_libraries`.
 Performance: Disabling initialization checks
 ============================================
 
-When memoryviews are used as class attributes, initialization checks are performed
-by default. Those checks are executed everytime a memoryview is accessed, introducing
-potential slowdowns.
+Every time the memoryview is accessed, Cython adds a check to make sure that it has been initialized.
 
 If you are looking for performance, you can disable them by setting the
 ``initializedcheck`` directive to ``False``.

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -660,6 +660,18 @@ object handling. For the details of how to compile and
 call functions in C files, see :ref:`using_c_libraries`.
 
 
+Performance: Disabling initialization checks
+============================================
+
+When memoryviews are used as class attributes, initialization checks are performed
+by default. Those checks are executed everytime a memoryview is accessed, introducing
+potential slowdowns.
+
+If you are looking for performance, you can disable them by setting the
+``initializedcheck`` directive to ``False``.
+See: :ref:`compiler-directives` for more information about this directive.
+
+
 .. _GIL: https://docs.python.org/dev/glossary.html#term-global-interpreter-lock
 .. _NumPy: https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html#memory-layout
 .. _example: https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html


### PR DESCRIPTION
With some delay, this is an attempt to improve the documentation regarding initialization
checks for typed memory-views under a performance perspective.

This was originally discussed in the users group with @da-woods:
https://groups.google.com/g/cython-users/c/rU0_mt3Vgn0

I am looking forward to comments regarding this yet minimalist section.

