### PR TITLE
Update preprocessing warning to be compatible with MSVC

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5436,7 +5436,11 @@ class CClassDefNode(ClassDefNode):
                         ))
                         code.putln("}")
                 code.putln("#else")
-                code.putln("#warning The buffer protocol is not supported in the Limited C-API.")
+                code.putln("    #ifdef _MSC_VER")
+                code.putln("        #pragma message (\"The buffer protocol is not supported in the Limited C-API.\")")
+                code.putln("    #else")
+                code.putln("        #warning \"The buffer protocol is not supported in the Limited C-API.\"")
+                code.putln("    #endif")
                 code.putln("#endif")
 
             code.globalstate.use_utility_code(

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5435,12 +5435,10 @@ class CClassDefNode(ClassDefNode):
                             typeptr_cname, buffer_slot.slot_name,
                         ))
                         code.putln("}")
+                code.putln("#elif defined(_MSC_VER)")
+                code.putln("#pragma message (\"The buffer protocol is not supported in the Limited C-API.\")")
                 code.putln("#else")
-                code.putln("    #ifdef _MSC_VER")
-                code.putln("        #pragma message (\"The buffer protocol is not supported in the Limited C-API.\")")
-                code.putln("    #else")
-                code.putln("        #warning \"The buffer protocol is not supported in the Limited C-API.\"")
-                code.putln("    #endif")
+                code.putln("#warning \"The buffer protocol is not supported in the Limited C-API.\"")
                 code.putln("#endif")
 
             code.globalstate.use_utility_code(


### PR DESCRIPTION
Solves #4825.

I am not sure about the standard (if any) for indenting code blocks in the generated C source code, so I wrote the 4-space indentation the naive way.