### PR TITLE
Error on memoryview argument capture on 0.29.x

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3240,7 +3240,8 @@ class DefNode(FuncDefNode):
                 if entry.type.is_memoryviewslice:
                     error(
                         self.pos,
-                        "Putting capturing a memoryview argument in a closure is not supported. "
+                        "Referring to a memoryview typed argument directly in a nested closure function "
+                        "is not supported in Cython 0.x. "
                         "Either upgrade to Cython 3, or assign the argument to a local variable "
                         "and capture that."
                     )

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3239,7 +3239,7 @@ class DefNode(FuncDefNode):
             if entry.in_closure:
                 if entry.type.is_memoryviewslice:
                     error(
-                        self.pos, 
+                        self.pos,
                         "Putting capturing a memoryview argument in a closure is not supported. "
                         "Either upgrade to Cython 3, or assign the argument to a local variable "
                         "and capture that."

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2637,8 +2637,11 @@ class CFuncDefNode(FuncDefNode):
         def put_into_closure(entry):
             if entry.in_closure and not arg.default:
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
-                code.put_var_incref(entry)
-                code.put_var_giveref(entry)
+                if entry.type.is_memoryviewslice:
+                    code.put_incref_memoryviewslice(entry.cname, True)
+                else:
+                    code.put_var_incref(entry)
+                    code.put_var_giveref(entry)
         for arg in self.args:
             put_into_closure(scope.lookup_here(arg.name))
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3234,6 +3234,13 @@ class DefNode(FuncDefNode):
         # Move arguments into closure if required
         def put_into_closure(entry):
             if entry.in_closure:
+                if entry.type.is_memoryviewslice:
+                    error(
+                        self.pos, 
+                        "Putting capturing a memoryview argument in a closure is not supported. "
+                        "Either upgrade to Cython 3, or assign the argument to a local variable "
+                        "and capture that."
+                    )
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
                 if entry.xdecref_cleanup:
                     # mostly applies to the starstar arg - this can sometimes be NULL

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2638,7 +2638,7 @@ class CFuncDefNode(FuncDefNode):
             if entry.in_closure and not arg.default:
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
                 if entry.type.is_memoryviewslice:
-                    code.put_incref_memoryviewslice(entry.cname, True)
+                    code.put_incref_memoryviewslice(entry.cname, have_gil=True)
                 else:
                     code.put_var_incref(entry)
                     code.put_var_giveref(entry)
@@ -3243,7 +3243,7 @@ class DefNode(FuncDefNode):
                         "Referring to a memoryview typed argument directly in a nested closure function "
                         "is not supported in Cython 0.x. "
                         "Either upgrade to Cython 3, or assign the argument to a local variable "
-                        "and capture that."
+                        "and use that in the nested function."
                     )
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
                 if entry.xdecref_cleanup:

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2506,3 +2506,23 @@ def test_const_buffer(const int[:] a):
     cdef const int[:] c = a
     print(a[0])
     print(c[-1])
+
+cdef arg_in_closure_cdef(int [:] a):
+    def inner():
+        return (a[0], a[1])
+    return inner
+
+def test_arg_in_closure_cdef(a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> inner = test_arg_in_closure_cdef(A)
+    acquired A
+    >>> inner()
+    (0, 1)
+
+    The assignment below is just to avoid printing what was collected
+    >>> del inner; ignore_me = gc.collect()
+    released A
+    """
+    return arg_in_closure_cdef(a)
+


### PR DESCRIPTION
Error on memoryview argument capture on 0.29.x
    
I don't believe it's easy to fix 
https://github.com/cython/cython/issues/4798 for def functions on 0.29.x Therefore,
generate an error message that explains two possible workarounds.
    
This at least makes sure that people don't end up with mysterious
crashes.

It is possible to fix for cdef functions though, so I've done that.

Best attempt at backporting https://github.com/cython/cython/pull/4848 for 0.29.x