### PR TITLE
MNT: always require va_start to have two arguments

### DIFF
--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -451,7 +451,6 @@ static void __pyx_fatalerror(const char *fmt, ...) Py_NO_RETURN {
     va_list vargs;
     char msg[200];
 
-
     va_start(vargs, fmt);
     vsnprintf(msg, 200, fmt, vargs);
     va_end(vargs);

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -451,7 +451,11 @@ static void __pyx_fatalerror(const char *fmt, ...) Py_NO_RETURN {
     va_list vargs;
     char msg[200];
 
+#if PY_VERSION_HEX >= 0x030A0000 || defined(HAVE_STDARG_PROTOTYPES)
     va_start(vargs, fmt);
+#else
+    va_start(vargs);
+#endif
     vsnprintf(msg, 200, fmt, vargs);
     va_end(vargs);
 

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -451,11 +451,8 @@ static void __pyx_fatalerror(const char *fmt, ...) Py_NO_RETURN {
     va_list vargs;
     char msg[200];
 
-#ifdef HAVE_STDARG_PROTOTYPES
+
     va_start(vargs, fmt);
-#else
-    va_start(vargs);
-#endif
     vsnprintf(msg, 200, fmt, vargs);
     va_end(vargs);
 


### PR DESCRIPTION
https://github.com/python/cpython/pull/93215 chance CPython to always use the
2-input version of va_start and dropped defining HAVE_STDARG_PROTOTYPES.  This
resulted in the 1-argument version being used when compiling cython source
which fails

This makes cython also always use the 2-argument version.
