### PR TITLE
ENH: allow arg in localtime

### DIFF
--- a/Cython/Includes/cpython/time.pxd
+++ b/Cython/Includes/cpython/time.pxd
@@ -30,14 +30,16 @@ cdef inline int _raise_from_errno() except -1 with gil:
     return <int> -1  # Let the C compiler know that this function always raises.
 
 
-cdef inline tm localtime() nogil except *:
+cdef inline tm localtime(time_t tic) nogil except *:
     """
     Analogue to the stdlib time.localtime.  The returned struct
     has some entries that the stdlib version does not: tm_gmtoff, tm_zone
     """
     cdef:
-        time_t tic = <time_t>time()
         tm* result
+
+    if tic is None:
+        tic = <time_t>time()
 
     result = libc_localtime(&tic)
     if result is NULL:

--- a/tests/run/time_pxd.pyx
+++ b/tests/run/time_pxd.pyx
@@ -62,3 +62,31 @@ def test_localtime():
             break
 
     return ltp, ltc
+
+
+def test_localtime_with_arg():
+    """
+    >>> ltp, ltc = test_localtime_with_arg()
+    >>> ltp.tm_year == ltc['tm_year']  or  (ltp.tm_year, ltc['tm_year'])
+    True
+    >>> ltp.tm_mon == ltc['tm_mon']  or  (ltp.tm_mon, ltc['tm_mon'])
+    True
+    >>> ltp.tm_mday == ltc['tm_mday']  or  (ltp.tm_mday, ltc['tm_mday'])
+    True
+    >>> ltp.tm_hour == ltc['tm_hour']  or  (ltp.tm_hour, ltc['tm_hour'])
+    True
+    >>> ltp.tm_min == ltc['tm_min']  or  (ltp.tm_min, ltc['tm_min'])
+    True
+    >>> ltp.tm_sec == ltc['tm_sec']  or  (ltp.tm_sec, ltc['tm_sec'])
+    True
+    >>> ltp.tm_wday == ltc['tm_wday']  or (ltp.tm_wday, ltc['tm_wday'])
+    True
+    >>> ltp.tm_yday == ltc['tm_yday']  or  (ltp.tm_yday, ltc['tm_yday'])
+    True
+    >>> ltp.tm_isdst == ltc['tm_isdst']  or  (ltp.tm_isdst, ltc['tm_isdst'])
+    True
+    """
+    # 1647471169 corresponds to 2022-03-16 22:52:49 UTC
+    ltp = time.localtime(1647471169)
+    ltc = ctime.localtime(1647471169)
+    return ltp, ltc


### PR DESCRIPTION
I neglected in the original PR to allow for a user-provided 'tic'.