### PR TITLE
revert setuptools pinning, do not override CC, CXX

### DIFF
--- a/.github/workflows/wheel-manylinux.yml
+++ b/.github/workflows/wheel-manylinux.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: 3.8
 
     - name: Install build dependencies
-      run: pip install -U "setuptools<60" pip wheel
+      run: pip install -U "setuptools" pip wheel
 
     - name: Make sdist and Python wheel
       run: make sdist pywheel

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -3,6 +3,8 @@
 GCC_VERSION=${GCC_VERSION:=8}
 
 # Set up compilers
+PLATFORM_CFLAGS=""
+PLATFORM_CXXFLAGS=""
 if [[ $TEST_CODE_STYLE == "1" ]]; then
   echo "Skipping compiler setup"
 elif [[ $OSTYPE == "linux-gnu"* ]]; then
@@ -27,8 +29,8 @@ elif [[ $OSTYPE == "linux-gnu"* ]]; then
   fi
 elif [[ $OSTYPE == "darwin"* ]]; then
   echo "Setting up macos compiler"
-  export CC="clang -Wno-deprecated-declarations"
-  export CXX="clang++ -stdlib=libc++ -Wno-deprecated-declarations"
+  PLATFORM_CFLAGS="-Wno-deprecated-declarations"
+  PLATFORM_CXXFLAGS="-stdlib=libc++"
 else
   echo "No setup specified for $OSTYPE"
 fi
@@ -106,7 +108,7 @@ export PATH="/usr/lib/ccache:$PATH"
 # Most modern compilers allow the last conflicting option
 # to override the previous ones, so '-O0 -O3' == '-O3'
 # This is true for the latest msvc, gcc and clang
-CFLAGS="-O0 -ggdb -Wall -Wextra"
+CFLAGS="-O0 -ggdb -Wall -Wextra $PLATFORM_CFLAGS"
 
 if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
 
@@ -159,6 +161,7 @@ if [[ $TEST_CODE_STYLE != "1" ]]; then
 fi
 
 export CFLAGS="$CFLAGS $EXTRA_CFLAGS"
+export CXXFLAGS="$CFLAGS $EXTRA_CFLAGS $PLATFORM_CXXFLAGS"
 python runtests.py \
   -vv $STYLE_ARGS \
   -x Debugger \

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -22,10 +22,8 @@ elif [[ $OSTYPE == "linux-gnu"* ]]; then
 
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 60 $ALTERNATIVE_ARGS
 
-  export CC="gcc"
   if [[ $BACKEND == *"cpp"* ]]; then
     sudo update-alternatives --set g++ /usr/bin/g++-$GCC_VERSION
-    export CXX="g++"
   fi
 elif [[ $OSTYPE == "darwin"* ]]; then
   echo "Setting up macos compiler"
@@ -69,7 +67,7 @@ elif [[ $PYTHON_VERSION == "3."[45]* ]]; then
   python -m pip install wheel || exit 1
   python -m pip install -r test-requirements-34.txt || exit 1
 else
-  python -m pip install -U pip "setuptools<60" wheel || exit 1
+  python -m pip install -U pip "setuptools" wheel || exit 1
 
   if [[ $PYTHON_VERSION != *"-dev" || $COVERAGE == "1" ]]; then
     python -m pip install -r test-requirements.txt || exit 1


### PR DESCRIPTION
Try reverting #4510 and also not setting CC/CXX. Let setuptools/distutils set the compilers. Note the ci-run.sh script would set CC/CXX, but the wheel building would not. 