### PR TITLE
✨ Enable OpenSSF Scorecard code scanning alert and badge

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,54 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '42 21 * * 0'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f437b3cc043103683806977b725b99217c67bd46 # tag=v2.0.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results. 
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Welcome to Cython!
 
 |OpenSSF Scorecard !|
 
-.. |OpenSSF Scorecard !| image:: https://api.securityscorecards.dev/projects/github.com/joycebrum/cython/badge
-   :target: https://api.securityscorecards.dev/projects/github.com/joycebrum/cython
+.. |OpenSSF Scorecard !| image:: https://api.securityscorecards.dev/projects/github.com/cython/cython/badge
+   :target: https://api.securityscorecards.dev/projects/github.com/cython/cython
 
 Cython is a language that makes writing C extensions for
 Python as easy as Python itself.  Cython is based on

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 Welcome to Cython!
 ==================
 
+|OpenSSF Scorecard !|
+
+.. |OpenSSF Scorecard !| image:: https://api.securityscorecards.dev/projects/github.com/joycebrum/cython/badge
+   :target: https://api.securityscorecards.dev/projects/github.com/joycebrum/cython
+
 Cython is a language that makes writing C extensions for
 Python as easy as Python itself.  Cython is based on
 Pyrex, but supports more cutting edge functionality and


### PR DESCRIPTION
This pull request intend to activate the OpenSSF Scorecard,  a tool to search for security risks. More informations about securitycards can be seen at https://securityscorecards.dev/

Besides listing the security risks and its possible solution, the OpenSSF Scorecard calculates a Score to the project, indicating it security coverage, as can be seen in the badge bellow.

![image](https://user-images.githubusercontent.com/22223372/189676507-c5bb2dce-d1a9-429f-bb65-5ba2cc91a948.png)

This change could help the project to improve its security coverage besides it can be a way of external users to evaluate the security and reliability of the project.

Please feel free to reach me out in case of doubts or concerns.