### PR TITLE
Enable parenthesized context managers

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7727,6 +7727,10 @@ class WithStatNode(StatNode):
     enter_call = None
     target_temp = None
 
+    def post_initialize(self):
+        # For consistency with GilStatNode
+        pass
+
     def analyse_declarations(self, env):
         self.manager.analyse_declarations(env)
         self.enter_call.analyse_declarations(env)
@@ -8499,12 +8503,17 @@ class GILStatNode(NogilTryFinallyStatNode):
     def __init__(self, pos, state, body, condition=None):
         self.state = state
         self.condition = condition
-        self.create_state_temp_if_needed(pos, state, body)
         TryFinallyStatNode.__init__(
             self, pos,
             body=body,
-            finally_clause=GILExitNode(
-                pos, state=state, state_temp=self.state_temp))
+        )
+
+    def post_initialize(self):
+        # body is usually not set it __init__
+        # This function is called after it has been set
+        self.create_state_temp_if_needed(self.pos, self.state, self.body)
+        self.finally_clause=GILExitNode(
+            self.pos, state=self.state, state_temp=self.state_temp)
 
     def create_state_temp_if_needed(self, pos, state, body):
         from .ParseTreeTransforms import YieldNodeCollector

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7727,10 +7727,6 @@ class WithStatNode(StatNode):
     enter_call = None
     target_temp = None
 
-    def post_initialize(self):
-        # For consistency with GilStatNode
-        pass
-
     def analyse_declarations(self, env):
         self.manager.analyse_declarations(env)
         self.enter_call.analyse_declarations(env)
@@ -8503,17 +8499,12 @@ class GILStatNode(NogilTryFinallyStatNode):
     def __init__(self, pos, state, body, condition=None):
         self.state = state
         self.condition = condition
+        self.create_state_temp_if_needed(pos, state, body)
         TryFinallyStatNode.__init__(
             self, pos,
             body=body,
-        )
-
-    def post_initialize(self):
-        # body is usually not set it __init__
-        # This function is called after it has been set
-        self.create_state_temp_if_needed(self.pos, self.state, self.body)
-        self.finally_clause=GILExitNode(
-            self.pos, state=self.state, state_temp=self.state_temp)
+            finally_clause=GILExitNode(
+                pos, state=state, state_temp=self.state_temp))
 
     def create_state_temp_if_needed(self, pos, state, body):
         from .ParseTreeTransforms import YieldNodeCollector

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2182,6 +2182,7 @@ def p_with_items(s, is_async=False):
     for item in reversed(items):
         # populate the bodies of the WithStatNodes/GILStatNodes
         item.body = body
+        item.post_initialize()  # GILStatNode has a little extra setup to do once body is set
         body = item
     return body
 

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2174,8 +2174,6 @@ def p_with_items(s, is_async=False):
         items = []
         while True:
             items.append(p_with_item(s, is_async))
-            #if (s.position()[1] > 1850):
-            #    import pdb; pdb.set_trace()
             if s.sy == ",":
                 s.next()
             else:

--- a/tests/run/test_grammar.py
+++ b/tests/run/test_grammar.py
@@ -64,8 +64,7 @@ if cython.compiled:
 
 
 def use_old_parser():
-    # FIXME: currently disabling new PEG parser tests.
-    return True
+    return False
 
 
 import unittest
@@ -1869,68 +1868,53 @@ class GrammarTests(unittest.TestCase):
         with manager() as x, manager():
             pass
 
-        if not use_old_parser():
-            test_cases = [
-                """if 1:
-                    with (
-                        manager()
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as x
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as (x, y),
-                        manager() as z,
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager(),
-                        manager()
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as x,
-                        manager() as y
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as x,
-                        manager()
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as x,
-                        manager() as y,
-                        manager() as z,
-                    ):
-                        pass
-                """,
-                """if 1:
-                    with (
-                        manager() as x,
-                        manager() as y,
-                        manager(),
-                    ):
-                        pass
-                """,
-            ]
-            for case in test_cases:
-                with self.subTest(case=case):
-                    compile(case, "<string>", "exec")
+        with (
+            manager()
+        ):
+            pass
+
+        with (
+            manager() as x
+        ):
+            pass
+
+        with (
+            manager() as (x, y),
+            manager() as z,
+        ):
+            pass
+
+        with (
+            manager(),
+            manager()
+        ):
+            pass
+
+        with (
+            manager() as x,
+            manager() as y
+        ):
+            pass
+
+        with (
+            manager() as x,
+            manager()
+        ):
+            pass
+
+        with (
+            manager() as x,
+            manager() as y,
+            manager() as z,
+        ):
+            pass
+
+        with (
+            manager() as x,
+            manager() as y,
+            manager(),
+        ):
+            pass
 
 
     def test_if_else_expr(self):


### PR DESCRIPTION
As described in https://docs.python.org/3/whatsnew/3.10.html#parenthesized-context-managers

The approach to parsing is largely copied from the CPython parser
(with comments to support it) - closer to the PEG approach of
"try the bracketed case first, and let it fail silently then
try the unbracketed case".

Fixes one of the items listed in https://github.com/cython/cython/issues/4595