### PR TITLE
move from deprecated find_loader to find_spec

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3254,13 +3254,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # packages require __path__, so all we can do is try to figure
             # out the module path at runtime by rerunning the import lookup
             code.putln("if (!CYTHON_PEP489_MULTI_PHASE_INIT) {")
-            module_name = self.full_module_name
             code.globalstate.use_utility_code(UtilityCode.load(
                 "SetPackagePathFromImportLib", "ImportExport.c"))
             code.putln(code.error_goto_if_neg(
                 '__Pyx_SetPackagePathFromImportLib(%s)' % (
                     code.globalstate.get_py_string_const(
-                        EncodedString(module_name)).cname),
+                        self.full_module_name).cname),
                 self.pos))
             code.putln("}")
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3255,8 +3255,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # out the module path at runtime by rerunning the import lookup
             code.putln("if (!CYTHON_PEP489_MULTI_PHASE_INIT) {")
             package_name, _ = self.full_module_name.rsplit('.', 1)
+            module_name = env.module_name
             if '.' in package_name:
                 parent_name = '"%s"' % (package_name.rsplit('.', 1)[0],)
+                module_name = '.' + module_name
             else:
                 parent_name = 'NULL'
             code.globalstate.use_utility_code(UtilityCode.load(
@@ -3265,7 +3267,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 '__Pyx_SetPackagePathFromImportLib(%s, %s)' % (
                     parent_name,
                     code.globalstate.get_py_string_const(
-                        EncodedString(env.module_name)).cname),
+                        EncodedString(module_name)).cname),
                 self.pos))
             code.putln("}")
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3258,7 +3258,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             module_name = env.module_name
             if '.' in package_name:
                 parent_name = '"%s"' % (package_name.rsplit('.', 1)[0],)
