### PR TITLE
Docs: don't say cdef functions exist in module dict

### DIFF
--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -166,12 +166,6 @@ example:
 
 .. literalinclude:: ../../examples/userguide/sharing_declarations/spammery.pyx
 
-.. note::
-
-    When a module exports a C function in this way, you can't make use of
-    this function directly from Python, nor can you use it from Cython 
-    using a normal import statement; you have to use :keyword:`cimport`.
-
 .. _sharing_extension_types:
 
 Sharing Extension Types

--- a/docs/src/userguide/sharing_declarations.rst
+++ b/docs/src/userguide/sharing_declarations.rst
@@ -168,10 +168,9 @@ example:
 
 .. note::
 
-    When a module exports a C function in this way, an object appears in the
-    module dictionary under the function's name. However, you can't make use of
-    this object from Python, nor can you use it from Cython using a normal import
-    statement; you have to use :keyword:`cimport`.
+    When a module exports a C function in this way, you can't make use of
+    this function directly from Python, nor can you use it from Cython 
+    using a normal import statement; you have to use :keyword:`cimport`.
 
 .. _sharing_extension_types:
 


### PR DESCRIPTION
Patch is against 0.29.x branch (to fix both versions of the
documentation).

Fixes https://github.com/cython/cython/issues/4862