### PR TITLE
Exceptions.c PyCode_New -> PyCode_NewEmpty

### DIFF
--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -742,10 +742,10 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
 static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
             const char *funcname, int c_line,
             int py_line, const char *filename) {
-    PyCodeObject *py_code = 0;
-    PyObject *py_funcname = 0;
+    PyCodeObject *py_code = NULL;
+    PyObject *py_funcname = NULL;
     #if PY_MAJOR_VERSION < 3
-    PyObject *py_srcfile = 0;
+    PyObject *py_srcfile = NULL;
 
     py_srcfile = PyString_FromString(filename);
     if (!py_srcfile) goto bad;
@@ -754,6 +754,7 @@ static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
     if (c_line) {
         #if PY_MAJOR_VERSION < 3
         py_funcname = PyString_FromFormat( "%s (%s:%d)", funcname, $cfilenm_cname, c_line);
+        if (!py_funcname) goto bad;
         #else
         py_funcname = PyUnicode_FromFormat( "%s (%s:%d)", funcname, $cfilenm_cname, c_line);
         if (!py_funcname) goto bad;
@@ -764,10 +765,10 @@ static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
     else {
         #if PY_MAJOR_VERSION < 3
         py_funcname = PyString_FromString(funcname);
+        if (!py_funcname) goto bad;
         #endif
     }
     #if PY_MAJOR_VERSION < 3
-    if (!py_funcname) goto bad;
     py_code = __Pyx_PyCode_New(
         0,            /*int argcount,*/
         0,            /*int posonlyargcount,*/
@@ -790,7 +791,7 @@ static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
     #else
     py_code = PyCode_NewEmpty(filename, funcname, py_line);
     #endif
-    Py_XDECREF(py_funcname);  // XDECREF is it's only set on Py3 if cline
+    Py_XDECREF(py_funcname);  // XDECREF since it's only set on Py3 if cline
     return py_code;
 bad:
     Py_XDECREF(py_funcname);

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -743,29 +743,30 @@ static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
             const char *funcname, int c_line,
             int py_line, const char *filename) {
     PyCodeObject *py_code = 0;
-    PyObject *py_srcfile = 0;
     PyObject *py_funcname = 0;
-
     #if PY_MAJOR_VERSION < 3
+    PyObject *py_srcfile = 0;
+
     py_srcfile = PyString_FromString(filename);
-    #else
-    py_srcfile = PyUnicode_FromString(filename);
-    #endif
     if (!py_srcfile) goto bad;
+    #endif
+
     if (c_line) {
         #if PY_MAJOR_VERSION < 3
         py_funcname = PyString_FromFormat( "%s (%s:%d)", funcname, $cfilenm_cname, c_line);
         #else
         py_funcname = PyUnicode_FromFormat( "%s (%s:%d)", funcname, $cfilenm_cname, c_line);
+        if (!py_funcname) goto bad;
+        funcname = PyUnicode_AsUTF8(py_funcname);
+        if (!funcname) goto bad;
         #endif
     }
     else {
         #if PY_MAJOR_VERSION < 3
         py_funcname = PyString_FromString(funcname);
-        #else
-        py_funcname = PyUnicode_FromString(funcname);
         #endif
     }
+    #if PY_MAJOR_VERSION < 3
     if (!py_funcname) goto bad;
     py_code = __Pyx_PyCode_New(
         0,            /*int argcount,*/
@@ -786,11 +787,16 @@ static PyCodeObject* __Pyx_CreateCodeObjectForTraceback(
         $empty_bytes  /*PyObject *lnotab*/
     );
     Py_DECREF(py_srcfile);
-    Py_DECREF(py_funcname);
+    #else
+    py_code = PyCode_NewEmpty(filename, funcname, py_line);
+    #endif
+    Py_XDECREF(py_funcname);  // XDECREF is it's only set on Py3 if cline
     return py_code;
 bad:
-    Py_XDECREF(py_srcfile);
     Py_XDECREF(py_funcname);
+    #if PY_MAJOR_VERSION < 3
+    Py_XDECREF(py_srcfile);
+    #endif
     return NULL;
 }
 


### PR DESCRIPTION
With reference to https://github.com/cython/cython/issues/4365#issuecomment-977023011
in Python 3 PyCode_NewEmpty does everything we need to set exception traceback code objects.

The downside is for the "cline" case, where it creates an extra unicode object, gets the `char*` from that, and then `PyCode_NewEmpty` will use that to create another unicode object (in principle this could probably mostly be avoided using `snprintf` or similar, but it doesn't seem worth it given that all these code objects are cached). For all other cases it should end up largely the same.

It's mainly an improvement on the Py3.11 case (where the `PyCode_New` replacement is likely fairly slow). For simplicity I've done it on all Python 3 versions, but it could also be done for Python 3.11 only.