### PR TITLE
Fix 3564 in 0.29

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2407,8 +2407,8 @@ class CCodeWriter(object):
                 UtilityCode.load_cached("ForceInitThreads", "ModuleSetupCode.c"))
         self.putln('__Pyx_RefNannySetupContext("%s", %d);' % (name, acquire_gil and 1 or 0))
 
-    def put_finish_refcount_context(self):
-        self.putln("__Pyx_RefNannyFinishContext();")
+    def put_finish_refcount_context(self, nogil=False):
+        self.putln("__Pyx_RefNannyFinishContextNogil()" if nogil else "__Pyx_RefNannyFinishContext();")
 
     def put_add_traceback(self, qualified_name, include_cline=True):
         """

--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -916,6 +916,26 @@ class ControlFlowAnalysis(CythonTransform):
             self.flow.block = None
         return node
 
+    def visit_AssertStatNode(self, node):
+        """Essentially an if-condition that wraps a RaiseStatNode.
+        """
+        self.mark_position(node)
+        next_block = self.flow.newblock()
+        parent = self.flow.block
+        # failure case
+        parent = self.flow.nextblock(parent)
+        self._visit(node.condition)
+        self.flow.nextblock()
+        self._visit(node.exception)
+        if self.flow.block:
+            self.flow.block.add_child(next_block)
+        parent.add_child(next_block)
+        if next_block.parents:
+            self.flow.block = next_block
+        else:
+            self.flow.block = None
+        return node
+
     def visit_WhileStatNode(self, node):
         condition_block = self.flow.nextblock()
         next_block = self.flow.newblock()

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1862,10 +1862,12 @@ class FuncDefNode(StatNode, BlockNode):
 
         use_refnanny = not lenv.nogil or lenv.has_with_gil_block
 
-        gilstate_decl = code.insertion_point()
+        gilstate_decl = None
         if acquire_gil or acquire_gil_for_var_decls_only:
             code.put_ensure_gil()
             code.funcstate.gil_owned = True
+        else:
+            gilstate_decl = code.insertion_point()
 
         if profile or linetrace:
             if not self.is_generator:
@@ -1991,7 +1993,7 @@ class FuncDefNode(StatNode, BlockNode):
         gil_owned = {
             'success': code.funcstate.gil_owned,
             'error': code.funcstate.gil_owned,
-            'gil_state_declared': False,
+            'gil_state_declared': gilstate_decl is None,
         }
         def assure_gil(code_path):
             if not gil_owned[code_path]:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1862,11 +1862,10 @@ class FuncDefNode(StatNode, BlockNode):
 
         use_refnanny = not lenv.nogil or lenv.has_with_gil_block
 
+        gilstate_decl = code.insertion_point()
         if acquire_gil or acquire_gil_for_var_decls_only:
             code.put_ensure_gil()
             code.funcstate.gil_owned = True
-        elif lenv.nogil and lenv.has_with_gil_block:
-            code.declare_gilstate()
 
         if profile or linetrace:
             if not self.is_generator:
@@ -1989,6 +1988,19 @@ class FuncDefNode(StatNode, BlockNode):
         code.putln("")
         code.putln("/* function exit code */")
 
+        gil_owned = {
+            'success': code.funcstate.gil_owned,
+            'error': code.funcstate.gil_owned,
+            'gil_state_declared': False,
+        }
+        def assure_gil(code_path):
+            if not gil_owned[code_path]:
+                if not gil_owned['gil_state_declared']:
+                    gilstate_decl.declare_gilstate()
+                    gil_owned['gil_state_declared'] = True
+                code.put_ensure_gil(declare_gilstate=False)
+                gil_owned[code_path] = True
+
         # ----- Default return value
         if not self.body.is_terminator:
             if self.return_type.is_pyobject:
@@ -1996,8 +2008,10 @@ class FuncDefNode(StatNode, BlockNode):
                 #    lhs = "(PyObject *)%s" % Naming.retval_cname
                 #else:
                 lhs = Naming.retval_cname
+                assure_gil('success')
                 code.put_init_to_py_none(lhs, self.return_type)
-            else:
+            elif not self.return_type.is_memoryviewslice:
+                # memory view structs receive their default value on initialisation
                 val = self.return_type.default_value
                 if val:
                     code.putln("%s = %s;" % (Naming.retval_cname, val))
@@ -2019,6 +2033,7 @@ class FuncDefNode(StatNode, BlockNode):
                 code.globalstate.use_utility_code(restore_exception_utility_code)
                 code.putln("{ PyObject *__pyx_type, *__pyx_value, *__pyx_tb;")
                 code.putln("__Pyx_PyThreadState_declare")
+                assure_gil('error')
                 code.putln("__Pyx_PyThreadState_assign")
                 code.putln("__Pyx_ErrFetch(&__pyx_type, &__pyx_value, &__pyx_tb);")
                 for entry in used_buffer_entries:
@@ -2038,20 +2053,14 @@ class FuncDefNode(StatNode, BlockNode):
                 # code.globalstate.use_utility_code(get_exception_tuple_utility_code)
                 # code.put_trace_exception()
 
-                if lenv.nogil and not lenv.has_with_gil_block:
-                    code.putln("{")
-                    code.put_ensure_gil()
-
+                assure_gil('error')
                 code.put_add_traceback(self.entry.qualified_name)
-
-                if lenv.nogil and not lenv.has_with_gil_block:
-                    code.put_release_ensured_gil()
-                    code.putln("}")
             else:
                 warning(self.entry.pos,
                         "Unraisable exception in function '%s'." %
                         self.entry.qualified_name, 0)
-                code.put_unraisable(self.entry.qualified_name, lenv.nogil)
+                assure_gil('error')
+                code.put_unraisable(self.entry.qualified_name)
             default_retval = self.return_type.default_value
             if err_val is None and default_retval:
                 err_val = default_retval
@@ -2062,19 +2071,33 @@ class FuncDefNode(StatNode, BlockNode):
                 code.putln("__Pyx_pretend_to_initialize(&%s);" % Naming.retval_cname)
 
             if is_getbuffer_slot:
+                assure_gil('error')
                 self.getbuffer_error_cleanup(code)
 
             # If we are using the non-error cleanup section we should
             # jump past it if we have an error. The if-test below determine
             # whether this section is used.
             if buffers_present or is_getbuffer_slot or self.return_type.is_memoryviewslice:
+                # In the buffer cases, we already called assure_gil('error') and own the GIL.
+                assert gil_owned['error'] or self.return_type.is_memoryviewslice
                 code.put_goto(code.return_from_error_cleanup_label)
+            else:
+                # align error and success GIL state
+                if gil_owned['success']:
+                    assure_gil('error')
+                elif gil_owned['error']:
+                    code.put_release_ensured_gil()
+                    gil_owned['error'] = False
 
         # ----- Non-error return cleanup
         code.put_label(code.return_label)
+        assert gil_owned['error'] == gil_owned['success'], "%s != %s" % (gil_owned['error'], gil_owned['success'])
+
         for entry in used_buffer_entries:
+            assure_gil('success')
             Buffer.put_release_buffer_code(code, entry)
         if is_getbuffer_slot:
+            assure_gil('success')
             self.getbuffer_normal_cleanup(code)
 
         if self.return_type.is_memoryviewslice:
@@ -2084,17 +2107,22 @@ class FuncDefNode(StatNode, BlockNode):
             cond = code.unlikely(self.return_type.error_condition(Naming.retval_cname))
             code.putln(
                 'if (%s) {' % cond)
-            if env.nogil:
+            if not gil_owned['success']:
                 code.put_ensure_gil()
             code.putln(
                 'PyErr_SetString(PyExc_TypeError, "Memoryview return value is not initialized");')
-            if env.nogil:
+            if not gil_owned['success']:
                 code.put_release_ensured_gil()
             code.putln(
                 '}')
 
         # ----- Return cleanup for both error and no-error return
-        code.put_label(code.return_from_error_cleanup_label)
+        if code.label_used(code.return_from_error_cleanup_label):
+            # If we came through the success path, then we took the same GIL decisions as for jumping here.
+            # If we came through the error path and did not jump, then we aligned both paths above.
+            # In the end, all paths are aligned from this point on.
+            assert gil_owned['error'] == gil_owned['success'], "%s != %s" % (gil_owned['error'], gil_owned['success'])
+            code.put_label(code.return_from_error_cleanup_label)
 
         for entry in lenv.var_entries:
             if not entry.used or entry.in_closure:
@@ -2121,6 +2149,7 @@ class FuncDefNode(StatNode, BlockNode):
                 code.put_xdecref_memoryviewslice(entry.cname,
                                                  have_gil=not lenv.nogil)
         if self.needs_closure:
+            assure_gil('success')
             code.put_decref(Naming.cur_scope_cname, lenv.scope_class.type)
 
         # ----- Return
@@ -2136,6 +2165,7 @@ class FuncDefNode(StatNode, BlockNode):
         if self.entry.is_special and self.entry.name == "__hash__":
             # Returning -1 for __hash__ is supposed to signal an error
             # We do as Python instances and coerce -1 into -2.
+            assure_gil('success')
             code.putln("if (unlikely(%s == -1) && !PyErr_Occurred()) %s = -2;" % (
                 Naming.retval_cname, Naming.retval_cname))
 
@@ -2145,16 +2175,16 @@ class FuncDefNode(StatNode, BlockNode):
                 # generators are traced when iterated, not at creation
                 if self.return_type.is_pyobject:
                     code.put_trace_return(
-                        Naming.retval_cname, nogil=not code.funcstate.gil_owned)
+                        Naming.retval_cname, nogil=not gil_owned['success'])
                 else:
                     code.put_trace_return(
-                        "Py_None", nogil=not code.funcstate.gil_owned)
+                        "Py_None", nogil=not gil_owned['success'])
 
         if not lenv.nogil:
             # GIL holding function
-            code.put_finish_refcount_context()
+            code.put_finish_refcount_context(nogil=not gil_owned['success'])
 
-        if acquire_gil or (lenv.nogil and lenv.has_with_gil_block):
+        if acquire_gil or (lenv.nogil and gil_owned['success']):
             # release the GIL (note that with-gil blocks acquire it on exit in their EnsureGILNode)
             code.put_release_ensured_gil()
             code.funcstate.gil_owned = False

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6218,6 +6218,7 @@ class ReraiseStatNode(StatNode):
                 UtilityCode.load_cached("ReRaiseException", "Exceptions.c"))
             code.putln("__Pyx_ReraiseException(); %s" % code.error_goto(self.pos))
 
+
 class AssertStatNode(StatNode):
     #  assert statement
     #
@@ -6239,9 +6240,6 @@ class AssertStatNode(StatNode):
                 self.value = value.coerce_to_pyobject(env)
         return self
 
-    nogil_check = Node.gil_error
-    gil_message = "Raising exception"
-
     def generate_execution_code(self, code):
         code.putln("#ifndef CYTHON_WITHOUT_ASSERTIONS")
         code.putln("if (unlikely(!Py_OptimizeFlag)) {")
@@ -6249,6 +6247,11 @@ class AssertStatNode(StatNode):
         self.cond.generate_evaluation_code(code)
         code.putln(
             "if (unlikely(!%s)) {" % self.cond.result())
+        in_nogil = not code.funcstate.gil_owned
+        if in_nogil:
+            # Apparently, evaluating condition and value does not require the GIL,
+            # but raising the exception now does.
+            code.put_ensure_gil()
         if self.value:
             self.value.generate_evaluation_code(code)
             code.putln(
@@ -6258,6 +6261,8 @@ class AssertStatNode(StatNode):
         else:
             code.putln(
                 "PyErr_SetNone(PyExc_AssertionError);")
+        if in_nogil:
+            code.put_release_ensured_gil()
         code.putln(
             code.error_goto(self.pos))
         code.putln(

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1859,19 +1859,6 @@ if VALUE is not None:
 
         return node
 
-    def _handle_nogil_cleanup(self, lenv, node):
-        "Handle cleanup for 'with gil' blocks in nogil functions."
-        if lenv.nogil and lenv.has_with_gil_block:
-            # Acquire the GIL for cleanup in 'nogil' functions, by wrapping
-            # the entire function body in try/finally.
-            # The corresponding release will be taken care of by
-            # Nodes.FuncDefNode.generate_function_definitions()
-            node.body = Nodes.NogilTryFinallyStatNode(
-                node.body.pos,
-                body=node.body,
-                finally_clause=Nodes.EnsureGILNode(node.body.pos),
-                finally_except_clause=Nodes.EnsureGILNode(node.body.pos))
-
     def _handle_fused(self, node):
         if node.is_generator and node.has_fused_arguments:
             node.has_fused_arguments = False
@@ -1912,7 +1899,6 @@ if VALUE is not None:
             node = self._create_fused_function(env, node)
         else:
             node.body.analyse_declarations(lenv)
-            self._handle_nogil_cleanup(lenv, node)
             self._super_visit_FuncDefNode(node)
 
         self.seen_vars_stack.pop()

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1832,7 +1832,7 @@ def p_assert_statement(s):
         value = p_test(s)
     else:
         value = None
-    return Nodes.AssertStatNode(pos, cond = cond, value = value)
+    return Nodes.AssertStatNode(pos, condition=cond, value=value)
 
 
 statement_terminators = cython.declare(set, set([';', 'NEWLINE', 'EOF']))

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1284,6 +1284,11 @@ static CYTHON_INLINE int __Pyx_Is_Little_Endian(void)
   #define __Pyx_RefNannySetupContext(name, acquire_gil) \
           __pyx_refnanny = __Pyx_RefNanny->SetupContext((name), __LINE__, __FILE__)
 #endif
+  #define __Pyx_RefNannyFinishContextNogil() { \
+              PyGILState_STATE __pyx_gilstate_save = PyGILState_Ensure(); \
+              __Pyx_RefNannyFinishContext(); \
+              PyGILState_Release(__pyx_gilstate_save); \
+          }
   #define __Pyx_RefNannyFinishContext() \
           __Pyx_RefNanny->FinishContext(&__pyx_refnanny)
   #define __Pyx_INCREF(r)  __Pyx_RefNanny->INCREF(__pyx_refnanny, (PyObject *)(r), __LINE__)
@@ -1297,6 +1302,7 @@ static CYTHON_INLINE int __Pyx_Is_Little_Endian(void)
 #else
   #define __Pyx_RefNannyDeclarations
   #define __Pyx_RefNannySetupContext(name, acquire_gil)
+  #define __Pyx_RefNannyFinishContextNogil()
   #define __Pyx_RefNannyFinishContext()
   #define __Pyx_INCREF(r) Py_INCREF(r)
   #define __Pyx_DECREF(r) Py_DECREF(r)

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -549,13 +549,17 @@ You can release the GIL around a section of code using the
     with nogil:
         <code to be executed with the GIL released>
 
-Code in the body of the with-statement must not raise exceptions or
-manipulate Python objects in any way, and must not call anything that
-manipulates Python objects without first re-acquiring the GIL.  Cython
-validates these operations at compile time, but cannot look into
-external C functions, for example.  They must be correctly declared
-as requiring or not requiring the GIL (see below) in order to make
+Code in the body of the with-statement must not manipulate Python objects
+in any way, and must not call anything that manipulates Python objects without
+first re-acquiring the GIL.  Cython validates these operations at compile time,
+but cannot look into external C functions, for example.  They must be correctly
+declared as requiring or not requiring the GIL (see below) in order to make
 Cython's checks effective.
+
+Since Cython 3.0, some simple Python statements can be used inside of ``nogil``
+sections: ``raise``, ``assert`` and ``print`` (the Py2 statement, not the function).
+Since they tend to be lone Python statements, Cython will automatically acquire
+and release the GIL around them for convenience.
 
 .. _gil:
 

--- a/tests/errors/e_assert.pyx
+++ b/tests/errors/e_assert.pyx
@@ -1,0 +1,25 @@
+# mode: error
+# tag: assert
+
+def nontrivial_assert_in_nogil(int a, obj):
+    with nogil:
+        # NOK
+        assert obj
+        assert a*obj
+        assert a, f"123{a}xyz"
+
+        # OK
+        assert a
+        assert a*a
+        assert a, "abc"
+        assert a, u"abc"
+
+
+_ERRORS = """
+7:15: Truth-testing Python object not allowed without gil
+8:15: Converting to Python object not allowed without gil
+8:16: Operation not allowed without gil
+8:16: Truth-testing Python object not allowed without gil
+9:18: String concatenation not allowed without gil
+9:18: String formatting not allowed without gil
+"""

--- a/tests/errors/e_assert.pyx
+++ b/tests/errors/e_assert.pyx
@@ -6,13 +6,14 @@ def nontrivial_assert_in_nogil(int a, obj):
         # NOK
         assert obj
         assert a*obj
-        assert a, f"123{a}xyz"
+        assert obj, "abc"
 
         # OK
         assert a
         assert a*a
         assert a, "abc"
         assert a, u"abc"
+        assert a, f"123{a}xyz"
 
 
 _ERRORS = """
