### PR TITLE
BUG: Fortify object buffers against included NULLs

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4612,7 +4612,7 @@ class BufferIndexNode(_IndexingBaseNode):
             res = self.result()
             code.putln("%s = (PyObject *) *%s;" % (res, self.buffer_ptr_code))
             # NumPy does (occasionally) allow NULL to denote None.
-            code.putln("if (%s == NULL) %s = Py_None;" % (res, res))
+            code.putln("if (unlikely(%s == NULL)) %s = Py_None;" % (res, res))
             code.putln("__Pyx_INCREF((PyObject*)%s);" % res)
 
     def free_subexpr_temps(self, code):

--- a/tests/buffers/bufaccess.pyx
+++ b/tests/buffers/bufaccess.pyx
@@ -1005,6 +1005,51 @@ def assign_to_object(object[object] buf, int idx, obj):
     buf[idx] = obj
 
 @testcase
+def check_object_nulled_1d(MockBuffer[object, ndim=1] buf, int idx, obj):
+    """
+    See comments on printbuf_object above.
+
+    >>> a = object()
+    >>> rc1 = get_refcount(a)
+    >>> A = ObjectMockBuffer(None, [a, a])
+    >>> check_object_nulled_1d(A, 0, a)
+    >>> decref(a)  # new reference "added" to A
+    >>> check_object_nulled_1d(A, 1, a)
+    >>> decref(a)
+    >>> A = ObjectMockBuffer(None, [a, a, a, a], strides=(2,))
+    >>> check_object_nulled_1d(A, 0, a)  # only 0 due to stride
+    >>> decref(a)
+    >>> get_refcount(a) == rc1
+    True
+    """
+    cdef void **data = <void **>buf.buffer
+    data[idx] = NULL
+    res = buf[idx]  # takes None
+    buf[idx] = obj
+    return res
+
+@testcase
+def check_object_nulled_2d(MockBuffer[object, ndim=2] buf, int idx1, int idx2, obj):
+    """
+    See comments on printbuf_object above.
+
+    >>> a = object()
+    >>> rc1 = get_refcount(a)
+    >>> A = ObjectMockBuffer(None, [a, a, a, a], shape=(2, 2))
+    >>> check_object_nulled_2d(A, 0, 0, a)
+    >>> decref(a)  # new reference "added" to A
+    >>> check_object_nulled_2d(A, 1, 1, a)
+    >>> decref(a)
+    >>> get_refcount(a) == rc1
+    True
+    """
+    cdef void **data = <void **>buf.buffer
+    data[idx1 + 2*idx2] = NULL
+    res = buf[idx1, idx2]  # takes None
+    buf[idx1, idx2] = obj
+    return res
+
+@testcase
 def assign_temporary_to_object(object[object] buf):
     """
     See comments on printbuf_object above.


### PR DESCRIPTION
While NumPy tends to not actively create object buffers initialized
only with NULL (rather than filled with None), at least older versions
of NumPy did do that.  And NumPy guards against this.

This guards against embedded NULLs in object buffers interpreting
a NULL as None (and anticipating a NULL value also when setting
the buffer for reference count purposes).

Closes gh-4858