### PR TITLE
CI: Updated used actions, allow workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   ci:
@@ -204,17 +204,17 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache [ccache]
-        uses: pat-s/always-upload-cache@v2.1.3
+        uses: pat-s/always-upload-cache@v3.0.1
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.ccache
@@ -226,14 +226,14 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload HTML docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: htmldocs
           path: docs/build/html
           if-no-files-found: ignore
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels-${{ runner.os }}
           path: dist/*.whl
@@ -246,25 +246,23 @@ jobs:
     env:
       BACKEND: c,cpp
       OS_NAME: ubuntu-18.04
-      PYTHON_VERSION: 3.9
+      PYTHON_VERSION: "3.10"
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v3
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Run Coverage
         env: { COVERAGE: 1, NO_CYTHON_COMPILE: 1 }
         run: bash ./Tools/ci-run.sh
-        
+
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pycoverage_html
           path: coverage-report-html


### PR DESCRIPTION
A bit of maintenance on the regular CI.
- Updates the used actions to their latest versions (v3)
  _(note that for actions/checkout, the `fetch-depth` is now 1 by default)_
- Allow triggering a run manually from the GitHub UI by adding `workflow_dispatch` (see [GitHub docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch))
- Run pycoverage job with Ubuntu 20.04 and Python 3.10