@@ -20,6 +21,5 @@ _ERRORS = """
 8:15: Converting to Python object not allowed without gil
 8:16: Operation not allowed without gil
 8:16: Truth-testing Python object not allowed without gil
-9:18: String concatenation not allowed without gil
-9:18: String formatting not allowed without gil
+9:15: Truth-testing Python object not allowed without gil
 """

--- a/tests/errors/nogil.pyx
+++ b/tests/errors/nogil.pyx
@@ -52,7 +52,7 @@ cdef object m():
         x, y = y, x
         obj[i] = x
         obj.fred = x
-        print obj
+        print obj  # allowed!
         del fred
         return obj
         raise obj  # allowed!
@@ -151,10 +151,10 @@ _ERRORS = u"""
 53:11: Indexing Python object not allowed without gil
 54:11: Accessing Python attribute not allowed without gil
 54:11: Assignment of Python object not allowed without gil
-55:8: Constructing Python tuple not allowed without gil
-55:8: Python print statement not allowed without gil
+
 56:8: Deleting Python object not allowed without gil
 57:8: Returning Python object not allowed without gil
+
 59:11: Truth-testing Python object not allowed without gil
 61:14: Truth-testing Python object not allowed without gil
 63:8: For-loop using object bounds or target not allowed without gil

--- a/tests/run/assert.pyx
+++ b/tests/run/assert.pyx
@@ -2,6 +2,10 @@
 
 cimport cython
 
+@cython.test_assert_path_exists(
+    '//AssertStatNode',
+    '//AssertStatNode//RaiseStatNode',
+)
 def f(a, b, int i):
     """
     >>> f(1, 2, 1)
