### PR TITLE
Disable USE_UNICODE_WRITER for limited api and Py3.11

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -125,7 +125,7 @@
   #undef CYTHON_USE_UNICODE_INTERNALS
   #define CYTHON_USE_UNICODE_INTERNALS 0
   #ifndef CYTHON_USE_UNICODE_WRITER
-    #define CYTHON_USE_UNICODE_WRITER 1
+    #define CYTHON_USE_UNICODE_WRITER 0
   #endif
   #undef CYTHON_USE_PYLONG_INTERNALS
   #define CYTHON_USE_PYLONG_INTERNALS 0
@@ -188,7 +188,9 @@
   #ifndef CYTHON_USE_UNICODE_INTERNALS
     #define CYTHON_USE_UNICODE_INTERNALS 1
   #endif
-  #if PY_VERSION_HEX < 0x030300F0
+  #if PY_VERSION_HEX < 0x030300F0 || PY_VERSION_HEX >= 0x030B00A2
+    // Python 3.11a2 hid _PyLong_FormatAdvancedWriter and _PyFloat_FormatAdvancedWriter
+    // therefore disable unicode writer until a better alternative appears
     #undef CYTHON_USE_UNICODE_WRITER
     #define CYTHON_USE_UNICODE_WRITER 0
   #elif !defined(CYTHON_USE_UNICODE_WRITER)


### PR DESCRIPTION
For the limited API, I'm not sure why USE_UNICODE_WRITER was ever
the default - PyObject_Format is part of the limited api so
should clearly be preferred.

Python 3.11 hid _PyLong_FormatAdvancedWriter and
_PyFloat_FormatAdvancedWriter. I've disabled USE_UNICODE_WRITER
for the moment but I suspect we want to find replacements in
the longer term.