### PR TITLE
Use standard C or C++ atomics for memoryviews

### DIFF
--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -31,7 +31,7 @@ typedef struct {
 // for standard C/C++ atomics, get the headers first so we have ATOMIC_INT_LOCK_FREE
 // defined when we decide to use them
 #if CYTHON_ATOMICS && (defined(__STDC_VERSION__) && \
-                        (__STDC_VERSION__ >= __STDC_VERSION__) && \
+                        (__STDC_VERSION__ >= 201112L) && \
                         !defined(__STDC_NO_ATOMICS__))
     #include <stdatomic.h>
 #elif CYTHON_ATOMICS && (defined(__cplusplus) && ( \
@@ -41,7 +41,7 @@ typedef struct {
 #endif
 
 #if CYTHON_ATOMICS && (defined(__STDC_VERSION__) && \
-                        (__STDC_VERSION__ >= __STDC_VERSION__) && \
+                        (__STDC_VERSION__ >= 201112L) && \
                         !defined(__STDC_NO_ATOMICS__) && \
                        ATOMIC_INT_LOCK_FREE == 2)
     /* C11 atomics are available
@@ -60,6 +60,7 @@ typedef struct {
     #endif
 #elif CYTHON_ATOMICS && (defined(__cplusplus) && ( \
                     (__cplusplus >= 201103L) || \
+                    /*_MSC_VER 1700 is Visual Studio 2012 */ \
                     (defined(_MSC_VER) && _MSC_VER >= 1700)) && \
                     ATOMIC_INT_LOCK_FREE == 2)
     /* C++11 atomics are available

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -44,10 +44,9 @@ typedef struct {
                         (__STDC_VERSION__ >= 201112L) && \
                         !defined(__STDC_NO_ATOMICS__) && \
                        ATOMIC_INT_LOCK_FREE == 2)
-    /* C11 atomics are available
-       require ATOMIC_INT_LOCK_FREE because I'm nervous about the __pyx_atomic_int[2]
-       alignment trick in MemoryView.pyx if it uses mutexes
-     */
+    // C11 atomics are available.
+    // Require ATOMIC_INT_LOCK_FREE because I'm nervous about the __pyx_atomic_int[2]
+    // alignment trick in MemoryView.pyx if it uses mutexes.
     #undef __pyx_atomic_int_type
     #define __pyx_atomic_int_type atomic_int
     // TODO - it might be possible to use a less strict memory ordering here
@@ -63,10 +62,9 @@ typedef struct {
                     /*_MSC_VER 1700 is Visual Studio 2012 */ \
                     (defined(_MSC_VER) && _MSC_VER >= 1700)) && \
                     ATOMIC_INT_LOCK_FREE == 2)
-    /* C++11 atomics are available
-       require ATOMIC_INT_LOCK_FREE because I'm nervous about the __pyx_atomic_int[2]
-       alignment trick in MemoryView.pyx if it uses mutexes
-     */
+    // C++11 atomics are available.
+    // Require ATOMIC_INT_LOCK_FREE because I'm nervous about the __pyx_atomic_int[2]
+    // alignment trick in MemoryView.pyx if it uses mutexes.
     #undef __pyx_atomic_int_type
     #define __pyx_atomic_int_type std::atomic_int
     // TODO - it might be possible to use a less strict memory ordering here

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -28,8 +28,8 @@ typedef struct {
 #define __pyx_atomic_int_type int
 #define __pyx_nonatomic_int_type int
 
-// for standard C/C++ atomics, get the headers first so we have ATOMIC_INT_LOCK_FREE
-// defined when we decide to use them
+// For standard C/C++ atomics, get the headers first so we have ATOMIC_INT_LOCK_FREE
+// defined when we decide to use them.
 #if CYTHON_ATOMICS && (defined(__STDC_VERSION__) && \
                         (__STDC_VERSION__ >= 201112L) && \
                         !defined(__STDC_NO_ATOMICS__))

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -69,11 +69,12 @@ typedef struct {
     #ifdef __PYX_DEBUG_ATOMICS
         #warning "Using GNU atomics"
     #endif
-#elif CYTHON_ATOMICS && defined(_MSC_VER) && CYTHON_COMPILING_IN_NOGIL
+#elif CYTHON_ATOMICS && defined(_MSC_VER)
     /* msvc */
     #include <intrin.h>
     #undef __pyx_atomic_int_type
     #define __pyx_atomic_int_type long
+    #define __pyx_nonatomic_int_type long
     #pragma intrinsic (_InterlockedExchangeAdd)
     #define __pyx_atomic_incr_aligned(value) _InterlockedExchangeAdd(value, 1)
     #define __pyx_atomic_decr_aligned(value) _InterlockedExchangeAdd(value, -1)


### PR DESCRIPTION
Use them in preference to the existing compiler-specific
atomic types.

In both cases this requires the 2011 edition of the standard.

Closes https://github.com/cython/cython/issues/4923