### PR TITLE
Support the full kw_only option for dataclasses

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -500,13 +500,15 @@ def get_known_standard_library_module_scope(module_name):
         _known_module_scopes[module_name] = mod
     elif module_name == "dataclasses":
         mod = ModuleScope(module_name, None, None)
-        indexed_type = PyrexTypes.SpecialPythonTypeConstructor(EncodedString("dataclasses.InitVar"))
-        initvar_string = EncodedString("InitVar")
-        entry = mod.declare_type(initvar_string, indexed_type, pos = None)
-        var_entry = Entry(initvar_string, None, PyrexTypes.py_object_type)
-        var_entry.is_pyglobal = True
-        var_entry.scope = mod
-        entry.as_variable = var_entry
+        for name in ['InitVar', 'KW_ONLY']:
+            name = EncodedString(name)
+            # KW_ONLY isn't actually indexable, but it works OK to allow it to be
+            indexed_type = PyrexTypes.SpecialPythonTypeConstructor(EncodedString("dataclasses."+name))
+            entry = mod.declare_type(name, indexed_type, pos = None)
+            var_entry = Entry(name, None, PyrexTypes.py_object_type)
+            var_entry.is_pyglobal = True
+            var_entry.scope = mod
+            entry.as_variable = var_entry
         _known_module_scopes[module_name] = mod
     return mod
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -722,6 +722,9 @@ class ExprNode(Node):
         # extension type or builtin type, return its type, else None.
         return None
 
+    def analyse_pytyping_modifiers(self, env):
+        return []
+
     def analyse_types(self, env):
         self.not_implemented("analyse_types")
 
@@ -2140,6 +2143,13 @@ class NameNode(AtomicExprNode):
             if entry.type.is_extension_type or entry.type.is_builtin_type:
                 return entry.type
         return None
+
+    def analyse_pytyping_modifiers(self, env):
+        modifiers = []
+        modifier_type = self.analyse_as_type(env)
+        if modifier_type.python_type_constructor_name and modifier_type.modifier_name:
+            modifiers.append(modifier_type.modifier_name)
+        return modifiers
 
     def analyse_target_declaration(self, env):
         return self._analyse_target_declaration(env, is_assignment_expression=False)
@@ -7284,6 +7294,13 @@ class AttributeNode(ExprNode):
                 else:
                     error(self.pos, "%s not a known value of %s" % (self.attribute, type))
         return None
+
+    def analyse_pytyping_modifiers(self, env):
+        modifiers = []
+        modifier_type = self.analyse_as_type(env)
+        if modifier_type.python_type_constructor_name and modifier_type.modifier_name:
+            modifiers.append(modifier_type.modifier_name)
+        return modifiers
 
     def _create_unbound_cmethod_entry(self, type, entry, env):
         # Create a temporary entry describing the unbound C method in `entry`
@@ -14164,7 +14181,7 @@ class AnnotationNode(ExprNode):
             arg_type.create_declaration_utility_code(env)
 
         # Check for declaration modifiers, e.g. "typing.Optional[...]" or "dataclasses.InitVar[...]"
-        modifiers = annotation.analyse_pytyping_modifiers(env) if annotation.is_subscript else []
+        modifiers = annotation.analyse_pytyping_modifiers(env)
 
         return modifiers, arg_type
 


### PR DESCRIPTION
Including kw_only on dataclasses.dataclass,
kw_only on individual fields, and the dataclasses.KW_ONLY
placeholder marker.

Part of https://github.com/cython/cython/issues/4303

Draft for the moment since proper testing will be enabled by
https://github.com/cython/cython/pull/4955