@@ -22,7 +26,9 @@ def f(a, b, int i):
 
 @cython.test_assert_path_exists(
     '//AssertStatNode',
-    '//AssertStatNode//TupleNode')
+    '//AssertStatNode//RaiseStatNode',
+    '//AssertStatNode//RaiseStatNode//TupleNode',
+)
 def g(a, b):
     """
     >>> g(1, "works")
@@ -38,7 +44,9 @@ def g(a, b):
 
 @cython.test_assert_path_exists(
     '//AssertStatNode',
-    '//AssertStatNode//TupleNode')
+    '//AssertStatNode//RaiseStatNode',
+    '//AssertStatNode//RaiseStatNode//TupleNode',
+)
 def g(a, b):
     """
     >>> g(1, "works")
@@ -54,8 +62,9 @@ def g(a, b):
 
 @cython.test_assert_path_exists(
     '//AssertStatNode',
-    '//AssertStatNode//TupleNode',
-    '//AssertStatNode//TupleNode//TupleNode')
+    '//AssertStatNode//RaiseStatNode',
+    '//AssertStatNode//RaiseStatNode//TupleNode',
+    '//AssertStatNode//RaiseStatNode//TupleNode//TupleNode',)
 def assert_with_tuple_arg(a):
     """
     >>> assert_with_tuple_arg(True)
@@ -67,9 +76,12 @@ def assert_with_tuple_arg(a):
 
 
 @cython.test_assert_path_exists(
-    '//AssertStatNode')
+    '//AssertStatNode',
+    '//AssertStatNode//RaiseStatNode',
+)
 @cython.test_fail_if_path_exists(
-    '//AssertStatNode//TupleNode')
+    '//AssertStatNode//TupleNode',
+)
 def assert_with_str_arg(a):
     """
     >>> assert_with_str_arg(True)

