### PR TITLE
Remove warning from unused temp in module init

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3492,6 +3492,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln(code.error_goto_if_null(env.module_cname, self.pos))
         code.putln("#endif")
         code.putln("#endif")  # CYTHON_PEP489_MULTI_PHASE_INIT
+        code.putln("CYTHON_UNUSED_VAR(%s);" % module_temp)  # only used in limited API
 
         code.putln(
             "%s = PyModule_GetDict(%s); %s" % (


### PR DESCRIPTION
Follow up to https://github.com/cython/cython/pull/4453.
That PR creates a temp that's only used in the limited API
(and therefore causes warnings on all other paths)