### PR TITLE
Notes about embedding and portable applications

### DIFF
--- a/docs/src/tutorial/embedding.rst
+++ b/docs/src/tutorial/embedding.rst
@@ -75,3 +75,10 @@ option.  Or use the
 script to embed multiple modules.  See the
 `embedding demo program <https://github.com/cython/cython/tree/master/Demos/embed>`_
 for a complete example setup.
+
+Be aware that your application will not contain any external dependencies that
+you use (including Python standard library modules) and so may not be truly portable.
+If you want to generate a portable application we recommend using a specialized
+tool (e.g. `PyInstaller <https://pyinstaller.org/en/stable/>`_
+or `cx_freeze <https://cx-freeze.readthedocs.io/en/latest/index.html>`_) to find and
+bundle these dependencies.

--- a/docs/src/userguide/external_C_code.rst
+++ b/docs/src/userguide/external_C_code.rst
@@ -471,7 +471,9 @@ For example, in the following snippet that includes :file:`grail.h`:
     }
 
 This C code can then be built together with the Cython-generated C code
-in a single program (or library).
+in a single program (or library). Be aware that this program will not include
+any external dependencies that your module uses. Therefore typically this will
+not generate a truly portable application for most cases.
 
 In Python 3.x, calling the module init function directly should be avoided.  Instead,
 use the `inittab mechanism <https://docs.python.org/3/c-api/import.html#c._inittab>`_


### PR DESCRIPTION
Try to make it clear that using cython --embed doesn't embed
any external dependencies.