### PR TITLE
Removed goto error from numpy cimport guard

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8549,10 +8549,8 @@ def cimport_numpy_check(node, code):
                 # warning is mainly for the sake of testing
                 warning(node.pos, "'numpy.import_array()' has been added automatically "
                         "since 'numpy' was cimported but 'numpy.import_array' was not called.", 0)
-                from .Code import TempitaUtilityCode
                 code.globalstate.use_utility_code(
-                         TempitaUtilityCode.load_cached("NumpyImportArray", "NumpyImportArray.c",
-                                            context = {'err_goto': code.error_goto(node.pos)})
+                         UtilityCode.load_cached("NumpyImportArray", "NumpyImportArray.c")
                     )
                 return  # no need to continue once the utility code is added
 

--- a/Cython/Utility/NumpyImportArray.c
+++ b/Cython/Utility/NumpyImportArray.c
@@ -15,7 +15,6 @@ if (unlikely(_import_array() == -1)) {
     PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import "
     "(auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; "
     "use '<void>numpy._import_array' to disable if you are certain you don't need it).");
-    {{ err_goto }};
 }
 #endif
 #endif


### PR DESCRIPTION
The label it was using was unrelated to the place where the utility
code was actually appearing, and it was essentially luck that it
seemed to work (largly because it was always going to __pyx_L1_error
label).

It's guarded anyway because of
`writer.putln(writer.error_goto_if_PyErr(output.module_pos))`
which is added after every block of utility code in the init
section.

The only thing we lose is a position that links it back to the
"cimport numpy" line.