### PR TITLE
Allow setting annotation_typing locally

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -366,7 +366,6 @@ directive_scopes = {  # defaults to available everywhere
     'test_fail_if_path_exists' : ('function', 'class', 'cclass'),
     'freelist': ('cclass',),
     'emit_code_comments': ('module',),
-    'annotation_typing': ('module',),  # FIXME: analysis currently lacks more specific function scope
     # Avoid scope-specific to/from_py_functions for c_string.
     'c_string_type': ('module',),
     'c_string_encoding': ('module',),

--- a/docs/src/userguide/migrating_to_cy30.rst
+++ b/docs/src/userguide/migrating_to_cy30.rst
@@ -172,3 +172,20 @@ rather than relying on the user to test and cast the type of each operand.
 The old behaviour can be restored with the 
 :ref:`directive <compiler-directives>` ``c_api_binop_methods=True``.
 More details are given in :ref:`arithmetic_methods`.
+
+Annotation typing
+=================
+
+Cython 3 has made substantial improvements in recognising types in
+annotations and it is well worth reading
+:ref:`the pure Python tutorial<pep484_type_annotations>` to understand
+some of the improvements.
+
+A notable backwards-compatible change is that ``x: int`` is now typed
+such that ``x`` is an exact Python ``int`` (Cython 0.29 would accept
+any Python object for ``x``).
+
+To make it easier to handle cases where your interpretation of type
+annotations differs from Cython's, Cython 3 now supports setting the
+``annotation_typing`` :ref:`directive <compiler-directives>` on a
+per-class or per-function level.

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -946,7 +946,8 @@ Cython code.  Here is the list of currently supported directives:
     Uses function argument annotations to determine the type of variables. Default
     is True, but can be disabled. Since Python does not enforce types given in
     annotations, setting to False gives greater compatibility with Python code.
-    Must be set globally.
+    From Cython 3.0 ``annotation_typing`` can be set on a per-function or
+    per-class basis.
 
 ``emit_code_comments`` (True / False)
     Copy the original source code line by line into C code comments in the generated

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -329,6 +329,36 @@ class HasPtr:
         return f"HasPtr({self.a[0]}, {self.b})"
 
 
+@cython.annotation_typing(False)
+def turn_off_typing(x: float, d: dict):
+    """
+    >>> turn_off_typing('not a float', [])  # ignore the typing
+    ('Python object', 'Python object', 'not a float', [])
+    """
+    return typeof(x), typeof(d), x, d
+
+
+@cython.annotation_typing(False)
+cdef class ClassTurnOffTyping:
+    x: float
+    d: dict
+
+    def get_var_types(self, arg: float):
+        """
+        >>> ClassTurnOffTyping().get_var_types(1.0)
+        ('Python object', 'Python object', 'Python object')
+        """
+        return typeof(self.x), typeof(self.d), typeof(arg)
+
+    @cython.annotation_typing(True)
+    def and_turn_it_back_on_again(self, arg: float):
+        """
+        >>> ClassTurnOffTyping().and_turn_it_back_on_again(1.0)
+        ('Python object', 'Python object', 'double')
+        """
+        return typeof(self.x), typeof(self.d), typeof(arg)
+
+
 _WARNINGS = """
 14:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 14:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.


### PR DESCRIPTION
To make it easier to handle cases where Cython's interpretation
differs from the user's interpretation.

Also improve the documentation about this

(ref https://github.com/cython/cython/issues/4885#issuecomment-1180852570)