### PR TITLE
Remove dataclass tests that used mutability

### DIFF
--- a/Tools/make_dataclass_tests.py
+++ b/Tools/make_dataclass_tests.py
@@ -17,6 +17,7 @@ unavailable_functions = frozenset(
 skip_tests = frozenset(
     {
         # needs Cython compile
+        # ====================
         ("TestCase", "test_field_default_default_factory_error"),
         ("TestCase", "test_two_fields_one_default"),
         ("TestCase", "test_overwrite_hash"),
@@ -57,6 +58,7 @@ skip_tests = frozenset(
         ("TestCase", "test_class_attrs"),
         ("TestStringAnnotations",),  # almost all the texts here use local variables
         # Currently unsupported
+        # =====================
         (
             "TestOrdering",
             "test_functools_total_ordering",
@@ -118,7 +120,10 @@ skip_tests = frozenset(
         # These tests are probably fine, but the string substitution in this file doesn't get it right
         ("TestRepr", "test_repr"),
         ("TestCase", "test_not_in_repr"),
+        # not possible to add attributes on extension types
+        ("TestCase", "test_post_init_classmethod"),
         # Bugs
+        # ====
         ("TestCase", "test_no_options"),  # @dataclass()
         ("TestCase", "test_field_no_default"),  # field()
         ("TestCase", "test_init_in_order"),  # field()
@@ -166,6 +171,7 @@ skip_tests = frozenset(
         ("TestCase", "test_init_var_with_default"),  # not sure...
         ("TestReplace", "test_initvar_with_default_value"),  # needs investigating
         # Maybe bugs?
+        # ==========
         # non-default argument 'z' follows default argument in dataclass __init__ - this message looks right to me!
         ("TestCase", "test_class_marker"),
         # cython.dataclasses.field parameter 'metadata' must be a literal value - possibly not something we can support?
@@ -202,10 +208,6 @@ version_specific_skips = {
         3,
         10,
     ),  # needs language support for | operator on types
-    ("TestCase", "test_post_init_classmethod"): (
-        3,
-        10,
-    ),  # not possible to add attributes on extension types
 }
 
 

--- a/tests/run/test_dataclasses.pyx
+++ b/tests/run/test_dataclasses.pyx
@@ -85,17 +85,6 @@ class Point3Dv1_TestCase_test_not_other_dataclass:
 
 @dataclass
 @cclass
-class C_TestCase_test_post_init_classmethod:
-    flag = False
-    x: int
-    y: int
-
-    @classmethod
-    def __post_init__(cls):
-        cls.flag = True
-
-@dataclass
-@cclass
 class C_TestCase_test_class_var_no_default:
     x: ClassVar[int]
 
@@ -562,14 +551,6 @@ class TestCase(unittest.TestCase):
             (x, y, z) = Point3D(4, 5, 6)
         Point3Dv1 = Point3Dv1_TestCase_test_not_other_dataclass
         self.assertNotEqual(Point3D(0, 0, 0), Point3Dv1())
-
-    @skip_on_versions_below((3, 10))
-    def test_post_init_classmethod(self):
-        C = C_TestCase_test_post_init_classmethod
-        self.assertFalse(C.flag)
-        c = C(3, 4)
-        self.assertEqual((c.x, c.y), (3, 4))
-        self.assertTrue(C.flag)
 
     def test_class_var_no_default(self):
         C = C_TestCase_test_class_var_no_default


### PR DESCRIPTION
We accidently made cdef classes mutable in Python 3.10. @maxbachmann has shown that it's trivially easy to crash them (e.g. by trying to change the name). Therefore we should make them immutable.

I included this test from the CPython test-suite because it seemed to work. However, it relies on a feature that's unsafe and unintended.