### PR TITLE
Fix an initialization reference counting error in the limited API

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2961,6 +2961,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         # start of module init/exec function (pre/post PEP 489)
         code.putln("{")
         code.putln('int stringtab_initialized = 0;')
+        code.putln("#if CYTHON_USE_MODULE_STATE")
+        code.putln('int pystate_addmodule_run = 0;')
+        code.putln("#endif")
+
         tempdecl_code = code.insertion_point()
 
         profile = code.globalstate.directives['profile']
@@ -3132,6 +3136,18 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln('}')
         code.putln("#if !CYTHON_USE_MODULE_STATE")
         code.put_decref_clear(env.module_cname, py_object_type, nanny=False, clear_before_decref=True)
+        code.putln("#else")
+        # This section is mainly for the limited API. env.module_cname still owns a reference so
+        # decrement that
+        code.put_decref(env.module_cname, py_object_type, nanny=False)
+        # Also remove the failed module from the module state lookup
+        # fetch/restore the error indicator because PyState_RemvoeModule might fail itself
+        code.putln("if (pystate_addmodule_run) {")
+        code.putln("PyObject *tp, *value, *tb;")
+        code.putln("PyErr_Fetch(&tp, &value, &tb);")
+        code.putln("PyState_RemoveModule(&%s);" % Naming.pymoduledef_cname)
+        code.putln("PyErr_Restore(tp, value, tb);")
+        code.putln("}")
         code.putln("#endif")
         code.putln('} else if (!PyErr_Occurred()) {')
         code.putln('PyErr_SetString(PyExc_ImportError, "init %s");' %
@@ -3484,7 +3500,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 doc,
                 env.module_cname))
         code.putln(code.error_goto_if_null(env.module_cname, self.pos))
-        code.putln("#elif CYTHON_COMPILING_IN_LIMITED_API")
+        code.putln("#elif CYTHON_USE_MODULE_STATE")
         # manage_ref is False (and refnanny calls are omitted) because refnanny isn't yet initialized
         module_temp = code.funcstate.allocate_temp(py_object_type, manage_ref=False)
         code.putln(
@@ -3493,10 +3509,17 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 Naming.pymoduledef_cname,
                 code.error_goto_if_null(module_temp, self.pos)))
         code.putln("{")
+        # So that PyState_FindModule works in the init function:
         code.putln("int add_module_result = PyState_AddModule(%s, &%s);" % (
             module_temp, Naming.pymoduledef_cname))
-        code.put_decref_clear(module_temp, type=py_object_type, nanny=False)
+        code.putln("%s = 0; /* transfer ownership from %s to %s pseudovariable */" % (
+            module_temp, module_temp, env.module_name
+        ))
+        # At this stage the module likely has a refcount of 2 - one owned by the list
+        # inside PyState_AddModule and one owned by "__pyx_m" (and returned from this
+        # function as a new reference).
         code.putln(code.error_goto_if_neg("add_module_result", self.pos))
+        code.putln("pystate_addmodule_run = 1;")
         code.putln("}")
         code.funcstate.release_temp(module_temp)
         code.putln('#else')

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -381,6 +381,12 @@
   #endif
 #endif
 
+#if CYTHON_USE_MODULE_STATE && CYTHON_PEP489_MULTI_PHASE_INIT
+#error "Cannot combine CYTHON_USE_MODULE_STATE and CYTHON_PEP489_MULTI_PHASE_INIT"
+/* since PyState_FindModule requires that each module-def is linked to 1 (or 0) modules
+and multi-phase init allows the same module to be imported many times */
+#endif
+
 #if !defined(CYTHON_FAST_PYCCALL)
 #define CYTHON_FAST_PYCCALL  (CYTHON_FAST_PYCALL && PY_VERSION_HEX >= 0x030600B1)
 #endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -381,12 +381,6 @@
   #endif
 #endif
 
-#if CYTHON_USE_MODULE_STATE && CYTHON_PEP489_MULTI_PHASE_INIT
-#error "Cannot combine CYTHON_USE_MODULE_STATE and CYTHON_PEP489_MULTI_PHASE_INIT"
-/* since PyState_FindModule requires that each module-def is linked to 1 (or 0) modules
-and multi-phase init allows the same module to be imported many times */
-#endif
-
 #if !defined(CYTHON_FAST_PYCCALL)
 #define CYTHON_FAST_PYCCALL  (CYTHON_FAST_PYCALL && PY_VERSION_HEX >= 0x030600B1)
 #endif


### PR DESCRIPTION
Supercedes https://github.com/cython/cython/pull/3702 (but fixes
the same error).

PyInit_* needs to return a new reference to the module object
so effectively we have to transfer ownership of a reference
to __pyx_m.

Also pay a bit more attention to cleaning up on the error path.

Co-authored-by: Matthias Braun <matze@braunis.de>