### PR TITLE
FIX: import internal cpython headers to fix for py311

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -500,6 +500,9 @@ static int __pyx_Generator_init(PyObject *module); /*proto*/
 
 #include <frameobject.h>
 #if PY_VERSION_HEX >= 0x030b00a6
+  #ifndef Py_BUILD_CORE
+    #define Py_BUILD_CORE 1
+  #endif
   #include "internal/pycore_frame.h"
 #endif
 

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -499,6 +499,9 @@ static int __pyx_Generator_init(PyObject *module); /*proto*/
 //@requires: ModuleSetupCode.c::IncludeStructmemberH
 
 #include <frameobject.h>
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
 
 #define __Pyx_Coroutine_Undelegate(gen) Py_CLEAR((gen)->yieldfrom)
 

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -785,6 +785,9 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
 #include "compile.h"
 #include "frameobject.h"
 #if PY_VERSION_HEX >= 0x030b00a6
+  #ifndef Py_BUILD_CORE
+    #define Py_BUILD_CORE 1
+  #endif
   #include "internal/pycore_frame.h"
 #endif
 #include "traceback.h"

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -784,6 +784,9 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
 
 #include "compile.h"
 #include "frameobject.h"
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
 #include "traceback.h"
 
 #if CYTHON_COMPILING_IN_LIMITED_API

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -784,13 +784,13 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
 
 #include "compile.h"
 #include "frameobject.h"
+#include "traceback.h"
 #if PY_VERSION_HEX >= 0x030b00a6
   #ifndef Py_BUILD_CORE
     #define Py_BUILD_CORE 1
   #endif
   #include "internal/pycore_frame.h"
 #endif
-#include "traceback.h"
 
 #if CYTHON_COMPILING_IN_LIMITED_API
 static void __Pyx_AddTraceback(const char *funcname, int c_line,

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2445,6 +2445,9 @@ static PyObject *__Pyx_PyFunction_FastCallDict(PyObject *func, PyObject **args, 
 #if PY_VERSION_HEX >= 0x03080000
   #include "frameobject.h"
 #if PY_VERSION_HEX >= 0x030b00a6
+  #ifndef Py_BUILD_CORE
+    #define Py_BUILD_CORE 1
+  #endif
   #include "internal/pycore_frame.h"
 #endif
   #define __Pxy_PyFrame_Initialize_Offsets()

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2444,6 +2444,9 @@ static PyObject *__Pyx_PyFunction_FastCallDict(PyObject *func, PyObject **args, 
 #if !CYTHON_VECTORCALL
 #if PY_VERSION_HEX >= 0x03080000
   #include "frameobject.h"
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
   #define __Pxy_PyFrame_Initialize_Offsets()
   #define __Pyx_PyFrame_GetLocalsplus(frame)  ((frame)->f_localsplus)
 #else
@@ -3106,5 +3109,3 @@ static CYTHON_INLINE void __Pyx_RaiseCppAttributeError(const char *varname); /*p
 static CYTHON_INLINE void __Pyx_RaiseCppAttributeError(const char *varname) {
     PyErr_Format(PyExc_AttributeError, "C++ attribute '%s' is not initialized", varname);
 }
-
-

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -38,6 +38,9 @@
   #include "compile.h"
   #include "frameobject.h"
 #if PY_VERSION_HEX >= 0x030b00a6
+  #ifndef Py_BUILD_CORE
+    #define Py_BUILD_CORE 1
+  #endif
   #include "internal/pycore_frame.h"
 #endif
   #include "traceback.h"

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -37,6 +37,9 @@
 
   #include "compile.h"
   #include "frameobject.h"
+#if PY_VERSION_HEX >= 0x030b00a6
+  #include "internal/pycore_frame.h"
+#endif
   #include "traceback.h"
 
   #if CYTHON_PROFILE_REUSE_FRAME

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -37,13 +37,13 @@
 
   #include "compile.h"
   #include "frameobject.h"
+  #include "traceback.h"
 #if PY_VERSION_HEX >= 0x030b00a6
   #ifndef Py_BUILD_CORE
     #define Py_BUILD_CORE 1
   #endif
   #include "internal/pycore_frame.h"
 #endif
-  #include "traceback.h"
 
   #if CYTHON_PROFILE_REUSE_FRAME
     #define CYTHON_FRAME_MODIFIER static


### PR DESCRIPTION
In 18b5dd68c6b616257ae243c0b6bb965ffc885a23 /
https://github.com/python/cpython/pull/31530 /
https://bugs.python.org/issue46836

The `_frame` struct was moved to an internal header, however the public API is
primarily read-only, and cython needs to build _frame objects so still import
the internal headers.

The version bounding is wrong (the problem commit won't be out until a6, but this condition will compile against the current CPYthon main branch.

I'm not at all sure that this is the right fix, but it compiled!