### PR TITLE
Don't make SkipDeclarations a cdef class

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.pxd
+++ b/Cython/Compiler/ParseTreeTransforms.pxd
@@ -6,9 +6,6 @@ from .Visitor cimport (
     CythonTransform, VisitorTransform, TreeVisitor,
     ScopeTrackingTransform, EnvTransform)
 
-cdef class SkipDeclarations: # (object):
-    pass
-
 cdef class NormalizeTree(CythonTransform):
     cdef bint is_in_statlist
     cdef bint is_in_expr


### PR DESCRIPTION
It's only ever used as a mixin class. It ends up working because
it's empty (so doesn't cause a layout conflict) but that also means
it can't use any cdef features so there's no real benefit to
it being a cdef class. It also probably prevents some of the
transforms being cdef classes since Cython spots that it's the
second base.

See https://github.com/cython/cython/pull/4351 (which would
detect this misuse at runtime).