### PR TITLE
Start of trying to handle nested annotation_types

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1194,6 +1194,7 @@ class TemplatedTypeNode(CBaseTypeNode):
                    "keyword_args", "dtype_node"]
 
     dtype_node = None
+    safe_annotation_mode = False
 
     name = None
 
@@ -1212,7 +1213,7 @@ class TemplatedTypeNode(CBaseTypeNode):
             else:
                 template_types = []
                 for template_node in self.positional_args:
-                    type = template_node.analyse_as_type(env)
+                    type = template_node.analyse_as_type(env, self.safe_annotation_mode)
                     if type is None and base_type.is_cpp_class:
                         error(template_node.pos, "unknown type in template argument")
                         type = error_type


### PR DESCRIPTION
This is the start of what I was proposing in https://github.com/cython/cython/issues/3883#issuecomment-1025226745 (just to try to illustrate what I meant). I'm almost certain it's not in a working state....

I think it should let nested types e.g. `typing.Tuple[int, int]` follow the "normal" Cython annotation-typing rules.

@scoder - I can pick this up properly and try to finish it if you want or I can leave it to you to fix as you'd like...