### PR TITLE
Add mt19937 random number generator to libcpp.

### DIFF
--- a/Cython/Includes/libcpp/random.pxd
+++ b/Cython/Includes/libcpp/random.pxd
@@ -1,0 +1,14 @@
+from libc.stdint cimport uint_fast32_t
+
+
+cdef extern from "<random>" namespace "std" nogil:
+    cdef cppclass mt19937:
+        ctypedef uint_fast32_t result_type
+
+        mt19937() except +
+        mt19937(result_type seed) except +
+        result_type operator()() except +
+        result_type min() except +
+        result_type max() except +
+        void discard(size_t z) except +
+        void seed(result_type seed) except +

--- a/tests/run/cpp_stl_random.pyx
+++ b/tests/run/cpp_stl_random.pyx
@@ -6,7 +6,7 @@ from libcpp.random cimport mt19937
 
 def mt19937_seed_test():
     """
-    >>> mt19937_seed_test()
+    >>> print(mt19937_seed_test())
     1608637542
     """
     cdef mt19937 rd = mt19937(42)
@@ -15,7 +15,7 @@ def mt19937_seed_test():
 
 def mt19937_reseed_test():
     """
-    >>> mt19937_reseed_test()
+    >>> print(mt19937_reseed_test())
     1608637542
     """
     cdef mt19937 rd
@@ -25,9 +25,11 @@ def mt19937_reseed_test():
 
 def mt19937_min_max():
     """
-    The minimum is zero and the maximum is 2 ** 32 - 1 because mt19937 is 32 bit.
-    >>> mt19937_min_max()
-    (0, 4294967295)
+    >>> x, y = mt19937_min_max()
+    >>> print(x)
+    0
+    >>> print(y)  # 2 ** 32 - 1 because mt19937 is 32 bit.
+    4294967295
     """
     cdef mt19937 rd
     return rd.min(), rd.max()
@@ -35,8 +37,11 @@ def mt19937_min_max():
 
 def mt19937_discard(z):
     """
-    >>> mt19937_discard(13)
-    (1972458954, 1972458954)
+    >>> x, y = mt19937_discard(13)
+    >>> print(x)
+    1972458954
+    >>> print(y)
+    1972458954
     """
     cdef mt19937 rd = mt19937(42)
     # Throw away z random numbers.

--- a/tests/run/cpp_stl_random.pyx
+++ b/tests/run/cpp_stl_random.pyx
@@ -1,0 +1,51 @@
+# mode: run
+# tag: cpp, cpp11
+
+from libcpp.random cimport mt19937
+
+
+def mt19937_seed_test():
+    """
+    >>> mt19937_seed_test()
+    1608637542
+    """
+    cdef mt19937 rd = mt19937(42)
+    return rd()
+
+
+def mt19937_reseed_test():
+    """
+    >>> mt19937_reseed_test()
+    1608637542
+    """
+    cdef mt19937 rd
+    rd.seed(42)
+    return rd()
+
+
+def mt19937_min_max():
+    """
+    The minimum is zero and the maximum is 2 ** 32 - 1 because mt19937 is 32 bit.
+    >>> mt19937_min_max()
+    (0, 4294967295)
+    """
+    cdef mt19937 rd
+    return rd.min(), rd.max()
+
+
+def mt19937_discard():
+    """
+    >>> mt19937_discard()
+    (1972458954, 1972458954)
+    """
+    cdef mt19937 rd = mt19937(42)
+    # Throw away z random numbers.
+    z = 13
+    rd.discard(z)
+    a = rd()
+
+    # Iterate over z random numbers.
+    rd.seed(42)
+    for _ in range(z + 1):
+        b = rd()
+    return a, b

--- a/tests/run/cpp_stl_random.pyx
+++ b/tests/run/cpp_stl_random.pyx
@@ -33,14 +33,13 @@ def mt19937_min_max():
     return rd.min(), rd.max()
 
 
-def mt19937_discard():
+def mt19937_discard(z):
     """
-    >>> mt19937_discard()
+    >>> mt19937_discard(13)
     (1972458954, 1972458954)
     """
     cdef mt19937 rd = mt19937(42)
     # Throw away z random numbers.
-    z = 13
     rd.discard(z)
     a = rd()
 


### PR DESCRIPTION
This PR adds the [`mt19937`](https://www.cplusplus.com/reference/random/mt19937/) random number generator to `libcpp`.