### PR TITLE
Account for possible struct padding when calculating itemsize

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3772,14 +3772,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             if not condition:
                 code.putln("")  # start in new line
             code.putln("#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x050B0000")
-            code.putln('sizeof(%s),' % objstruct)
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
             code.putln("#elif CYTHON_COMPILING_IN_LIMITED_API")
-            code.putln('sizeof(%s),' % objstruct)
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
             code.putln("#else")
-            code.putln('sizeof(%s),' % sizeof_objstruct)
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (sizeof_objstruct, sizeof_objstruct))
             code.putln("#endif")
         else:
-            code.put('sizeof(%s), ' % objstruct)
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
 
         # check_size
         if type.check_size and type.check_size in ('error', 'warn', 'ignore'):

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -554,7 +554,8 @@ static PyTypeObject *__Pyx_ImportType(PyObject *module, const char *module_name,
             // (most likely because alignof isn't available)
             alignment = size % alignment;
         }
-        itemsize = itemsize > (Py_ssize_t)alignment ? itemsize : (Py_ssize_t)alignment;
+        if (itemsize < (Py_ssize_t)alignment)
+            itemsize = (Py_ssize_t)alignment;
     }
     if ((size_t)(basicsize + itemsize) < size) {
         PyErr_Format(PyExc_ValueError,


### PR DESCRIPTION
I think this is the right thing to do for https://github.com/cython/cython/issues/4827#issuecomment-1186178009. It adds a bit of extra leeway to the size check to account for any padding that the compiler might have added. It gives a better answer on more recent compilers (where `alignof` exists).

Obviously extra leeway does make the check a little weaker (but only for variable sized objects)