### PR TITLE
Fix initialization of init=False dataclass fields

### DIFF
--- a/tests/run/pure_cdef_class_dataclass.py
+++ b/tests/run/pure_cdef_class_dataclass.py
@@ -29,3 +29,30 @@ class MyDataclass:
 
     a: int = 1
     self: list = cython.dataclasses.field(default_factory=list, hash=False)  # test that arguments of init don't conflict
+
+
+class DummyObj:
+    def __repr__(self):
+        return "DummyObj()"
+
+
+@cython.dataclasses.dataclass
+@cython.cclass
+class NoInitFields:
+    """
+    >>> NoInitFields()
+    NoInitFields(has_default=DummyObj(), has_factory='From a lambda', neither=None)
+    >>> NoInitFields().has_default is NoInitFields().has_default
+    True
+    """
+    has_default : object = cython.dataclasses.field(default=DummyObj(), init=False)
+    has_factory : object = cython.dataclasses.field(default_factory=lambda: "From a lambda", init=False)
+    # Cython will default-initialize to None
+    neither : object = cython.dataclasses.field(init=False)
+
+    def __post_init__(self):
+        if not cython.compiled:
+            # Cython will default-initialize this to None, while Python won't
+            # and not initializing it will mess up repr
+            assert not hasattr(self, "neither")
+            self.neither = None

--- a/tests/run/pure_cdef_class_dataclass.py
+++ b/tests/run/pure_cdef_class_dataclass.py
@@ -47,20 +47,17 @@ class NoInitFields:
 
     >>> NoInitFields(1)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ...
     TypeError: NoInitFields.__init__() takes 1 positional argument but 2 were given
-    >>> NoInitFields(has_default=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+
+    >>> NoInitFields(has_default=1)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ...
-    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'has_default'
-    >>> NoInitFields(has_factory=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    TypeError: ...has_default...
+    >>> NoInitFields(has_factory=1)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ...
-    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'has_factory'
-    >>> NoInitFields(neither=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    TypeError: ...has_factory...
+    >>> NoInitFields(neither=1)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ...
-    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'neither'
+    TypeError: ...neither...
     """
     has_default : object = cython.dataclasses.field(default=DummyObj(), init=False)
     has_factory : object = cython.dataclasses.field(default_factory=lambda: "From a lambda", init=False)

--- a/tests/run/pure_cdef_class_dataclass.py
+++ b/tests/run/pure_cdef_class_dataclass.py
@@ -44,6 +44,23 @@ class NoInitFields:
     NoInitFields(has_default=DummyObj(), has_factory='From a lambda', neither=None)
     >>> NoInitFields().has_default is NoInitFields().has_default
     True
+
+    >>> NoInitFields(1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    TypeError: NoInitFields.__init__() takes 1 positional argument but 2 were given
+    >>> NoInitFields(has_default=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'has_default'
+    >>> NoInitFields(has_factory=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'has_factory'
+    >>> NoInitFields(neither=1)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    TypeError: NoInitFields.__init__() got an unexpected keyword argument 'neither'
     """
     has_default : object = cython.dataclasses.field(default=DummyObj(), init=False)
     has_factory : object = cython.dataclasses.field(default_factory=lambda: "From a lambda", init=False)


### PR DESCRIPTION
init=False (in a field name) means that it isn't an argument to
`__init__`. It does not mean that the field isn't initialized if
a default method of initialization is provided.