### PR TITLE
Further unified memoryview reference counting

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2826,8 +2826,11 @@ class CFuncDefNode(FuncDefNode):
         def put_into_closure(entry):
             if entry.in_closure and not arg.default:
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
-                code.put_var_incref(entry)
-                code.put_var_giveref(entry)
+                if entry.type.is_memoryviewslice:
+                    entry.type.generate_incref_memoryviewslice(code, entry.cname, True)
+                else:
+                    code.put_var_incref(entry)
+                    code.put_var_giveref(entry)
         for arg in self.args:
             put_into_closure(scope.lookup_here(arg.name))
 

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2579,6 +2579,25 @@ def test_arg_in_closure(int [:] a):
         return (a[0], a[1])
     return inner
 
+cdef arg_in_closure_cdef(int [:] a):
+    def inner():
+        return (a[0], a[1])
+    return inner
+
+def test_arg_in_closure_cdef(a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> inner = test_arg_in_closure_cdef(A)
+    acquired A
+    >>> inner()
+    (0, 1)
+
+    The assignment below is just to avoid printing what was collected
+    >>> del inner; ignore_me = gc.collect()
+    released A
+    """
+    return arg_in_closure_cdef(a)
+
 @testcase
 def test_local_in_closure(a):
     """

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2551,13 +2551,48 @@ def test_loop_reassign(int[:] a):
     3
     4
     5
-    released A
     15
+    released A
     """
     cdef int sum = 0
     for ai in a:
         sum += ai
         print(ai)
         a = None  # this should not mess up the loop though!
-    # release happens here, when the loop temp is released
     print(sum)
+    # release happens in the wrapper function
+
+@testcase
+def test_arg_in_closure(int [:] a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> inner = test_arg_in_closure(A)
+    acquired A
+    >>> inner()
+    (0, 1)
+
+    The assignment below is just to avoid printing what was collected
+    >>> del inner; ignore_me = gc.collect()
+    released A
+    """
+    def inner():
+        return (a[0], a[1])
+    return inner
+
+@testcase
+def test_local_in_closure(a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> inner = test_local_in_closure(A)
+    acquired A
+    >>> inner()
+    (0, 1)
+
+    The assignment below is just to avoid printing what was collected
+    >>> del inner; ignore_me = gc.collect()
+    released A
+    """
+    cdef int[:] a_view = a
+    def inner():
+        return (a_view[0], a_view[1])
+    return inner


### PR DESCRIPTION
+ fixed crash with a captured memoryview argument
(https://github.com/cython/cython/issues/4798)

Moves reference counting of memoryview arguments entirely into
the def function wrapper. New behaviour is:

```
def wrapper(x, ...):
  # summary of generated code!
  xview = memoryview(x)
  # handle rest of args
  if error_in_rest_of_args:
    cleanup(xview)
  ret_value = func(xview, ...)
  cleanup(xview)
  return ret_value
```

while old behaviour was

```
def wrapper(x, ...)
  xview = memoryview(x)
  # handle rest of args
  if error_in_rest_of_args:
    cleanup(xview)
  return func(xview, ...)

def func(xview, ...):
   # body goes here
   cleanup(xview)
   return ...
```

This treats memoryviews in the same way as PyObjects.

The next step (not done here) is to unify put_var_incref_memoryviewslice
with put_var_incref of other types.

One observable consequence is that a memoryview argument is released
later in functions that reassign their argument. E.g.:

```
def f(double[:] xview, x):
  # where xview is a view of x...
  xview = None
  # In the old version, the memoryview would be released and you
  # could probably resize x. In the new version the memoryview
  # would be held until the end of the wrapper function and you
  # could not resize x
  x.append(1)
```

I don't think this is a major problem but it's worth mentioning.