### PR TITLE
Disable Cython reimplementation of trashcan

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -276,7 +276,12 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
 
 // This requires CPython version >= 2.7.4
 // (or >= 3.2.4 but we don't support such old Python 3 versions anyway)
-#if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x02070400
+#if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x03080000
+// https://github.com/python/cpython/pull/11841 merged so Cython reimplementation
+// is no longer necessary
+#define __Pyx_TRASHCAN_BEGIN Py_TRASHCAN_BEGIN
+#define __Pyx_TRASHCAN_END Py_TRASHCAN_END
+#elif CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x02070400
 #define __Pyx_TRASHCAN_BEGIN_CONDITION(op, cond) \
     do { \
         PyThreadState *_tstate = NULL; \


### PR DESCRIPTION
If I understand correctly, the Cython-specific reimplementation
of trashcan isn't needed of Python 3.8+ (because the patch it
was based on was merged into Python). Therefore on these versions
it can be disabled and the Python macros used instead.

This is specifically needed for Python 3.11 since it removes
hides functions that are used in the Cython reimplementation.
However, I've gone back further.

(Admittedly I don't understand the exact special-case this was for
too well, but I'm hoping this is tested...)