--- a/tests/run/with_gil_automatic.pyx
+++ b/tests/run/with_gil_automatic.pyx
@@ -5,6 +5,8 @@
 cimport cython
 
 
+#### print
+
 @cython.test_assert_path_exists(
     "//GILStatNode",
     "//GILStatNode//GILStatNode",
@@ -23,6 +25,9 @@ def test_print_in_nogil_section(x):
     "//GILStatNode",
     "//GILStatNode//PrintStatNode",
 )
+@cython.test_fail_if_path_exists(
+    "//GILStatNode//GILStatNode",
+)
 cpdef int test_print_in_nogil_func(x) nogil except -1:
     """
     >>> _ = test_print_in_nogil_func(123)
@@ -30,6 +35,8 @@ cpdef int test_print_in_nogil_func(x) nogil except -1:
     """
     print f"--{x}--"
 
+
+#### raise
 
 @cython.test_assert_path_exists(
     "//GILStatNode",
@@ -51,11 +58,82 @@ def test_raise_in_nogil_section(x):
     "//GILStatNode",
     "//GILStatNode//RaiseStatNode",
 )
+@cython.test_fail_if_path_exists(
+    "//GILStatNode//GILStatNode",
+)
 cpdef int test_raise_in_nogil_func(x) nogil except -1:
     """
-    >>> try: test_raise_in_nogil_func(123)
-    ... except ValueError as exc: print(exc)
-    ... else: print("NOT RAISED !")
-    --123--
+    >>> test_raise_in_nogil_func(123)
+    Traceback (most recent call last):
+    ValueError: --123--
     """
     raise ValueError(f"--{x}--")
