### PR TITLE
add a depfile support to cythonize

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -74,6 +74,7 @@ def cython_compile(path_pattern, options):
                 compile_time_env=options.compile_time_env,
                 force=options.force,
                 quiet=options.quiet,
+                depfile=options.depfile,
                 **options.options)
 
             if ext_modules and options.build:
@@ -171,6 +172,7 @@ def create_args_parser():
                       help='compile as much as possible, ignore compilation failures')
     parser.add_argument('--no-docstrings', dest='no_docstrings', action='store_true', default=None,
                       help='strip docstrings')
+    parser.add_argument('-M', '--depfile', action='store_true', help='produce depfiles for the sources')
     parser.add_argument('sources', nargs='*')
     return parser
 

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1051,21 +1051,10 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     # paths below the base_dir are relative, otherwise absolute
                     paths = []
                     for fname in dependencies:
-                        if src_base_dir in fname:
+                        if fname.startswith(src_base_dir):
                             paths.append(os.path.relpath(fname, src_base_dir))
                         else:
                             paths.append(os.path.abspath(fname))
-
-                    # manually add missing *.pyx files for each *.pxd :
-                    # `cimport foo` means a possible dependence on a `foo.pyx`
-                    # but `all_dependencies(...)` above only list a `foo.pxd`
-                    missing = []
-                    for fname in paths:
-                        base, ext = os.path.splitext(fname)
-                        pyxf = base + '.pyx'
-                        if ext == ".pxd" and pyxf not in paths:
-                            missing.append(pyxf)
-                    paths += missing
 
                     depline = os.path.split(c_file)[1] + ": \\\n  "
                     depline += " \\\n  ".join(paths) + "\n"

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1056,6 +1056,17 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                         else:
                             paths.append(os.path.abspath(fname))
 
+                    # manually add missing *.pyx files for each *.pxd :
+                    # `cimport foo` means a possible dependence on a `foo.pyx`
+                    # but `all_dependencies(...)` above only list a `foo.pxd`
+                    missing = []
+                    for fname in paths:
+                        base, ext = os.path.splitext(fname)
+                        pyxf = base + '.pyx'
+                        if ext == ".pxd" and pyxf not in paths:
+                            missing.append(pyxf)
+                    paths += missing
+
                     depline = os.path.split(c_file)[1] + ": \\\n  "
                     depline += " \\\n  ".join(paths) + "\n"
                     with open(c_file+'.dep', 'w') as outfile:

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1048,6 +1048,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                 if depfile:
                     dependencies = deps.all_dependencies(source)
                     src_base_dir, _ = os.path.split(source)
+                    if not src_base_dir.endswith(os.sep):
+                        src_base_dir += os.sep
                     # paths below the base_dir are relative, otherwise absolute
                     paths = []
                     for fname in dependencies:

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -957,6 +957,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
     :param compiler_directives: Allow to set compiler directives in the ``setup.py`` like this:
                                 ``compiler_directives={'embedsignature': True}``.
                                 See :ref:`compiler-directives`.
