### PR TITLE
mark extension types as immutable

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -230,6 +230,15 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
         // Other than this check, the Py_TPFLAGS_HEAPTYPE flag is unused
         // in PyType_Ready().
         t->tp_flags |= Py_TPFLAGS_HEAPTYPE;
+#if PY_VERSION_HEX >= 0x030A0000
+        // As of https://github.com/python/cpython/pull/25520
+        // PyType_Ready marks types as immutable if they are static types
+        // and requires the Py_TPFLAGS_IMMUTABLETYPE flag to mark types as
+        // immutable
+        // Manually set the Py_TPFLAGS_IMMUTABLETYPE flag, since the type
+        // is immutable
+        t->tp_flags |= Py_TPFLAGS_IMMUTABLETYPE;
+#endif
 #else
         // avoid C warning about unused helper function
         (void)__Pyx_PyObject_CallMethod0;

--- a/tests/run/cclass_assign_attr_GH3100.pyx
+++ b/tests/run/cclass_assign_attr_GH3100.pyx
@@ -1,3 +1,13 @@
+cdef extern from *:
+    """
+    #ifdef CYTHON_USE_TYPESPECS
+    #define TYPESPECS 1
+    #else
+    #define TYPESPECS 0
+    #endif
+    """
+    int TYPESPECS
+
 cdef class Foo:
     """
     >>> D = Foo.__dict__
@@ -19,7 +29,24 @@ cdef class Foo:
     staticmeth2 = staticmeth
 
 cdef class ChangeName:
+    # the class seems to need some contents for changing the
+    # name to cause a problem
+    cdef public str attr1
+    cdef public int attr2
+
+if TYPESPECS:
+    __doc__ = """
+    For typespecs, cdef classes are mutable on some Python versions
+    (and it's easiest to leave them that way). Therefore the test
+    is just that reassigning the name doesn't cause a crash
+
+    >>> try:
+    ...     ChangeName.__name__ = "SomethingElse"
+    ... except TypeError:
+    ...     pass  # either type error or changing the name is fine
     """
+else:
+    __doc__ = """
     GH-5079
     Assigning to the cdef class name shouldn't cause a crash.
     The important bit of this test is the not crashing - it's
@@ -34,7 +61,3 @@ cdef class ChangeName:
     'ChangeName'
     """
 
-    # the class seems to need some contents for changing the
-    # name to cause a problem
-    cdef public str attr1
-    cdef public int attr2

--- a/tests/run/cclass_assign_attr_GH3100.pyx
+++ b/tests/run/cclass_assign_attr_GH3100.pyx
@@ -1,6 +1,6 @@
 cdef extern from *:
     """
-    #ifdef CYTHON_USE_TYPESPECS
+    #ifdef CYTHON_USE_TYPE_SPECS
     #define TYPESPECS 1
     #else
     #define TYPESPECS 0

--- a/tests/run/cclass_assign_attr_GH3100.pyx
+++ b/tests/run/cclass_assign_attr_GH3100.pyx
@@ -17,3 +17,24 @@ cdef class Foo:
     meth2 = meth
     classmeth2 = classmeth
     staticmeth2 = staticmeth
+
+cdef class ChangeName:
+    """
+    GH-5079
+    Assigning to the cdef class name shouldn't cause a crash.
+    The important bit of this test is the not crashing - it's
+    possible that typespec/limited-API defined classes will be
+    naturally mutable and that isn't a huge problem
+
+    >>> ChangeName.__name__ = "SomethingElse"  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
+    >>> ChangeName.__name__
+    'ChangeName'
+    """
+
+    # the class seems to need some contents for changing the
+    # name to cause a problem
+    cdef public str attr1
+    cdef public int attr2


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/25520 types are automatically marked as immutable if they are static.
While we still have the `Py_TPFLAGS_HEAPTYPE` hack in place we need to manually mark our types as immutable.