### PR TITLE
silence unused warning on MSVC

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2108,12 +2108,9 @@ class CCodeWriter(object):
         self.funcstate.scope.use_entry_utility_code(entry)
 
     def put_var_declaration_unused_if_needed(self, entry, definition=True):
-        #print "Code.put_var_declaration:", entry.name, "definition =", definition ###
         if entry.visibility == 'private' and not (definition or entry.defined_in_pxd):
-            #print "...private and not definition, skipping", entry.cname ###
             return
         if entry.visibility == "private" and not entry.used:
-            #print "...private and not used, skipping", entry.cname ###
             return
         if not entry.cf_used:
             self.putln("CYTHON_UNUSED_VAR(%s);" % entry.cname)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8104,7 +8104,7 @@ class SequenceNode(ExprNode):
             code.put_decref(target_list, py_object_type)
             code.putln('%s = %s; %s = NULL;' % (target_list, sublist_temp, sublist_temp))
             code.putln('#else')
-            code.putln('(void)%s;' % sublist_temp)  # avoid warning about unused variable
+            code.putln('CYTHON_UNUSED_VAR(%s);' % sublist_temp)
             code.funcstate.release_temp(sublist_temp)
             code.putln('#endif')
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1883,7 +1883,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             self.generate_self_cast(scope, code)
 
         # silence unused warnings about unused variables
-        if not py_attrs and not py_buffers and not base_type:
+        if not (py_attrs or py_buffers or base_type):
             code.putln("CYTHON_UNUSED_VAR(o);")
 
         if base_type:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -789,13 +789,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         self._put_setup_code(code, "PythonCompatibility")
         self._put_setup_code(code, "MathInitCode")
 
-        # Using "(void)cname" to prevent "unused" warnings.
         if options.c_line_in_traceback:
-            cinfo = "%s = %s; (void)%s; " % (Naming.clineno_cname, Naming.line_c_macro, Naming.clineno_cname)
+            cinfo = "%s = %s; CYTHON_UNUSED_VAR(%s); " % (Naming.clineno_cname, Naming.line_c_macro, Naming.clineno_cname)
         else:
             cinfo = ""
         code.putln("#define __PYX_MARK_ERR_POS(f_index, lineno) \\")
