### PR TITLE
Disable co_varnames identity check on Python 3.11

### DIFF
--- a/tests/run/tuple_constants.pyx
+++ b/tests/run/tuple_constants.pyx
@@ -36,12 +36,12 @@ def test_deduplicated_args():
     # are generated often with the same argument names. Therefore it's worth ensuring that
     # they are correctly deduplicated
     import sys
-    runtest = (
+    check_identity_of_co_varnames = (
         not hasattr(sys, "pypy_version_info") and  # test doesn't work on PyPy (which is probably fair enough)
         sys.version_info < (3, 11)  # on Python 3.11 co_varnames returns a new, dynamically-calculated tuple
                                     # each time it is run
     )
-    if runtest:
+    if check_identity_of_co_varnames:
         assert func1.__code__.co_varnames is func2.__code__.co_varnames
 
 @cython.test_assert_path_exists("//TupleNode",

--- a/tests/run/tuple_constants.pyx
+++ b/tests/run/tuple_constants.pyx
@@ -36,7 +36,12 @@ def test_deduplicated_args():
     # are generated often with the same argument names. Therefore it's worth ensuring that
     # they are correctly deduplicated
     import sys
-    if not hasattr(sys, "pypy_version_info"):  # test doesn't work on PyPy (which is probably fair enough)
+    runtest = (
+        not hasattr(sys, "pypy_version_info") and  # test doesn't work on PyPy (which is probably fair enough)
+        sys.version_info < (3, 11)  # on Python 3.11 co_varnames returns a new, dynamically-calculated tuple
+                                    # each time it is run
+    )
+    if runtest:
         assert func1.__code__.co_varnames is func2.__code__.co_varnames
 
 @cython.test_assert_path_exists("//TupleNode",


### PR DESCRIPTION
CPython no longer stores the varnames tuple. Instead it stores it
as part of a larger list of names and calculates it dynamically
on request.