### PR TITLE
Reallow capture of memoryview arguments

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3237,14 +3237,6 @@ class DefNode(FuncDefNode):
         # Move arguments into closure if required
         def put_into_closure(entry):
             if entry.in_closure:
-                if entry.type.is_memoryviewslice:
-                    error(
-                        self.pos,
-                        "Referring to a memoryview typed argument directly in a nested closure function "
-                        "is not supported in Cython 0.x. "
-                        "Either upgrade to Cython 3, or assign the argument to a local variable "
-                        "and use that in the nested function."
-                    )
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
                 if entry.xdecref_cleanup:
                     # mostly applies to the starstar arg - this can sometimes be NULL

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2587,3 +2587,4 @@ def test_arg_in_closure_cdef(a):
     released A
     """
     return arg_in_closure_cdef(a)
+

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2550,6 +2550,25 @@ def test_const_buffer(const int[:] a):
     print(a[0])
     print(c[-1])
 
+
+@testcase
+def test_arg_in_closure(int [:] a):
+    """
+    >>> A = IntMockBuffer("A", range(6), shape=(6,))
+    >>> inner = test_arg_in_closure(A)
+    acquired A
+    >>> inner()
+    (0, 1)
+
+    The assignment below is just to avoid printing what was collected
+    >>> del inner; ignore_me = gc.collect()
+    released A
+    """
+    def inner():
+        return (a[0], a[1])
+    return inner
+
+
 cdef arg_in_closure_cdef(int [:] a):
     def inner():
         return (a[0], a[1])
@@ -2568,4 +2587,3 @@ def test_arg_in_closure_cdef(a):
     released A
     """
     return arg_in_closure_cdef(a)
-


### PR DESCRIPTION
It was actually OK in def functions. It looks very dodgy:

```
__Pyx_XDEC_MEMVIEW(closure->arg)
```

gets called twice and `INC` gets called once. However this is
actually OK since XDEC really means "clear" (this is why I
renamed it in master...)

Fixes https://github.com/cython/cython/issues/4798 (completely
I think).

Sorry for the mess with this!