### PR TITLE
Fix missing TypeError on invalid arg count to range

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -826,7 +826,7 @@ class IterationTransform(Visitor.EnvTransform):
             step_pos = range_function.pos
             step_value = 1
             step = ExprNodes.IntNode(step_pos, value='1', constant_result=1)
-        else:
+        elif len(args) == 3:
             step = args[2]
             step_pos = step.pos
             if not isinstance(step.constant_result, _py_int_types):
@@ -838,6 +838,8 @@ class IterationTransform(Visitor.EnvTransform):
                 return node
             step = ExprNodes.IntNode(step_pos, value=str(step_value),
                                      constant_result=step_value)
+        else:
+            return node
 
         if len(args) == 1:
             bound1 = ExprNodes.IntNode(range_function.pos, value='0',

--- a/tests/run/for_in_iter.py
+++ b/tests/run/for_in_iter.py
@@ -162,3 +162,12 @@ def for_in_gen(N):
     """
     for i in range(N):
         yield i
+
+def for_in_range_invalid_arg_count():
+    """
+    >>> for_in_range_invalid_arg_count()     # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    """
+    for i in range(1, 2, 3, 4):
+        pass


### PR DESCRIPTION
Cython generated the same optimized C code for
`for i in range(1,2,3,4)` and `for i in range(1,2,3)`.
This PR deactivates this optimization when to many arguments are
provided to match the behavior of Python.