### PR TITLE
add missing unicode APIs

### DIFF
--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -1,6 +1,7 @@
-from libc.stdint cimport uint8_t, uint16_t
 
 cdef extern from *:
+    ctypedef unsigned char  uint8_t
+    ctypedef unsigned short uint16_t
     ctypedef uint8_t Py_UCS1
     ctypedef uint16_t Py_UCS2
 

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -32,8 +32,7 @@ cdef extern from *:
     Py_UCS2 *PyUnicode_2BYTE_DATA(object o)
     Py_UCS4 *PyUnicode_4BYTE_DATA(object o)
 
-    # Deprecated since version 3.10, will be removed in version 3.12.
-    int PyUnicode_WCHAR_KIND
+    int PyUnicode_WCHAR_KIND  # Deprecated since version 3.10, will be removed in version 3.12.
     int PyUnicode_1BYTE_KIND
     int PyUnicode_2BYTE_KIND
     int PyUnicode_4BYTE_KIND

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -1,8 +1,8 @@
 from libc.stdint cimport uint8_t, uint16_t
 
 cdef extern from *:
-    ctypedef uint8_t Py_UCS1;
-    ctypedef uint16_t Py_UCS2;
+    ctypedef uint8_t Py_UCS1
+    ctypedef uint16_t Py_UCS2
 
     # Return true if the object o is a Unicode object or an instance
     # of a Unicode subtype. Changed in version 2.2: Allowed subtypes

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -1,9 +1,7 @@
 
 cdef extern from *:
-    ctypedef unsigned char  uint8_t
-    ctypedef unsigned short uint16_t
-    ctypedef uint8_t Py_UCS1
-    ctypedef uint16_t Py_UCS2
+    ctypedef unsigned char Py_UCS1  # uint8_t
+    ctypedef unsigned short Py_UCS2  # uint16_t
 
     # Return true if the object o is a Unicode object or an instance
     # of a Unicode subtype. Changed in version 2.2: Allowed subtypes

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -33,7 +33,7 @@ cdef extern from *:
     Py_UCS2 *PyUnicode_2BYTE_DATA(object o)
     Py_UCS4 *PyUnicode_4BYTE_DATA(object o)
 
-    int PyUnicode_WCHAR_KIND  # Deprecated since version 3.10, will be removed in version 3.12.
+    int PyUnicode_WCHAR_KIND  # Deprecated since Python 3.10, removed in 3.12.
     int PyUnicode_1BYTE_KIND
     int PyUnicode_2BYTE_KIND
     int PyUnicode_4BYTE_KIND

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -23,6 +23,21 @@ cdef extern from *:
     # New in version 3.3.
     Py_ssize_t PyUnicode_GET_LENGTH(object o)
 
+    Py_UCS1 *PyUnicode_1BYTE_DATA(object o)
+    Py_UCS2 *PyUnicode_2BYTE_DATA(object o)
+    Py_UCS4 *PyUnicode_4BYTE_DATA(object o)
+
+    int PyUnicode_WCHAR_KIND
+    int PyUnicode_1BYTE_KIND
+    int PyUnicode_2BYTE_KIND
+    int PyUnicode_4BYTE_KIND
+    void PyUnicode_WRITE(int kind, void *data, Py_ssize_t index, Py_UCS4 value)
+    Py_UCS4 PyUnicode_READ(int kind, void *data, Py_ssize_t index)
+    Py_UCS4 PyUnicode_READ_CHAR(object o, Py_ssize_t index)
+
+    unsigned int PyUnicode_KIND(object o)
+    void *PyUnicode_DATA(object o)
+
     # Return the size of the object's internal buffer in bytes. o has
     # to be a PyUnicodeObject (not checked).
     Py_ssize_t PyUnicode_GET_DATA_SIZE(object o)
@@ -34,6 +49,8 @@ cdef extern from *:
     # Return a pointer to the internal buffer of the object. o has to
     # be a PyUnicodeObject (not checked).
     char* PyUnicode_AS_DATA(object o)
