### PR TITLE
Fix C++ error from Cython unused

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2103,10 +2103,10 @@ class CCodeWriter(object):
         if entry.visibility == "private" and not entry.used:
             #print "...private and not used, skipping", entry.cname ###
             return
-        if storage_class:
-            self.put("%s " % storage_class)
         if not entry.cf_used:
             self.put('CYTHON_UNUSED ')
+        if storage_class:
+            self.put("%s " % storage_class)
         if entry.is_cpp_optional:
             self.put(entry.type.cpp_optional_declaration_code(
                 entry.cname, dll_linkage=dll_linkage))

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3752,7 +3752,7 @@ class DefNodeWrapper(FuncDefNode):
             with_pymethdef = False
 
         dc = self.return_type.declaration_code(entry.func_cname)
-        header = "static %s%s(%s)" % (mf, dc, arg_code)
+        header = "%sstatic %s(%s)" % (mf, dc, arg_code)
         code.putln("%s; /*proto*/" % header)
 
         if proto_only:


### PR DESCRIPTION
I was getting a whole lot on errors along the lines of

```
cfunc_convert_with_memoryview.cpp:11097:8: note: in expansion of macro ‘CYTHON_UNUSED’
11097 | static CYTHON_UNUSED int __pyx_memoryview_getbuffer(PyObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags) {
      |        ^~~~~~~~~~~~~
cfunc_convert_with_memoryview.cpp:407:31: note: an attribute that appertains to a type-specifier is ignored
  407 |         #define CYTHON_UNUSED [[maybe_unused]]
```

This swaps the order of static and CYTHON_UNUSED.

I think whether the error appears is probably dependent on the exact compiler version (so wasn't appearing on the CI).