### PR TITLE
Make Cython async functions set CO_COROUTINE and CO_ASYNC_GENERATOR code flags

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9839,10 +9839,12 @@ class CodeObjectNode(ExprNode):
             flags.append('CO_VARARGS')
         if self.def_node.starstar_arg:
             flags.append('CO_VARKEYWORDS')
-        if self.def_node.is_generator and self.def_node.is_coroutine:
+        if self.def_node.is_asyncgen:
+            flags.append('CO_ASYNC_GENERATOR')
+        elif self.def_node.is_coroutine:
             flags.append('CO_COROUTINE')
-            if self.def_node.is_asyncgen:
-                flags.append('CO_ASYNC_GENERATOR')
+        elif self.def_node.is_generator:
+            flags.append('CO_GENERATOR')
 
         code.putln("%s = (PyObject*)__Pyx_PyCode_New(%d, %d, %d, %d, 0, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s); %s" % (
             self.result_code,

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9839,6 +9839,10 @@ class CodeObjectNode(ExprNode):
             flags.append('CO_VARARGS')
         if self.def_node.starstar_arg:
             flags.append('CO_VARKEYWORDS')
+        if self.def_node.is_generator and self.def_node.is_coroutine:
+            flags.append('CO_COROUTINE')
+            if self.def_node.is_asyncgen:
+                flags.append('CO_ASYNC_GENERATOR')
 
         code.putln("%s = (PyObject*)__Pyx_PyCode_New(%d, %d, %d, %d, 0, %s, %s, %s, %s, %s, %s, %s, %s, %s, %d, %s); %s" % (
             self.result_code,

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -650,9 +650,6 @@ class __Pyx_FakeReference {
 #endif
 #define __Pyx_NoneAsNull(obj)  (__Pyx_Py_IsNone(obj) ? NULL : (obj))
 
-#ifndef CO_GENERATOR
-  #define CO_GENERATOR 0x20
-#endif
 #ifndef CO_COROUTINE
   #define CO_COROUTINE 0x80
 #endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -650,6 +650,9 @@ class __Pyx_FakeReference {
 #endif
 #define __Pyx_NoneAsNull(obj)  (__Pyx_Py_IsNone(obj) ? NULL : (obj))
 
+#ifndef CO_GENERATOR
+  #define CO_GENERATOR 0x20
+#endif
 #ifndef CO_COROUTINE
   #define CO_COROUTINE 0x80
 #endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -650,6 +650,13 @@ class __Pyx_FakeReference {
 #endif
 #define __Pyx_NoneAsNull(obj)  (__Pyx_Py_IsNone(obj) ? NULL : (obj))
 
+#ifndef CO_COROUTINE
+  #define CO_COROUTINE 0x80
+#endif
+#ifndef CO_ASYNC_GENERATOR
+  #define CO_ASYNC_GENERATOR 0x200
+#endif
+
 #ifndef Py_TPFLAGS_CHECKTYPES
   #define Py_TPFLAGS_CHECKTYPES 0
 #endif

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -754,7 +754,7 @@ class AsyncBadSyntaxTest(unittest.TestCase):
             async def g(): pass
             await z
         await = 1
-        if sys.version_info > (3,10,5):
+        if sys.version_info >= (3,10,6):
             self.assertTrue(inspect.iscoroutinefunction(f))
 
 
@@ -778,7 +778,7 @@ class TokenizerRegrTest(unittest.TestCase):
         exec(buf, ns, ns)
         self.assertEqual(ns['i499'](), 499)
         self.assertEqual(type(ns['foo']()).__name__, 'coroutine')
-        if sys.version_info > (3,10,5):
+        if sys.version_info >= (3,10,6):
             self.assertTrue(inspect.iscoroutinefunction(ns['foo']))
 
 

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -14,7 +14,7 @@ import copy
 #import types
 import pickle
 import os.path
-#import inspect
+import inspect
 import unittest
 import warnings
 import contextlib
@@ -754,7 +754,7 @@ class AsyncBadSyntaxTest(unittest.TestCase):
             async def g(): pass
             await z
         await = 1
-        #self.assertTrue(inspect.iscoroutinefunction(f))
+        self.assertTrue(inspect.iscoroutinefunction(f))
 
 
 class TokenizerRegrTest(unittest.TestCase):
@@ -777,7 +777,7 @@ class TokenizerRegrTest(unittest.TestCase):
         exec(buf, ns, ns)
         self.assertEqual(ns['i499'](), 499)
         self.assertEqual(type(ns['foo']()).__name__, 'coroutine')
-        #self.assertTrue(inspect.iscoroutinefunction(ns['foo']))
+        self.assertTrue(inspect.iscoroutinefunction(ns['foo']))
 
 
 class CoroutineTest(unittest.TestCase):

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -754,7 +754,8 @@ class AsyncBadSyntaxTest(unittest.TestCase):
             async def g(): pass
             await z
         await = 1
-        self.assertTrue(inspect.iscoroutinefunction(f))
+        if sys.version_info > (3,10,5):
+            self.assertTrue(inspect.iscoroutinefunction(f))
 
 
 class TokenizerRegrTest(unittest.TestCase):
@@ -777,7 +778,8 @@ class TokenizerRegrTest(unittest.TestCase):
         exec(buf, ns, ns)
         self.assertEqual(ns['i499'](), 499)
         self.assertEqual(type(ns['foo']()).__name__, 'coroutine')
-        self.assertTrue(inspect.iscoroutinefunction(ns['foo']))
+        if sys.version_info > (3,10,5):
+            self.assertTrue(inspect.iscoroutinefunction(ns['foo']))
 
 
 class CoroutineTest(unittest.TestCase):


### PR DESCRIPTION
After the CPython change in https://github.com/python/cpython/pull/94050, it seems reasonable to try it.

Closes https://github.com/cython/cython/issues/2273