### PR TITLE
fix incorrect template definition

### DIFF
--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -43,7 +43,7 @@ cdef extern from "<deque>" namespace "std" nogil:
         deque(deque&) except +
         deque(size_t) except +
         deque(size_t, T&) except +
-        #deque[input_iterator](input_iterator, input_iterator)
+        #deque[InputIt](InputIt, InputIt)
         T& operator[](size_t)
         #deque& operator=(deque&)
         bint operator==(deque&, deque&)
@@ -53,7 +53,7 @@ cdef extern from "<deque>" namespace "std" nogil:
         bint operator<=(deque&, deque&)
         bint operator>=(deque&, deque&)
         void assign(size_t, T&) except +
-        void assign(input_iterator, input_iterator) except +
+        void assign[InputIt](InputIt, InputIt) except +
         T& at(size_t) except +
         T& back()
         iterator begin()
@@ -67,7 +67,7 @@ cdef extern from "<deque>" namespace "std" nogil:
         T& front()
         iterator insert(iterator, T&) except +
         void insert(iterator, size_t, T&) except +
-        void insert(iterator, input_iterator, input_iterator) except +
+        void insert[InputIt](iterator, InputIt, InputIt) except +
         size_t max_size()
         void pop_back()
         void pop_front()

--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -43,7 +43,7 @@ cdef extern from "<vector>" namespace "std" nogil:
         vector(vector&) except +
         vector(size_type) except +
         vector(size_type, T&) except +
-        #vector[input_iterator](input_iterator, input_iterator)
+        #vector[InputIt](InputIt, InputIt)
         T& operator[](size_type)
         #vector& operator=(vector&)
         bint operator==(vector&, vector&)
@@ -53,7 +53,7 @@ cdef extern from "<vector>" namespace "std" nogil:
         bint operator<=(vector&, vector&)
         bint operator>=(vector&, vector&)
         void assign(size_type, const T&)
-        void assign[input_iterator](input_iterator, input_iterator) except +
+        void assign[InputIt](InputIt, InputIt) except +
         T& at(size_type) except +
         T& back()
         iterator begin()
@@ -68,7 +68,7 @@ cdef extern from "<vector>" namespace "std" nogil:
         T& front()
         iterator insert(iterator, const T&) except +
         iterator insert(iterator, size_type, const T&) except +
-        iterator insert[Iter](iterator, Iter, Iter) except +
+        iterator insert[InputIt](iterator, InputIt, InputIt) except +
         size_type max_size()
         void pop_back()
         void push_back(T&) except +


### PR DESCRIPTION
This adds a missing template specifier to some template definition and updates the template typenames to match the names on cppreference.com.