### PR TITLE
Make memoryviewslice and cython.array be collections.abc.Sequence

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -971,6 +971,24 @@ cdef class _memoryviewslice(memoryview):
         return self.from_object
 
 
+@cname('__pyx_register_memviewtypes_as_sequence')
+cdef void register_memviewtypes_as_sequence():
+    try:
+        import sys
+        if sys.version_info >= (3, 3):
+            from collections.abc import Sequence
+        else:
+            from collections import Sequence
+        # The main value of registering _memoryviewslice as a
+        # Sequence is that it can be used in strucutal pattern
+        # matching in Python 3.10+
+        Sequence.register(_memoryviewslice)
+        Sequence.register(array)
+    except:
+        pass  # ignore failure, it's a minor issue
+
+register_memviewtypes_as_sequence()
+
 @cname('__pyx_memoryview_fromslice')
 cdef memoryview_fromslice({{memviewslice_name}} memviewslice,
                           int ndim,

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -242,7 +242,6 @@ cdef class array:
     except:
         pass
 
-
 @cname("__pyx_array_allocate_buffer")
 cdef int _allocate_buffer(array self) except -1:
     # use malloc() for backwards compatibility
@@ -995,21 +994,15 @@ cdef class _memoryviewslice(memoryview):
     except:
         pass
 
-
-@cname('__pyx_register_memviewtypes_as_sequence')
-cdef void register_memviewtypes_as_sequence():
-    try:
-        Sequence = __pyx_collections_abc_Sequence
-        if Sequence:
-            # The main value of registering _memoryviewslice as a
-            # Sequence is that it can be used in structural pattern
-            # matching in Python 3.10+
-            Sequence.register(_memoryviewslice)
-            Sequence.register(array)
-    except:
-        pass  # ignore failure, it's a minor issue
-
-register_memviewtypes_as_sequence()
+try:
+    if __pyx_collections_abc_Sequence:
+        # The main value of registering _memoryviewslice as a
+        # Sequence is that it can be used in structural pattern
+        # matching in Python 3.10+
+        __pyx_collections_abc_Sequence.register(_memoryviewslice)
+        __pyx_collections_abc_Sequence.register(array)
+except:
+    pass  # ignore failure, it's a minor issue
 
 @cname('__pyx_memoryview_fromslice')
 cdef memoryview_fromslice({{memviewslice_name}} memviewslice,

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -980,7 +980,7 @@ cdef void register_memviewtypes_as_sequence():
         else:
             from collections import Sequence
         # The main value of registering _memoryviewslice as a
-        # Sequence is that it can be used in strucutal pattern
+        # Sequence is that it can be used in structural pattern
         # matching in Python 3.10+
         Sequence.register(_memoryviewslice)
         Sequence.register(array)

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -29,8 +29,8 @@ _WARNINGS = """
 # from MemoryView.pyx
 958:29: Ambiguous exception value, same as default return value: 0
 958:29: Ambiguous exception value, same as default return value: 0
-983:46: Ambiguous exception value, same as default return value: 0
-983:46: Ambiguous exception value, same as default return value: 0
-1073:29: Ambiguous exception value, same as default return value: 0
-1073:29: Ambiguous exception value, same as default return value: 0
+1001:46: Ambiguous exception value, same as default return value: 0
+1001:46: Ambiguous exception value, same as default return value: 0
+1091:29: Ambiguous exception value, same as default return value: 0
+1091:29: Ambiguous exception value, same as default return value: 0
 """

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -27,10 +27,10 @@ _WARNINGS = """
 36:10: 'cpdef_cname_method' redeclared
 
 # from MemoryView.pyx
-976:29: Ambiguous exception value, same as default return value: 0
-976:29: Ambiguous exception value, same as default return value: 0
-1023:46: Ambiguous exception value, same as default return value: 0
-1023:46: Ambiguous exception value, same as default return value: 0
-1113:29: Ambiguous exception value, same as default return value: 0
-1113:29: Ambiguous exception value, same as default return value: 0
+975:29: Ambiguous exception value, same as default return value: 0
+975:29: Ambiguous exception value, same as default return value: 0
+1016:46: Ambiguous exception value, same as default return value: 0
+1016:46: Ambiguous exception value, same as default return value: 0
+1106:29: Ambiguous exception value, same as default return value: 0
+1106:29: Ambiguous exception value, same as default return value: 0
 """

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -27,10 +27,10 @@ _WARNINGS = """
 36:10: 'cpdef_cname_method' redeclared
 
 # from MemoryView.pyx
-958:29: Ambiguous exception value, same as default return value: 0
-958:29: Ambiguous exception value, same as default return value: 0
-1001:46: Ambiguous exception value, same as default return value: 0
-1001:46: Ambiguous exception value, same as default return value: 0
-1091:29: Ambiguous exception value, same as default return value: 0
-1091:29: Ambiguous exception value, same as default return value: 0
+976:29: Ambiguous exception value, same as default return value: 0
+976:29: Ambiguous exception value, same as default return value: 0
+1023:46: Ambiguous exception value, same as default return value: 0
+1023:46: Ambiguous exception value, same as default return value: 0
+1113:29: Ambiguous exception value, same as default return value: 0
+1113:29: Ambiguous exception value, same as default return value: 0
 """

--- a/tests/memoryview/cythonarray.pyx
+++ b/tests/memoryview/cythonarray.pyx
@@ -286,3 +286,17 @@ def test_char_array_in_python_api(*shape):
     arr = array(shape=shape, itemsize=sizeof(char), format='c', mode='c')
     arr[:] = b'x'
     return arr
+
+def test_is_Sequence():
+    """
+    >>> test_is_Sequence()
+    True
+    """
+    import sys
+    if sys.version_info < (3, 3):
+        from collections import Sequence
+    else:
+        from collections.abc import Sequence
+    arr = array(shape=(5,), itemsize=sizeof(char), format='c', mode='c')
+    return isinstance(arr, Sequence)
+

--- a/tests/memoryview/cythonarray.pyx
+++ b/tests/memoryview/cythonarray.pyx
@@ -290,6 +290,8 @@ def test_char_array_in_python_api(*shape):
 def test_is_Sequence():
     """
     >>> test_is_Sequence()
+    1
+    1
     True
     """
     import sys
@@ -297,6 +299,26 @@ def test_is_Sequence():
         from collections import Sequence
     else:
         from collections.abc import Sequence
+
     arr = array(shape=(5,), itemsize=sizeof(char), format='c', mode='c')
+    for i in range(arr.shape[0]):
+        arr[i] = f'{i}'.encode('ascii')
+    print(arr.count(b'1'))  # test for presence of added collection method
+    print(arr.index(b'1'))  # test for presence of added collection method
+
+    if sys.version_info >= (3, 10):
+        # test structural pattern match in Python
+        # (because Cython hasn't implemented it yet, and because the details
+        # of what Python considers a sequence are important)
+        globs = {'arr': arr}
+        exec("""
+match arr:
+    case [*_]:
+        res = True
+    case _:
+        res = False
+""", globs)
+        assert globs['res']
+
     return isinstance(arr, Sequence)
 

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -1205,3 +1205,14 @@ def test_conversion_failures():
                 assert get_refcount(dmb) == dmb_before, "before %s after %s" % (dmb_before, get_refcount(dmb))
             else:
                 assert False, "Conversion should fail!"
+
+def test_is_Sequence(double[:] a):
+    """
+    >>> test_is_Sequence(DoubleMockBuffer(None, range(6), shape=(6,)))
+    True
+    """
+    if sys.version_info < (3, 3):
+        from collections import Sequence
+    else:
+        from collections.abc import Sequence
+    return isinstance(<object>a, Sequence)

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -1209,10 +1209,32 @@ def test_conversion_failures():
 def test_is_Sequence(double[:] a):
     """
     >>> test_is_Sequence(DoubleMockBuffer(None, range(6), shape=(6,)))
+    1
+    1
     True
     """
     if sys.version_info < (3, 3):
         from collections import Sequence
     else:
         from collections.abc import Sequence
+
+    for i in range(a.shape[0]):
+        a[i] = i
+    print(a.count(1.0))  # test for presence of added collection method
+    print(a.index(1.0))  # test for presence of added collection method
+
+    if sys.version_info >= (3, 10):
+        # test structural pattern match in Python
+        # (because Cython hasn't implemented it yet, and because the details
+        # of what Python considers a sequence are important)
+        globs = {'arr': a}
+        exec("""
+match arr:
+    case [*_]:
+        res = True
+    case _:
+        res = False
+""", globs)
+        assert globs['res']
+
     return isinstance(<object>a, Sequence)


### PR DESCRIPTION
The main reason to do this is so that they'll work in sequence
patterns in structural pattern matching in Python 3.10+.
Since the builtin "memoryview"
type and "array.array" are sequences, I think this is reasonable.