### PR TITLE
Improve test coverage of special methods with type conversions

### DIFF
--- a/tests/run/special_methods_T561.pyx
+++ b/tests/run/special_methods_T561.pyx
@@ -956,3 +956,44 @@ cdef class ReverseMethodsExist:
         return "radd"
     def __rsub__(self, other):
         return "rsub"
+
+
+cdef class OddTypeConversions:
+    """
+    The user can set the signature of special method arguments so that
+    it doesn't match the C signature. This just tests that a few work
+    (and fills in a hole in coverage of the Cython source)
+
+    >>> obj = OddTypeConversions()
+    >>> obj[1]
+    1
+    >>> obj["not a number!"]
+    Traceback (most recent call last):
+    ...
+    TypeError: an integer is required
+    >>> obj < obj
+    In comparison 0
+    True
+    >>> obj == obj
+    In comparison 2
+    False
+
+    Here I'm not sure how reproducible the flags are between Python versions.
+    Therefore I'm just checking that they end with ".0"
+    >>> memoryview(obj)  # doctest:+ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    RuntimeError: From __getbuffer__ with flags ....0
+    """
+    # force conversion of object to int
+    def __getitem__(self, int x):
+        return x
+
+    # force conversion of comparison (int) to object
+    def __richcmp__(self, other, object comparison):
+        print "In comparison", comparison
+        return not bool(comparison)
+
+    # force conversion of flags (int) to double
+    def __getbuffer__(self, Py_buffer *buffer, double flags):
+        raise RuntimeError("From __getbuffer__ with flags {}".format(flags))

--- a/tests/run/special_methods_T561.pyx
+++ b/tests/run/special_methods_T561.pyx
@@ -958,13 +958,13 @@ cdef class ReverseMethodsExist:
         return "rsub"
 
 
-cdef class OddTypeConversions:
+cdef class ArgumentTypeConversions:
     """
     The user can set the signature of special method arguments so that
     it doesn't match the C signature. This just tests that a few work
     (and fills in a hole in coverage of the Cython source)
 
-    >>> obj = OddTypeConversions()
+    >>> obj = ArgumentTypeConversions()
     >>> obj[1]
     1
     >>> obj["not a number!"]


### PR DESCRIPTION
https://github.com/cython/cython/issues/4163

```
if old_type.is_pyobject:
    if arg.default:  # 4325 ↛ 4326
        code.putln("if (%s) {" % arg.hdr_cname)
    else:
        code.putln("assert(%s); {" % arg.hdr_cname)
        self.generate_arg_conversion_from_pyobject(arg, code)
        code.putln("}")
    elif new_type.is_pyobject:  # 4331 ↛ 4334
        self.generate_arg_conversion_to_pyobject(arg, code)
    else:
        if new_type.assignable_from(old_type):
            code.putln("%s = %s;" % (arg.entry.cname, arg.hdr_cname))
        else:
            error(arg.pos, "Cannot convert 1 argument from '%s' to '%s'" % (old_type, new_type))
```

It doesn't cover the arg.default case (since I don't think any
of these methods accept a default argument), or the failed conversion
case. But does cover the pyobject->C, C->pyobject and C->C cases