### PR TITLE
Improve C++ non-member operator lookup

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1039,6 +1039,15 @@ class Scope(object):
         function_alternatives = []
         if function is not None:
             function_alternatives = function.all_alternatives()
+        nonmember_alternatives = []
+        if self.is_cpp_class_scope and function and function.scope is self:
+            # for C++ classes we can have both member and non-member operators
+            # and we really want to consider both
+            global_scope = self.global_scope()
+            if global_scope:
+                global_func = global_scope.lookup_here("operator%s" % operator)
+                if global_func:
+                    nonmember_alternatives = global_func.all_alternatives()
 
         # look-up nonmember methods listed within a class
         method_alternatives = []

--- a/tests/errors/cpp_operators_binop_1.pyx
+++ b/tests/errors/cpp_operators_binop_1.pyx
@@ -1,0 +1,35 @@
+# mode: error
+# tag: cpp
+
+cimport cython
+
+cdef extern from *:
+    cdef cppclass NoAddSub:
+        pass
+
+    cdef cppclass HasOps:
+        pass
+
+    int operator+(const HasOps&, int)
+    int operator-(int, const HasOps&)
+
+# Don't add to this testcase! it's to test the case that there is *one*
+# non-member operator found that it should be discarded
+
+cdef void misuse_classes():
+    # similar to https://github.com/cython/cython/issues/4539
+    # Unlike the case for increment/decrement operators it wasn't actually failing
+    # but is still worth testing
+    # Cython should not match the operators for a different type
+    cdef NoAddSub no
+    print(no + 1)
+    print(1 + no)
+    print(no - 1)
+    print(1 - no)
+
+_ERRORS = """
+23:10: Cannot assign type 'NoAddSub' to 'const HasOps'
+24:10: Cannot assign type 'long' to 'const HasOps'
+24:14: Cannot assign type 'NoAddSub' to 'int'
+25:10: Cannot assign type 'NoAddSub' to 'int'
+"""

--- a/tests/errors/cpp_operators_binop_1.pyx
+++ b/tests/errors/cpp_operators_binop_1.pyx
@@ -28,8 +28,10 @@ cdef void misuse_classes():
     print(1 - no)
 
 _ERRORS = """
-23:10: Cannot assign type 'NoAddSub' to 'const HasOps'
-24:10: Cannot assign type 'long' to 'const HasOps'
-24:14: Cannot assign type 'NoAddSub' to 'int'
-25:10: Cannot assign type 'NoAddSub' to 'int'
+25:10: Cannot assign type 'NoAddSub' to 'const HasOps'
+26:10: Cannot assign type 'long' to 'const HasOps'
+26:14: Cannot assign type 'NoAddSub' to 'int'
+27:10: Cannot assign type 'NoAddSub' to 'int'
+27:15: Cannot assign type 'long' to 'const HasOps'
+28:14: Cannot assign type 'NoAddSub' to 'const HasOps'
 """

--- a/tests/errors/cpp_operators_increment_1.pyx
+++ b/tests/errors/cpp_operators_increment_1.pyx
@@ -23,6 +23,5 @@ cdef void misuse_classes():
     cython.operator.preincrement(no)
 
 _ERRORS = """
-23:19: '++' operator not defined for NoIncrement (Cannot assign type 'NoIncrement' to 'OnlyPreNonMember')
 23:19: Invalid operand type for '++' (NoIncrement)
 """

--- a/tests/errors/cpp_operators_increment_1.pyx
+++ b/tests/errors/cpp_operators_increment_1.pyx
@@ -1,0 +1,28 @@
+# mode: error
+# tag: cpp
+
+cimport cython
+
+cdef extern from *:
+    cdef cppclass NoIncrement:
+        pass
+
+    cdef cppclass OnlyPreNonMember:
+        pass
+
+    OnlyPreNonMember operator++(OnlyPreNonMember)
+
+# Don't add to this testcase! it's to test the case that there is *one*
+# non-member operator found for NoIncrement and that it should be discarded
+
+
+cdef void misuse_classes():
+    # https://github.com/cython/cython/issues/4539
+    # NoIncrement would mistakenly find the non-member operator++ for a different type
+    cdef NoIncrement no
+    cython.operator.preincrement(no)
+
+_ERRORS = """
+23:19: '++' operator not defined for NoIncrement (Cannot assign type 'NoIncrement' to 'OnlyPreNonMember')
+23:19: Invalid operand type for '++' (NoIncrement)
+"""

