### PR TITLE
Add warning banner for latest version of documentation

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,7 +3,7 @@
 {% block header %}
 {%- if development %}
 <div id="development-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
-    {% trans %}This document is for the development version.
+    {% trans %}This version of the documentation is for the in-development branch of Cython.
     For the stable version, see {% endtrans %}
     <a href="/en/stable/{{ pagename }}{{ file_suffix }}">{% trans %}here{% endtrans %}</a>.
 </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,15 @@
 {% extends "!layout.html" %}
 
+{% block header %}
+{%- if development %}
+<div id="development-warning" style="padding: .5em; text-align: center; background-color: #FFBABA; color: #6A0E0E;">
+    {% trans %}This document is for the development version.
+    For the stable version, see {% endtrans %}
+    <a href="/en/stable/{{ pagename }}{{ file_suffix }}">{% trans %}here{% endtrans %}</a>.
+</div>
+{%- endif %}
+{% endblock %}
+
 {% block relbar1 %}
 {{ super() }}
 {% if pagename != "src/donating" %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,6 +184,10 @@ html_context = {
     'css_files': ['_static/css/tabs.css'],
 }
 
+development = True if release.startswith('3.0') else False
+
+html_context = {'development': development}
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,7 +184,7 @@ html_context = {
     'css_files': ['_static/css/tabs.css'],
 }
 
-development = True if release.startswith('3.0') else False
+development = 'a' in release or 'b' in release
 
 html_context = {'development': development}
 


### PR DESCRIPTION
This PR adds a new banner for latest version of documentation to indicate that this is development version.

Rationale:
* Current default documentation shows by default all commited changes not released. This can be confusing for users.
* User can see the version of documentation but it can be easilly overlooked.
* there are multiple bugs complaining about current default: #4577, #4010
* django framework uses simmilar approach: See warning banner here: https://docs.djangoproject.com/en/dev/

Current solution simulates django approach - we will show a warning.

To see this PR in action see: https://matusvalo-cython.readthedocs.io/en/latest/index.html

Closes #4577. Maybe also #4010.
