### PR TITLE
Allow to embed modules into one executable

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -118,6 +118,8 @@ def create_cython_argparser():
     parser.add_argument('--embed', action='store_const', const='main',
                       help='Generate a main() function that embeds the Python interpreter. '
                            'Pass --embed=<method_name> for a name other than main().')
+    parser.add_argument('--embed-modules', action='store', type=comma_list,
+                      help='')
     parser.add_argument('-2', dest='language_level', action='store_const', const=2,
                       help='Compile based on Python-2 syntax and code semantics.')
     parser.add_argument('-3', dest='language_level', action='store_const', const=3,
@@ -169,6 +171,8 @@ def create_cython_argparser():
 
     return parser
 
+def comma_list(string):
+    return string.split(',')
 
 def parse_command_line_raw(parser, args):
     # special handling for --embed and --embed=xxxx as they aren't correctly parsed

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3357,13 +3357,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             wmain = "wmain"
         else:
             wmain = Options.embed
-        main_method = UtilityCode.load_cached("MainFunction", "Embed.c")
-        code.globalstate.use_utility_code(
-            main_method.specialize(
-                module_name=env.module_name,
-                module_is_main=module_is_main,
-                main_method=Options.embed,
-                wmain_method=wmain))
+        main_method = TempitaUtilityCode.load_cached(
+                "MainFunction", "Embed.c",
+                context={
+                    'module_name': env.module_name,
+                    'module_is_main': module_is_main,
+                    'main_method': Options.embed,
+                    'wmain_method': wmain,
+                    'embed_modules': tuple(Options.embed_modules)})
+        code.globalstate.use_utility_code(main_method)
 
     def punycode_module_name(self, prefix, name):
         # adapted from PEP483

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -133,6 +133,8 @@ lookup_module_cpdef = False
 #: Default is False.
 embed = None
 
+embed_modules = []
+
 # In previous iterations of Cython, globals() gave the first non-Cython module
 # globals in the call stack.  Sage relies on this behavior for variable injection.
 old_style_globals = ShouldBeFromDirective('old_style_globals')


### PR DESCRIPTION
This PR integrates functionality into cython command. New parameter `--embed-modules` is introduced which embeds multiple modules into one executable. Command

```
cython --embed --embed-modules=lcmath combinatorics.pyx
```

generates C file which can be compiled and staticaly linked with `lcmath` module to produce one single executable.

The PR is not migrating the functionality of `-p` switch of `cython_freeze`. Moreover, the scope of this PR is not adding documentation and removal of `cython_freeze`. It
will be done in later PRs.


fixes #2849
