### PR TITLE
Implement reversed C++ iteration

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2929,7 +2929,7 @@ class IteratorNode(ScopedExprNode):
         This supports C++ classes with reverse_iterator implemented.
         """
         if not (isinstance(self.sequence, SimpleCallNode) and 
-                len(self.sequence.args) == 1):
+                self.sequence.args_tuple and len(self.sequence.args_tuple) == 1):
             return False
         func = self.sequence.function
         if func.is_name and func.name == "reversed":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2929,7 +2929,7 @@ class IteratorNode(ScopedExprNode):
         This supports C++ classes with reverse_iterator implemented.
         """
         if not (isinstance(self.sequence, SimpleCallNode) and 
-                self.sequence.args_tuple and len(self.sequence.args_tuple) == 1):
+                self.sequence.arg_tuple and len(self.sequence.arg_tuple) == 1):
             return False
         func = self.sequence.function
         if func.is_name and func.name == "reversed":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2928,7 +2928,8 @@ class IteratorNode(ScopedExprNode):
 
         This supports C++ classes with reverse_iterator implemented.
         """
-        if not isinstance(self.sequence, SimpleCallNode):
+        if not (isinstance(self.sequence, SimpleCallNode) and 
+                len(self.sequence.args) == 1):
             return False
         func = self.sequence.function
         if func.is_name and func.name == "reversed":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2928,7 +2928,7 @@ class IteratorNode(ScopedExprNode):
 
         This supports C++ classes with reverse_iterator implemented.
         """
-        if not (isinstance(self.sequence, SimpleCallNode) and 
+        if not (isinstance(self.sequence, SimpleCallNode) and
                 self.sequence.arg_tuple and len(self.sequence.arg_tuple.args) == 1):
             return False
         func = self.sequence.function

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2929,7 +2929,7 @@ class IteratorNode(ScopedExprNode):
         This supports C++ classes with reverse_iterator implemented.
         """
         if not (isinstance(self.sequence, SimpleCallNode) and 
-                self.sequence.arg_tuple and len(self.sequence.arg_tuple) == 1):
+                self.sequence.arg_tuple and len(self.sequence.arg_tuple.args) == 1):
             return False
         func = self.sequence.function
         if func.is_name and func.name == "reversed":

--- a/tests/run/cpp_iterators.pyx
+++ b/tests/run/cpp_iterators.pyx
@@ -2,6 +2,10 @@
 # tag: cpp, werror, no-cpp-locals
 
 from libcpp.deque cimport deque
+from libcpp.list cimport list as stdlist
+from libcpp.map cimport map as stdmap
+from libcpp.set cimport set as stdset
+from libcpp.string cimport string
 from libcpp.vector cimport vector
 from cython.operator cimport dereference as deref
 
@@ -268,3 +272,68 @@ def test_iteration_over_attribute_of_call():
     for i in get_object_with_iterable_attribute().vec:
         print(i)
 
+def test_iteration_over_reversed_list(py_v):
+    """
+    >>> test_iteration_over_reversed_list([2, 4, 6])
+    6
+    4
+    2
+    """
+    cdef stdlist[int] lint
+    for e in py_v:
+        lint.push_back(e)
+    for e in reversed(lint):
+        print(e)
+
+def test_iteration_over_reversed_map(py_v):
+    """
+    >>> test_iteration_over_reversed_map([(1, 10), (2, 20), (3, 30)])
+    3 30
+    2 20
+    1 10
+    """
+    cdef stdmap[int, int] m
+    for k, v in py_v:
+        m[k] = v
+    for k, v in reversed(m):
+        print("%s %s" % (k, v))
+
+def test_iteration_over_reversed_set(py_v):
+    """
+    >>> test_iteration_over_reversed_set([1, 2, 3])
+    3
+    2
+    1
+    """
+    cdef stdset[int] s
+    for e in py_v:
+        s.insert(e)
+    for e in reversed(s):
+        print(e)
+
+def test_iteration_over_reversed_string():
+    """
+    >>> test_iteration_over_reversed_string()
+    n
+    o
+    h
+    t
+    y
+    c
+    """
+    cdef string cppstr = "cython"
+    for c in reversed(cppstr):
+        print(chr(c))
+
+def test_iteration_over_reversed_vector(py_v):
+    """
+    >>> test_iteration_over_reversed_vector([1, 2, 3])
+    3
+    2
+    1
+    """
+    cdef vector[int] vint
+    for e in py_v:
+        vint.push_back(e)
+    for e in reversed(vint):
+        print(e)

--- a/tests/run/cpp_iterators.pyx
+++ b/tests/run/cpp_iterators.pyx
@@ -337,3 +337,21 @@ def test_iteration_over_reversed_vector(py_v):
         vint.push_back(e)
     for e in reversed(vint):
         print(e)
+
+def test_non_built_in_reversed_function(py_v):
+    """
+    >>> test_non_built_in_reversed_function([1, 3, 5])
+    Non-built-in reversed called.
+    5
+    3
+    1
+    """
+    def reversed(arg):
+        print("Non-built-in reversed called.")
+        return arg[::-1]
+
+    cdef vector[int] vint
+    for e in py_v:
+        vint.push_back(e)
+    for e in reversed(vint):
+        print(e)


### PR DESCRIPTION
This pull request aims to
 1. support C++ classes with rbegin/rend implemented for reversed iteration, and
 2. solve the compilation error when the type of temporary variable used to store the result of iterator has 'constness'.
One example of 2. is when iterating std::map, Cython uses std::map<Key, Value>::value_type as the type of temporary variable to store the value of an iterator. However, std::map<Key, Value>::value_type will deduce to std::pair<const Key, Value>, which cannot be reused within a loop as its first component is const.

Related to #2225