### PR TITLE
cancel unfinished CI run to save CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
This cancels the ci for previous commits on the same branch and previous commits in a PR, which should save CI time since the CI builds do no longer stack up when pushing multiple times while the CI is still running.