### PR TITLE
Add STL `sample` for sampling without replacement.

### DIFF
--- a/Cython/Includes/libcpp/algorithm.pxd
+++ b/Cython/Includes/libcpp/algorithm.pxd
@@ -154,6 +154,8 @@ cdef extern from "<algorithm>" namespace "std" nogil:
     OutputIt unique_copy[ExecutionPolicy, InputIt, OutputIt, BinaryPred](
         ExecutionPolicy&& policy, InputIt first, InputIt last, OutputIt d_first, BinaryPred pred) except +
 
+    SampleIt sample[PopulationIt, SampleIt, Distance, URBG](PopulationIt first, PopulationIt last, SampleIt out, Distance n, URBG&& g) except +
+
     # Partitioning operations
     bool is_partitioned[Iter, Pred](Iter first, Iter last, Pred p) except +
     bool is_partitioned[ExecutionPolicy, Iter, Pred](ExecutionPolicy&& policy, Iter first, Iter last, Pred p) except +
@@ -316,5 +318,3 @@ cdef extern from "<algorithm>" namespace "std" nogil:
     bool next_permutation[BidirIt, Compare](BidirIt first, BidirIt last, Compare comp) except +
     bool prev_permutation[BidirIt](BidirIt first, BidirIt last) except +
     bool prev_permutation[BidirIt, Compare](BidirIt first, BidirIt last, Compare comp) except +
-
-

--- a/tests/run/cpp_stl_algo_sample.pyx
+++ b/tests/run/cpp_stl_algo_sample.pyx
@@ -1,0 +1,40 @@
+# mode: run
+# tags: cpp, cpp17
+
+from libcpp.algorithm cimport sample
+from libcpp.iterator cimport back_inserter
+from libcpp.random cimport mt19937
+from libcpp.utility cimport move
+from libcpp.vector cimport vector
+
+
+def sample_multiple(population_size, int sample_size):
+    """
+    >>> sample_multiple(10, 3)
+    [3, 5, 6]
+    >>> sample_multiple(50, 7)
+    [6, 8, 10, 29, 38, 39, 42]
+    """
+    cdef:
+        vector[int] x, y
+        int i
+        mt19937 rd = mt19937(1)
+
+    [x.push_back(i) for i in range(population_size)]
+    sample(x.begin(), x.end(), back_inserter(y), sample_size, move(rd))
+    print(y)
+
+
+def sample_single(population_size):
+    """
+    >>> sample_single(10)
+    5
+    """
+    cdef:
+        vector[int] x
+        int i
+        mt19937 rd = mt19937(1)
+
+    [x.push_back(i) for i in range(population_size)]
+    sample(x.begin(), x.end(), &i, 1, move(rd))
+    print(i)


### PR DESCRIPTION
This PR adds the STL [`sample`](https://en.cppreference.com/w/cpp/algorithm/sample) function to sample without replacement.