### PR TITLE
add emplace_back to vector

### DIFF
--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -86,3 +86,5 @@ cdef extern from "<vector>" namespace "std" nogil:
         T* data()
         const T* const_data "data"()
         void shrink_to_fit() except +
+        iterator emplace(const_iterator, ...) except +
+        T& emplace_back(...) except +


### PR DESCRIPTION
This PR implements #2171 using C variadics. This is already done in a similar way in [optional.pxd](https://github.com/cython/cython/blob/master/Cython/Includes/libcpp/optional.pxd):
```
T& emplace(...)
```
This definition could be improved when variadic templates are supported at some point, but since the types are not really relevant for Cython it should be fine to use C variadics here (especially since I do not expect that variadic templates will be supported anytime soon). Adding `emplace_back` is useful, since it is not only potentially faster, but allows for simpler implementations as well:
```
vec.push_back(move(MyClass(var)))
```
vs
```
vec.emplace_back(var)
```