### PR TITLE
Fix memoryviews in generator expressions

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -831,14 +831,14 @@ class FunctionState(object):
         allocated and released one of the same type). Type is simply registered
         and handed back, but will usually be a PyrexType.
 
-        If type.is_pyobject, manage_ref comes into play. If manage_ref is set to
+        If type.needs_refcounting, manage_ref comes into play. If manage_ref is set to
         True, the temp will be decref-ed on return statements and in exception
         handling clauses. Otherwise the caller has to deal with any reference
         counting of the variable.
 
-        If not type.is_pyobject, then manage_ref will be ignored, but it
+        If not type.needs_refcounting, then manage_ref will be ignored, but it
         still has to be passed. It is recommended to pass False by convention
-        if it is known that type will never be a Python object.
+        if it is known that type will never be a reference counted type.
 
         static=True marks the temporary declaration with "static".
         This is only used when allocating backing store for a module-level
@@ -857,7 +857,7 @@ class FunctionState(object):
             type = PyrexTypes.c_ptr_type(type)  # A function itself isn't an l-value
         elif type.is_cpp_class and not type.is_fake_reference and self.scope.directives['cpp_locals']:
             self.scope.use_utility_code(UtilityCode.load_cached("OptionalLocals", "CppSupport.cpp"))
-        if not type.is_pyobject and not type.is_memoryviewslice:
+        if not type.needs_refcounting:
             # Make manage_ref canonical, so that manage_ref will always mean
             # a decref is needed.
             manage_ref = False
@@ -910,17 +910,17 @@ class FunctionState(object):
         for name, type, manage_ref, static in self.temps_allocated:
             freelist = self.temps_free.get((type, manage_ref))
             if freelist is None or name not in freelist[1]:
-                used.append((name, type, manage_ref and type.is_pyobject))
+                used.append((name, type, manage_ref and type.needs_refcounting))
         return used
 
     def temps_holding_reference(self):
         """Return a list of (cname,type) tuples of temp names and their type
-        that are currently in use. This includes only temps of a
-        Python object type which owns its reference.
+        that are currently in use. This includes only temps
+        with a reference counted type which owns its reference.
         """
         return [(name, type)
                 for name, type, manage_ref in self.temps_in_use()
-                if manage_ref and type.is_pyobject]
+                if manage_ref and type.needs_refcounting]
 
     def all_managed_temps(self):
         """Return a list of (cname, type) tuples of refcount-managed Python objects.

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10170,6 +10170,8 @@ class YieldExprNode(ExprNode):
             if type.is_pyobject:
                 code.putln('%s = 0;' % save_cname)
                 code.put_xgotref(cname, type)
+            elif type.is_memoryviewslice:
+                code.putln('%s.memview = NULL; %s.data = NULL;' % (save_cname, save_cname))
         self.generate_sent_value_handling_code(code, Naming.sent_value_cname)
         if self.result_is_used:
             self.allocate_temp_result(code)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1726,7 +1726,9 @@ class _HandleGeneratorArguments(VisitorTransform, SkipDeclarations):
                 self.gen_node = gen_node
 
             # replace the node inside the generator with a looked-up name
-            name_node = ExprNodes.NameNode(pos=pos, name=name)
+            # (initialized_check can safely be False because the source variable will be checked
+            # before it is captured if the check is required)
+            name_node = ExprNodes.NameNode(pos, name=name, initialized_check=False)
             name_node.entry = self.gen_node.def_node.gbody.local_scope.lookup(name_node.name)
             name_node.type = name_node.entry.type
             self.substitutions[node] = name_node

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -443,7 +443,9 @@ def type_infer(double[:, :] arg):
 @cython.test_fail_if_path_exists("//CoerceToPyTypeNode")
 def memview_iter(double[:, :] arg):
     """
-    memview_iter(DoubleMockBuffer("C", range(6), (2,3)))
+    >>> memview_iter(DoubleMockBuffer("C", range(6), (2,3)))
+    acquired C
+    released C
     True
     """
     cdef double total = 0

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2669,3 +2669,32 @@ def test_local_in_closure(a):
     def inner():
         return (a_view[0], a_view[1])
     return inner
+
+@testcase
+def test_local_in_generator_expression(a, initialize, execute_now):
+    """
+    >>> A1 = IntMockBuffer("A1", range(6), shape=(6,))
+    >>> A2 = IntMockBuffer("A2", range(6), shape=(6,))
+    >>> test_local_in_generator_expression(A1, False, False)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    UnboundLocalError...
+
+    >>> test_local_in_generator_expression(A1, True, True)
+    acquired A1
+    released A1
+    True
+
+    >>> genexp = test_local_in_generator_expression(A2, True, False)
+    acquired A2
+    >>> sum(genexp)
+    released A2
+    2
+    """
+    cdef int[:] a_view
+    if initialize:
+        a_view = a
+    if execute_now:
+        return any(ai > 3 for ai in a_view)
+    else:
+        return (ai > 3 for ai in a_view)

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2675,17 +2675,17 @@ def test_local_in_generator_expression(a, initialize, execute_now):
     """
     >>> A1 = IntMockBuffer("A1", range(6), shape=(6,))
     >>> A2 = IntMockBuffer("A2", range(6), shape=(6,))
-    >>> test_local_in_generator_expression(A1, False, False)  # doctest: +ELLIPSIS
+    >>> test_local_in_generator_expression(A1, initialize=False, execute_now=False)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
         ...
     UnboundLocalError...
 
-    >>> test_local_in_generator_expression(A1, True, True)
+    >>> test_local_in_generator_expression(A1, initialize=True, execute_now=True)
     acquired A1
     released A1
     True
 
-    >>> genexp = test_local_in_generator_expression(A2, True, False)
+    >>> genexp = test_local_in_generator_expression(A2, initialize=True, execute_now=False)
     acquired A2
     >>> sum(genexp)
     released A2


### PR DESCRIPTION
as a result of f946fe22fff32077dc58beeb64ec1ebc85d37632
And fix at least one pre-existing reference counting leak
for memoryview references in things like
`any(i > 0 for i in memview)`