### PR TITLE
PYPY: do not call __Pyx_Coroutine_del (tp_finalize) - it reconstructs dead objects

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1952,7 +1952,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
     __Pyx_Coroutine_del,                /*tp_del*/
 #endif
     0,                                  /*tp_version_tag*/
-#if PY_VERSION_HEX >= 0x030400a1 && !defined PYPY_VERSION
+#if PY_VERSION_HEX >= 0x030400a1 && !CYTHON_COMPILING_IN_PYPY
     __Pyx_Coroutine_del,                /*tp_finalize*/
 #endif
 #if PY_VERSION_HEX >= 0x030800b1

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1952,7 +1952,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
     __Pyx_Coroutine_del,                /*tp_del*/
 #endif
     0,                                  /*tp_version_tag*/
-#if PY_VERSION_HEX >= 0x030400a1
+#if PY_VERSION_HEX >= 0x030400a1 && !defined PYPY_VERSION
     __Pyx_Coroutine_del,                /*tp_finalize*/
 #endif
 #if PY_VERSION_HEX >= 0x030800b1

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -57,6 +57,7 @@ run.async_iter_pep492
 run.embedsignatures
 run.py35_asyncio_async_def
 run.asyncio_generators
+run.py35_pep492_interop
 
 # gc issue?
 external_ref_reassignment

--- a/tests/pypy_crash_bugs.txt
+++ b/tests/pypy_crash_bugs.txt
@@ -5,9 +5,5 @@
 run.fastcall
 memslice
 
-# """Fatal RPython error: NotImplementedError
-# Aborted (core dumped)"""
-run.py35_pep492_interop
-
 # gc issue?
 memoryview_in_subclasses


### PR DESCRIPTION
As stated in `pypy_bugs.txt`, "very little coroutine-related works" but at least do not segfault. The call to `__Pyx_Coroutine_del` manipulates `ob_refcnt` to resurrect the object, which might fail on PyPy, so disable it. I need to find a way around this, the code should be executed elsewhere, which might fix some of the coroutine breakage on PyPy. 

When digging into the code, it seems much of this was taken at some point from CPython (PR #73) in 2011 and then expanded on. Does CPython still use this paradigm or is there a point where the coroutine is finished and can be cleaned up before the destructor?