--- a/tests/errors/cpp_operators_increment_2.pyx
+++ b/tests/errors/cpp_operators_increment_2.pyx
@@ -1,0 +1,57 @@
+# mode: error
+# tag: cpp
+
+cimport cython
+
+cdef extern from *:
+    cdef cppclass NoIncrement:
+        pass
+
+    cdef cppclass OnlyPre:
+        OnlyPre operator++()
+
+    cdef cppclass OnlyPreNonMember:
+        pass
+
+    OnlyPreNonMember operator++(OnlyPreNonMember)
+
+    cdef cppclass OnlyPost:
+        OnlyPost operator++(int)
+
+    cdef cppclass OnlyPostNonMember:
+        pass
+
+    # FIXME this is redeclared rather than an overload added
+    OnlyPostNonMember operator++(OnlyPostNonMember, int)
+
+
+cdef void misuse_classes():
+    # https://github.com/cython/cython/issues/4539
+    # NoIncrement would mistakenly find the non-member operator++ for a different type
+    cdef NoIncrement no
+    cdef OnlyPre o_pre
+    cdef OnlyPreNonMember o_pre_nm
+    cdef OnlyPost o_post
+    cdef OnlyPostNonMember o_post_nm
+    cython.operator.postincrement(no)
+    cython.operator.postincrement(o_pre)  # TODO - error message is wrong
+    cython.operator.postincrement(o_pre_nm)
+    cython.operator.preincrement(no)
+    cython.operator.preincrement(o_post)
+    cython.operator.preincrement(o_post_nm)
+
+# TODO - not all the error messages are quite right (but they should all fail)
+_ERRORS = """
+36:19: '++' operator not defined for NoIncrement (Call with wrong number of arguments (expected 1, got 2))
+36:19: Invalid operand type for '++' (NoIncrement)
+37:19: '++' operator not defined for OnlyPre (Call with wrong number of arguments (expected 0, got 2))
+37:19: Invalid operand type for '++' (OnlyPre)
+38:19: '++' operator not defined for OnlyPreNonMember (Call with wrong number of arguments (expected 1, got 2))
+38:19: Invalid operand type for '++' (OnlyPreNonMember)
+39:19: '++' operator not defined for NoIncrement (Cannot assign type 'NoIncrement' to 'OnlyPreNonMember')
+39:19: Invalid operand type for '++' (NoIncrement)
+40:19: '++' operator not defined for OnlyPost (Cannot assign type 'OnlyPost' to 'OnlyPreNonMember')
+40:19: Invalid operand type for '++' (OnlyPost)
+41:19: '++' operator not defined for OnlyPostNonMember (Cannot assign type 'OnlyPostNonMember' to 'OnlyPreNonMember')
+41:19: Invalid operand type for '++' (OnlyPostNonMember)
+"""

--- a/tests/errors/cpp_operators_increment_2.pyx
+++ b/tests/errors/cpp_operators_increment_2.pyx
@@ -21,7 +21,7 @@ cdef extern from *:
     cdef cppclass OnlyPostNonMember:
         pass
 
-    # FIXME this is redeclared rather than an overload added
+    # FIXME this is rejected as redeclared rather than an overload added
     OnlyPostNonMember operator++(OnlyPostNonMember, int)
 
 
@@ -34,24 +34,15 @@ cdef void misuse_classes():
     cdef OnlyPost o_post
     cdef OnlyPostNonMember o_post_nm
     cython.operator.postincrement(no)
-    cython.operator.postincrement(o_pre)  # TODO - error message is wrong
-    cython.operator.postincrement(o_pre_nm)
+    cython.operator.postincrement(o_pre)  # TODO - should generate error
+    cython.operator.postincrement(o_pre_nm)  # TODO should generate error
     cython.operator.preincrement(no)
-    cython.operator.preincrement(o_post)
-    cython.operator.preincrement(o_post_nm)
+    cython.operator.preincrement(o_post)  # TODO - this generates an error for the wrong reasons currently
+    cython.operator.preincrement(o_post_nm)  # TODO - this generates an error for the wrong reasons currently
 
