### PR TITLE
Force EncodedString on dataclass types

### DIFF
--- a/Cython/Compiler/Dataclass.py
+++ b/Cython/Compiler/Dataclass.py
@@ -590,7 +590,7 @@ def get_field_type(pos, entry):
         # try to return PyType_Type. This case should only happen with
         # attributes defined with cdef so Cython is free to make it's own
         # decision
-        s = entry.type.declaration_code("", for_display=1)
+        s = EncodedString(entry.type.declaration_code("", for_display=1))
         return ExprNodes.StringNode(pos, value=s)
 
 

--- a/tests/run/cdef_class_dataclass.pyx
+++ b/tests/run/cdef_class_dataclass.pyx
@@ -197,12 +197,20 @@ cdef class TestVisibility:
     'double'
     >>> hasattr(inst, "c")
     True
+    >>> "d" in TestVisibility.__dataclass_fields__
+    True
+    >>> TestVisibility.__dataclass_fields__["d"].type
+    'object'
+    >>> hasattr(inst, "d")
+    True
     """
     cdef double a
     a = 1.0
     b: double = 2.0
     cdef public double c
     c = 3.0
+    cdef public object d
+    d = object()
 
 @dataclass(frozen=True)
 cdef class TestFrozen:


### PR DESCRIPTION
Fixes #4704

PyrexTypes.declaration_code is kind of inconsistent about whether
it returns an encoded string or not. Therefore this is probably
a lazy fix (of applying EncodedString anyway rather than making
the interface consistent).