### PR TITLE
Add tp_inline_values_offset to slot_table

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1064,9 +1064,9 @@ class SlotTable(object):
             EmptySlot("tp_finalize", ifdef="PY_VERSION_HEX >= 0x030400a1"),
             EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1"),
             EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
+            EmptySlot("tp_inline_values_offset", ifdef="PY_VERSION_HEX >= 0x030B00A2"),
             # PyPy specific extension - only here to avoid C compiler warnings.
             EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000"),
-            EmptySlot("tp_inline_values_offset", ifdef="PY_VERSION_HEX >= 0x030B00A2"),
         )
 
         #------------------------------------------------------------------------------------------

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1066,6 +1066,7 @@ class SlotTable(object):
             EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
             # PyPy specific extension - only here to avoid C compiler warnings.
             EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000"),
+            EmptySlot("tp_inline_values_offset", ifdef="PY_VERSION_HEX >= 0x030B00A2"),
         )
 
         #------------------------------------------------------------------------------------------

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -463,6 +463,9 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -732,6 +735,9 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -866,6 +872,9 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -1204,6 +1213,9 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -400,11 +400,11 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_as_async,                        /* tp_as_async */
+    &__Pyx_async_gen_as_async,                  /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
-    (reprfunc)__Pyx_async_gen_repr,                   /* tp_repr */
+    (reprfunc)__Pyx_async_gen_repr,             /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -417,20 +417,20 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_HAVE_FINALIZE,               /* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_traverse,           /* tp_traverse */
+    (traverseproc)__Pyx_async_gen_traverse,     /* tp_traverse */
     0,                                          /* tp_clear */
 #if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
     // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
-    __Pyx_Coroutine_compare,            /*tp_richcompare*/
+    __Pyx_Coroutine_compare,                    /*tp_richcompare*/
 #else
-    0,                                  /*tp_richcompare*/
+    0,                                          /*tp_richcompare*/
 #endif
     offsetof(__pyx_CoroutineObject, gi_weakreflist), /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    __Pyx_async_gen_methods,                          /* tp_methods */
-    __Pyx_async_gen_memberlist,                       /* tp_members */
-    __Pyx_async_gen_getsetlist,                       /* tp_getset */
+    __Pyx_async_gen_methods,                    /* tp_methods */
+    __Pyx_async_gen_memberlist,                 /* tp_members */
+    __Pyx_async_gen_getsetlist,                 /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
@@ -447,9 +447,9 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
 #if CYTHON_USE_TP_FINALIZE
-    0,                                  /*tp_del*/
+    0,                                          /*tp_del*/
 #else
-    __Pyx_Coroutine_del,                /*tp_del*/
+    __Pyx_Coroutine_del,                        /*tp_del*/
 #endif
     0,                                          /* tp_version_tag */
 #if CYTHON_USE_TP_FINALIZE
@@ -464,7 +464,7 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -671,15 +671,15 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_asend_as_async = {
 static PyTypeObject __pyx__PyAsyncGenASendType_type = {
     PyVarObject_HEAD_INIT(0, 0)
     "async_generator_asend",                    /* tp_name */
-    sizeof(__pyx_PyAsyncGenASend),                    /* tp_basicsize */
+    sizeof(__pyx_PyAsyncGenASend),              /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)__Pyx_async_gen_asend_dealloc,        /* tp_dealloc */
+    (destructor)__Pyx_async_gen_asend_dealloc,  /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_asend_as_async,                  /* tp_as_async */
+    &__Pyx_async_gen_asend_as_async,            /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
@@ -699,14 +699,14 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
     0,                                          /* tp_clear */
 #if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
     // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
-    __Pyx_Coroutine_compare,            /*tp_richcompare*/
+    __Pyx_Coroutine_compare,                    /*tp_richcompare*/
 #else
-    0,                                  /*tp_richcompare*/
+    0,                                          /*tp_richcompare*/
 #endif
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
     (iternextfunc)__Pyx_async_gen_asend_iternext,     /* tp_iternext */
-    __Pyx_async_gen_asend_methods,                    /* tp_methods */
+    __Pyx_async_gen_asend_methods,              /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
@@ -736,7 +736,7 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -874,7 +874,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                         /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -1151,14 +1151,14 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_athrow_as_async = {
 static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     PyVarObject_HEAD_INIT(0, 0)
     "async_generator_athrow",                   /* tp_name */
-    sizeof(__pyx_PyAsyncGenAThrow),                   /* tp_basicsize */
+    sizeof(__pyx_PyAsyncGenAThrow),             /* tp_basicsize */
     0,                                          /* tp_itemsize */
-    (destructor)__Pyx_async_gen_athrow_dealloc,       /* tp_dealloc */
+    (destructor)__Pyx_async_gen_athrow_dealloc, /* tp_dealloc */
     0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_athrow_as_async,                 /* tp_as_async */
+    &__Pyx_async_gen_athrow_as_async,           /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
@@ -1178,14 +1178,14 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     0,                                          /* tp_clear */
 #if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
     // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
-    __Pyx_Coroutine_compare,            /*tp_richcompare*/
+    __Pyx_Coroutine_compare,                    /*tp_richcompare*/
 #else
-    0,                                  /*tp_richcompare*/
+    0,                                          /*tp_richcompare*/
 #endif
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
     (iternextfunc)__Pyx_async_gen_athrow_iternext,    /* tp_iternext */
-    __Pyx_async_gen_athrow_methods,                   /* tp_methods */
+    __Pyx_async_gen_athrow_methods,             /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
@@ -1215,7 +1215,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                         /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1626,7 +1626,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
@@ -1818,7 +1818,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
@@ -1971,7 +1971,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
@@ -2120,7 +2120,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
@@ -2531,7 +2531,7 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1622,6 +1622,9 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -1811,6 +1814,9 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -1961,6 +1967,9 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -2106,6 +2115,9 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -2514,6 +2526,9 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
     0,                                  /*tp_version_tag*/
 #if PY_VERSION_HEX >= 0x030400a1
     0,                                  /*tp_finalize*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1623,7 +1623,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -1815,7 +1815,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -1968,7 +1968,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -2117,7 +2117,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -2528,7 +2528,7 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
     0,                                  /*tp_finalize*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1041,7 +1041,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-0,                                      /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
@@ -1585,7 +1585,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-0,                                      /*tp_pypy_flags*/
+    0,                                  /*tp_pypy_flags*/
 #endif
 };
 #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1041,7 +1041,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+0,                                      /*tp_pypy_flags*/
 #endif
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
@@ -1585,7 +1585,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
-    0,                                          /*tp_pypy_flags*/
+0,                                      /*tp_pypy_flags*/
 #endif
 };
 #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1037,6 +1037,9 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
 #endif
@@ -1577,6 +1580,9 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1038,7 +1038,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/
@@ -1582,7 +1582,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM+0 >= 0x06000000
     0,                                          /*tp_pypy_flags*/


### PR DESCRIPTION
To remove a compiler warning since this slot was added in
3.11a2.

I'll make a separate backport for 0.29.x (since the branches have diverged a little here)