### PR TITLE
[Ticket 2940] fix mangling for .pxd cdef public functions

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1617,7 +1617,7 @@ class ModuleScope(Scope):
         entry = self.lookup_here(name)
         if entry and entry.defined_in_pxd:
             if entry.visibility != "private":
-                mangled_cname = self.mangle(Naming.var_prefix, name)
+                mangled_cname = self.mangle(Naming.func_prefix, name)
                 if entry.cname == mangled_cname:
                     cname = name
                     entry.cname = cname

--- a/tests/compile/pxd_mangling_names.srctree
+++ b/tests/compile/pxd_mangling_names.srctree
@@ -1,0 +1,43 @@
+# mode: compile
+# ticket: 2940
+
+PYTHON setup.py build_ext --inplace
+#PYTHON -c "import a; a.test()"
+
+######## setup.py ########
+
+from Cython.Build import cythonize
+from Cython.Distutils.extension import Extension
+from distutils.core import setup
+
+setup(
+    ext_modules=cythonize([Extension("a", ["a.py", "b.c"])]),
+)
+
+######## a.pxd ########
+
+cdef public int foo()
+
+cdef extern from "b.h":
+    cpdef int bar()
+
+######## a.py ########
+
+def foo():
+    return 42
+
+def test():
+    assert bar() == 42
+
+######## b.h ########
+
+#pragma once
+
+int bar();
+
+######## b.c ########
+
+#include "a.h"
+
+int bar() { return foo(); }
+

--- a/tests/compile/pxd_mangling_names.srctree
+++ b/tests/compile/pxd_mangling_names.srctree
@@ -2,7 +2,7 @@
 # ticket: 2940
 
 PYTHON setup.py build_ext --inplace
-#PYTHON -c "import a; a.test()"
+PYTHON -c "import a; a.test()"
 
 ######## setup.py ########
 
@@ -31,9 +31,12 @@ def test():
 
 ######## b.h ########
 
-#pragma once
+#ifndef B_H
+#define B_H
 
 int bar();
+
+#endif
 
 ######## b.c ########
 

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -16,7 +16,7 @@ run.partial_circular_import
 # https://foss.heptapod.net/pypy/pypy/issues/3185
 run.language_level
 run.pure_pxd
-run.pxd_mangling_names
+compile.pxd_mangling_names
 
 # Silly error with doctest matching slightly different string outputs rather than
 # an actual bug but one I can't easily resolve

--- a/tests/pypy2_bugs.txt
+++ b/tests/pypy2_bugs.txt
@@ -16,8 +16,9 @@ run.partial_circular_import
 # https://foss.heptapod.net/pypy/pypy/issues/3185
 run.language_level
 run.pure_pxd
+run.pxd_mangling_names
 
-# Silly error with doctest matching slightly different string outputs rather than 
+# Silly error with doctest matching slightly different string outputs rather than
 # an actual bug but one I can't easily resolve
 run.with_gil
 


### PR DESCRIPTION
Fixes #2940 

This PR fixes a typo that caused `cdef public` functions from .pxd files to be erroneously mangled.

The unmangled name is chosen when the definition from the .py file is processed, but on the condition that the cname determined while processing the declaration from the .pxd file was the mangled one (instead of a user-defined one).

It also adds a test for the ticket.