### PR TITLE
Add tp_inline_values_offset to slot_table (0.29.x)

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -890,6 +890,7 @@ slot_table = (
     EmptySlot("tp_finalize", ifdef="PY_VERSION_HEX >= 0x030400a1"),
     EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1"),
     EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
+    EmptySlot("tp_inline_values_offset", ifdef="PY_VERSION_HEX >= 0x030B00A2"),
 )
 
 #------------------------------------------------------------------------------------------

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -364,11 +364,11 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_as_async,                        /* tp_as_async */
+    &__Pyx_async_gen_as_async,                  /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
-    (reprfunc)__Pyx_async_gen_repr,                   /* tp_repr */
+    (reprfunc)__Pyx_async_gen_repr,             /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */
@@ -381,20 +381,20 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_HAVE_FINALIZE,               /* tp_flags */
     0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_traverse,           /* tp_traverse */
+    (traverseproc)__Pyx_async_gen_traverse,     /* tp_traverse */
     0,                                          /* tp_clear */
 #if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
     // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
-    __Pyx_Coroutine_compare,            /*tp_richcompare*/
+    __Pyx_Coroutine_compare,                    /*tp_richcompare*/
 #else
-    0,                                  /*tp_richcompare*/
+    0,                                          /*tp_richcompare*/
 #endif
     offsetof(__pyx_CoroutineObject, gi_weakreflist), /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    __Pyx_async_gen_methods,                          /* tp_methods */
-    __Pyx_async_gen_memberlist,                       /* tp_members */
-    __Pyx_async_gen_getsetlist,                       /* tp_getset */
+    __Pyx_async_gen_methods,                    /* tp_methods */
+    __Pyx_async_gen_memberlist,                 /* tp_members */
+    __Pyx_async_gen_getsetlist,                 /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
     0,                                          /* tp_descr_get */
@@ -411,9 +411,9 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /* tp_subclasses */
     0,                                          /* tp_weaklist */
 #if CYTHON_USE_TP_FINALIZE
-    0,                                  /*tp_del*/
+    0,                                          /*tp_del*/
 #else
-    __Pyx_Coroutine_del,                /*tp_del*/
+    __Pyx_Coroutine_del,                        /*tp_del*/
 #endif
     0,                                          /* tp_version_tag */
 #if CYTHON_USE_TP_FINALIZE
@@ -428,7 +428,7 @@ static PyTypeObject __pyx_AsyncGenType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 };
 
@@ -601,15 +601,15 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_asend_as_async = {
 static PyTypeObject __pyx__PyAsyncGenASendType_type = {
     PyVarObject_HEAD_INIT(0, 0)
     "async_generator_asend",                    /* tp_name */
-    sizeof(__pyx_PyAsyncGenASend),                    /* tp_basicsize */
+    sizeof(__pyx_PyAsyncGenASend),              /* tp_basicsize */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor)__Pyx_async_gen_asend_dealloc,        /* tp_dealloc */
+    (destructor)__Pyx_async_gen_asend_dealloc,  /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_asend_as_async,                  /* tp_as_async */
+    &__Pyx_async_gen_asend_as_async,            /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
@@ -666,7 +666,7 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 };
 
@@ -784,7 +784,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                         /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1008,14 +1008,14 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_athrow_as_async = {
 static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     PyVarObject_HEAD_INIT(0, 0)
     "async_generator_athrow",                   /* tp_name */
-    sizeof(__pyx_PyAsyncGenAThrow),                   /* tp_basicsize */
+    sizeof(__pyx_PyAsyncGenAThrow),             /* tp_basicsize */
     0,                                          /* tp_itemsize */
-    (destructor)__Pyx_async_gen_athrow_dealloc,       /* tp_dealloc */
+    (destructor)__Pyx_async_gen_athrow_dealloc, /* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_athrow_as_async,                 /* tp_as_async */
+    &__Pyx_async_gen_athrow_as_async,           /* tp_as_async */
 #else
     0,                                          /*tp_reserved*/
 #endif
@@ -1035,14 +1035,14 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     0,                                          /* tp_clear */
 #if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
     // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
-    __Pyx_Coroutine_compare,            /*tp_richcompare*/
+    __Pyx_Coroutine_compare,                    /*tp_richcompare*/
 #else
-    0,                                  /*tp_richcompare*/
+    0,                                          /*tp_richcompare*/
 #endif
     0,                                          /* tp_weaklistoffset */
     PyObject_SelfIter,                          /* tp_iter */
     (iternextfunc)__Pyx_async_gen_athrow_iternext,    /* tp_iternext */
-    __Pyx_async_gen_athrow_methods,                   /* tp_methods */
+    __Pyx_async_gen_athrow_methods,             /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
@@ -1072,7 +1072,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                         /*tp_inline_values_offset*/
 #endif
 };
 

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -784,7 +784,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                         /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1072,7 +1072,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                         /*tp_inline_values_offset*/
+    0,                                          /*tp_inline_values_offset*/
 #endif
 };
 

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -427,6 +427,9 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 
@@ -662,6 +665,9 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 
@@ -776,6 +782,9 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1061,6 +1070,9 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 };
 

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1564,7 +1564,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1724,7 +1724,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1838,7 +1838,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1949,7 +1949,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 
@@ -2348,7 +2348,7 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
     0,                                  /*tp_finalize*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 #endif

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1563,6 +1563,9 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 #if PY_VERSION_HEX < 0x030500B1 || defined(__Pyx_IterableCoroutine_USED) || CYTHON_USE_ASYNC_SLOTS
@@ -1720,6 +1723,9 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 static int __pyx_Coroutine_init(void) {
@@ -1831,6 +1837,9 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 
@@ -1938,6 +1947,9 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 };
 
@@ -2334,6 +2346,9 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
     0,                                  /*tp_version_tag*/
 #if PY_VERSION_HEX >= 0x030400a1
     0,                                  /*tp_finalize*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 };
 #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -737,7 +737,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 
@@ -1269,7 +1269,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030B00A2
-    0,                                 /*tp_inline_values_offset*/
+    0,                                  /*tp_inline_values_offset*/
 #endif
 };
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -736,6 +736,9 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
+#endif
 };
 
 
@@ -1264,6 +1267,9 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #endif
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
+#endif
+#if PY_VERSION_HEX >= 0x030B00A2
+    0,                                 /*tp_inline_values_offset*/
 #endif
 };
 


### PR DESCRIPTION
To silence a compiler warning since it was added in Python 3.11a2.

For 0.29.x branch only