### PR TITLE
Fix class pointer annotations

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1915,7 +1915,6 @@ class NameNode(AtomicExprNode):
     #  cf_maybe_null   boolean   Maybe uninitialized before this node
     #  allow_null      boolean   Don't raise UnboundLocalError
     #  nogil           boolean   Whether it is used in a nogil context
-    #  annotation      AnnotationNode or None   Deliberately not a subexpr
 
     is_name = True
     is_cython_module = False
@@ -1929,7 +1928,6 @@ class NameNode(AtomicExprNode):
     allow_null = False
     nogil = False
     inferred_type = None
-    annotation = None
 
     def as_cython_attribute(self):
         return self.cython_attribute

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1915,6 +1915,7 @@ class NameNode(AtomicExprNode):
     #  cf_maybe_null   boolean   Maybe uninitialized before this node
     #  allow_null      boolean   Don't raise UnboundLocalError
     #  nogil           boolean   Whether it is used in a nogil context
+    #  annotation      AnnotationNode or None   Deliberately not a subexpr
 
     is_name = True
     is_cython_module = False
@@ -1928,6 +1929,7 @@ class NameNode(AtomicExprNode):
     allow_null = False
     nogil = False
     inferred_type = None
+    annotation = None
 
     def as_cython_attribute(self):
         return self.cython_attribute

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -914,7 +914,7 @@ class InterpretCompilerDirectives(CythonTransform):
 
     def visit_NameNode(self, node):
         if node.annotation:
-            node.annotation = self.visit(node.annotation)
+            self.visit(node.annotation)
         if node.name in self.cython_module_names:
             node.is_cython_module = True
         else:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -913,6 +913,8 @@ class InterpretCompilerDirectives(CythonTransform):
         return node
 
     def visit_NameNode(self, node):
+        if node.annotation:
+            node.annotation = self.visit(node.annotation)
         if node.name in self.cython_module_names:
             node.is_cython_module = True
         else:

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -278,6 +278,21 @@ def call_take_ptr():
     python_dict = {"abc": 123}
     take_ptr(cython.cast(cython.pointer(PyObject), python_dict))
 
+@cython.cclass
+class HasPtr:
+    """
+    >>> HasPtr()
+    HasPtr(1, 1)
+    """
+    a: cython.pointer(cython.int)
+    b: cython.int
+
+    def __init__(self):
+        self.b = 1
+        self.a = cython.address(self.b)
+    def __repr__(self):
+        return f"HasPtr({self.a[0]}, {self.b})"
+
 
 _WARNINGS = """
 9:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.


### PR DESCRIPTION
Fixes #4514

It looks like annotations attached to namenodes weren't correctly
processed with "InterpretCompilerDirectivesTransform"