### PR TITLE
MRG: add --module-name argument to cython command

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -227,14 +227,10 @@ def parse_command_line(args):
     if len(sources) == 0 and not options.show_version:
         parser.error("cython: Need at least one source file\n")
     if Options.embed and len(sources) > 1:
-        parser.error(
-            "cython: Only one source file allowed when using --embed\n")
+        parser.error("cython: Only one source file allowed when using --embed\n")
     if options.module_name:
         if options.timestamps:
-            parser.error(
-                "cython: Cannot use --module-name with --timestamps\n")
+            parser.error("cython: Cannot use --module-name with --timestamps\n")
         if len(sources) > 1:
-            parser.error(
-                "cython: Only one source file allowed when using "
-                "--module-name\n")
+            parser.error("cython: Only one source file allowed when using --module-name\n")
     return options, sources

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -145,6 +145,11 @@ def create_cython_argparser():
                       dest='compile_time_env', type=str,
                       action=ParseCompileTimeEnvAction,
                       help='Provides compile time env like DEF would do.')
+    parser.add_argument("--module-name",
+                      dest='module_name', type=str, action='store',
+                      help='Fully qualified module name. If not given, is '
+                           'deduced from the import path if source file is in '
+                           'a package, or equals the filename otherwise.')
     parser.add_argument('sources', nargs='*', default=[])
 
     # TODO: add help
@@ -222,5 +227,14 @@ def parse_command_line(args):
     if len(sources) == 0 and not options.show_version:
         parser.error("cython: Need at least one source file\n")
     if Options.embed and len(sources) > 1:
-        parser.error("cython: Only one source file allowed when using -embed\n")
+        parser.error(
+            "cython: Only one source file allowed when using --embed\n")
+    if options.module_name:
+        if options.timestamps:
+            parser.error(
+                "cython: Cannot use --module-name with --timestamps\n")
+        if len(sources) > 1:
+            parser.error(
+                "cython: Only one source file allowed when using "
+                "--module-name\n")
     return options, sources

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -584,6 +584,9 @@ def compile_multiple(sources, options):
     a CompilationResultSet. Performs timestamp checking and/or recursion
     if these are specified in the options.
     """
+    if len(sources) > 1 and options.module_name:
+        raise RuntimeError('Full module name can only be set '
+                           'for single source compilation')
     # run_pipeline creates the context
     # context = Context.from_options(options)
     sources = [os.path.abspath(source) for source in sources]
@@ -602,8 +605,9 @@ def compile_multiple(sources, options):
             if (not timestamps) or out_of_date:
                 if verbose:
                     sys.stderr.write("Compiling %s\n" % source)
-
-                result = run_pipeline(source, options, context=context)
+                result = run_pipeline(source, options,
+                                      full_module_name=options.module_name,
+                                      context=context)
                 results.add(source, result)
                 # Compiling multiple sources in one context doesn't quite
                 # work properly yet.

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -735,6 +735,7 @@ default_options = dict(
     formal_grammar=False,
     gdb_debug=False,
     compile_time_env=None,
+    module_name=None,
     common_utility_include_dir=None,
     output_dir=None,
     build_dir=None,

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -495,6 +495,21 @@ class CmdLineParserTest(TestCase):
         self.check_default_global_options()
         self.check_default_options(options, ['compiler_directives'])
 
+    def test_module_name(self):
+        options, sources = parse_command_line([
+            'source.pyx'
+        ])
+        self.assertEqual(options.module_name, None)
+        self.check_default_global_options()
+        self.check_default_options(options)
+        options, sources = parse_command_line([
+            '--module-name', 'foo.bar',
+            'source.pyx'
+        ])
+        self.assertEqual(options.module_name, 'foo.bar')
+        self.check_default_global_options()
+        self.check_default_options(options, ['module_name'])
+
     def test_errors(self):
         def error(*args):
             old_stderr = sys.stderr
@@ -505,7 +520,6 @@ class CmdLineParserTest(TestCase):
                 sys.stderr = old_stderr
             self.assertTrue(stderr.getvalue())
 
-        error('-1')
         error('-I')
         error('--version=-a')
         error('--version=--annotate=true')
@@ -514,3 +528,9 @@ class CmdLineParserTest(TestCase):
         error('--verbose=1')
         error('--cleanup')
         error('--debug-disposal-code-wrong-name', 'file3.pyx')
+        # No source file (source file appears to be module name).
+        error('--module-name', 'foo.pyx')
+        # Cannot use --module-name with more than one source file.
+        error('--module-name', 'foo.bar', 'foo.pyx', 'bar.pyx')
+        # Cannot use --module-name with --timestamps
+        error('--module-name', 'foo.bar', '--timestamps', 'foo.pyx')

--- a/tests/compile/module_name_arg.srctree
+++ b/tests/compile/module_name_arg.srctree
@@ -3,7 +3,7 @@ CYTHON a.pyx
 CYTHON --module-name w b.pyx
 CYTHON --module-name my_module.submod.x c.pyx
 PYTHON setup.py build_ext --inplace
-PYTHON -c "import checks"
+PYTHON checks.py
 
 ######## checks.py ########
 
@@ -25,7 +25,7 @@ for module_name, should_import in (
         import_module(module_name)
     except exc:
         if should_import:
-            assert False, "Connot import module " + module_name
+            assert False, "Cannot import module " + module_name
     else:
         if not should_import:
             assert False, ("Can import module " + module_name +

--- a/tests/compile/module_name_arg.srctree
+++ b/tests/compile/module_name_arg.srctree
@@ -1,0 +1,52 @@
+# Test that we can set module name with --module-name arg to cython
+CYTHON a.pyx
+CYTHON --module-name w b.pyx
+CYTHON --module-name my_module.submod.x c.pyx
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import checks"
+
+######## checks.py ########
+
+from importlib import import_module
+
+try:
+    exc = ModuleNotFoundError
+except NameError:
+    exc = ImportError
+
+for module_name, should_import in (
+    ('a', True),
+    ('b', False),
+    ('w', True),
+    ('my_module.submod.x', True),
+    ('c', False),
+    ):
+    try:
+        import_module(module_name)
+    except exc:
+        if should_import:
+            assert False, "Connot import module " + module_name
+    else:
+        if not should_import:
+            assert False, ("Can import module " + module_name +
+                           " but import should not be possible")
+
+
+######## setup.py ########
+
+from distutils.core import setup
+from distutils.extension import Extension
+
+setup(
+  ext_modules = [
+    Extension("a", ["a.c"]),
+    Extension("w", ["b.c"]),
+    Extension("my_module.submod.x", ["c.c"]),
+  ],
+)
+
+######## a.pyx ########
+######## b.pyx ########
+######## c.pyx ########
+######## my_module/__init__.py ########
+######## my_module/submod/__init__.py ########


### PR DESCRIPTION
I'd like to ask for feedback for this implementation of a
`--module-name` command line argument to the `cython` utility.

It can be useful to specify the module name for the output file
directly, rather than working it out from the enclosing file tree -
particularly for out of tree build systems, like Meson.

See: https://github.com/rgommers/scipy/issues/31#issuecomment-1002662816
for background.

However, the implementation here is a little ugly, because the cython
command line utility always executes through the `compile_multiple` code
path in `Main.py`.  This in turn is because the passed `sources`
argument is a list, and not a string, and therefore, the check around
line 629 always fails, meaning that I have to recover the passed
`module_name` from `options` in `compile_multiple`, rather than using
the `full_module_name` argument available in `compile_single`.

Is this the right thing to do?  If so, I'll write up some tests.