### PR TITLE
Avoid double redirect in old documentation

### DIFF
--- a/docs/src/reference/directives.rst
+++ b/docs/src/reference/directives.rst
@@ -3,4 +3,4 @@
 Compiler Directives
 ===================
 
-See `Compilation <compilation.html#compiler-directives>`_.
+See :ref:`compiler-directives`.


### PR DESCRIPTION
Avoid pointing users to a link that just says "this section was
moved to...". Just take them to the correct page first time.

This annoys me surprisingly often when looking things up. As
far as I can tell it's just the one link that does this.