### PR TITLE
Catch redeclaration of var by cfunc

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2439,7 +2439,8 @@ class CClassScope(ClassScope):
             cname = punycodify_name(c_safe_identifier(name), Naming.unicode_vtabentry_prefix)
         if entry:
             if not entry.is_cfunction:
-                warning(pos, "'%s' redeclared  " % name, 0)
+                error(pos, "'%s' redeclared " % name)
+                entry.already_declared_here()
             else:
                 if defining and entry.func_cname:
                     error(pos, "'%s' already defined" % name)

--- a/tests/errors/redeclaration_of_var_by_cfunc_T600.pyx
+++ b/tests/errors/redeclaration_of_var_by_cfunc_T600.pyx
@@ -1,0 +1,14 @@
+# ticket: 600
+# mode: error
+
+cdef class Bar:
+    cdef list _operands
+
+    cdef int _operands(self):
+        return -1
+
+
+_ERRORS = """
+7:9: '_operands' redeclared
+5:14: Previous declaration is here
+"""


### PR DESCRIPTION
Fixes #600

To reproduce:
```cython
cdef class Bar:
    cdef list _operands

    cdef int _operands(self):
        return -1
```

This is how the error looks right now:
```text
Traceback (most recent call last):
  File "c:\Python\projects\cython\venv\cyth.py", line 15, in <module>
    ext_modules=cythonize(
  File "c:\python\projects\cython\Cython\Build\Dependencies.py", line 1143, in cythonize
    cythonize_one(*args)
  File "c:\python\projects\cython\Cython\Build\Dependencies.py", line 1289, in cythonize_one
    result = compile_single(pyx_file, options, full_module_name=full_module_name)
  File "c:\python\projects\cython\Cython\Compiler\Main.py", line 576, in compile_single
    return run_pipeline(source, options, full_module_name)
  File "c:\python\projects\cython\Cython\Compiler\Main.py", line 504, in run_pipeline
    err, enddata = Pipeline.run_pipeline(pipeline, source)
  File "c:\python\projects\cython\Cython\Compiler\Pipeline.py", line 394, in run_pipeline
    data = run(phase, data)
  File "c:\python\projects\cython\Cython\Compiler\Pipeline.py", line 371, in run
    return phase(data)
  File "c:\python\projects\cython\Cython\Compiler\Pipeline.py", line 52, in generate_pyx_code_stage
    module_node.process_implementation(options, result)
  File "c:\python\projects\cython\Cython\Compiler\ModuleNode.py", line 206, in process_implementation
    self.generate_c_code(env, options, result)
  File "c:\python\projects\cython\Cython\Compiler\ModuleNode.py", line 501, in generate_c_code
    self.body.generate_function_definitions(env, code)
  File "c:\python\projects\cython\Cython\Compiler\Nodes.py", line 403, in generate_function_definitions
    stat.generate_function_definitions(env, code)
  File "c:\python\projects\cython\Cython\Compiler\Nodes.py", line 5289, in generate_function_definitions
    self.body.generate_function_definitions(self.scope, code)
  File "c:\python\projects\cython\Cython\Compiler\Nodes.py", line 403, in generate_function_definitions
    stat.generate_function_definitions(env, code)
  File "c:\python\projects\cython\Cython\Compiler\Nodes.py", line 2293, in generate_function_definitions
    err_val = self.error_value()
  File "c:\python\projects\cython\Cython\Compiler\Nodes.py", line 2853, in error_value
    return self.entry.type.exception_value
AttributeError: 'BuiltinObjectType' object has no attribute 'exception_value'
```

After fix:
```text
Error compiling Cython file:
------------------------------------------------------------
...
cdef class Bar:
    cdef list _operands

    cdef int _operands(self):
        ^
------------------------------------------------------------

test.pyx:4:9: '_operands' redeclared

Error compiling Cython file:
------------------------------------------------------------
...
cdef class Bar:
    cdef list _operands
             ^
------------------------------------------------------------

test.pyx:2:14: Previous declaration is here
Traceback (most recent call last):
  File "c:\Python\projects\cython\venv\cyth.py", line 15, in <module>
    ext_modules=cythonize(
  File "c:\python\projects\cython\Cython\Build\Dependencies.py", line 1143, in cythonize
    cythonize_one(*args)
  File "c:\python\projects\cython\Cython\Build\Dependencies.py", line 1310, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: test.pyx
```

---

What's interesting is before the fix this would just compile
```cython
cdef class Bar:
    cdef list _operands

    cdef _operands(self):
        pass
```
