### PR TITLE
ENH: use context manager when opening files

### DIFF
--- a/Cython/Parser/ConcreteSyntaxTree.pyx
+++ b/Cython/Parser/ConcreteSyntaxTree.pyx
@@ -32,13 +32,14 @@ import re
 def extract_names(path):
     # All parse tree types are #defined in these files as ints.
     type_names = {}
-    for line in open(path):
-        if line.startswith('#define'):
-            try:
-                _, name, value = line.strip().split()
-                type_names[int(value)] = name
-            except:
-                pass
+    with open(path) as fid:
+        for line in fid:
+            if line.startswith('#define'):
+                try:
+                    _, name, value = line.strip().split()
+                    type_names[int(value)] = name
+                except:
+                    pass
     return type_names
 
 cdef dict type_names = {}
@@ -61,7 +62,8 @@ def handle_includes(source, path):
         included = os.path.join(os.path.dirname(path), include_line.group(1)[1:-1])
         if not os.path.exists(included):
             return include_line.group(0) + ' # no such path: ' + included
-        return handle_includes(open(included).read(), path)
+        with open(included) as fid:
+            return handle_includes(fid.read(), path)
     # TODO: Proper string tokenizing.
     return re.sub(r'^include\s+([^\n]+[\'"])\s*(#.*)?$', include_here, source, flags=re.M)
 
@@ -69,7 +71,8 @@ def p_module(path):
     cdef perrdetail err
     cdef int flags
     cdef node* n
-    source = open(path).read()
+    with open(path) as fid:
+        source = fid.read()
     if '\ninclude ' in source:
         # TODO: Tokanizer needs to understand includes.
         source = handle_includes(source, path)

--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -117,7 +117,8 @@ def handle_special_build(modname, pyxfilename):
         # locs = {}
         # execfile(special_build, globls, locs)
         # ext = locs["make_ext"](modname, pyxfilename)
-        mod = imp.load_source("XXXX", special_build, open(special_build))
+        with open(special_build) as fid:
+            mod = imp.load_source("XXXX", special_build, fid)
         make_ext = getattr(mod,'make_ext',None)
         if make_ext:
             ext = make_ext(modname, pyxfilename)
@@ -144,7 +145,8 @@ def handle_dependencies(pyxfilename):
     # but we know more about dependencies so force a rebuild if
     # some of the dependencies are newer than the pyxfile.
     if os.path.exists(dependfile):
-        depends = open(dependfile).readlines()
+        with open(dependfile) as fid:
+            depends = fid.readlines()
         depends = [depend.strip() for depend in depends]
 
         # gather dependencies in the "files" variable

--- a/pyximport/test/test_pyximport.py
+++ b/pyximport/test/test_pyximport.py
@@ -41,33 +41,36 @@ def test_with_reload():
     tempdir = make_tempdir()
     sys.path.append(tempdir)
     filename = os.path.join(tempdir, "dummy.pyx")
-    open(filename, "w").write("print 'Hello world from the Pyrex install hook'")
+    with open(filename, "w") as fid:
+        fid.write("print 'Hello world from the Pyrex install hook'")
     import dummy
     reload(dummy)
 
     depend_filename = os.path.join(tempdir, "dummy.pyxdep")
-    depend_file = open(depend_filename, "w")
-    depend_file.write("*.txt\nfoo.bar")
-    depend_file.close()
+    with open(depend_filename, "w") as depend_file:
+        depend_file.write("*.txt\nfoo.bar")
 
     build_filename = os.path.join(tempdir, "dummy.pyxbld")
