### PR TITLE
Remove "assignable" requirement from cpp_locals

### DIFF
--- a/tests/run/cpp_locals_directive.pyx
+++ b/tests/run/cpp_locals_directive.pyx
@@ -19,13 +19,9 @@ cdef extern from *:
             C(C&& rhs) : x(rhs.x), print_destructor(rhs.print_destructor) {
                 rhs.print_destructor = false; // moved-from instances are deleted silently
             }
-            C& operator=(C&& rhs) {
-                x=rhs.x;
-                print_destructor=rhs.print_destructor;
-                rhs.print_destructor = false; // moved-from instances are deleted silently
-                return *this;
-            }
-            C(const C& rhs) = default;
+            // also test that we don't require the assignment operator
+            C& operator=(C&& rhs) = delete;
+            C(const C& rhs) = delete;
             C& operator=(const C& rhs) = default;
             ~C() {
                 if (print_destructor) print_C_destructor();


### PR DESCRIPTION
Fixes #4558 by making the assignment operation of a cpp_locals
variable actually use "emplace".

I've done this by creating a class that implements __Pyx_Optional_Type
rather than justing using std::optional directly (and rewriting
operator= for that). This seemed less intrusive that changing the
code generation to call "emplace" directly, but possibly less
efficient in some cases.