+
+    :param depfile: produce depfiles for the sources if True.
     """
     if exclude is None:
         exclude = []
@@ -964,6 +966,8 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
         options['include_path'] = ['.']
     if 'common_utility_include_dir' in options:
         safe_makedirs(options['common_utility_include_dir'])
+
+    depfile = options.pop('depfile', None)
 
     if pythran is None:
         pythran_options = None
@@ -1039,6 +1043,16 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     c_file = os.path.join(build_dir, c_file)
                     dir = os.path.dirname(c_file)
                     safe_makedirs_once(dir)
+
+                # write out the depfile, if requested
+                if depfile:
+                    src_base_dir, _ = os.path.split(source)
+                    relpaths = [os.path.relpath(fname, src_base_dir)
+                                for fname in deps.all_dependencies(source) ]
+                    depline = os.path.split(c_file)[1] + ": "
+                    depline += " \ \n".join(relpaths) + "\n"
+                    with open(c_file+'.dep', 'w') as outfile:
+                        outfile.write(depline)
 
                 if os.path.exists(c_file):
                     c_timestamp = os.path.getmtime(c_file)

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1050,7 +1050,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     relpaths = [os.path.relpath(fname, src_base_dir)
                                 for fname in deps.all_dependencies(source) ]
                     depline = os.path.split(c_file)[1] + ": "
-                    depline += " \ \n".join(relpaths) + "\n"
+                    depline += " \\\n  ".join(relpaths) + "\n"
                     with open(c_file+'.dep', 'w') as outfile:
                         outfile.write(depline)
 

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1046,11 +1046,18 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
 
                 # write out the depfile, if requested
                 if depfile:
+                    dependencies = deps.all_dependencies(source)
                     src_base_dir, _ = os.path.split(source)
-                    relpaths = [os.path.relpath(fname, src_base_dir)
-                                for fname in deps.all_dependencies(source) ]
+                    # paths below the base_dir are relative, otherwise absolute
+                    paths = []
+                    for fname in dependencies:
+                        if src_base_dir in fname:
+                            paths.append(os.path.relpath(fname, src_base_dir))
+                        else:
+                            paths.append(os.path.abspath(fname))
+
                     depline = os.path.split(c_file)[1] + ": \\\n  "
-                    depline += " \\\n  ".join(relpaths) + "\n"
+                    depline += " \\\n  ".join(paths) + "\n"
                     with open(c_file+'.dep', 'w') as outfile:
                         outfile.write(depline)
 

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1049,7 +1049,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     src_base_dir, _ = os.path.split(source)
                     relpaths = [os.path.relpath(fname, src_base_dir)
                                 for fname in deps.all_dependencies(source) ]
-                    depline = os.path.split(c_file)[1] + ": "
+                    depline = os.path.split(c_file)[1] + ": \\\n  "
                     depline += " \\\n  ".join(relpaths) + "\n"
                     with open(c_file+'.dep', 'w') as outfile:
                         outfile.write(depline)

--- a/tests/build/depfile.srctree
+++ b/tests/build/depfile.srctree
@@ -1,5 +1,5 @@
 CYTHONIZE -M foo.pyx
-PYTHON -c'import check.py'
+PYTHON check.py
 
 ######## foo.pyx ########
 

--- a/tests/build/depfile.srctree
+++ b/tests/build/depfile.srctree
@@ -17,13 +17,10 @@ def foo():
     return "foo"
 
 
-
 ######## bar.pxd ########
 
 cdef inline void empty():
     print("empty")
-
-
 
 
 ######## check.py ########
@@ -33,4 +30,4 @@ import os
 with open("foo.c.dep", "r") as f:
     contents = f.read().replace("\n", " ").replace("\\", "")
 
-assert sorted(contents.split()) == ['bar.pxd', 'baz.pxi', 'foo.c:', 'foo.pyx']
+assert sorted(contents.split()) == ['bar.pxd', 'baz.pxi', 'foo.c:', 'foo.pyx'], contents

--- a/tests/build/depfile.srctree
+++ b/tests/build/depfile.srctree
@@ -1,0 +1,36 @@
+CYTHONIZE -M foo.pyx
+PYTHON -c'import check.py'
+
+######## foo.pyx ########
+
+from bar cimport empty
+
+include "baz.pxi"
+
+empty()
+print(foo())
+
+
+######## baz.pxi ########
+
+def foo():
+    return "foo"
+
+
+
+######## bar.pxd ########
+
+cdef inline void empty():
+    print("empty")
+
+
+
+
+######## check.py ########
+
+import os
+
+with open("foo.c.dep", "r") as f:
+    contents = f.read().replace("\n", " ").replace("\\", "")
+
+assert sorted(contents.split()) == ['bar.pxd', 'baz.pxi', 'foo.c:', 'foo.pyx']

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -28,14 +28,25 @@ contents = [fname.replace(cy_prefix, "cy_prefix") for fname in contents]
 np_prefix, _ = os.path.split(np.__file__)
 contents = [fname.replace(np_prefix, "np_prefix") for fname in contents]
 
-assert sorted(contents) == [
+# filter out the version number from `np_prefix/__init__.cython-30.pxd`.
+# Also allow for legacy numpy versions, which depend on 
+# `cy_prefix/Includes/numpy/__init__.pxd` instead
+contents_ = []
+for entry in contents:
+    if entry.startswith('np_prefix/__init__.cython-') and entry.endswith('.pxd'):
+        contents_.append('np_prefix/__init__.version.pxd')
+    elif entry == 'cy_prefix/Includes/numpy/__init__.pxd':
+        contents_.append('np_prefix/__init__.version.pxd')
+    else:
+        contents_.append(entry)
+
+assert sorted(contents_) == [
     'cy_prefix/Includes/cpython/object.pxd',
     'cy_prefix/Includes/cpython/ref.pxd',
     'cy_prefix/Includes/cpython/type.pxd',
-    'cy_prefix/Includes/libc/stdint.pxd',
     'cy_prefix/Includes/libc/stdio.pxd',
     'cy_prefix/Includes/libc/string.pxd',
     'dep_np.c:',
     'dep_np.pyx',
-    'np_prefix/__init__.cython-30.pxd',
-], contents
+    'np_prefix/__init__.version.pxd',
+], sorted(contents)

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -6,7 +6,6 @@ PYTHON check_np.py
 ######## dep_np.pyx ########
 
 cimport numpy as np
-from numpy.random cimport bitgen_t
 np.import_array()
 
 
@@ -37,7 +36,5 @@ assert (sorted(contents) == ['cy_prefix/Includes/cpython/object.pxd',
                              'cy_prefix/Includes/libc/string.pxd',
                              'dep_np.c:',
                              'dep_np.pyx',
-                             'np_prefix/__init__.cython-30.pxd',
-                             'np_prefix/random/__init__.pxd',
-                             'np_prefix/random/bit_generator.pxd'] )
+                             'np_prefix/__init__.cython-30.pxd'] )
 

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -13,6 +13,7 @@ np.import_array()
 ######## check_np.py ########
 
 import os
+import re
 
 import numpy as np
 import Cython
@@ -29,24 +30,21 @@ np_prefix, _ = os.path.split(np.__file__)
 contents = [fname.replace(np_prefix, "np_prefix") for fname in contents]
 
 # filter out the version number from `np_prefix/__init__.cython-30.pxd`.
-# Also allow for legacy numpy versions, which depend on 
-# `cy_prefix/Includes/numpy/__init__.pxd` instead
-contents_ = []
-for entry in contents:
-    if entry.startswith('np_prefix/__init__.cython-') and entry.endswith('.pxd'):
-        contents_.append('np_prefix/__init__.version.pxd')
-    elif entry == 'cy_prefix/Includes/numpy/__init__.pxd':
-        contents_.append('np_prefix/__init__.version.pxd')
-    else:
-        contents_.append(entry)
+contents = [re.sub('[.]cython-[0-9]+', '', entry) for entry in contents]
 
-assert sorted(contents_) == [
-    'cy_prefix/Includes/cpython/object.pxd',
+expected = ['cy_prefix/Includes/cpython/object.pxd',
     'cy_prefix/Includes/cpython/ref.pxd',
     'cy_prefix/Includes/cpython/type.pxd',
     'cy_prefix/Includes/libc/stdio.pxd',
     'cy_prefix/Includes/libc/string.pxd',
     'dep_np.c:',
-    'dep_np.pyx',
-    'np_prefix/__init__.version.pxd',
-], sorted(contents)
+    'dep_np.pyx',]
+
+# Also account for legacy numpy versions, which do not ship
+# `__init__.pxd` hence the fallback is used:
+if 'cy_prefix/Includes/numpy/__init__.pxd' in contents:
+    expected.append('cy_prefix/Includes/numpy/__init__.pxd')
+else:
+    expected.append('np_prefix/__init__.pxd')
+
+assert sorted(contents) == sorted(expected), sorted(contents)

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -1,7 +1,7 @@
 # tag: numpy
 
-CYTHONIZE -M .pyx
-PYTHON -c'import check_np.py'
+CYTHONIZE -M dep_np.pyx
+PYTHON check_np.py
 
 ######## dep_np.pyx ########
 

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -38,4 +38,4 @@ assert sorted(contents) == [
     'dep_np.c:',
     'dep_np.pyx',
     'np_prefix/__init__.cython-30.pxd',
-]
+], contents

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -28,13 +28,14 @@ contents = [fname.replace(cy_prefix, "cy_prefix") for fname in contents]
 np_prefix, _ = os.path.split(np.__file__)
 contents = [fname.replace(np_prefix, "np_prefix") for fname in contents]
 
-assert (sorted(contents) == ['cy_prefix/Includes/cpython/object.pxd',
-                             'cy_prefix/Includes/cpython/ref.pxd',
-                             'cy_prefix/Includes/cpython/type.pxd',
-                             'cy_prefix/Includes/libc/stdint.pxd',
-                             'cy_prefix/Includes/libc/stdio.pxd',
-                             'cy_prefix/Includes/libc/string.pxd',
-                             'dep_np.c:',
-                             'dep_np.pyx',
-                             'np_prefix/__init__.cython-30.pxd'] )
-
+assert sorted(contents) == [
+    'cy_prefix/Includes/cpython/object.pxd',
+    'cy_prefix/Includes/cpython/ref.pxd',
+    'cy_prefix/Includes/cpython/type.pxd',
+    'cy_prefix/Includes/libc/stdint.pxd',
+    'cy_prefix/Includes/libc/stdio.pxd',
+    'cy_prefix/Includes/libc/string.pxd',
+    'dep_np.c:',
+    'dep_np.pyx',
+    'np_prefix/__init__.cython-30.pxd',
+]

--- a/tests/build/depfile_numpy.srctree
+++ b/tests/build/depfile_numpy.srctree
@@ -1,0 +1,43 @@
+# tag: numpy
+
+CYTHONIZE -M .pyx
+PYTHON -c'import check_np.py'
+
+######## dep_np.pyx ########
+
+cimport numpy as np
+from numpy.random cimport bitgen_t
+np.import_array()
+
+
+
+######## check_np.py ########
+
+import os
+
+import numpy as np
+import Cython
+
+with open("dep_np.c.dep", "r") as f:
+    contents = f.read().replace("\n", " ").replace("\\", "")
+
+contents = contents.split()
+
+cy_prefix, _ = os.path.split(Cython.__file__)
+contents = [fname.replace(cy_prefix, "cy_prefix") for fname in contents]
+
+np_prefix, _ = os.path.split(np.__file__)
+contents = [fname.replace(np_prefix, "np_prefix") for fname in contents]
+
+assert (sorted(contents) == ['cy_prefix/Includes/cpython/object.pxd',
+                             'cy_prefix/Includes/cpython/ref.pxd',
+                             'cy_prefix/Includes/cpython/type.pxd',
+                             'cy_prefix/Includes/libc/stdint.pxd',
+                             'cy_prefix/Includes/libc/stdio.pxd',
+                             'cy_prefix/Includes/libc/string.pxd',
+                             'dep_np.c:',
+                             'dep_np.pyx',
+                             'np_prefix/__init__.cython-30.pxd',
+                             'np_prefix/random/__init__.pxd',
+                             'np_prefix/random/bit_generator.pxd'] )
+

--- a/tests/build/depfile_package.srctree
+++ b/tests/build/depfile_package.srctree
@@ -10,8 +10,7 @@ import os
 with open("pkg/test.c.dep", "r") as f:
     contents = f.read().replace("\n", " ").replace("\\", "")
 
-assert (sorted(contents.split()) == 
-        sorted(['test.c:', 'sub/incl.pxi', 'test.pxd', 'test.pyx']))
+assert sorted(contents.split()) == sorted(['test.c:', 'sub/incl.pxi', 'test.pxd', 'test.pyx']), contents
 
 
 with open("pkg/sub/test.c.dep", "r") as f:
@@ -19,9 +18,7 @@ with open("pkg/sub/test.c.dep", "r") as f:
 
 contents = [os.path.relpath(entry, '.')
             if os.path.isabs(entry) else entry for entry in contents.split()]
-assert (sorted(contents) == 
-        sorted(['test.c:', 'incl.pxi', 'test.pyx',
-                'pkg/test.pxd']))  # this one is in fact one level up
+assert sorted(contents) == sorted(['test.c:', 'incl.pxi', 'test.pyx', 'pkg/test.pxd']), contents  # last is really one level up
 
 
 ######## pkg/__init__.py ########

--- a/tests/build/depfile_package.srctree
+++ b/tests/build/depfile_package.srctree
@@ -21,7 +21,7 @@ contents = [os.path.relpath(entry, '.')
             if os.path.isabs(entry) else entry for entry in contents.split()]
 assert (sorted(contents) == 
         sorted(['test.c:', 'incl.pxi', 'test.pyx',
-                'pkg/test.pxd', 'pkg/test.pyx']))  # these two are in fact one level up
+                'pkg/test.pxd']))  # this one is in fact one level up
 
 
 ######## pkg/__init__.py ########

--- a/tests/build/depfile_package.srctree
+++ b/tests/build/depfile_package.srctree
@@ -1,0 +1,61 @@
+'''
+PYTHON -m Cython.Build.Cythonize -i pkg --depfile
+PYTHON package_test.py
+'''
+
+######## package_test.py ########
+
+import os
+
+with open("pkg/test.c.dep", "r") as f:
+    contents = f.read().replace("\n", " ").replace("\\", "")
+
+assert (sorted(contents.split()) == 
+        sorted(['test.c:', 'sub/incl.pxi', 'test.pxd', 'test.pyx']))
+
+
+with open("pkg/sub/test.c.dep", "r") as f:
+    contents = f.read().replace("\n", " ").replace("\\", "")
+
+contents = [os.path.relpath(entry, '.')
+            if os.path.isabs(entry) else entry for entry in contents.split()]
+assert (sorted(contents) == 
+        sorted(['test.c:', 'incl.pxi', 'test.pyx',
+                'pkg/test.pxd', 'pkg/test.pyx']))  # these two are in fact one level up
+
+
+######## pkg/__init__.py ########
+
+
+######## pkg/test.pyx ########
+
+TEST = "pkg.test"
+
+include "sub/incl.pxi"
+
+cdef object get_str():
+   return TEST
+
+
+######## pkg/test.pxd ########
+
+cdef object get_str()
+
+
+######## pkg/sub/__init__.py ########
+
+
+######## pkg/sub/test.pyx ########
+# cython: language_level=3
+
+from ..test cimport get_str
+
+include 'incl.pxi'
+
+TEST = 'pkg.sub.test'
+
+
+######## pkg/sub/incl.pxi ########
+
+pass
+


### PR DESCRIPTION
Here's an initial WIP attempt at addressing https://github.com/cython/cython/pull/4510#issuecomment-999361757,  gh-1214 and gh-1459; see also https://github.com/mesonbuild/meson/issues/9049

This PR is deliberately simplistic : given a `foo.pyx` which cimport `bar.pxd` and includes `baz.pxi`, 
```
$ cythonize -M foo.pyx
```
produces `foo.c.dep` file in with foo.pyx dependencies along with `foo.c`.

An immediate question to mainainers: is this a reasonable place to plug it? Is this simple interface OK?  
I'd also appreciate a pointer to how to best add tests for this. I can of course write out several tempfiles, or is there a better way?

Also, @eli-schwartz what would meson need --- in the example above, does it need a list of dependencies for the `foo.c` file (thus `foo.c: foo.pyx bar.pxd baz.pxi`) or for the `pyx` file (thus `foo.pyx: bar.pxd baz.pxi`)?