### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET for fix test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           - os: macos-10.15
             python-version: 3.8
             backend: c
-            env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
+            env: { MACOSX_DEPLOYMENT_TARGET: 10.15 }
           - os: macos-10.15
             python-version: 3.9
             backend: c


### PR DESCRIPTION
It looks like Python 3.8 now needs MACOSX_DEPLOYMENT_TARGET=10.15