### PR TITLE
Remove __contains__->PySequence_Contains slots

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -273,12 +273,10 @@ builtin_types_table = [
                                     ]),
     ("bytearray", "PyByteArray_Type", [
                                     ]),
-    ("bytes",   "PyBytes_Type",    [BuiltinMethod("__contains__",  "TO",   "b", "PySequence_Contains"),
-                                    BuiltinMethod("join",  "TO",   "O", "__Pyx_PyBytes_Join",
+    ("bytes",   "PyBytes_Type",    [BuiltinMethod("join",  "TO",   "O", "__Pyx_PyBytes_Join",
                                                   utility_code=UtilityCode.load("StringJoin", "StringTools.c")),
                                     ]),
-    ("str",     "PyString_Type",   [BuiltinMethod("__contains__",  "TO",   "b", "PySequence_Contains"),
-                                    BuiltinMethod("join",  "TO",   "O", "__Pyx_PyString_Join",
+    ("str",     "PyString_Type",   [BuiltinMethod("join",  "TO",   "O", "__Pyx_PyString_Join",
                                                   builtin_return_type='basestring',
                                                   utility_code=UtilityCode.load("StringJoin", "StringTools.c")),
                                     ]),
@@ -286,11 +284,9 @@ builtin_types_table = [
                                     BuiltinMethod("join",  "TO",   "T", "PyUnicode_Join"),
                                     ]),
 
-    ("tuple",   "PyTuple_Type",    [BuiltinMethod("__contains__",  "TO",   "b", "PySequence_Contains"),
-                                    ]),
+    ("tuple",   "PyTuple_Type",    []),
 
-    ("list",    "PyList_Type",     [BuiltinMethod("__contains__",  "TO",   "b", "PySequence_Contains"),
-                                    BuiltinMethod("insert",  "TzO",  "r", "PyList_Insert"),
+    ("list",    "PyList_Type",     [BuiltinMethod("insert",  "TzO",  "r", "PyList_Insert"),
                                     BuiltinMethod("reverse", "T",    "r", "PyList_Reverse"),
                                     BuiltinMethod("append",  "TO",   "r", "__Pyx_PyList_Append",
                                                   utility_code=UtilityCode.load("ListAppend", "Optimize.c")),
@@ -328,8 +324,7 @@ builtin_types_table = [
                                     ]),
 #    ("file",    "PyFile_Type",     []),  # not in Py3
 
-    ("set",       "PySet_Type",    [BuiltinMethod("__contains__",  "TO",   "b", "PySequence_Contains"),
-                                    BuiltinMethod("clear",   "T",  "r", "PySet_Clear"),
+    ("set",       "PySet_Type",    [BuiltinMethod("clear",   "T",  "r", "PySet_Clear"),
                                     # discard() and remove() have a special treatment for unhashable values
                                     BuiltinMethod("discard", "TO", "r", "__Pyx_PySet_Discard",
                                                   utility_code=UtilityCode.load("py_set_discard", "Optimize.c")),

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -65,8 +65,8 @@ cdef class MyDict(dict):
         return dict.__contains__(self, key)
 
 import sys
-sys_impl = getattr(sys, 'implementation', None)
-if not (sys_impl and sys_impl.name == 'pypy' and sys_impl.version < (7, 3, 10)):
+pypy_version = getattr(sys, 'pypy_version_info', None)
+if not (pypy_version and pypy_version < (7, 3, 10)):
     __doc__ = """
     >>> MyDict(a=1).__contains__("a")
     MyDict.__contains__

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -37,11 +37,7 @@ cdef class MyList(list):
         return list.__contains__(self, value)  # probably optimized
 
 cdef class MyDict(dict):
-    """
-    >>> MyDict(a=1).__contains__("a")
-    MyDict.__contains__
-    True
-    """
+    # tests for __contains__ are in the global __doc__ to version-check a PyPy bug
 
     @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
                                     "//ComprehensionNode//AttributeNode[@attribute='items']")
@@ -67,6 +63,15 @@ cdef class MyDict(dict):
     def __contains__(self, key):
         print "MyDict.__contains__"
         return dict.__contains__(self, key)
+
+import sys
+sys_impl = getattr(sys, 'implementation')
+if not (sys_impl and sys_impl.name == 'pypy' and sys_impl.version < (7, 3, 10)):
+    __doc__ = """
+    >>> MyDict(a=1).__contains__("a")
+    MyDict.__contains__
+    True
+    """
 
 @cython.final
 cdef class MyDictFinal(dict):

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -4,7 +4,21 @@
 
 cimport cython
 
+# The "contains" tests relate to GH-4785 - replacing the method
+# call with PySequence_Contains was causing infinite recursion
+# for some classes
+
 cdef class MyList(list):
+    """
+    >>> l = MyList()
+    >>> l.__contains__(1)
+    MyList.__contains__
+    False
+    >>> l.append(1)
+    >>> l.__contains__(1)
+    MyList.__contains__
+    True
+    """
     def test_append(self, x):
         """
         >>> l = MyList()
@@ -18,7 +32,17 @@ cdef class MyList(list):
         """
         self.append(x)
 
+    def __contains__(self, value):
+        print "MyList.__contains__"
+        return list.__contains__(self, value)  # probably optimized
+
 cdef class MyDict(dict):
+    """
+    >>> MyDict(a=1).__contains__("a")
+    MyDict.__contains__
+    True
+    """
+
     @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
                                     "//ComprehensionNode//AttributeNode[@attribute='items']")
     @cython.test_fail_if_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
@@ -39,6 +63,10 @@ cdef class MyDict(dict):
         l = [ v for v in self.values() ]
         l.sort()
         return l
+
+    def __contains__(self, key):
+        print "MyDict.__contains__"
+        return dict.__contains__(self, key)
 
 @cython.final
 cdef class MyDictFinal(dict):
@@ -155,3 +183,17 @@ cdef class MyDictOverride2(MyDict):
         l = [ v for v in self.values() ]
         l.sort()
         return l
+
+class MyBytes(bytes):
+    """
+    >>> mb = MyBytes(b"abc")
+    >>> mb.__contains__(b"a")
+    MyBytes.__contains__
+    True
+    >>> mb.__contains__(b"z")
+    MyBytes.__contains__
+    False
+    """
+    def __contains__(self, value):
+        print "MyBytes.__contains__"
+        return bytes.__contains__(self, value)

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -65,7 +65,7 @@ cdef class MyDict(dict):
         return dict.__contains__(self, key)
 
 import sys
-sys_impl = getattr(sys, 'implementation')
+sys_impl = getattr(sys, 'implementation', None)
 if not (sys_impl and sys_impl.name == 'pypy' and sys_impl.version < (7, 3, 10)):
     __doc__ = """
     >>> MyDict(a=1).__contains__("a")


### PR DESCRIPTION
Since they prevent explicitly calling base-class `__contains__`.
https://github.com/cython/cython/issues/4785

Draft for now to see what breaks - I suspect some test will, but I'm not sure if anything significant like `x in container` will