### PR TITLE
Fix reference counting in memoryview loops

### DIFF
--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -233,7 +233,10 @@ class LetNodeMixin:
         if self._result_in_temp:
             self.temp = self.temp_expression.result()
         else:
-            self.temp_expression.make_owned_reference(code)
+            if self.temp_type.is_memoryviewslice:
+                self.temp_expression.make_owned_memoryviewslice(code)
+            else:
+                self.temp_expression.make_owned_reference(code)
             self.temp = code.funcstate.allocate_temp(
                 self.temp_type, manage_ref=True)
             code.putln("%s = %s;" % (self.temp, self.temp_expression.result()))
@@ -246,7 +249,7 @@ class LetNodeMixin:
             self.temp_expression.generate_disposal_code(code)
             self.temp_expression.free_temps(code)
         else:
-            if self.temp_type.is_pyobject:
+            if self.temp_type.needs_refcounting:
                 code.put_decref_clear(self.temp, self.temp_type)
             code.funcstate.release_temp(self.temp)
 

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2516,3 +2516,48 @@ def test_const_buffer(const int[:] a):
     cdef const int[:] c = a
     print(a[0])
     print(c[-1])
+
+@testcase
+def test_loop(int[:] a, throw_exception):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> test_loop(A, False)
+    acquired A
+    15
+    released A
+    >>> try:
+    ...     test_loop(A, True)
+    ... except ValueError:
+    ...     pass
+    acquired A
+    released A
+    """
+    cdef int sum = 0
+    for ai in a:
+        sum += ai
+    if throw_exception:
+        raise ValueError()
+    print(sum)
+
+@testcase
+def test_loop_reassign(int[:] a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> test_loop_reassign(A)
+    acquired A
+    0
+    1
+    2
+    3
+    4
+    5
+    released A
+    15
+    """
+    cdef int sum = 0
+    for ai in a:
+        sum += ai
+        print(ai)
+        a = None  # this should not mess up the loop though!
+    # release happens here, when the loop temp is released
+    print(sum)


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/4662

Memoryview temps weren't being properly incremented (at the start
of the loop) or decremented (at the end of the loop). They were
decremented in the exception handling case.

Long-term I think we really should unify reference counting for
memoryviews further. It's *slightly* different from PyObjects
(mainly that it happens in wrapper functions rather than the
main function) and that leads to a large chance that it just
gets missed.