### PR TITLE
Add mt19937_64 random number generator to libcpp

### DIFF
--- a/Cython/Includes/libcpp/random.pxd
+++ b/Cython/Includes/libcpp/random.pxd
@@ -1,4 +1,4 @@
-from libc.stdint cimport uint_fast32_t
+from libc.stdint cimport uint_fast32_t, uint_fast64_t
 
 
 cdef extern from "<random>" namespace "std" nogil:
@@ -7,6 +7,18 @@ cdef extern from "<random>" namespace "std" nogil:
 
         mt19937() except +
         mt19937(result_type seed) except +
+        result_type operator()() except +
+        result_type min() except +
+        result_type max() except +
+        void discard(size_t z) except +
+        void seed(result_type seed) except +
+
+
+    cdef cppclass mt19937_64:
+        ctypedef uint_fast64_t result_type
+
+        mt19937_64() except +
+        mt19937_64(result_type seed) except +
         result_type operator()() except +
         result_type min() except +
         result_type max() except +

--- a/tests/run/cpp_stl_random.pyx
+++ b/tests/run/cpp_stl_random.pyx
@@ -1,7 +1,7 @@
 # mode: run
 # tag: cpp, cpp11
 
-from libcpp.random cimport mt19937
+from libcpp.random cimport mt19937, mt19937_64
 
 
 def mt19937_seed_test():
@@ -9,8 +9,8 @@ def mt19937_seed_test():
     >>> print(mt19937_seed_test())
     1608637542
     """
-    cdef mt19937 rd = mt19937(42)
-    return rd()
+    cdef mt19937 gen = mt19937(42)
+    return gen()
 
 
 def mt19937_reseed_test():
@@ -18,9 +18,9 @@ def mt19937_reseed_test():
     >>> print(mt19937_reseed_test())
     1608637542
     """
-    cdef mt19937 rd
-    rd.seed(42)
-    return rd()
+    cdef mt19937 gen
+    gen.seed(42)
+    return gen()
 
 
 def mt19937_min_max():
@@ -31,8 +31,8 @@ def mt19937_min_max():
     >>> print(y)  # 2 ** 32 - 1 because mt19937 is 32 bit.
     4294967295
     """
-    cdef mt19937 rd
-    return rd.min(), rd.max()
+    cdef mt19937 gen
+    return gen.min(), gen.max()
 
 
 def mt19937_discard(z):
@@ -43,13 +43,64 @@ def mt19937_discard(z):
     >>> print(y)
     1972458954
     """
-    cdef mt19937 rd = mt19937(42)
+    cdef mt19937 gen = mt19937(42)
     # Throw away z random numbers.
-    rd.discard(z)
-    a = rd()
+    gen.discard(z)
+    a = gen()
 
     # Iterate over z random numbers.
-    rd.seed(42)
+    gen.seed(42)
     for _ in range(z + 1):
-        b = rd()
+        b = gen()
+    return a, b
+
+
+def mt19937_64_seed_test():
+    """
+    >>> print(mt19937_64_seed_test())
+    13930160852258120406
+    """
+    cdef mt19937_64 gen = mt19937_64(42)
+    return gen()
+
+
+def mt19937_64_reseed_test():
+    """
+    >>> print(mt19937_64_reseed_test())
+    13930160852258120406
+    """
+    cdef mt19937_64 gen
+    gen.seed(42)
+    return gen()
+
+
+def mt19937_64_min_max():
+    """
+    >>> x, y = mt19937_64_min_max()
+    >>> print(x)
+    0
+    >>> print(y)  # 2 ** 64 - 1 because mt19937_64 is 64 bit.
+    18446744073709551615
+    """
+    cdef mt19937_64 gen
+    return gen.min(), gen.max()
+
+
+def mt19937_64_discard(z):
+    """
+    >>> x, y = mt19937_64_discard(13)
+    >>> print(x)
+    11756813601242511406
+    >>> print(y)
+    11756813601242511406
+    """
+    cdef mt19937_64 gen = mt19937_64(42)
+    # Throw away z random numbers.
+    gen.discard(z)
+    a = gen()
+
+    # Iterate over z random numbers.
+    gen.seed(42)
+    for _ in range(z + 1):
+        b = gen()
     return a, b


### PR DESCRIPTION
As `mt19937` already included in #4746, it is better to include `mt19937_64` as well for int64 random variables.