### PR TITLE
Allow setting type flags for pattern matching

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -317,6 +317,7 @@ directive_types = {
     'auto_pickle': bool,
     'locals': dict,
     'final' : bool,  # final cdef classes and methods
+    'collection_type': one_of('sequence', 'mapping'),
     'nogil' : bool,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
@@ -348,6 +349,7 @@ directive_scopes = {  # defaults to available everywhere
     # 'module', 'function', 'class', 'with statement'
     'auto_pickle': ('module', 'cclass'),
     'final' : ('cclass', 'function'),
+    'collection_type': ('cclass',),
     'nogil' : ('function', 'with statement'),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
@@ -396,7 +398,7 @@ immediate_decorator_directives = {
     'inline', 'exceptval', 'returns',
     # class directives
     'freelist', 'no_gc', 'no_gc_clear', 'type_version_tag', 'final',
-    'auto_pickle', 'internal',
+    'auto_pickle', 'internal', 'collection_type',
     # testing directives
     'test_fail_if_path_exists', 'test_assert_path_exists',
 }

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1524,6 +1524,8 @@ class PyExtensionType(PyObjectType):
     #  check_size       'warn', 'error', 'ignore'    What to do if tp_basicsize does not match
     #  dataclass_fields  OrderedDict nor None   Used for inheriting from dataclasses
     #  multiple_bases    boolean          Does this class have multiple bases
+    #  has_sequence_flag  boolean        Set Py_TPFLAGS_SEQUENCE
+    #  has_mapping_flag   boolean        Set Py_TPFLAGS_MAPPING
 
     is_extension_type = 1
     has_attributes = 1
@@ -1532,6 +1534,8 @@ class PyExtensionType(PyObjectType):
     objtypedef_cname = None
     dataclass_fields = None
     multiple_bases = False
+    has_sequence_flag = False
+    has_mapping_flag = False
 
     def __init__(self, name, typedef_flag, base_type, is_external=0, check_size=None):
         self.name = name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1748,6 +1748,11 @@ class ModuleScope(Scope):
 
         if self.directives.get('final'):
             entry.type.is_final_type = True
+        collection_type = self.directives.get('collection_type')
+        if collection_type == 'sequence':
+            entry.type.has_sequence_flag = True
+        elif collection_type == 'mapping':
+            entry.type.has_mapping_flag = True
 
         # cdef classes are always exported, but we need to set it to
         # distinguish between unused Cython utility code extension classes

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -558,6 +558,11 @@ class TypeFlagsSlot(SlotDescriptor):
             value += "|Py_TPFLAGS_HAVE_GC"
         if scope.may_have_finalize():
             value += "|Py_TPFLAGS_HAVE_FINALIZE"
+        if scope.parent_type.has_sequence_flag:
+            value += "|Py_TPFLAGS_SEQUENCE"
+        if scope.parent_type.has_mapping_flag:
+            assert not scope.parent_type.has_sequence_flag
+            value += "|Py_TPFLAGS_MAPPING"
         return value
 
     def generate_spec(self, scope, code):

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -230,6 +230,15 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
         // Other than this check, the Py_TPFLAGS_HEAPTYPE flag is unused
         // in PyType_Ready().
         t->tp_flags |= Py_TPFLAGS_HEAPTYPE;
+#if PY_VERSION_HEX >= 0x030A0000
+        // As of https://github.com/python/cpython/pull/25520
+        // PyType_Ready marks types as immutable if they are static types
+        // and requires the Py_TPFLAGS_IMMUTABLETYPE flag to mark types as
+        // immutable
+        // Manually set the Py_TPFLAGS_IMMUTABLETYPE flag, since the type
+        // is immutable
+        t->tp_flags |= Py_TPFLAGS_IMMUTABLETYPE;
+#endif
 #else
         // avoid C warning about unused helper function
         (void)__Pyx_PyObject_CallMethod0;

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -109,6 +109,7 @@ except:
 ### cython.array class
 #
 
+@cython.collection_type("sequence")
 @cname("__pyx_array")
 cdef class array:
 
@@ -959,6 +960,7 @@ cdef int transpose_memslice({{memviewslice_name}} *memslice) except -1 nogil:
 #
 ### Creating new memoryview objects from slices and memoryviews
 #
+@cython.collection_type("sequence")
 @cname('__pyx_memoryviewslice')
 cdef class _memoryviewslice(memoryview):
     "Internal class for passing memoryview slices to Python"

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -743,6 +743,12 @@ class __Pyx_FakeReference {
 #ifndef Py_TPFLAGS_HAVE_FINALIZE
   #define Py_TPFLAGS_HAVE_FINALIZE 0
 #endif
+#ifndef Py_TPFLAGS_SEQUENCE
+  #define Py_TPFLAGS_SEQUENCE 0
+#endif
+#ifndef Py_TPFLAGS_MAPPING
+  #define Py_TPFLAGS_MAPPING 0
+#endif
 
 #ifndef METH_STACKLESS
   // already defined for Stackless Python (all versions) and C-Python >= 3.7

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -1001,6 +1001,28 @@ disable this auto-generation and can be used to support pickling of more
 complicated types.
 
 
+Pattern matching and extension types (Python 3.10+)
+===================================================
+
+Python 3.10 introduced the structural pattern matching feature, where
+Python objects can be decomposed if they meet a particular set of rules.
+For a type to be treated as a sequence in pattern matching it must
+have the flag ``Py_TPFLAGS_SEQUENCE`` in its internal "type flags",
+and similarly for a type to be treated as a mapping it must have
+``Py_TPFLAGS_MAPPING`` set.
+
+For normal classes, one of the main ways to mark as class as a
+sequence or mapping would be to register the class with 
+either ``abc.collections.Sequence`` or ``abc.collections.Mapping``.
+Unfortunately for Cython extension types this does not work because
+Cython extension types are immutable (usually, with certain C defines
+set this may not always be true).
+
+Therefore a Cython extension type can be decorated with
+``cython.collection_type("sequence")`` or 
+``cython.collection_type("mapping")`` to enable pattern matching to
+use the type as intended.
+
 Public and external extension types
 ====================================
 

--- a/tests/run/collection_flags.pyx
+++ b/tests/run/collection_flags.pyx
@@ -1,0 +1,79 @@
+# mode: run
+
+cimport cython
+import sys
+
+@cython.collection_type("sequence")
+cdef class IsSequence:
+    pass
+
+@cython.collection_type("mapping")
+cdef class IsMapping:
+    pass
+
+cdef class Neither:
+    pass
+
+@cython.collection_type("mapping")
+cdef class IsMappingInheritsNeither(Neither):
+    pass
+
+@cython.collection_type("mapping")
+cdef class IsMappingInheritsSequence(IsSequence):
+    pass
+
+cdef class IsMappingInheritsMapping(IsMapping):
+    pass
+
+@cython.collection_type("sequence")
+cdef class IsSequenceInheritsNeither(Neither):
+    pass
+
+@cython.collection_type("sequence")
+cdef class IsSequenceInheritsMapping(IsMapping):
+    pass
+
+cdef class IsSequenceInheritsSequence(IsSequence):
+    pass
+
+# On Python < 3.10 the test is simply that it compiles
+# TODO - when Cython supports match-case itself then test that
+if sys.version_info > (3, 10):
+    ns = {}
+    exec("""
+def test_sequence_then_mapping(x):
+    match x:
+        case [*_]:
+            return "S"
+        case {}:
+            return "M"
+
+def test_mapping_then_sequence(x):
+    match x:
+        case {}:
+            return "M"
+        case [*_]:
+            return "S"
+""", ns)
+    test_sequence_then_mapping = ns['test_sequence_then_mapping']
+    test_mapping_then_sequence = ns['test_mapping_then_sequence']
+
+    __doc__ = """
+    >>> test_mapping_then_sequence(IsSequence())
+    'S'
+    >>> test_mapping_then_sequence(IsSequenceInheritsNeither())
+    'S'
+    >>> test_mapping_then_sequence(IsSequenceInheritsMapping())
+    'S'
+    >>> test_mapping_then_sequence(IsSequenceInheritsSequence())
+    'S'
+    >>> test_sequence_then_mapping(IsMapping())
+    'M'
+    >>> test_sequence_then_mapping(IsMappingInheritsNeither())
+    'M'
+    >>> test_sequence_then_mapping(IsMappingInheritsSequence())
+    'M'
+    >>> test_sequence_then_mapping(IsMappingInheritsMapping())
+    'M'
+    >>> test_sequence_then_mapping(Neither())
+    """


### PR DESCRIPTION
via an additional decorator for cdef classes.

Closes #5027 and removes blocker for #5023