### PR TITLE
Avoid triggering type-check assert for cyfuncs [0.29.x]

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2322,7 +2322,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
         return __Pyx_PyFunction_FastCall(func, NULL, 0);
     }
 #endif
-#ifdef __Pyx_CyFunction_USED && defined(NDEBUG)
+#if defined(__Pyx_CyFunction_USED) && defined(NDEBUG)
     // TODO PyCFunction_GET_FLAGS has a type-check assert that breaks with a CyFunction
     // in debug mode. There is likely to be a better way of avoiding tripping this
     // check that doesn't involve disabling the optimized path.

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2322,7 +2322,10 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
         return __Pyx_PyFunction_FastCall(func, NULL, 0);
     }
 #endif
-#ifdef __Pyx_CyFunction_USED
+#ifdef __Pyx_CyFunction_USED && defined(NDEBUG)
+    // TODO PyCFunction_GET_FLAGS has a type-check assert that breaks with a CyFunction
+    // in debug mode. There is likely to be a better way of avoiding tripping this
+    // check that doesn't involve disabling the optimized path.
     if (likely(PyCFunction_Check(func) || __Pyx_CyFunction_Check(func)))
 #else
     if (likely(PyCFunction_Check(func)))

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -116,7 +116,7 @@ CFLAGS="-O0 -ggdb -Wall -Wextra"
 ODD_VERSION=$(python3 -c "import sys; print(sys.version_info[1]%2)")
 if [[ $BACKEND == *"cpp"* && $ODD_VERSION == "1" ]]; then
     CFLAGS="$CFLAGS -UNDEBUG"
-else if [[ $ODD_VERSION == "0" ]]; then
+elif [[ $ODD_VERSION == "0" ]]; then
     CFLAGS="$CFLAGS -UNDEBUG"
 fi
 

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -109,6 +109,16 @@ export PATH="/usr/lib/ccache:$PATH"
 # to override the previous ones, so '-O0 -O3' == '-O3'
 # This is true for the latest msvc, gcc and clang
 CFLAGS="-O0 -ggdb -Wall -Wextra"
+# Trying to cover debug assertions in the CI without adding
+# extra jobs. Therefore, odd-numbered minor versions of Python
+# running C++ jobs get NDEBUG undefined, and even-numbered
+# versions running C jobs get NDEBUG undefined.
+ODD_VERSION=$(python3 -c "import sys; print(sys.version_info[1]%2)")
+if [[ $BACKEND == *"cpp"* && $ODD_VERSION == "1" ]]; then
+    CFLAGS="$CFLAGS -UNDEBUG"
+else if [[ $ODD_VERSION == "0" ]]; then
+    CFLAGS="$CFLAGS -UNDEBUG"
+fi
 
 if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
 


### PR DESCRIPTION
Fixes #4804 (but not hugely satisfactorally)