### PR TITLE
Let C++ references work in fused types

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2769,6 +2769,8 @@ class CReferenceBaseType(BaseType):
 
     # Common base type for C reference and C++ rvalue reference types.
 
+    subtypes = ['ref_base_type']
+
     def __init__(self, base_type):
         self.ref_base_type = base_type
 

--- a/tests/run/fused_cpp.pyx
+++ b/tests/run/fused_cpp.pyx
@@ -41,3 +41,13 @@ def typeid_call2(cython.integral x):
     """
     cdef const type_info* a = &typeid(cython.integral)
     return a[0] == tidint[0]
+
+cdef fused_ref(cython.integral& x):
+    return x*2
+
+def test_fused_ref(int x):
+    """
+    >>> test_fused_ref(5)
+    (10, 10)
+    """
+    return fused_ref(x), fused_ref[int](x)


### PR DESCRIPTION
Fixes #4717