### PR TITLE
Update to Python 3.11 alpha 6

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -525,6 +525,15 @@ class __Pyx_FakeReference {
   #define PyMem_RawFree(p)             PyMem_Free(p)
 #endif
 
+#if !CYTHON_COMPILING_IN_PYSTON && PY_VERSION_HEX >= 0x30B00A6
+   // Get PyFrameObject internal C API structure. For example,
+   // __Pyx_PyFrame_SetLineNumber() sets directly the the f_lineno field.
+#  ifndef Py_BUILD_CORE
+#    define Py_BUILD_CORE 1
+#  endif
+#  include "internal/pycore_frame.h"
+#endif
+
 #if CYTHON_COMPILING_IN_PYSTON
   // special C-API functions only in Pyston
   #define __Pyx_PyCode_HasFreeVars(co)  PyCode_HasFreeVars(co)


### PR DESCRIPTION
Include pycore_frame.h of the Python internal C API to get the
PyFrameObject structure.

For example, it is needed by the __Pyx_PyFrame_SetLineNumber() macro
to set the frame->f_lineno field.