### PR TITLE
move c++11 specific tests into separate files

### DIFF
--- a/tests/run/cpp_stl_list.pyx
+++ b/tests/run/cpp_stl_list.pyx
@@ -61,26 +61,6 @@ def iteration_test(L):
     finally:
         del l
 
-def const_iteration_test(L):
-    """
-    >>> const_iteration_test([1,2,4,8])
-    1
-    2
-    4
-    8
-    """
-    l = new cpp_list[int]()
-    try:
-        for a in L:
-            l.push_back(a)
-        it = l.cbegin()
-        while it != l.cend():
-            a = deref(it)
-            incr(it)
-            print(a)
-    finally:
-        del l
-
 def reverse_iteration_test(L):
     """
     >>> reverse_iteration_test([1,2,4,8])
@@ -126,14 +106,6 @@ cdef list to_pylist(cpp_list[int]& l):
         incr(it)
     return L
 
-cdef list const_to_pylist(cpp_list[int]& l):
-    cdef list L = []
-    it = l.cbegin()
-    while it != l.cend():
-        L.append(deref(it))
-        incr(it)
-    return L
-
 def item_ptr_test(L, int x):
     """
     >>> item_ptr_test(range(10), 100)
@@ -143,16 +115,6 @@ def item_ptr_test(L, int x):
     cdef int* li_ptr = &l.front()
     li_ptr[0] = x
     return to_pylist(l)
-
-def const_item_ptr_test(L, int x):
-    """
-    >>> item_ptr_test(range(10), 100)
-    [100, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    """
-    cdef cpp_list[int] l = L
-    cdef int* li_ptr = &l.front()
-    li_ptr[0] = x
-    return const_to_pylist(l)
 
 def test_value_type(x):
     """

--- a/tests/run/cpp_stl_list_cpp11.pyx
+++ b/tests/run/cpp_stl_list_cpp11.pyx
@@ -1,0 +1,45 @@
+# mode: run
+# tag: cpp, werror, no-cpp-locals, cpp11
+
+from cython.operator cimport dereference as deref
+from cython.operator cimport preincrement as incr
+
+from libcpp.list cimport list as cpp_list
+
+def const_iteration_test(L):
+    """
+    >>> const_iteration_test([1,2,4,8])
+    1
+    2
+    4
+    8
+    """
+    l = new cpp_list[int]()
+    try:
+        for a in L:
+            l.push_back(a)
+        it = l.cbegin()
+        while it != l.cend():
+            a = deref(it)
+            incr(it)
+            print(a)
+    finally:
+        del l
+
+cdef list const_to_pylist(cpp_list[int]& l):
+    cdef list L = []
+    it = l.cbegin()
+    while it != l.cend():
+        L.append(deref(it))
+        incr(it)
+    return L
+
+def const_item_ptr_test(L, int x):
+    """
+    >>> const_item_ptr_test(range(10), 100)
+    [100, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    """
+    cdef cpp_list[int] l = L
+    cdef int* li_ptr = &l.front()
+    li_ptr[0] = x
+    return const_to_pylist(l)

--- a/tests/run/cpp_stl_vector.pyx
+++ b/tests/run/cpp_stl_vector.pyx
@@ -92,26 +92,6 @@ def iteration_test(L):
     finally:
         del v
 
-def const_iteration_test(L):
-    """
-    >>> const_iteration_test([1,2,4,8])
-    1
-    2
-    4
-    8
-    """
-    v = new vector[int]()
-    try:
-        for a in L:
-            v.push_back(a)
-        it = v.cbegin()
-        while it != v.cend():
-            a = d(it)
-            incr(it)
-            print(a)
-    finally:
-        del v
-
 def reverse_iteration_test(L):
     """
     >>> reverse_iteration_test([1,2,4,8])

--- a/tests/run/cpp_stl_vector_cpp11.pyx
+++ b/tests/run/cpp_stl_vector_cpp11.pyx
@@ -1,0 +1,27 @@
+# mode: run
+# tag: cpp, werror, no-cpp-locals, cpp11
+
+from cython.operator cimport dereference as d
+from cython.operator cimport preincrement as incr
+
+from libcpp.vector cimport vector
+
+def const_iteration_test(L):
+    """
+    >>> const_iteration_test([1,2,4,8])
+    1
+    2
+    4
+    8
+    """
+    v = new vector[int]()
+    try:
+        for a in L:
+            v.push_back(a)
+        it = v.cbegin()
+        while it != v.cend():
+            a = d(it)
+            incr(it)
+            print(a)
+    finally:
+        del v


### PR DESCRIPTION
@scoder #4530 mistakenly added some C++11 specific tests into the general test files. This moves those tests into separate files.