### PR TITLE
 Disable CYTHON_FAST_PYCALL on Py3.10 (0.29.x) 

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -192,7 +192,8 @@
   #ifndef CYTHON_FAST_PYCALL
     // Python 3.11 deleted localplus argument from frame object, which is used in our
     // fast_pycall code
-    #define CYTHON_FAST_PYCALL (PY_VERSION_HEX < 0x030B00A1)
+    // On Python 3.10 it causes issues when used while profiling/debugging
+    #define CYTHON_FAST_PYCALL (PY_VERSION_HEX < 0x030A0000)
   #endif
   #ifndef CYTHON_PEP489_MULTI_PHASE_INIT
     #define CYTHON_PEP489_MULTI_PHASE_INIT (PY_VERSION_HEX >= 0x03050000)

--- a/tests/run/call_trace_gh4609.srctree
+++ b/tests/run/call_trace_gh4609.srctree
@@ -1,0 +1,44 @@
+PYTHON setup.py build_ext -i
+PYTHON run.py
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(
+  ext_modules = cythonize("*.pyx"),
+)
+
+####### call_func.pyx ##########
+
+import mod
+
+def cy_method(x):
+    return mod.function(x)
+    
+####### mod.py #################
+
+mod_global = "this is a mod global"
+
+def function(a, mod_global=None):
+    if mod_global is not None:
+        mod_global = a
+    
+    return
+    
+####### run.py #################
+
+from call_func import cy_method
+import mod
+import sys
+
+def trace(frame, event, arg):
+    assert(mod.mod_global == "this is a mod global")
+
+    return trace
+    
+sys.settrace(trace)
+
+cy_method("s")
+assert(mod.mod_global == "this is a mod global")


### PR DESCRIPTION
It causes issues while profiling or debugging where global
variables can end up inadvertently changed.

Test largely copied from @seberg's reproducer

Fixes https://github.com/cython/cython/issues/4609