### PR TITLE
Fix bug with complex powers of negative numbers

### DIFF
--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -265,7 +265,7 @@ static {{type}} __Pyx_PyComplex_As_{{type_name}}(PyObject* o) {
             if (a.imag == 0) {
                 if (a.real == 0) {
                     return a;
-                } else if (b.imag == 0) {
+                } else if ((b.imag == 0) && (a.real >= 0)) {
                     z.real = pow{{m}}(a.real, b.real);
                     z.imag = 0;
                     return z;

--- a/tests/run/complex_numbers_T305.pyx
+++ b/tests/run/complex_numbers_T305.pyx
@@ -80,6 +80,8 @@ def test_pow(double complex z, double complex w, tol=None):
     True
     >>> test_pow(-0.5, 1j, tol=1e-15)
     True
+    >>> test_pow(-1, 0.5, tol=1e-15)
+    True
     """
     if tol is None:
         return z**w


### PR DESCRIPTION
A shortcut was incorrectly applied that returned NaN instead of an imaginary number

Fixes https://github.com/cython/cython/issues/5013

PR is against 0.29.x

Not completely sure how to make the tests reliable for this - I think we'd need to try `CYTHON_CCOMPLEX` both on and off.