### PR TITLE
Improve detection of C complex.h

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7675,8 +7675,9 @@ class AttributeNode(ExprNode):
             rhs.generate_disposal_code(code)
             rhs.free_temps(code)
         elif self.obj.type.is_complex:
-            code.putln("__Pyx_SET_C%s(%s, %s);" % (
+            code.putln("__Pyx_SET_C%s%s(%s, %s);" % (
                 self.member.upper(),
+                self.obj.type.implementation_suffix,
                 self.obj.result_as(self.obj.type),
                 rhs.result_as(self.ctype())))
             rhs.generate_disposal_code(code)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10892,8 +10892,10 @@ class TypecastNode(ExprNode):
         if self.type.is_complex:
             operand_result = self.operand.result()
             if self.operand.type.is_complex:
-                real_part = self.type.real_type.cast_code("__Pyx_CREAL(%s)" % operand_result)
-                imag_part = self.type.real_type.cast_code("__Pyx_CIMAG(%s)" % operand_result)
+                real_part = self.type.real_type.cast_code(
+                    self.operand.type.real_code(operand_result))
+                imag_part = self.type.real_type.cast_code(
+                    self.operand.type.imag_code(operand_result))
             else:
                 real_part = self.type.real_type.cast_code(operand_result)
                 imag_part = "0"
@@ -13857,8 +13859,8 @@ class CoerceToComplexNode(CoercionNode):
 
     def calculate_result_code(self):
         if self.arg.type.is_complex:
-            real_part = "__Pyx_CREAL(%s)" % self.arg.result()
-            imag_part = "__Pyx_CIMAG(%s)" % self.arg.result()
+            real_part = self.arg.type.real_code(self.arg.result())
+            imag_part = self.arg.type.imag_code(self.arg.result())
         else:
             real_part = self.arg.result()
             imag_part = "0"

--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -4,7 +4,8 @@
 #if !defined(CYTHON_CCOMPLEX)
   #if defined(__cplusplus)
     #define CYTHON_CCOMPLEX 1
-  #elif defined(_Complex_I)
+  #elif defined(_Complex_I) || (__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_COMPLEX__))
+    // <complex.h> should exist since C99, but only C11 defines a test to detect it
     #define CYTHON_CCOMPLEX 1
   #else
     #define CYTHON_CCOMPLEX 0

--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -25,7 +25,6 @@
   #define _Complex_I 1.0fj
 #endif
 
-
 /////////////// RealImag.proto ///////////////
 
 #if CYTHON_CCOMPLEX
@@ -50,11 +49,23 @@
     #define __Pyx_SET_CIMAG(z,y) __Pyx_CIMAG(z) = (y)
 #endif
 
+/////////////// RealImagCy.proto /////////////
+
+// alternative version of RealImag.proto where we definitely want to use
+// Cython utility code implementation. Mainly for integer complex types
+// which simply aren't covered by the C or C++ standards (although
+// practically will probably work in C++)
+
+#define __Pyx_CREAL_CY(z) ((z).real)
+#define __Pyx_CIMAG_CY(z) ((z).imag)
+
+#define __Pyx_SET_CREAL_CY(z,x) __Pyx_CREAL_CY(z) = (x)
+#define __Pyx_SET_CIMAG_CY(z,y) __Pyx_CIMAG_CY(z) = (y)
 
 /////////////// Declarations.proto ///////////////
 //@proto_block: complex_type_declarations
 
-#if CYTHON_CCOMPLEX
+#if CYTHON_CCOMPLEX && ({{is_float}})
   #ifdef __cplusplus
     typedef ::std::complex< {{real_type}} > {{type_name}};
   #else
@@ -68,7 +79,7 @@ static CYTHON_INLINE {{type}} {{type_name}}_from_parts({{real_type}}, {{real_typ
 
 /////////////// Declarations ///////////////
 
-#if CYTHON_CCOMPLEX
+#if CYTHON_CCOMPLEX && ({{is_float}})
   #ifdef __cplusplus
     static CYTHON_INLINE {{type}} {{type_name}}_from_parts({{real_type}} x, {{real_type}} y) {
       return ::std::complex< {{real_type}} >(x, y);
@@ -90,9 +101,9 @@ static CYTHON_INLINE {{type}} {{type_name}}_from_parts({{real_type}}, {{real_typ
 
 /////////////// ToPy.proto ///////////////
 
-#define __pyx_PyComplex_FromComplex(z) \
-        PyComplex_FromDoubles((double)__Pyx_CREAL(z), \
-                              (double)__Pyx_CIMAG(z))
+#define __pyx_PyComplex_FromComplex{{"" if is_float else "_Cy"}}(z) \
+        PyComplex_FromDoubles((double)__Pyx_CREAL{{"" if is_float else "_CY"}}(z), \
+                              (double)__Pyx_CIMAG{{"" if is_float else "_CY"}}(z))
 
 
 /////////////// FromPy.proto ///////////////
@@ -117,7 +128,7 @@ static {{type}} __Pyx_PyComplex_As_{{type_name}}(PyObject* o) {
 
 /////////////// Arithmetic.proto ///////////////
 
-#if CYTHON_CCOMPLEX
+#if CYTHON_CCOMPLEX && ({{is_float}})
     #define __Pyx_c_eq{{func_suffix}}(a, b)   ((a)==(b))
     #define __Pyx_c_sum{{func_suffix}}(a, b)  ((a)+(b))
     #define __Pyx_c_diff{{func_suffix}}(a, b) ((a)-(b))
@@ -156,7 +167,7 @@ static {{type}} __Pyx_PyComplex_As_{{type_name}}(PyObject* o) {
 
 /////////////// Arithmetic ///////////////
 
-#if CYTHON_CCOMPLEX
+#if CYTHON_CCOMPLEX && ({{is_float}})
 #else
     static CYTHON_INLINE int __Pyx_c_eq{{func_suffix}}({{type}} a, {{type}} b) {
        return (a.real == b.real) && (a.imag == b.imag);


### PR DESCRIPTION
The existing check didn't really work (but I've left it...). I think it's based on the quote:
> POSIX recommends checking if the macro _Imaginary_I is defined to
> identify imaginary number support.

My reading is that this is a way to determine if a special imaginary type exists, but only after including the header. Until you've included complex.h the macro won't be defined anyway.

From C11 there's a feature macro to determine if complex.h exists so I've used that as the main way of detecting it.

In principle this could be backported to 0.29.x, but I don't think it should be.

I've also fixed a couple of existing bugs that this exposed:
* integer complex types can't be handled by C (or C++ in principle) so must use the Cython implementation
* extern typedef complex types can't be handled by C so must use the Cython implementation