### PR TITLE
Make sure we call __del__ for final types

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1677,19 +1677,19 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             self.generate_self_cast(scope, code)
 
         has_del = False
-        type_scope = scope
-        while type_scope:
-            del_entry = type_scope.lookup_here("__del__")
+        current_type_scope = scope
+        while current_type_scope:
+            del_entry = current_type_scope.lookup_here("__del__")
             if del_entry:
                 has_del = del_entry.is_special
                 break
-            if (type_scope.parent_type.is_extern or not type_scope.implemented or 
-                    type_scope.parent_type.multiple_bases):
+            if (current_type_scope.parent_type.is_extern or not current_type_scope.implemented or 
+                    current_type_scope.parent_type.multiple_bases):
                 # we don't know if we have __del__, so assume we do and call it
                 has_del = True
                 break
-            base_type = type_scope.parent_type.base_type
-            type_scope = base_type.scope if base_type else None
+            current_base_type = current_type_scope.parent_type.base_type
+            current_type_scope = current_base_type.scope if current_base_type else None
         
         if not is_final_type or has_del:
             # in Py3.4+, call tp_finalize() as early as possible

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1675,7 +1675,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         if py_attrs or cpp_destructable_attrs or memoryview_slices or weakref_slot or dict_slot:
             self.generate_self_cast(scope, code)
-        
+
         if not is_final_type or scope.may_have_finalize():
             # in Py3.4+, call tp_finalize() as early as possible
             code.putln("#if CYTHON_USE_TP_FINALIZE")

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5218,6 +5218,8 @@ class CClassDefNode(ClassDefNode):
             api=self.api,
             buffer_defaults=self.buffer_defaults(env),
             shadow=self.shadow)
+        if self.bases and len(self.bases.args) > 1:
+            self.entry.type.multiple_bases = True
 
     def analyse_declarations(self, env):
         #print "CClassDefNode.analyse_declarations:", self.class_name
@@ -5307,6 +5309,8 @@ class CClassDefNode(ClassDefNode):
             api=self.api,
             buffer_defaults=self.buffer_defaults(env),
             shadow=self.shadow)
+        if self.bases and len(self.bases.args) > 1:
+            self.entry.type.multiple_bases = True
 
         if self.shadow:
             home_scope.lookup(self.class_name).as_variable = self.entry

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1522,6 +1522,7 @@ class PyExtensionType(PyObjectType):
     #  is_external      boolean          Defined in a extern block
     #  check_size       'warn', 'error', 'ignore'    What to do if tp_basicsize does not match
     #  dataclass_fields  OrderedDict nor None   Used for inheriting from dataclasses
+    #  multiple_bases    boolean          Does this class have multiple bases
 
     is_extension_type = 1
     has_attributes = 1
@@ -1529,6 +1530,7 @@ class PyExtensionType(PyObjectType):
 
     objtypedef_cname = None
     dataclass_fields = None
+    multiple_bases = False
 
     def __init__(self, name, typedef_flag, base_type, is_external=0, check_size=None):
         self.name = name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2325,7 +2325,7 @@ class CClassScope(ClassScope):
             del_entry = current_type_scope.lookup_here("__del__")
             if del_entry and del_entry.is_special:
                 return True
