### PR TITLE
pin setuptools<60

### DIFF
--- a/.github/workflows/wheel-manylinux.yml
+++ b/.github/workflows/wheel-manylinux.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: 3.8
 
     - name: Install build dependencies
-      run: pip install -U setuptools pip wheel
+      run: pip install -U "setuptools<60" pip wheel
 
     - name: Make sdist and Python wheel
       run: make sdist pywheel

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -69,7 +69,7 @@ elif [[ $PYTHON_VERSION == "3."[45]* ]]; then
   python -m pip install wheel || exit 1
   python -m pip install -r test-requirements-34.txt || exit 1
 else
-  python -m pip install -U pip setuptools wheel || exit 1
+  python -m pip install -U pip "setuptools<60" wheel || exit 1
 
   if [[ $PYTHON_VERSION != *"-dev" || $COVERAGE == "1" ]]; then
     python -m pip install -r test-requirements.txt || exit 1


### PR DESCRIPTION
Try to unbreak CI?

It seems around the time CI stopped passing, setuptools changed from 59.7.0 to 60.0.0, see [this comment](https://github.com/cython/cython/pull/4509#issuecomment-998767635) for more info