### PR TITLE
Use fallthrough attribute only for C++17 and later

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -429,7 +429,7 @@
 
 
 #ifndef CYTHON_FALLTHROUGH
-  #if defined(__cplusplus) && __cplusplus >= 201103L
+  #if defined(__cplusplus) && __cplusplus >= 201703L
     #if __has_cpp_attribute(fallthrough)
       #define CYTHON_FALLTHROUGH [[fallthrough]]
     #elif __has_cpp_attribute(clang::fallthrough)


### PR DESCRIPTION
Currently, Cython uses the C++ attribute `fallthrough` for C++11 and later. But this attribute became part of the standard only with C++17 (https://en.cppreference.com/w/cpp/language/attributes/fallthrough). 

Therefore, Clang 13 with option `-pedantic` issues warnings of the following form if combined with `-std=c++11` or `-std=c++14`:
```
.../pynest/pynestkernel.cxx:27879:9: warning: use of the 'fallthrough' attribute is a C++17 extension [-Wc++17-extensions]
        CYTHON_FALLTHROUGH;
        ^
.../pynest/pynestkernel.cxx:275:36: note: expanded from macro 'CYTHON_FALLTHROUGH'
      #define CYTHON_FALLTHROUGH [[fallthrough]]
```

This PR changes changes the conditions for `fallthrough` so it is used only with C++17 and later.