+
+
+#### assert
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//AssertStatNode",
+)
+@cython.test_fail_if_path_exists(
+    "//GILStatNode//GILStatNode",
+)
+def assert_in_nogil_section(int x):
+    """
+    >>> assert_in_nogil_section(123)
+    >>> assert_in_nogil_section(0)
+    Traceback (most recent call last):
+    AssertionError
+    """
+    with nogil:
+        assert x
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//AssertStatNode",
+)
+@cython.test_fail_if_path_exists(
+    "//GILStatNode//GILStatNode",
+)
+def assert_in_nogil_section_ustring(int x):
+    """
+    >>> assert_in_nogil_section_string(123)
+    >>> assert_in_nogil_section_string(0)
+    Traceback (most recent call last):
+    AssertionError: failed!
+    """
+    with nogil:
+        assert x, u"failed!"
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//AssertStatNode",
+)
+@cython.test_fail_if_path_exists(
+    "//GILStatNode//GILStatNode",
+)
+def assert_in_nogil_section_string(int x):
+    """
+    >>> assert_in_nogil_section_string(123)
+    >>> assert_in_nogil_section_string(0)
+    Traceback (most recent call last):
+    AssertionError: failed!
+    """
+    with nogil:
+        assert x, "failed!"
+
+
+@cython.test_fail_if_path_exists(
+    "//GILStatNode",
+)
+cpdef int assert_in_nogil_func(int x) nogil except -1:
+    """
+    >>> _ = assert_in_nogil_func(123)
+    >>> assert_in_nogil_func(0)
+    Traceback (most recent call last):
+    AssertionError: failed!
+    """
+    assert x, "failed!"

