### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,43 +155,43 @@ jobs:
           # MacOS sub-jobs
           # ==============
           # (C-only builds are used to create wheels)
-          - os: macos-10.15
+          - os: macos-11
             python-version: 2.7
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 2.7
             backend: cpp
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.5
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.6
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.7
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.15 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.8
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.15 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.9
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.9
             backend: cpp
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: "3.10"
             backend: c
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
-          - os: macos-10.15
+          - os: macos-11
             python-version: "3.10"
             backend: cpp
             env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22