### PR TITLE
pyston support: backport memory corruption fix #4200 to v0.29 branch

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -54,7 +54,7 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
         }
     }
 
-#if PY_VERSION_HEX >= 0x03050000
+#if PY_VERSION_HEX >= 0x03050000 && !defined(PYSTON_MAJOR_VERSION)
     {
         // Make sure GC does not pick up our non-heap type as heap type with this hack!
         // For details, see https://github.com/cython/cython/issues/3603
@@ -93,7 +93,7 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
 
     r = PyType_Ready(t);
 
-#if PY_VERSION_HEX >= 0x03050000
+#if PY_VERSION_HEX >= 0x03050000 && !defined(PYSTON_MAJOR_VERSION)
         t->tp_flags &= ~Py_TPFLAGS_HEAPTYPE;
 
         if (gc_was_enabled) {


### PR DESCRIPTION
We run into the #4200 error again with Pyston because some projects are using the v0.29 but only v0.30 contains the fix.
It would be very helpful for use if this fix is included in the next 0.29 release