### PR TITLE
Allow const qualifier for memoryview on objects

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1147,7 +1147,17 @@ class MemoryViewSliceTypeNode(CBaseTypeNode):
 
     def analyse(self, env, could_be_name=False):
 
-        base_type = self.base_type_node.analyse(env)
+        if isinstance(self.base_type_node, CConstOrVolatileTypeNode):
+            # In this tree the 'const' qualifier of this memoryview is attached
+            # to the node of the base type, but its meaning is
+            # 'const memoryview'.  For non-PyObject types this doesn't make a
+            # difference, but for PyObject it does: The objects are not
+            # read-only (they cannot be!), but the memory locations in the view
+            # are read-only.  Hence we need tell the CConstOrVolatileTypeNode
+            # that it should simply ignore the 'const'.
+            base_type = self.base_type_node.analyse(env, allow_const_pyobject=True)
+        else:
+            base_type = self.base_type_node.analyse(env)
         if base_type.is_error: return base_type
 
         from . import MemoryView
@@ -1360,9 +1370,12 @@ class CConstOrVolatileTypeNode(CBaseTypeNode):
 
     child_attrs = ["base_type"]
 
-    def analyse(self, env, could_be_name=False):
+    def analyse(self, env, could_be_name=False, allow_const_pyobject=False):
+        # allow_const_pyobject: boolean
+        # Let caller force us to accept a 'const object'. Used for
+        # 'const object[:]'
         base = self.base_type.analyse(env, could_be_name)
-        if base.is_pyobject:
+        if base.is_pyobject and (self.is_volatile or not allow_const_pyobject):
             error(self.pos,
                   "Const/volatile base type cannot be a Python object")
         return PyrexTypes.c_const_or_volatile_type(base, self.is_const, self.is_volatile)

--- a/tests/memoryview/constobjmemview.pyx
+++ b/tests/memoryview/constobjmemview.pyx
@@ -1,0 +1,4 @@
+# mode: compile
+
+cdef f():
+    cdef const object[:] a

--- a/tests/memoryview/error_constobj.pyx
+++ b/tests/memoryview/error_constobj.pyx
@@ -1,0 +1,17 @@
+# mode: error
+
+import numpy as np
+
+# Cannot qualify plain object 'const'
+cdef const object a  # <<< error
+
+# Cannot assign to const memoryview
+arr = np.array([object() for _ in range(10)])
+cdef const object[:] arrview = arr
+arrview[2] = object()  # <<< error
+
+
+_ERRORS = u"""
+6:5: Const/volatile base type cannot be a Python object
+11:7: Assignment to const dereference
+"""

--- a/tests/memoryview/extension_type_memoryview.pyx
+++ b/tests/memoryview/extension_type_memoryview.pyx
@@ -34,3 +34,25 @@ def test_getitem_typed():
     for i in range(view.shape[0]):
         item = view[i]
         print item.dummy
+
+def test_setitem():
+    """
+    >>> test_setitem()
+    10
+    11
+    """
+    for i in range(view.shape[0]):
+        view[i] = ExtensionType(10+i)
+        print view[i].dummy
+
+def test_setitem_typed():
+    """
+    >>> test_setitem_typed()
+    20
+    21
+    """
+    cdef ExtensionType item
+    for i in range(view.shape[0]):
+        item = ExtensionType(20+i)
+        view[i] = item
+        print view[i].dummy

