### PR TITLE
Always initialize `state` to avoid `ubsan` error

### DIFF
--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -675,10 +675,8 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
     PyGILState_STATE state;
     if (nogil)
         state = PyGILState_Ensure();
-#ifdef _MSC_VER
     /* arbitrary, to suppress warning */
     else state = (PyGILState_STATE)-1;
-#endif
 #endif
     CYTHON_UNUSED_VAR(clineno);
     CYTHON_UNUSED_VAR(lineno);


### PR DESCRIPTION
When compiling `cython` generated code with `ubsan` enabled, it warns that in `__Pyx_WriteUnraisable()`, `state` can be used without initialization. It seems we need to extend the workaround beyond MSVC here.

Using Cent OS 7 (manylinux_2014 image), with gcc 10 and libubsan.