### PR TITLE
Allow bound cfuncs to be coerced to object

### DIFF
--- a/tests/run/cfunc_convert.pyx
+++ b/tests/run/cfunc_convert.pyx
@@ -266,3 +266,28 @@ def make_map():
         "f2": cfunc_dup_f2,
     }
     return map
+
+
+cdef class HasCdefFunc:
+    cdef int x
+    def __init__(self, x):
+        self.x = x
+
+    cdef int func(self, int y):
+        return self.x + y
+
+def test_unbound_methods():
+    """
+    >>> f = test_unbound_methods()
+    >>> f(HasCdefFunc(1), 2)
+    3
+    """
+    return HasCdefFunc.func
+
+def test_bound_methods():
+    """
+    >>> f = test_bound_methods()
+    >>> f(2)
+    3
+    """
+    return HasCdefFunc(1).func


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/4890 (although likely
doesn't generate the optimized code they were really after).

This is an initial pass at the problem that just uses functools.
It's likely that Cython could generate more efficient code in
future.