### PR TITLE
CI: Remove allow_failures for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
         env: [{}]
 
         include:
-          # Temporary - Allow failure on Python 3.11-dev jobs until they are considered stable
-          - python-version: 3.11-dev
-            allowed_failure: true
+          # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
           #- python-version: 3.12-dev
           #  allowed_failure: true
 


### PR DESCRIPTION
[Python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html) is now [in beta](https://www.python.org/downloads/release/python-3110b1/) and considered feature frozen. That means we can start helping making Python 3.11 more stable by fixing internal bugs and reporting upstream bugs.

This commit removes `allowed_failure: true` element of the CI configuration. It might happen that the CI will not always pass, but that only makes us aware of any existing and appearing bugs, and does not always have to be a strict blocker for PRs, especially in early beta.

Cython is one of the lowest level dependencies for many project, so early adoption of Python 3.11 can accelerate adoption across the whole ecosystem, especially as numpy and pandas are enabled to start to support Python 3.11.