### PR TITLE
Fix function definions in finally clauses

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8287,6 +8287,7 @@ class TryFinallyStatNode(StatNode):
     def generate_function_definitions(self, env, code):
         self.body.generate_function_definitions(env, code)
         self.finally_clause.generate_function_definitions(env, code)
+        self.finally_except_clause.generate_function_definitions(env, code)
 
     def put_error_catcher(self, code, temps_to_clean_up, exc_vars,
                           exc_lineno_cnames=None, exc_filename_cname=None):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8287,7 +8287,8 @@ class TryFinallyStatNode(StatNode):
     def generate_function_definitions(self, env, code):
         self.body.generate_function_definitions(env, code)
         self.finally_clause.generate_function_definitions(env, code)
-        self.finally_except_clause.generate_function_definitions(env, code)
+        if self.finally_except_clause:
+            self.finally_except_clause.generate_function_definitions(env, code)
 
     def put_error_catcher(self, code, temps_to_clean_up, exc_vars,
                           exc_lineno_cnames=None, exc_filename_cname=None):

--- a/tests/run/tryfinally.pyx
+++ b/tests/run/tryfinally.pyx
@@ -549,3 +549,21 @@ def complex_finally_clause(x, obj):
             del l[0], lobj[0]
             assert all(i == 3 for i in l), l
     return 99
+
+def function_in_finally():
+    """
+    https://github.com/cython/cython/issues/4651 - function definitions in the
+    except copy of the finally clause weren't generated
+
+    >>> function_in_finally()
+    in try
+    in func()
+    finished
+    """
+    try:
+        print('in try')
+    finally:
+        def func():
+            print('in func()')
+        func()
+    print('finished')


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/4651.

This creates two copies of the function, one for the exception
cause and one for the non-exception case. It's probably inefficient
but the simplest solution