### PR TITLE
only cancel successive runs for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This should skip workflows only in pull requests, since the commit sha should be unique. In case the ci is run for the same commit sha (e.g. when creating new branches), I think it is fine to cancel the CI.

@da-woods this should help with https://github.com/cython/cython/pull/5006#issuecomment-1236300023