+
+    bint PyUnicode_IsIdentifier(object o)
 
     # Return 1 or 0 depending on whether ch is a whitespace character.
     bint Py_UNICODE_ISSPACE(Py_UCS4 ch)
@@ -64,6 +81,8 @@ cdef extern from *:
 
     # Return 1 or 0 depending on whether ch is an alphanumeric character.
     bint Py_UNICODE_ISALNUM(Py_UCS4 ch)
+
+    bint Py_UNICODE_ISPRINTABLE(Py_UCS4 ch)
 
     # Return the character ch converted to lower case.
     # Used to return a Py_UNICODE value before Py3.3.

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -111,6 +111,18 @@ cdef extern from *:
     # UTF-8 encoded bytes.  The size is determined with strlen().
     unicode PyUnicode_FromString(const char *u)
 
+    unicode PyUnicode_New(Py_ssize_t size, Py_UCS4 maxchar)
+    unicode PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)
+    unicode PyUnicode_FromFormat(const char *format, ...)
+    Py_ssize_t PyUnicode_GetLength(object unicode) except -1
+    Py_ssize_t PyUnicode_CopyCharacters(object to, Py_ssize_t to_start, object from, Py_ssize_t from_start, Py_ssize_t how_many) except -1
+    Py_ssize_t PyUnicode_Fill(object unicode, Py_ssize_t start, Py_ssize_t length, Py_UCS4 fill_char) except -1
+    int PyUnicode_WriteChar(object unicode, Py_ssize_t index, Py_UCS4 character) except -1
+    Py_UCS4 PyUnicode_ReadChar(object unicode, Py_ssize_t index) except -1
+    unicode PyUnicode_Substring(object str, Py_ssize_t start, Py_ssize_t end)
+    Py_UCS4 *PyUnicode_AsUCS4(object u, Py_UCS4 *buffer, Py_ssize_t buflen, int copy_null) except NULL
+    Py_UCS4 *PyUnicode_AsUCS4Copy(object u) except NULL
+
     # Create a Unicode Object from the given Unicode code point ordinal.
     #
     # The ordinal must be in range(0x10000) on narrow Python builds

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -1,4 +1,9 @@
+from libc.stdint cimport uint8_t, uint16_t
+
 cdef extern from *:
+    ctypedef uint8_t Py_UCS1;
+    ctypedef uint16_t Py_UCS2;
+
     # Return true if the object o is a Unicode object or an instance
     # of a Unicode subtype. Changed in version 2.2: Allowed subtypes
     # to be accepted.

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -27,6 +27,7 @@ cdef extern from *:
     Py_UCS2 *PyUnicode_2BYTE_DATA(object o)
     Py_UCS4 *PyUnicode_4BYTE_DATA(object o)
 
+    # Deprecated since version 3.10, will be removed in version 3.12.
     int PyUnicode_WCHAR_KIND
     int PyUnicode_1BYTE_KIND
     int PyUnicode_2BYTE_KIND
@@ -134,7 +135,7 @@ cdef extern from *:
     unicode PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)
     unicode PyUnicode_FromFormat(const char *format, ...)
     Py_ssize_t PyUnicode_GetLength(object unicode) except -1
-    Py_ssize_t PyUnicode_CopyCharacters(object to, Py_ssize_t to_start, object from, Py_ssize_t from_start, Py_ssize_t how_many) except -1
+    Py_ssize_t PyUnicode_CopyCharacters(object to, Py_ssize_t to_start, object from_, Py_ssize_t from_start, Py_ssize_t how_many) except -1
     Py_ssize_t PyUnicode_Fill(object unicode, Py_ssize_t start, Py_ssize_t length, Py_UCS4 fill_char) except -1
     int PyUnicode_WriteChar(object unicode, Py_ssize_t index, Py_UCS4 character) except -1
     Py_UCS4 PyUnicode_ReadChar(object unicode, Py_ssize_t index) except -1


### PR DESCRIPTION
Most other functions in this CPython API files come with the Python documentation (e.g. the C++ API does not come with docs). They tend to get easily out of sync with the official CPython documentation and can get quite long. However if you prefer to have the documentation added I can copy them over from the Cpython docs.