-    build_file = open(build_filename, "w")
-    build_file.write("""
+    with open(build_filename, "w") as build_file:
+        build_file.write("""
 from distutils.extension import Extension
 def make_ext(name, filename):
     return Extension(name=name, sources=[filename])
 """)
-    build_file.close()
 
-    open(os.path.join(tempdir, "foo.bar"), "w").write(" ")
-    open(os.path.join(tempdir, "1.txt"), "w").write(" ")
-    open(os.path.join(tempdir, "abc.txt"), "w").write(" ")
+    with open(os.path.join(tempdir, "foo.bar"), "w") as fid:
+        fid.write(" ")
+    with open(os.path.join(tempdir, "1.txt"), "w") as fid:
+        fid.write(" ")
+    with open(os.path.join(tempdir, "abc.txt"), "w") as fid:
+        fid.write(" ")
     reload(dummy)
     assert len(pyximport._test_files)==1, pyximport._test_files
     reload(dummy)
 
     time.sleep(1)  # sleep a second to get safer mtimes
-    open(os.path.join(tempdir, "abc.txt"), "w").write(" ")
+    with open(os.path.join(tempdir, "abc.txt"), "w") as fid:
+        fid.write(" ")
     print("Here goes the reload")
     reload(dummy)
     assert len(pyximport._test_files) == 1, pyximport._test_files

--- a/pyximport/test/test_reload.py
+++ b/pyximport/test/test_reload.py
@@ -18,14 +18,16 @@ def test():
     tempdir = test_pyximport.make_tempdir()
     sys.path.append(tempdir)
     hello_file = os.path.join(tempdir, "hello.pyx")
-    open(hello_file, "w").write("x = 1; print x; before = 'before'\n")
+    with open(hello_file, "w") as fid:
+        fid.write("x = 1; print x; before = 'before'\n")
     import hello
     assert hello.x == 1
 
     time.sleep(1)  # sleep to make sure that new "hello.pyx" has later
                    # timestamp than object file.
 
-    open(hello_file, "w").write("x = 2; print x; after = 'after'\n")
+    with open(hello_file, "w") as fid:
+        fid.write("x = 2; print x; after = 'after'\n")
     reload(hello)
     assert hello.x == 2, "Reload should work on Python 2.3 but not 2.2"
     test_pyximport.remove_tempdir(tempdir)

--- a/runtests.py
+++ b/runtests.py
@@ -1352,8 +1352,11 @@ class CythonCompileTestCase(unittest.TestCase):
                 self.run_cython(test_directory, module, module_path, workdir2, incdir, annotate)
                 diffs = []
                 for file in os.listdir(workdir2):
-                    if (open(os.path.join(workdir, file)).read()
-                        != open(os.path.join(workdir2, file)).read()):
+                    with open(os.path.join(workdir, file)) as fid:
+                        txt1 = fid.read()
+                    with open(os.path.join(workdir2, file)) as fid:
+                        txt2 = fid.read()
+                    if (txt1 != txt2):
                         diffs.append(file)
                         os.system('diff -u %s/%s %s/%s > %s/%s.diff' % (
                             workdir, file,

--- a/runtests.py
+++ b/runtests.py
@@ -1356,7 +1356,7 @@ class CythonCompileTestCase(unittest.TestCase):
                         txt1 = fid.read()
                     with open(os.path.join(workdir2, file)) as fid:
                         txt2 = fid.read()
-                    if (txt1 != txt2):
+                    if txt1 != txt2:
                         diffs.append(file)
                         os.system('diff -u %s/%s %s/%s > %s/%s.diff' % (
                             workdir, file,

--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -78,9 +78,10 @@ if sys.platform == 'win32':
     assert opt == '-c'
     count = 0
     regex = re.compile(pattern)
-    for line in open(file):
-        if regex.search(line):
-            count += 1
+    with open(file) as fid:
+        for line in fid:
+            if regex.search(line):
+                count += 1
     print(count)
     sys.exit(count == 0)
 else:

--- a/tests/run/cpdef_pickle.srctree
+++ b/tests/run/cpdef_pickle.srctree
@@ -56,7 +56,8 @@ from lib.cy import WithoutC, WithCPDef, WithCDefWrapper
 def tryThis(obj):
     print("Pickling %s ..." % obj.__class__.__name__)
     try:
-        pkl.dump(obj, open("test.pkl", "wb"))
+        with open("test.pkl", "wb") as fid:
+            pkl.dump(obj, fid)
         print("\t... OK")
     except Exception as e:
         print("\t... KO: %s" % str(e))


### PR DESCRIPTION
When testing windows + PyPy over at [pypy/binary-testing](https://github.com/pypy/binary-testing/runs/5065921724?check_suite_focus=true#step:6), I came across a number of places where Cython was not using a context manager when opening files. I found these by grepping for `open(` without a `with`: 
```
git grep "open(" | grep -v with
```