### PR TITLE
Fix example from Using C++ in Cython

### DIFF
--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -572,7 +572,6 @@ possible to declare them in the :file:`setup.py` file::
 
    setup(ext_modules = cythonize(
               "rect.pyx",                 # our Cython source
-              sources=["Rectangle.cpp"],  # additional source file(s)
               language="c++",             # generate C++ code
          ))
 
@@ -598,8 +597,7 @@ is then handled by ``cythonize()`` as follows::
 
    setup(ext_modules = cythonize(Extension(
               "rect",                                # the extension name
-              sources=["rect.pyx", "Rectangle.cpp"], # the Cython source and
-                                                     # additional C++ source files
+              sources=["rect.pyx"],                  # the Cython source and
               language="c++",                        # generate and compile C++ code
          )))
 
@@ -621,7 +619,6 @@ any source code, to compile it in C++ mode and link it statically against the
 :file:`Rectangle.cpp` code file::
 
    # distutils: language = c++
-   # distutils: sources = Rectangle.cpp
 
 .. note::
 


### PR DESCRIPTION
Fixes #3069 (and probably closes #3744 ?)

[Link](https://cython.readthedocs.io/en/latest/src/userguide/wrapping_CPlusPlus.html#specify-c-language-in-setup-py) to a new documentation page, containing the problem

So, the deal is, this code might have worked over a 10 years ago (8a5206ff80a3618eb79f1b6fbddfbd5ee661fa27) but now it does not.

What is the problem?
In the example, to build some extension for a cpp class Rectangle.cpp getting is added to sources (along rest.cpp) for setup(), so setuptools compiles it into an Rectangle.obj, which causes a ton of problems, and probably not the thing we want to achieve.

This fix seems weird, I may just missed something important about keeping Rectangle.cpp as a source.

Well, at least I tested all of those cases, and it seems like the only way to make them work is the one, presented in this pr.