-# TODO - not all the error messages are quite right (but they should all fail)
 _ERRORS = """
-36:19: '++' operator not defined for NoIncrement (Call with wrong number of arguments (expected 1, got 2))
 36:19: Invalid operand type for '++' (NoIncrement)
-37:19: '++' operator not defined for OnlyPre (Call with wrong number of arguments (expected 0, got 2))
-37:19: Invalid operand type for '++' (OnlyPre)
-38:19: '++' operator not defined for OnlyPreNonMember (Call with wrong number of arguments (expected 1, got 2))
-38:19: Invalid operand type for '++' (OnlyPreNonMember)
-39:19: '++' operator not defined for NoIncrement (Cannot assign type 'NoIncrement' to 'OnlyPreNonMember')
 39:19: Invalid operand type for '++' (NoIncrement)
-40:19: '++' operator not defined for OnlyPost (Cannot assign type 'OnlyPost' to 'OnlyPreNonMember')
 40:19: Invalid operand type for '++' (OnlyPost)
-41:19: '++' operator not defined for OnlyPostNonMember (Cannot assign type 'OnlyPostNonMember' to 'OnlyPreNonMember')
 41:19: Invalid operand type for '++' (OnlyPostNonMember)
 """

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -142,14 +142,14 @@ cdef extern from "cpp_operators_helper.h" nogil:
         bool operator bool()
         bool value
 
-    cdef cppclass TestNonmembersOps1:
-        const_char* operator++(const TestNonmembersOps1&)
-        const char* operator++(const TestNonmembersOps1&, int)
+    cdef cppclass TestNonmemberOps1:
+        const_char* operator++(const TestNonmemberOps1&)
+        const char* operator++(const TestNonmemberOps1&, int)
 
-    cdef cppclass TestNonmembersOps2:
+    cdef cppclass TestNonmemberOps2:
         pass
-    const_char* operator++(const TestNonmembersOps2&)
-    const_char* operator++(const TestNonmembersOps2&, int)
+    const_char* operator++(const TestNonmemberOps2&)
+    const_char* operator++(const TestNonmemberOps2&, int)
 
 
 cdef cppclass TruthSubClass(TruthClass):
@@ -181,6 +181,10 @@ def test_incdec():
     unary -- [const_char *]
     post ++ [const_char *]
     post -- [const_char *]
+    TestNonmemberOps1 prefix ++ [const_char *]
+    TestNonmemberOps1 postfix ++ [const_char *]
+    TestNonmemberOps2 prefix ++ [const_char *]
+    TestNonmemberOps2 postfix ++ [const_char *]
     """
     cdef TestOps* t = new TestOps()
     a = cython.operator.preincrement(t[0])
@@ -193,15 +197,18 @@ def test_incdec():
     out(d, typeof(d))
     del t
 
-    cdef TestNonmembersOps1* t1 = new TestNonmembersOps1()
-    cdef TestNonmembersOps2* t2 = new TestNonmembersOps2()
+    cdef TestNonmemberOps1* t1 = new TestNonmemberOps1()
+    cdef TestNonmemberOps2* t2 = new TestNonmemberOps2()
     try:
+        # FIXME related to https://github.com/cython/cython/issues/4535
+        # global scope operator++ with different numbers of arguments don't get
+        # added as alteratives, but get rejected as redeclarations
         e = cython.operator.preincrement(t1[0])
         out(e, typeof(e))
         f = cython.operator.postincrement(t1[0])
         out(f, typeof(f))
         g = cython.operator.preincrement(t2[0])
-        out(h, typeof(h))
+        out(g, typeof(g))
         h = cython.operator.postincrement(t2[0])
         out(h, typeof(h))
     finally:
@@ -293,7 +300,6 @@ def test_nonmember_binop():
     out(1. << t[0], typeof(1. << t[0]))
     out(1. >> t[0], typeof(1. >> t[0]))
 
-    # for some reason we need a cdef here - not sure this is quite right
     y = cython.operator.comma(1., t[0])
     out(y, typeof(y))
     del t

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -102,29 +102,29 @@ cdef extern from "cpp_operators_helper.h" nogil:
         int& operator--(int) except +
 
         int& operator+(int) except +
-        int& operator+(int,const TestOps&) except +
+        int& operator+(int,const RefTestOps&) except +
         int& operator-(int) except +
-        int& operator-(int,const TestOps&) except +
+        int& operator-(int,const RefTestOps&) except +
         int& operator*(int) except +
         # deliberately omitted operator* to test case where only defined outside class
         int& operator/(int) except +
-        int& operator/(int,const TestOps&) except +
+        int& operator/(int,const RefTestOps&) except +
         int& operator%(int) except +
-        int& operator%(int,const TestOps&) except +
+        int& operator%(int,const RefTestOps&) except +
 
         int& operator|(int) except +
-        int& operator|(int,const TestOps&) except +
+        int& operator|(int,const RefTestOps&) except +
         int& operator&(int) except +
-        int& operator&(int,const TestOps&) except +
+        int& operator&(int,const RefTestOps&) except +
         int& operator^(int) except +
-        int& operator^(int,const TestOps&) except +
+        int& operator^(int,const RefTestOps&) except +
         int& operator,(int) except +
-        int& operator,(int,const TestOps&) except +
+        int& operator,(int,const RefTestOps&) except +
 
         int& operator<<(int) except +
-        int& operator<<(int,const TestOps&) except +
+        int& operator<<(int,const RefTestOps&) except +
         int& operator>>(int) except +
-        int& operator>>(int,const TestOps&) except +
+        int& operator>>(int,const RefTestOps&) except +
 
         int& operator==(int) except +
         int& operator!=(int) except +
@@ -141,6 +141,15 @@ cdef extern from "cpp_operators_helper.h" nogil:
         TruthClass(bool)
         bool operator bool()
         bool value
+
+    cdef cppclass TestNonmembersOps1:
+        const_char* operator++(const TestNonmembersOps1&)
+        const char* operator++(const TestNonmembersOps1&, int)
+
+    cdef cppclass TestNonmembersOps2:
+        pass
+    const_char* operator++(const TestNonmembersOps2&)
+    const_char* operator++(const TestNonmembersOps2&, int)
 
 
 cdef cppclass TruthSubClass(TruthClass):
@@ -183,6 +192,21 @@ def test_incdec():
     d = cython.operator.postdecrement(t[0])
     out(d, typeof(d))
     del t
+
+    cdef TestNonmembersOps1* t1 = new TestNonmembersOps1()
+    cdef TestNonmembersOps2* t2 = new TestNonmembersOps2()
+    try:
+        e = cython.operator.preincrement(t1[0])
+        out(e, typeof(e))
+        f = cython.operator.postincrement(t1[0])
+        out(f, typeof(f))
+        g = cython.operator.preincrement(t2[0])
+        out(h, typeof(h))
+        h = cython.operator.postincrement(t2[0])
+        out(h, typeof(h))
+    finally:
+        del t1
+        del t2
 
 def test_binop():
     """

