### PR TITLE
Replace fused __self__ getset with slot memberdef

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1463,30 +1463,17 @@ bad:
     return result;
 }
 
-static PyObject *
-__Pyx_FusedFunction_get_self(__pyx_FusedFunctionObject *m, void *closure)
-{
-    PyObject *self = m->self;
-    CYTHON_UNUSED_VAR(closure);
-    if (unlikely(!self)) {
-        PyErr_SetString(PyExc_AttributeError, "'function' object has no attribute '__self__'");
-    } else {
-        Py_INCREF(self);
-    }
-    return self;
-}
-
 static PyMemberDef __pyx_FusedFunction_members[] = {
     {(char *) "__signatures__",
      T_OBJECT,
      offsetof(__pyx_FusedFunctionObject, __signatures__),
      READONLY,
      0},
+    {(char *) "__self__", T_OBJECT_EX, offsetof(__pyx_FusedFunctionObject, self), READONLY, 0},
     {0, 0, 0, 0, 0},
 };
 
 static PyGetSetDef __pyx_FusedFunction_getsets[] = {
-    {(char *) "__self__", (getter)__Pyx_FusedFunction_get_self, 0, 0, 0},
     // __doc__ is None for the fused function type, but we need it to be
     // a descriptor for the instance's __doc__, so rebuild the descriptor in our subclass
     // (all other descriptors are inherited)

--- a/tests/run/function_self.py
+++ b/tests/run/function_self.py
@@ -25,13 +25,8 @@ def fused(x):
     >>> hasattr(nested, "__self__")
     False
 
-    #>>> hasattr(fused, "__self__")  # FIXME this fails for fused functions
-    #False
-    # but this is OK:
-    >>> fused.__self__  #doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'function' object has no attribute '__self__'...
+    >>> hasattr(fused, "__self__")
+    False
     """
     def nested_in_fused(y):
         return x+y
@@ -74,15 +69,11 @@ if sys.version_info[0] > 2 or cython.compiled:
 
 if cython.compiled:
     __doc__ = """
-    >>> fused['double'].__self__   #doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'function' object has no attribute '__self__'...
+    >>> hasattr(fused['double'], '__self__')
+    False
 
-    >>> C.fused['double'].__self__   #doctest: +ELLIPSIS
-    Traceback (most recent call last):
-        ...
-    AttributeError: 'function' object has no attribute '__self__'...
+    >>> hasattr(C.fused['double'], '__self__')
+    False
 
     >>> c = C()
     >>> c.fused['double'].__self__ is c   #doctest: +ELLIPSIS


### PR DESCRIPTION
It's a bit simpler, and it lets `hasattr` work correctly where-as
the getset didn't (hasattr returned true, but it still raised an
error).