-            if (current_type_scope.parent_type.is_extern or not current_type_scope.implemented or 
+            if (current_type_scope.parent_type.is_extern or not current_type_scope.implemented or
                     current_type_scope.parent_type.multiple_bases):
                 # we don't know if we have __del__, so assume we do and call it
                 return True

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2314,6 +2314,25 @@ class CClassScope(ClassScope):
         """
         return self.needs_gc() and not self.directives.get('no_gc_clear', False)
 
+    def may_have_finalize(self):
+        """
+        This covers cases where we definitely have a __del__ function
+        and also cases where one of the base classes could have a __del__
+        function but we don't know.
+        """
+        current_type_scope = self
+        while current_type_scope:
+            del_entry = current_type_scope.lookup_here("__del__")
+            if del_entry and del_entry.is_special:
+                return True
+            if (current_type_scope.parent_type.is_extern or not current_type_scope.implemented or 
+                    current_type_scope.parent_type.multiple_bases):
+                # we don't know if we have __del__, so assume we do and call it
+                return True
+            current_base_type = current_type_scope.parent_type.base_type
+            current_type_scope = current_base_type.scope if current_base_type else None
+        return False
+
     def get_refcounted_entries(self, include_weakref=False,
                                include_gc_simple=True):
         py_attrs = []

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -556,8 +556,7 @@ class TypeFlagsSlot(SlotDescriptor):
             value += "|Py_TPFLAGS_BASETYPE"
         if scope.needs_gc():
             value += "|Py_TPFLAGS_HAVE_GC"
-        entry = scope.lookup("__del__")
-        if entry and entry.is_special:
+        if scope.may_have_finalize():
             value += "|Py_TPFLAGS_HAVE_FINALIZE"
         return value
 

--- a/runtests.py
+++ b/runtests.py
@@ -482,6 +482,7 @@ VER_DEP_MODULES = {
     (3,4): (operator.lt, lambda x: x in ['run.py34_signature',
                                          'run.test_unicode',  # taken from Py3.7, difficult to backport
                                          'run.pep442_tp_finalize',
+                                         'run.pep442_tp_finalize_cimport',
                                          ]),
     (3,4,999): (operator.gt, lambda x: x in ['run.initial_file_path',
                                              ]),

--- a/tests/run/pep442_tp_finalize_cimport.srctree
+++ b/tests/run/pep442_tp_finalize_cimport.srctree
@@ -7,12 +7,13 @@ PYTHON runtests.py
 
 import gc
 from testclasses import *
+import baseclasses
 
 def test_has_del():
     inst = HasIndirectDel()
     inst = None
     gc.collect()
-    assert HasIndirectDel.del_called_count
+    assert baseclasses.HasDel_del_called_count
     
 def test_no_del():
     inst = NoIndirectDel()
@@ -40,10 +41,12 @@ cdef class DoesntHaveDel:
     
 ####### baseclasses.pyx ######
 
+HasDel_del_called_count = 0
+
 cdef class HasDel:
-    del_called_count = 0
     def __del__(self):
-        HasDel.del_called_count += 1
+        global HasDel_del_called_count
+        HasDel_del_called_count += 1
         
 cdef class DoesntHaveDel:
     pass

--- a/tests/run/pep442_tp_finalize_cimport.srctree
+++ b/tests/run/pep442_tp_finalize_cimport.srctree
@@ -1,0 +1,64 @@
+"""
+PYTHON setup.py build_ext -i
+PYTHON runtests.py
+"""
+
+####### runtests.py #######
+
+import gc
+from testclasses import *
+
+def test_has_del():
+    inst = HasIndirectDel()
+    inst = None
+    gc.collect()
+    assert HasIndirectDel.del_called_count
+    
+def test_no_del():
+    inst = NoIndirectDel()
+    inst = None
+    gc.collect()
+    # The test here is that it doesn't crash
+    
+test_has_del()
+test_no_del()
+
+######## setup.py ########
+
+from setuptools import setup
+from Cython.Build import cythonize
+
+setup(ext_modules = cythonize('*.pyx'))
+
+####### baseclasses.pxd ######
+
+cdef class HasDel:
+    pass
+    
+cdef class DoesntHaveDel:
+    pass
+    
+####### baseclasses.pyx ######
+
+cdef class HasDel:
+    del_called_count = 0
+    def __del__(self):
+        HasDel.del_called_count += 1
+        
+cdef class DoesntHaveDel:
+    pass
+
+######## testclasses.pyx ######
+
+cimport cython
+from baseclasses cimport HasDel, DoesntHaveDel
+
+@cython.final
+cdef class HasIndirectDel(HasDel):
+    pass
+
+@cython.final
+cdef class NoIndirectDel(DoesntHaveDel):
+    # But Cython can't tell that we don't have __del__ until runtime,
+    # so has to generate code to call it (and not crash!)
+    pass


### PR DESCRIPTION
including final types that inherit `__del__` from elsewhere (either
known or unknown).

Fixes #4995