### PR TITLE
Fix the step for uploading platform-specific wheels to GitHub

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,12 +86,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            dist/*manylinux*.whl
-            dist/*musllinux*.whl
-            dist/*macos*.whl
-            dist/*win32*.whl
-            dist/*win_amd64*.whl
+          files: wheelhouse/*.whl
           prerelease: >-
             ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b')
               || contains(github.ref_name, 'rc') || contains(github.ref_name, 'dev') }}


### PR DESCRIPTION
`cibuildwheel` puts the wheels into `wheelhouse`, not `dist`. There also doesn't seem to be any reason to list a bunch of separate per-platform wildcards, so replace them with `*.whl`.