### PR TITLE
PYPY: pypy does not implement PyCode_NewWithPosOnlyArgs

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -537,7 +537,7 @@ class __Pyx_FakeReference {
         }
         return co;
     }
-#elif PY_VERSION_HEX >= 0x030800B2 && !defined(PYPY_VERSION)
+#elif PY_VERSION_HEX >= 0x030800B2 && !CYTHON_COMPILING_IN_PYPY
 
   #define __Pyx_PyCode_New(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos) \
           PyCode_NewWithPosOnlyArgs(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -537,7 +537,7 @@ class __Pyx_FakeReference {
         }
         return co;
     }
-#elif PY_VERSION_HEX >= 0x030800B2
+#elif PY_VERSION_HEX >= 0x030800B2 && !defined PYPY_VERSION
 
   #define __Pyx_PyCode_New(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos) \
           PyCode_NewWithPosOnlyArgs(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -537,7 +537,7 @@ class __Pyx_FakeReference {
         }
         return co;
     }
-#elif PY_VERSION_HEX >= 0x030800B2 && !defined PYPY_VERSION
+#elif PY_VERSION_HEX >= 0x030800B2 && !defined(PYPY_VERSION)
 
   #define __Pyx_PyCode_New(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos) \
           PyCode_NewWithPosOnlyArgs(a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, fline, lnos)


### PR DESCRIPTION
Since it seems this code path will go away in CPython3.11, I don't really want to implement it only to remove it. Would it be reasonable to fall back to the older code path on PyPy?