--- a/tests/run/with_gil_automatic.pyx
+++ b/tests/run/with_gil_automatic.pyx
@@ -75,9 +75,8 @@ cpdef int test_raise_in_nogil_func(x) nogil except -1:
 @cython.test_assert_path_exists(
     "//GILStatNode",
     "//GILStatNode//AssertStatNode",
-)
-@cython.test_fail_if_path_exists(
-    "//GILStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode//RaiseStatNode",
 )
 def assert_in_nogil_section(int x):
     """
@@ -93,9 +92,8 @@ def assert_in_nogil_section(int x):
 @cython.test_assert_path_exists(
     "//GILStatNode",
     "//GILStatNode//AssertStatNode",
-)
-@cython.test_fail_if_path_exists(
-    "//GILStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode//RaiseStatNode",
 )
 def assert_in_nogil_section_ustring(int x):
     """
@@ -111,9 +109,8 @@ def assert_in_nogil_section_ustring(int x):
 @cython.test_assert_path_exists(
     "//GILStatNode",
     "//GILStatNode//AssertStatNode",
-)
-@cython.test_fail_if_path_exists(
-    "//GILStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode",
+    "//GILStatNode//AssertStatNode//GILStatNode//RaiseStatNode",
 )
 def assert_in_nogil_section_string(int x):
     """
@@ -126,8 +123,10 @@ def assert_in_nogil_section_string(int x):
         assert x, "failed!"
 
 
-@cython.test_fail_if_path_exists(
-    "//GILStatNode",
+@cython.test_assert_path_exists(
+    "//AssertStatNode",
+    "//AssertStatNode//GILStatNode",
+    "//AssertStatNode//GILStatNode//RaiseStatNode",
 )
 cpdef int assert_in_nogil_func(int x) nogil except -1:
     """