-        code.putln("    { %s = %s[f_index]; (void)%s; %s = lineno; (void)%s; %s}" % (
+        code.putln("    { %s = %s[f_index]; CYTHON_UNUSED_VAR(%s); %s = lineno; CYTHON_UNUSED_VAR(%s); %s}" % (
             Naming.filename_cname, Naming.filetable_cname, Naming.filename_cname,
             Naming.lineno_cname, Naming.lineno_cname,
             cinfo
@@ -853,7 +852,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         PyrexTypes.c_int_type.create_from_py_utility_code(env)
 
         code.put(Nodes.branch_prediction_macros)
-        code.putln('static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }')
+        code.putln('static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { CYTHON_UNUSED_VAR(ptr); }')
         code.putln('')
         code.putln('#if !CYTHON_USE_MODULE_STATE')
         code.putln('static PyObject *%s = NULL;' % env.module_cname)

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3153,7 +3153,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("#endif")
         code.putln('}')
 
-        tempdecl_code.put_temp_declarations(code.funcstate, function_code)
+        tempdecl_code.put_temp_declarations(code.funcstate)
+        function_code.put_temp_declarations_unused_if_needed(code.funcstate)
 
         code.exit_cfunc_scope()
 
@@ -3198,7 +3199,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.put_finish_refcount_context()
                 code.putln("return 0;")
 
-                self.tempdecl_code.put_temp_declarations(code.funcstate, function_code)
+                self.tempdecl_code.put_temp_declarations(code.funcstate)
+                function_code.put_temp_declarations_unused_if_needed(code.funcstate)
                 self.tempdecl_code = None
 
                 needs_error_handling = code.label_used(code.error_label)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -4601,9 +4601,6 @@ class GeneratorBodyDefNode(DefNode):
         else:
             code.putln('%s /* generator body */\n{' % header)
 
-    def generate_ignore_unused_arg(self, code):
-        code.putln("CYTHON_UNUSED_VAR(%s);" % Naming.local_tstate_cname)
-
     def generate_function_definitions(self, env, code):
         lenv = self.local_scope
 
@@ -4637,7 +4634,7 @@ class GeneratorBodyDefNode(DefNode):
             code_object = self.code_object.calculate_result_code(code) if self.code_object else None
             code.put_trace_frame_init(code_object)
 
-        self.generate_ignore_unused_arg(code)
+        code.putln("CYTHON_UNUSED_VAR(%s);" % Naming.local_tstate_cname)
 
         # ----- Resume switch point.
         code.funcstate.init_closure_temps(lenv.scope_class.type.scope)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5787,7 +5787,7 @@ class ExprStatNode(StatNode):
         if not self.expr.is_temp and self.expr.result():
             result = self.expr.result()
             if not self.expr.type.is_void:
-                result = "(void)(%s)" % result
+                result = "CYTHON_UNUSED_VAR(%s)" % result
             code.putln("%s;" % result)
         self.expr.generate_disposal_code(code)
         self.expr.free_temps(code)

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -1245,7 +1245,7 @@ static int __pyx_AsyncGen_init(PyObject *module) {
 #if CYTHON_USE_TYPE_SPECS
     __pyx_AsyncGenType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_AsyncGenType_spec, NULL);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     // on Windows, C-API functions can't be used in slots statically
     __pyx_AsyncGenType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
     __pyx_AsyncGenType = __Pyx_FetchCommonType(&__pyx_AsyncGenType_type);

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -121,7 +121,7 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
     if (!PyErr_ExceptionMatches(PyExc_AttributeError)) goto bad;
     PyErr_Clear();
     // We pass the ABI module reference to avoid keeping the user module alive by foreign type usages.
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     cached_type = __Pyx_PyType_FromModuleAndSpec(abi_module, spec, bases);
     if (unlikely(!cached_type)) goto bad;
     if (unlikely(__Pyx_fix_up_extension_type_from_spec(spec, (PyTypeObject *) cached_type) < 0)) goto bad;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -256,7 +256,7 @@ static PyObject *__Pyx_Coroutine_GetAsyncIter_Generic(PyObject *obj) {
     }
 #else
     // avoid C warning about 'unused function'
-    if ((0)) (void) __Pyx_PyObject_CallMethod0(obj, PYIDENT("__aiter__"));
+    (void) &__Pyx_PyObject_CallMethod0;
 #endif
 
     obj_type_name = __Pyx_PyType_GetName(Py_TYPE(obj));
@@ -1864,7 +1864,7 @@ static int __pyx_Coroutine_init(PyObject *module) {
 #if CYTHON_USE_TYPE_SPECS
     __pyx_CoroutineType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CoroutineType_spec, NULL);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     __pyx_CoroutineType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
     __pyx_CoroutineType = __Pyx_FetchCommonType(&__pyx_CoroutineType_type);
 #endif
@@ -2014,7 +2014,7 @@ static int __pyx_IterableCoroutine_init(PyObject *module) {
 #if CYTHON_USE_TYPE_SPECS
     __pyx_IterableCoroutineType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_IterableCoroutineType_spec, NULL);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     __pyx_IterableCoroutineType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
     __pyx_IterableCoroutineType = __Pyx_FetchCommonType(&__pyx_IterableCoroutineType_type);
 #endif
@@ -2159,7 +2159,7 @@ static int __pyx_Generator_init(PyObject *module) {
 #if CYTHON_USE_TYPE_SPECS
     __pyx_GeneratorType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_GeneratorType_spec, NULL);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     // on Windows, C-API functions can't be used in slots statically
     __pyx_GeneratorType_type.tp_getattro = __Pyx_PyObject_GenericGetAttrNoDict;
     __pyx_GeneratorType_type.tp_iter = PyObject_SelfIter;
@@ -2566,7 +2566,7 @@ static PyTypeObject __Pyx__PyExc_StopAsyncIteration_type = {
 
 static int __pyx_StopAsyncIteration_init(PyObject *module) {
 #if PY_VERSION_HEX >= 0x030500B1
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     __Pyx_PyExc_StopAsyncIteration = PyExc_StopAsyncIteration;
 #else
     PyObject *builtins = PyEval_GetBuiltins();
@@ -2584,7 +2584,7 @@ static int __pyx_StopAsyncIteration_init(PyObject *module) {
     __Pyx__PyExc_StopAsyncIteration_type.tp_dictoffset = ((PyTypeObject*)PyExc_BaseException)->tp_dictoffset;
     __Pyx__PyExc_StopAsyncIteration_type.tp_base = (PyTypeObject*)PyExc_Exception;
 
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     __Pyx_PyExc_StopAsyncIteration = (PyObject*) __Pyx_FetchCommonType(&__Pyx__PyExc_StopAsyncIteration_type);
     if (unlikely(!__Pyx_PyExc_StopAsyncIteration))
         return -1;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -256,7 +256,7 @@ static PyObject *__Pyx_Coroutine_GetAsyncIter_Generic(PyObject *obj) {
     }
 #else
     // avoid C warning about 'unused function'
-    (void) &__Pyx_PyObject_CallMethod0;
+    CYTHON_UNUSED_VAR(&__Pyx_PyObject_CallMethod0);
 #endif
 
     obj_type_name = __Pyx_PyType_GetName(Py_TYPE(obj));

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1052,7 +1052,7 @@ static int __pyx_CyFunction_init(PyObject *module) {
 #if CYTHON_USE_TYPE_SPECS
     __pyx_CyFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CyFunctionType_spec, NULL);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     __pyx_CyFunctionType = __Pyx_FetchCommonType(&__pyx_CyFunctionType_type);
 #endif
     if (unlikely(__pyx_CyFunctionType == NULL)) {
@@ -1597,7 +1597,7 @@ static int __pyx_FusedFunction_init(PyObject *module) {
     __pyx_FusedFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_FusedFunctionType_spec, bases);
     Py_DECREF(bases);
 #else
-    (void) module;
+    CYTHON_UNUSED_VAR(module);
     // Set base from __Pyx_FetchCommonTypeFromSpec, in case it's different from the local static value.
     __pyx_FusedFunctionType_type.tp_base = __pyx_CyFunctionType;
     __pyx_FusedFunctionType = __Pyx_FetchCommonType(&__pyx_FusedFunctionType_type);

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -11,8 +11,8 @@ static int __Pyx_fix_up_extension_type_from_spec(PyType_Spec *spec, PyTypeObject
 #if CYTHON_USE_TYPE_SPECS
 static int __Pyx_fix_up_extension_type_from_spec(PyType_Spec *spec, PyTypeObject *type) {
 #if PY_VERSION_HEX > 0x030900B1 || CYTHON_COMPILING_IN_LIMITED_API
-    (void) spec;
-    (void) type;
+    CYTHON_UNUSED_VAR(spec);
+    CYTHON_UNUSED_VAR(type);
 #else
     // Set tp_weakreflist, tp_dictoffset, tp_vectorcalloffset
     // Copied and adapted from https://bugs.python.org/issue38140

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -445,7 +445,7 @@ static CYTHON_INLINE PyObject* __Pyx_set_iterator(PyObject* iterable, int is_set
         return iterable;
     }
 #else
-    (void)is_set;
+    CYTHON_UNUSED_VAR(is_set);
     *p_source_is_set = 0;
 #endif
     *p_orig_length = 0;
@@ -461,8 +461,8 @@ static CYTHON_INLINE int __Pyx_set_iter_next(
         if (unlikely(!*value)) {
             return __Pyx_IterFinish();
         }
-        (void)orig_length;
-        (void)ppos;
+        CYTHON_UNUSED_VAR(orig_length);
+        CYTHON_UNUSED_VAR(ppos);
         return 1;
     }
 #if CYTHON_COMPILING_IN_CPYTHON
@@ -1318,7 +1318,8 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, long intval, 
             }
         {{else}}
             {{if c_op == '*'}}
-                (void)a; (void)b;
+                CYTHON_UNUSED_VAR(a);
+                CYTHON_UNUSED_VAR(b);
                 #ifdef HAVE_LONG_LONG
                 ll{{ival}} = {{ival}};
                 goto long_long;
@@ -1464,8 +1465,8 @@ def zerodiv_check(operand, _is_mod=op == 'Remainder', _needs_check=(order == 'CO
 static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, double floatval, int inplace, int zerodivision_check) {
     const double {{'a' if order == 'CObj' else 'b'}} = floatval;
     double {{fval}}{{if op not in ('Eq', 'Ne')}}, result{{endif}};
-    // Prevent "unused" warnings.
-    (void)inplace; (void)zerodivision_check;
+    CYTHON_MAYBE_UNUSED_VAR(inplace);
+    CYTHON_MAYBE_UNUSED_VAR(zerodivision_check);
 
     {{if op in ('Eq', 'Ne')}}
     if (op1 == op2) {


### PR DESCRIPTION
@scoder this revives #4149 since I forgot (yet again) how to restore a deleted branch from a PR. I am pretty sure you or @da-woods already explained me how this can be done ...

This implementation uses `code.insertion_point` as suggested by @da-woods to place function calls behind the variable declarations for C89.
After this the remaining usages of `CYTHON_UNUSED` are:
```
static CYTHON_UNUSED PyObject* __Pyx_Method_ClassMethod(PyObject *method);
static CYTHON_UNUSED int __Pyx_PyType_Ready(PyTypeObject *t);
static CYTHON_UNUSED double __Pyx__PyBytes_AsDouble(PyObject *obj, const char* start, Py_ssize_t length) {
```