--- a/tests/run/cpp_operators_helper.h
+++ b/tests/run/cpp_operators_helper.h
@@ -139,8 +139,8 @@ public:
   bool value;
 };
 
-#define NON_MEMBER_PREFIX(cls, op) const char* operator op(const cls&) { return ##cls" prefix "##op; }
-#define NON_MEMBER_POSTFIX(cls, op) const char* operator op(const cls&, int) { return ##cls" postfix "##op; }
+#define NON_MEMBER_PREFIX(cls, op) const char* operator op(const cls&) { return #cls" prefix "#op; }
+#define NON_MEMBER_POSTFIX(cls, op) const char* operator op(const cls&, int) { return #cls" postfix "#op; }
 
 /* a small number of extra non-member ops */
 class TestNonmemberOps1 {

--- a/tests/run/cpp_operators_helper.h
+++ b/tests/run/cpp_operators_helper.h
@@ -138,3 +138,16 @@ public:
   operator bool() { return value; }
   bool value;
 };
+
+#define NON_MEMBER_PREFIX(cls, op) const char* operator op(const cls&) { return ##cls" prefix "##op; }
+#define NON_MEMBER_POSTFIX(cls, op) const char* operator op(const cls&, int) { return ##cls" postfix "##op; }
+
+/* a small number of extra non-member ops */
+class TestNonmemberOps1 {
+};
+class TestNonmemberOps2 {
+};
+NON_MEMBER_PREFIX(TestNonmemberOps1, ++)
+NON_MEMBER_POSTFIX(TestNonmemberOps1, ++)
+NON_MEMBER_PREFIX(TestNonmemberOps2, ++)
+NON_MEMBER_POSTFIX(TestNonmemberOps2, ++)


### PR DESCRIPTION
Supersedes https://github.com/cython/cython/pull/4542 hopefully.

This PR is a little less drastic in the changes it makes - it doesn't try to move complete validation into PyrexTypes.best_match (given that for most functions the validation happens in analyse_types).

It modifies `best_match` slightly so it can take an optional arg0 argument (that only applies to non-member functions). This allows member functions to be compared directly with nonmember functions so that all the alternatives for operators (member functions, non-member functions declared in a global scope, non-member functions declared in a class scope) can be evaluated in one go.

In the case where a single argument exists it evaluates the suitability in the `UnopNode.analyse_types` by attempting coercion. This basically matches what `BinopNode` currently does so seems a sensible approach.