--- a/tests/memoryview/extension_type_nditer.pyx
+++ b/tests/memoryview/extension_type_nditer.pyx
@@ -1,0 +1,112 @@
+# mode: run
+# tag: numpy
+
+cimport numpy as np
+import numpy as np
+
+
+cdef class A(object):
+    cdef public int data
+
+    def __init__(self, n):
+        self.data = n
+
+## readonly nditer through ndarray of A, summing their data.
+def test_readonly():
+    """
+    >>> test_readonly()
+    45
+    """
+
+    array_of_A = np.array([A(i) for i in range(10)])
+
+    cdef A scalar_A
+    cdef const A[:] chunk
+    cdef int total = 0
+  
+    with np.nditer(array_of_A, flags=['refs_ok', 'external_loop'],
+            op_flags=['readonly'], op_dtypes=('object')) as it:
+
+        for chunk in it:
+            for i in range(chunk.shape[0]):
+                scalar_A = chunk[i]
+                total += scalar_A.data
+
+    print total
+
+## readonly nditer through ndarray of A, but modifying the objects
+def test_readonly_modify():
+    """
+    >>> test_readonly_modify()
+    [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+    """
+
+    array_of_A = np.array([A(i) for i in range(10)])
+
+    cdef A scalar_A
+    cdef const A[:] chunk
+    cdef int total = 0
+  
+    with np.nditer(array_of_A, flags=['refs_ok', 'external_loop'],
+            op_flags=['readonly'], op_dtypes=('object')) as it:
+
+        for chunk in it:
+            for i in range(chunk.shape[0]):
+                scalar_A = chunk[i]
+                scalar_A.data *= 2
+
+    print([a.data for a in array_of_A])
+
+# readwrite nditer through ndarray of A, replace objects with twice their data
+
+def test_readwrite():
+    """
+    >>> test_readwrite()
+    [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+    """
+
+    array_of_A = np.array([A(i) for i in range(10)], dtype=A)
+
+    cdef A scalar_A
+    cdef A[:] chunk
+    cdef int total = 0
+  
+    with np.nditer(array_of_A, flags=['refs_ok', 'external_loop'],
+            op_flags=['readwrite'], op_dtypes=('object')) as it:
+
+        for chunk in it:
+            for i in range(chunk.shape[0]):
+                scalar_A = chunk[i]
+                chunk[i] = A(2 * scalar_A.data)
+
+    print([a.data for a in array_of_A])
+    
+
+# 2 operand nditer: Read from first, write to second
+def test_readonly_writeonly():
+    """
+    >>> test_readonly_writeonly()
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+    """
+
+    array_in = np.array([A(i) for i in range(10)])
+    array_out = np.empty(10, dtype=A)
+
+    cdef A scalar_A
+    cdef const A[:] chunk_in
+    cdef A[:] chunk_out
+    cdef int total = 0
+  
+    with np.nditer([array_in, array_out], flags=['refs_ok', 'external_loop'],
+            op_flags=[['readonly'], ['writeonly']],
+            op_dtypes=(A, A)) as it:
+
+        for (chunk_in, chunk_out) in it:
+            for i in range(chunk_in.shape[0]):
+                scalar_A = chunk_in[i]
+                chunk_out[i] = A(2 * scalar_A.data)
+
+    print([a.data for a in array_in])
+    print([a.data for a in array_out])
+    


### PR DESCRIPTION
As [suggested](https://github.com/cython/cython/issues/2485#issuecomment-1079691738) by @da-woods I'm simply bypassing the check for a "const object" _if_ we are in a `MemoryViewSliceTypeNode`.  It feels quite hacky, but the numerous tests I've added are happy with that approach.  Note that some of the new tests emit compiler warnings like
```
extension_type_nditer.c:7112:27: warning: incompatible pointer types assigning to 'struct __pyx_obj_21extension_type_nditer_A *' from 'PyObject *' (aka 'struct _object *') [-Wincompatible-pointer-types]
              *__pyx_t_21 = __pyx_t_1;
                          ^ ~~~~~~~~~
```
This is a known issue and tracked in #3993. Finally I'm wondering whether this change would be a candidate to go in 0.29.x instead of (only) master so that it could be picked up downstream soon.

FWIW my gut feeling is that a cleaner way to get 'const object[:]` to work is...
1. Let `MemoryViewSliceTypeNode` have a const attribute
2. Let the parser attach the `const` qualifier in `const object[:] a` _not_ to the base type node, but to the memoryview node.

I tried to go that route, too, but my unfamiliarity with such internals let me become overwhelmed quite quickly.