### PR TITLE
__Pyx_KwValues_FASTCALL: avoid triggering UB by adding non-zero to NULL (caught by UBSAN nullptr-with-nonzero-offset)

### DIFF
--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -422,7 +422,7 @@ bad:
 #if CYTHON_METH_FASTCALL
     #define __Pyx_Arg_FASTCALL(args, i) args[i]
     #define __Pyx_NumKwargs_FASTCALL(kwds) PyTuple_GET_SIZE(kwds)
-    #define __Pyx_KwValues_FASTCALL(args, nargs) (&args[nargs])
+    #define __Pyx_KwValues_FASTCALL(args, nargs) ({ typeof (args) _a = (args); _a ? (&_a[nargs]) : NULL;})
     static CYTHON_INLINE PyObject * __Pyx_GetKwValue_FASTCALL(PyObject *kwnames, PyObject *const *kwvalues, PyObject *s);
     #define __Pyx_KwargsAsDict_FASTCALL(kw, kwvalues) _PyStack_AsDict(kwvalues, kw)
 #else


### PR DESCRIPTION
According to the standard pointer arithmetic is only defined in these situations:
- `nullptr` ± 0 => `nullptr`
- P±N and N±P are pointers that point at an element of the same array with index I±N

`**nullptr**`** + N≠0 is undefined behavior** - even if you don't dereference the resulting pointer.

Since [InstCombine] icmp eq/ne (gep inbounds P, Idx..), null -> icmp eq/ne P, null) https://reviews.llvm.org/D66608 LLVM middle-end uses those guarantees for transformations and mis-compilations have been observed:
- https://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20190826/687838.html
- https://github.com/google/filament/pull/1566


To prevent help weed out bugs before they lead to future miscompilations a new UBSAN check has been added: `nullptr-with-nonzero-offset`
- [UBSan][clang][compiler-rt] Applying non-zero offset to nullptr is undefined behaviour https://reviews.llvm.org/D67122

This new nullptr-with-nonzero-offset check fails on invocations of this macro. Fix the macro to avoid adding to NULL.