### PR TITLE
Redo pypy tp flags

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1079,7 +1079,7 @@ class SlotTable(object):
             EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)"),
             EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
             # PyPy specific extension - only here to avoid C compiler warnings.
-            EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000"),
+            EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000"),
         )
 
         #------------------------------------------------------------------------------------------

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -463,7 +463,7 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -732,7 +732,7 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -867,7 +867,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -1205,7 +1205,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                          /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1622,7 +1622,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -1811,7 +1811,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -1961,7 +1961,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -2107,7 +2107,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1041,7 +1041,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };
@@ -1582,7 +1582,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
     0,                                  /*tp_print*/
 #endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX > 0x03080000
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000
     0,                                          /*tp_pypy_flags*/
 #endif
 };

--- a/tests/build/module_api.srctree
+++ b/tests/build/module_api.srctree
@@ -108,7 +108,7 @@ void inita(void)
    if (!sys_modules) return;
    mod = PyInit_a();
    if (!mod) return;
-#if PY_VERSION_HEX >= 0x03050000
+#if PY_VERSION_HEX >= 0x03050000 && !CYTHON_COMPILING_IN_PYPY
    /* FIXME: this is incomplete and users shouldn't have to do this in the first place... */
    if (!PyModule_Check(mod)) {
       PyModuleDef *mdef = (PyModuleDef*)mod;

--- a/tests/build/module_api.srctree
+++ b/tests/build/module_api.srctree
@@ -108,9 +108,10 @@ void inita(void)
    if (!sys_modules) return;
    mod = PyInit_a();
    if (!mod) return;
-#if PY_VERSION_HEX >= 0x03050000 && !CYTHON_COMPILING_IN_PYPY
+#if PY_VERSION_HEX >= 0x03050000 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
    /* FIXME: this is incomplete and users shouldn't have to do this in the first place... */
    if (!PyModule_Check(mod)) {
+      /* In PEP 489 multi-phase init, PyInit_a returns PyModuleDef */
       PyModuleDef *mdef = (PyModuleDef*)mod;
       PyObject *modname = PyUnicode_FromString("a");
       if (!modname) return;

--- a/tests/run/posonly.py
+++ b/tests/run/posonly.py
@@ -107,7 +107,7 @@ def test_use_positional_as_keyword1(a, /):
     >>> test_use_positional_as_keyword1(1)
     >>> test_use_positional_as_keyword1(a=1)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_use_positional_as_keyword1() ... keyword arguments...
+    TypeError: test_use_positional_as_keyword1() ... keyword argument...
     """
 
 def test_use_positional_as_keyword2(a, /, b):
@@ -116,7 +116,7 @@ def test_use_positional_as_keyword2(a, /, b):
     >>> test_use_positional_as_keyword2(1, b=2)
     >>> test_use_positional_as_keyword2(a=1, b=2)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_use_positional_as_keyword2() ... positional...arguments...
+    TypeError: test_use_positional_as_keyword2() ... positional...argument...
     """
 
 def test_use_positional_as_keyword3(a, b, /):
@@ -212,7 +212,7 @@ def test_no_standard_args_usage(a, b, /, *, c):
     >>> test_no_standard_args_usage(1, 2, c=3)
     >>> test_no_standard_args_usage(1, b=2, c=3)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_no_standard_args_usage() ... positional... arguments...
+    TypeError: test_no_standard_args_usage() ... positional... argument...
     """
 
 #def test_change_default_pos_only():
@@ -383,7 +383,7 @@ def test_serialization2(a, /, b):
     (1, 2)
     >>> unpickled_optional(a=1, b=2)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: test_serialization2() ... positional... arguments...
+    TypeError: test_serialization2() ... positional... argument...
     """
     return (a, b)
 

--- a/tests/run/test_genericclass.py
+++ b/tests/run/test_genericclass.py
@@ -162,8 +162,12 @@ class TestClassGetitem(unittest.TestCase):
     # BEGIN - Additional tests from cython
     def test_no_class_getitem(self):
         class C: ...
-        # note that PyPy raises AttributeError on __class_getitem__
-        with self.assertRaises(TypeError if not hasattr(sys, "pypy_version_info") else AttributeError):
+        # PyPy<7.3.8 raises AttributeError on __class_getitem__
+        if sys.implementation.name == 'pypy' and sys.implementation.version < (7, 3, 8):
+            err = AttributeError
+        else:
+            err = TypeError
+        with self.assertRaises(err):
             C[int]
 
     # END - Additional tests from cython

--- a/tests/run/test_genericclass.py
+++ b/tests/run/test_genericclass.py
@@ -163,7 +163,7 @@ class TestClassGetitem(unittest.TestCase):
     def test_no_class_getitem(self):
         class C: ...
         # PyPy<7.3.8 raises AttributeError on __class_getitem__
-        if sys.implementation.name == 'pypy' and sys.implementation.version < (7, 3, 8):
+        if hasattr(sys, "pypy_version_info")  and sys.pypy_version_info < (7, 3, 8):
             err = AttributeError
         else:
             err = TypeError

--- a/tests/run/test_genericclass_exttype.pyx
+++ b/tests/run/test_genericclass_exttype.pyx
@@ -51,8 +51,12 @@ cdef class Invalid4:
 class TestClassGetitem(unittest.TestCase):
     # BEGIN - Additional tests from cython
     def test_no_class_getitem(self):
-        # note that PyPy raises AttributeError on __class_getitem__
-        with self.assertRaises(TypeError if not hasattr(sys, "pypy_version_info") else AttributeError):
+        # PyPy<7.3.8 raises AttributeError on __class_getitem__
+        if sys.implementation.name == 'pypy' and sys.implementation.version < (7, 3, 8):
+            err = AttributeError
+        else:
+            err = TypeError
+        with self.assertRaises(err):
             UnSupport[int]
 
     # END - Additional tests from cython

--- a/tests/run/test_genericclass_exttype.pyx
+++ b/tests/run/test_genericclass_exttype.pyx
@@ -52,7 +52,7 @@ class TestClassGetitem(unittest.TestCase):
     # BEGIN - Additional tests from cython
     def test_no_class_getitem(self):
         # PyPy<7.3.8 raises AttributeError on __class_getitem__
-        if sys.implementation.name == 'pypy' and sys.implementation.version < (7, 3, 8):
+        if hasattr(sys, "pypy_version_info")  and sys.pypy_version_info < (7, 3, 8):
             err = AttributeError
         else:
             err = TypeError


### PR DESCRIPTION
After testing #4509 on PyPy3.8, it became clear that I messed up the condition: `PY_VERSION_HEX > 0x03080000` should have been `PY_VERSION_HEX >= 0x03090000` since the intention was to match a future PyPy3.9 build and not match any PyPy3.8 build (which of course has `PY_VERSION_HEX == 0x03081200`.

Along the way, the next release of PyPy will change a non-compatible `AttributeError` into a `TypeError`.

Also PyPy 3.8 cleans up a singular/plural error message.
```
def f(a, b, /):
    pass
```

When calling `f(3, b=4)` CPython emits
> TypeError: f() got some positional-only arguments passed as keyword arguments: 'b'

while PyPy emits
> TypeError: f() got a positional-only argument passed as keyword argument: 'b'

For `f(a=3, b=4)`, both implementations emit
> TypeError: f() got some positional-only arguments passed as keyword arguments: 'a, b'