### PR TITLE
Disable pycontextvar test on PyPy

### DIFF
--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -10,7 +10,6 @@ sequential_parallel
 yield_from_pep380
 memoryview_inplace_division
 
-run.pycontextvar
 run.unicodemethods
 run.unicode_imports
 run.test_genericclass

--- a/tests/pypy_crash_bugs.txt
+++ b/tests/pypy_crash_bugs.txt
@@ -12,5 +12,3 @@ run.py35_pep492_interop
 # gc issue?
 memoryview_in_subclasses
 
-# segfault in test_get_value_no_default
-run.pycontextvar

--- a/tests/pypy_crash_bugs.txt
+++ b/tests/pypy_crash_bugs.txt
@@ -11,3 +11,6 @@ run.py35_pep492_interop
 
 # gc issue?
 memoryview_in_subclasses
+
+# segfault in test_get_value_no_default
+run.pycontextvar

--- a/tests/run/pycontextvar.pyx
+++ b/tests/run/pycontextvar.pyx
@@ -13,7 +13,15 @@ CVAR_WITH_DEFAULT = PyContextVar_New_with_default("cvar_wd", "DEFAULT")
 import contextvars
 PYCVAR = contextvars.ContextVar("pycvar")
 
+def disable_for_pypy737(f):
+    import sys
+    # will be fixed in PyPy 7.3.8
+    if hasattr(sys, 'pypy_version_info') and sys.pypy_version_info < (7,3,8):
+        return None
+    return f
 
+
+@disable_for_pypy737
 def test_get_value(var, default=NOTHING):
     """
     >>> test_get_value(CVAR)
@@ -30,6 +38,7 @@ def test_get_value(var, default=NOTHING):
     return get_value(var, default) if default is not NOTHING else get_value(var)
 
 
+@disable_for_pypy737
 def test_get_value_no_default(var, default=NOTHING):
     """
     >>> test_get_value_no_default(CVAR)
@@ -43,3 +52,5 @@ def test_get_value_no_default(var, default=NOTHING):
     'default'
     """
     return get_value_no_default(var, default) if default is not NOTHING else get_value_no_default(var)
+
+__test__ = {}


### PR DESCRIPTION
Now that they've implemented the PyContextVar C API it segfaults
instead of just failing. Therefore, move it to the "crash bugs"
list so that it doesn't get run.