--- a/tests/run/with_gil_automatic.pyx
+++ b/tests/run/with_gil_automatic.pyx
@@ -1,0 +1,35 @@
+# mode: run
+# tag: nogil
+# cython: language_level=2
+
+cimport cython
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//GILStatNode",
+    "//GILStatNode//GILStatNode//PrintStatNode",
+)
+def test_print_in_nogil(x):
+    """
+    >>> test_print_in_nogil(123)
+    --123--
+    """
+    with nogil:
+        print f"--{x}--"
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//GILStatNode",
+    "//GILStatNode//GILStatNode//RaiseStatNode",
+)
+def test_raise_in_nogil(x):
+    """
+    >>> try: test_raise_in_nogil(123)
+    ... except ValueError as exc: print(exc)
+    ... else: print("NOT RAISED !")
+    --123--
+    """
+    with nogil:
+        raise ValueError(f"--{x}--")

--- a/tests/run/with_gil_automatic.pyx
+++ b/tests/run/with_gil_automatic.pyx
@@ -10,9 +10,9 @@ cimport cython
     "//GILStatNode//GILStatNode",
     "//GILStatNode//GILStatNode//PrintStatNode",
 )
-def test_print_in_nogil(x):
+def test_print_in_nogil_section(x):
     """
-    >>> test_print_in_nogil(123)
+    >>> test_print_in_nogil_section(123)
     --123--
     """
     with nogil:
@@ -21,15 +21,41 @@ def test_print_in_nogil(x):
 
 @cython.test_assert_path_exists(
     "//GILStatNode",
+    "//GILStatNode//PrintStatNode",
+)
+cpdef int test_print_in_nogil_func(x) nogil except -1:
+    """
+    >>> _ = test_print_in_nogil_func(123)
+    --123--
+    """
+    print f"--{x}--"
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
     "//GILStatNode//GILStatNode",
     "//GILStatNode//GILStatNode//RaiseStatNode",
 )
-def test_raise_in_nogil(x):
+def test_raise_in_nogil_section(x):
     """
-    >>> try: test_raise_in_nogil(123)
+    >>> try: test_raise_in_nogil_section(123)
     ... except ValueError as exc: print(exc)
     ... else: print("NOT RAISED !")
     --123--
     """
     with nogil:
         raise ValueError(f"--{x}--")
+
+
+@cython.test_assert_path_exists(
+    "//GILStatNode",
+    "//GILStatNode//RaiseStatNode",
+)
+cpdef int test_raise_in_nogil_func(x) nogil except -1:
+    """
+    >>> try: test_raise_in_nogil_func(123)
+    ... except ValueError as exc: print(exc)
+    ... else: print("NOT RAISED !")
+    --123--
+    """
+    raise ValueError(f"--{x}--")


### PR DESCRIPTION
Closes #4637.

This is repeat of reverted incomplete change proposed in #4703 

This change set was obtained using 
```
git checkout 0.29.x
git cherry-pick 7d99b0f085bb254e9a9b4a9fe50aefe133837a81 c6cf09ee6 01085d2ad588bf41e2d17cff6aa96d0507087ce3  792d80bad 97e1b9641
```

and conflicts in `Cython/Compiler/Nodes.py` manually resolved.

#4703 only contained the first commit there. 

I checked that scikit-image could be built with this change-set.

Locally run tests reports 3 errors:

```
ERROR: runTest (__main__.CythonUnitTestCase)
[-1] compiling (c) tests in test_grammar

ERROR: runTest (__main__.CythonUnitTestCase)
[-1] compiling (cpp) tests in test_grammar

ERROR: test_embed (__main__.EmbedTest)
```

I do not think these are related to the changes, and are likely caused by not setting some environment variables. 

Tests were run using `PYTHONPATH=$(pwd):$PYTHONPATH python runtests.py`.
