### PR TITLE
Change MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           - os: macos-10.15
             python-version: 3.7
             backend: c
-            env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
+            env: { MACOSX_DEPLOYMENT_TARGET: 10.15 }
           - os: macos-10.15
             python-version: 3.8
             backend: c


### PR DESCRIPTION
For Py3.7

See if it fixes breaking CI. I'm not sure why it's only failing for one Python version though