### PR TITLE
Add exception handling for `libcpp::stack::push`

### DIFF
--- a/Cython/Includes/libcpp/stack.pxd
+++ b/Cython/Includes/libcpp/stack.pxd
@@ -6,6 +6,6 @@ cdef extern from "<stack>" namespace "std" nogil:
         #stack(Container&)
         bint empty()
         void pop()
-        void push(T&)
+        void push(T&) except +
         size_t size()
         T& top()


### PR DESCRIPTION
This adds a simple exception handling to `stack::pop`.

Tests are to be added, if needed.