-                module_name = '.' + module_name
+                if sys.version_info > (3, 4):
+                    module_name = '.' + module_name
             else:
                 parent_name = 'NULL'
             code.globalstate.use_utility_code(UtilityCode.load(

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3254,18 +3254,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # packages require __path__, so all we can do is try to figure
             # out the module path at runtime by rerunning the import lookup
             code.putln("if (!CYTHON_PEP489_MULTI_PHASE_INIT) {")
-            package_name, _ = self.full_module_name.rsplit('.', 1)
-            module_name = env.module_name
-            if '.' in package_name:
-                parent_name = '"%s"' % (package_name.rsplit('.', 1)[0],)
-                module_name = '.' + module_name
-            else:
-                parent_name = 'NULL'
+            module_name = self.full_module_name
             code.globalstate.use_utility_code(UtilityCode.load(
                 "SetPackagePathFromImportLib", "ImportExport.c"))
             code.putln(code.error_goto_if_neg(
-                '__Pyx_SetPackagePathFromImportLib(%s, %s)' % (
-                    parent_name,
+                '__Pyx_SetPackagePathFromImportLib(%s)' % (
                     code.globalstate.get_py_string_const(
                         EncodedString(module_name)).cname),
                 self.pos))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3258,7 +3258,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             module_name = env.module_name
             if '.' in package_name:
                 parent_name = '"%s"' % (package_name.rsplit('.', 1)[0],)
-                if sys.version_info > (3, 4):
+                if sys.version_info >= (3, 4):
                     module_name = '.' + module_name
             else:
                 parent_name = 'NULL'

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3258,8 +3258,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             module_name = env.module_name
             if '.' in package_name:
                 parent_name = '"%s"' % (package_name.rsplit('.', 1)[0],)
-                if sys.version_info >= (3, 4):
-                    module_name = '.' + module_name
+                module_name = '.' + module_name
             else:
                 parent_name = 'NULL'
             code.globalstate.use_utility_code(UtilityCode.load(

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -405,9 +405,9 @@ bad:
 
 // PY_VERSION_HEX >= 0x03030000
 #if PY_MAJOR_VERSION >= 3 && !CYTHON_PEP489_MULTI_PHASE_INIT
-static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, PyObject *module_name);
+static int __Pyx_SetPackagePathFromImportLib(PyObject *module_name);
 #else
-#define __Pyx_SetPackagePathFromImportLib(a, b) 0
+#define __Pyx_SetPackagePathFromImportLib(a) 0
 #endif
 
 /////////////// SetPackagePathFromImportLib ///////////////
@@ -416,16 +416,16 @@ static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, Py
 
 // PY_VERSION_HEX >= 0x03030000
 #if PY_MAJOR_VERSION >= 3 && !CYTHON_PEP489_MULTI_PHASE_INIT
-static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, PyObject *module_name) {
+static int __Pyx_SetPackagePathFromImportLib(PyObject *module_name) {
     PyObject *importlib, *osmod, *ossep, *parts, *package_path;
     PyObject *file_path = NULL;
     int result;
     PyObject *spec;
-    // package_path = [importlib.util.find_spec(module_name, package).origin.rsplit(os.sep, 1)[0]]
+    // package_path = [importlib.util.find_spec(module_name).origin.rsplit(os.sep, 1)[0]]
     importlib = PyImport_ImportModule("importlib.util");
     if (unlikely(!importlib))
         goto bad;
-    spec = PyObject_CallMethod(importlib, "find_spec", "(Os)", module_name, parent_package_name);
+    spec = PyObject_CallMethod(importlib, "find_spec", "(O)", module_name);
     Py_DECREF(importlib);
     if (unlikely(!spec))
         goto bad;

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -415,12 +415,12 @@ static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, Py
 //@substitute: naming
 
 // PY_VERSION_HEX >= 0x03030000
-#if !CYTHON_PEP489_MULTI_PHASE_INIT
+#if PY_MAJOR_VERSION >= 3 && !CYTHON_PEP489_MULTI_PHASE_INIT
 static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, PyObject *module_name) {
     PyObject *importlib, *osmod, *ossep, *parts, *package_path;
     PyObject *file_path = NULL;
     int result;
-#if PY_VERSION_HEX > 0x03040000
+#if PY_VERSION_HEX >= 0x03040000
     PyObject *spec;
     // package_path = [importlib.util.find_spec(module_name, package).origin.rsplit(os.sep, 1)[0]]
     importlib = PyImport_ImportModule("importlib.util");
@@ -484,7 +484,7 @@ static int __Pyx_SetPackagePathFromImportLib(const char* parent_package_name, Py
 
 bad:
     PyErr_WriteUnraisable(module_name);
-#if PY_VERSION_HEX <= 0x03040000
+#if PY_VERSION_HEX < 0x03040000
     Py_XDECREF(path);
 #endif
     Py_XDECREF(file_path);

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -1,7 +1,6 @@
 # Specific bugs that only apply to pypy2
 
 build.cythonize_script
-build.cythonize_script_package
 run.initial_file_path
 run.reduce_pickle
 run.final_in_pxd

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -1,5 +1,7 @@
 # Specific bugs that only apply to pypy2
 
+build.cythonize_script
+build.cythonize_script_package
 run.initial_file_path
 run.reduce_pickle
 run.final_in_pxd

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -1,6 +1,5 @@
 # Specific bugs that only apply to pypy2
 
-build.cythonize_script
 run.initial_file_path
 run.reduce_pickle
 run.final_in_pxd


### PR DESCRIPTION
Closes #4763. When `!CYTHON_PEP489_MULTI_PHASE_INIT`, the module setup code sets `__path__` and `__file__` via calls to `importlib.find_loader`. That was deprecated in favor of `find_spec` in python 3.4. The deprecation warning is causing problems when running with `-Werror`. This PR
- uses the eqivalent of `package_path = [importlib.util.find_spec(module_name, package).origin.rsplit(os.sep, 1)[0]]`
- if `package` exists (`module_name` is a sub-package), prefix `'.'` to module_name

I tested this with `pypy3.8 runtests.py --no-cpp -vv`

It would be nice to backport this to the next 0.29 release if possible.