### PR TITLE
Do not redefine _USE_MATH_DEFINES in generated code

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1285,7 +1285,9 @@ static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObj
 /////////////// MathInitCode ///////////////
 
 #if defined(_WIN32) || defined(WIN32) || defined(MS_WINDOWS)
-  #define _USE_MATH_DEFINES
+  #if !defined(_USE_MATH_DEFINES)
+    #define _USE_MATH_DEFINES
+  #endif
 #endif
 #include <math.h>
 


### PR DESCRIPTION
We unconditionally add `/D_USE_MATH_DEFINES` via cmdline and doing this triggers `-Wmacro-redefined` in cython-generated code.