### PR TITLE
[Docs] Use annotation since #4293 is fixed

### DIFF
--- a/docs/examples/tutorial/clibraries/queue.py
+++ b/docs/examples/tutorial/clibraries/queue.py
@@ -2,7 +2,7 @@ from cython.cimports import cqueue
 
 @cython.cclass
 class Queue:
-    _c_queue = cython.declare(cython.pointer(cqueue.Queue))
+    _c_queue: cython.pointer(cqueue.Queue)
 
     def __cinit__(self):
         self._c_queue = cqueue.queue_new()

--- a/docs/src/tutorial/clibraries.rst
+++ b/docs/src/tutorial/clibraries.rst
@@ -125,9 +125,6 @@ Here is a first start for the Queue class:
         .. literalinclude:: ../../examples/tutorial/clibraries/queue.py
             :caption: queue.py
 
-        .. note:: Currently, Cython contains a bug not allowing using
-            annotations with types containing pointers (GitHub issue :issue:`4293`).
-
     .. group-tab:: Cython
 
         .. literalinclude:: ../../examples/tutorial/clibraries/queue.pyx


### PR DESCRIPTION
#4293 seems to be fixed so we can use annotation and remove note.
