### PR TITLE
DOC: update sphinx

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.5.3
+sphinx==4.4.0
 sphinx-issues==1.2.0
 sphinx-tabs==3.0.0
 jupyter


### PR DESCRIPTION
The [codestyle CI run](https://github.com/cython/cython/runs/5706061570?check_suite_focus=true#step:5:357) is failing with
```
ImportError: cannot import name 'environmentfilter' from 'jinja2' \
     (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2
```

This seems to have started failing when jinja2 updated to `Jinja2-3.1.1` a few days ago. I think updating sphinx will fix that problem, let's see if it causes more problems.