### PR TITLE
Stop cfunc/ccall/class applying to inner funcs/classes

### DIFF
--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -319,6 +319,32 @@ def test_cdef_nogil(x):
     return result
 
 
+@cython.cfunc
+@cython.inline
+def has_inner_func1(x):
+    # the inner function must remain a Python function
+    # (and inline must not be applied to it)
+    def inner():
+        return x
+    return inner
+
+
+with cython.cfunc:
+    def has_inner_func2(x):
+        # cfunc is not applied to "inner"
+        def inner():
+            return x
+        return inner
+
+
+def test_has_inner_func():
+    """
+    >>> test_has_inner_func()
+    (1, 2)
+    """
+    return has_inner_func1(1)(), has_inner_func2(2)()
+
+
 @cython.locals(counts=cython.int[10], digit=cython.int)
 def count_digits_in_carray(digits):
     """


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/4092

Inner classes isn't tested because they don't officially work
at this stage (see https://github.com/cython/cython/issues/4572).
It should be tested if/when they're fully supported