### PR TITLE
Fix linkage for `cdef public` functions in C++ mode

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -262,7 +262,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             api_guard = self.api_name(Naming.api_guard_prefix, env)
             h_code_start.putln("#ifndef %s" % api_guard)
             h_code_start.putln("")
-            self.generate_extern_c_macro_definition(h_code_start)
+            self.generate_extern_c_macro_definition(h_code_start, env)
             h_code_start.putln("")
             self.generate_dl_import_macro(h_code_start)
             if h_extension_types:
@@ -804,7 +804,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("    { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }")
 
         code.putln("")
-        self.generate_extern_c_macro_definition(code)
+        self.generate_extern_c_macro_definition(code, env)
         code.putln("")
 
         code.putln("#define %s" % self.api_name(Naming.h_guard_prefix, env))
@@ -876,14 +876,17 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if has_np_pythran(env):
             env.use_utility_code(UtilityCode.load_cached("PythranConversion", "CppSupport.cpp"))
 
-    def generate_extern_c_macro_definition(self, code):
+    def generate_extern_c_macro_definition(self, code, env):
         name = Naming.extern_c_macro
         code.putln("#ifndef %s" % name)
-        code.putln("  #ifdef __cplusplus")
-        code.putln('    #define %s extern "C"' % name)
-        code.putln("  #else")
-        code.putln("    #define %s extern" % name)
-        code.putln("  #endif")
+        if env.is_cpp():
+            code.putln('    #define %s extern "C++"' % name)
+        else:
+            code.putln("  #ifdef __cplusplus")
+            code.putln('    #define %s extern "C"' % name)
+            code.putln("  #else")
+            code.putln("    #define %s extern" % name)
+            code.putln("  #endif")
         code.putln("#endif")
 
     def generate_dl_import_macro(self, code):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -262,7 +262,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             api_guard = self.api_name(Naming.api_guard_prefix, env)
             h_code_start.putln("#ifndef %s" % api_guard)
             h_code_start.putln("")
-            self.generate_extern_c_macro_definition(h_code_start, env)
+            self.generate_extern_c_macro_definition(h_code_start, env.is_cpp())
             h_code_start.putln("")
             self.generate_dl_import_macro(h_code_start)
             if h_extension_types:
@@ -804,7 +804,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("    { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }")
 
         code.putln("")
-        self.generate_extern_c_macro_definition(code, env)
+        self.generate_extern_c_macro_definition(code, env.is_cpp())
         code.putln("")
 
         code.putln("#define %s" % self.api_name(Naming.h_guard_prefix, env))
@@ -876,10 +876,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if has_np_pythran(env):
             env.use_utility_code(UtilityCode.load_cached("PythranConversion", "CppSupport.cpp"))
 
-    def generate_extern_c_macro_definition(self, code, env):
+    def generate_extern_c_macro_definition(self, code, is_cpp):
         name = Naming.extern_c_macro
         code.putln("#ifndef %s" % name)
-        if env.is_cpp():
+        if is_cpp:
             code.putln('    #define %s extern "C++"' % name)
         else:
             code.putln("  #ifdef __cplusplus")

--- a/docs/examples/tutorial/embedding/embedded.pyx
+++ b/docs/examples/tutorial/embedding/embedded.pyx
@@ -3,6 +3,7 @@
 # The following two lines are for test purposes only, please ignore them.
 # distutils: sources = embedded_main.c
 # tag: py3only
+# tag: no-cpp
 
 TEXT_TO_SAY = 'Hello from Python!'
 

--- a/tests/compile/excvalcheck.h
+++ b/tests/compile/excvalcheck.h
@@ -1,12 +1,6 @@
-#ifdef __cplusplus
-extern "C" {
-#endif
 extern DL_EXPORT(int) spam(void);
 extern DL_EXPORT(void) grail(void);
 extern DL_EXPORT(char *)tomato(void);
-#ifdef __cplusplus
-}
-#endif
 
 int spam(void) {return 0;}
 void grail(void) {return;}

--- a/tests/compile/nogil.h
+++ b/tests/compile/nogil.h
@@ -1,25 +1,13 @@
-#ifdef __cplusplus
-extern "C" {
-#endif
 extern DL_EXPORT(void) e1(void);
 extern DL_EXPORT(int*) e2(void);
-#ifdef __cplusplus
-}
-#endif
 
 void e1(void) {return;}
 int* e2(void) {return 0;}
 
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 extern DL_EXPORT(PyObject *) g(PyObject*);
 extern DL_EXPORT(void) g2(PyObject*);
-#ifdef __cplusplus
-}
-#endif
 
 PyObject *g(PyObject* o) {if (o) {}; return 0;}
 void g2(PyObject* o) {if (o) {}; return;}

--- a/tests/run/cpp_extern.srctree
+++ b/tests/run/cpp_extern.srctree
@@ -68,6 +68,9 @@ size_t size_vector1() {
 
 #include <vector>
 extern "C" {
+// #include within `extern "C"` is legal.
+// We want to make sure here that Cython C++ functions are flagged as `extern "C++"`.
+// Otherwise they would be interpreted with C-linkage if the header is include within a `extern "C"` block.
 #include "foo.h"
 }
 

--- a/tests/run/cpp_extern.srctree
+++ b/tests/run/cpp_extern.srctree
@@ -6,6 +6,7 @@
 PYTHON setup.py build_ext --inplace
 PYTHON -c "from foo import test; test()"
 PYTHON -c "from bar import test; test()"
+PYTHON -c "from baz import test; test()"
 """
 
 ######## setup.py ########
@@ -14,21 +15,22 @@ from Cython.Build import cythonize
 from Cython.Distutils.extension import Extension
 from distutils.core import setup
 
-compile_args = ["-Wno-deprecated-declarations", "-Werror"]
-
 foo = Extension(
     "foo",
     ["foo.pyx", "foo1.cpp", "foo2.cpp"],
-    extra_compile_args = compile_args,
 )
 bar = Extension(
     "bar",
     ["bar.pyx", "bar1.c", "bar2.cpp"],
-    extra_compile_args = compile_args,
+)
+baz = Extension(
+    "baz",
+    ["baz.pyx", "baz1.c", "baz2.cpp"],
+    define_macros = [("__PYX_EXTERN_C", 'extern "C"')],
 )
 
 setup(
-    ext_modules=cythonize([foo, bar]),
+    ext_modules=cythonize([foo, bar, baz]),
 )
 
 ######## foo.pyx ########
@@ -105,3 +107,42 @@ extern "C" {
 
 extern "C" int get_int2() { return (int)get_char(); }
 
+######## baz.pyx ########
+
+# distutils: language = c++
+
+cdef public char get_char():
+    return 42
+
+cdef extern from "baz_header.h":
+    cdef int get_int1()
+    cdef int get_int2()
+
+def test():
+    assert get_int1() == 42
+    assert get_int2() == 42
+
+######## baz_header.h ########
+
+#ifdef __cplusplus
+  #define BAZ_EXTERN_C extern "C"
+#else
+  #define BAZ_EXTERN_C
+#endif
+
+BAZ_EXTERN_C int get_int1();
+int get_int2();
+
+######## baz1.c ########
+
+#undef __PYX_EXTERN_C
+#define __PYX_EXTERN_C
+#include "baz.h"
+
+int get_int1() { return (int)get_char(); }
+
+######## baz2.cpp ########
+
+#include "baz.h"
+
+int get_int2() { return (int)get_char(); }

--- a/tests/run/cpp_extern.srctree
+++ b/tests/run/cpp_extern.srctree
@@ -1,0 +1,107 @@
+# mode: run
+# tag: cpp
+# ticket: 1839
+
+"""
+PYTHON setup.py build_ext --inplace
+PYTHON -c "from foo import test; test()"
+PYTHON -c "from bar import test; test()"
+"""
+
+######## setup.py ########
+
+from Cython.Build import cythonize
+from Cython.Distutils.extension import Extension
+from distutils.core import setup
+
+compile_args = ["-Wno-deprecated-declarations", "-Werror"]
+
+foo = Extension(
+    "foo",
+    ["foo.pyx", "foo1.cpp", "foo2.cpp"],
+    extra_compile_args = compile_args,
+)
+bar = Extension(
+    "bar",
+    ["bar.pyx", "bar1.c", "bar2.cpp"],
+    extra_compile_args = compile_args,
+)
+
+setup(
+    ext_modules=cythonize([foo, bar]),
+)
+
+######## foo.pyx ########
+
+# distutils: language = c++
+
+from libcpp cimport vector
+
+cdef public vector.vector[int] get_vector():
+    return [1,2,3]
+
+cdef extern from "foo_header.h":
+    cdef size_t size_vector1()
+    cdef size_t size_vector2()
+
+def test():
+    assert size_vector1() == 3
+    assert size_vector2() == 3
+
+######## foo_header.h ########
+
+size_t size_vector1();
+size_t size_vector2();
+
+######## foo1.cpp ########
+
+#include <vector>
+#include "foo.h"
+
+size_t size_vector1() {
+    return get_vector().size();
+}
+
+######## foo2.cpp ########
+
+#include <vector>
+extern "C" {
+#include "foo.h"
+}
+
+size_t size_vector2() {
+    return get_vector().size();
+}
+
+######## bar.pyx ########
+
+cdef public char get_char():
+    return 42
+
+cdef extern from "bar_header.h":
+    cdef int get_int1()
+    cdef int get_int2()
+
+def test():
+    assert get_int1() == 42
+    assert get_int2() == 42
+
+######## bar_header.h ########
+
+int get_int1();
+int get_int2();
+
+######## bar1.c ########
+
+#include "bar.h"
+
+int get_int1() { return (int)get_char(); }
+
+######## bar2.cpp ########
+
+extern "C" {
+#include "bar.h"
+}
+
+extern "C" int get_int2() { return (int)get_char(); }
+


### PR DESCRIPTION
Fixes #1839 

`cdef public` functions should be declared with the appropriate linkage:
- in C mode, either `extern` or `extern "C"`, depending on whether the header file is included in (resp. object code is linked against) a C or a C++ compilation unit. Choice is made at compile-time through `#ifdef __cplusplus` macros. NB: This is the current behavior.
- in C++ mode, `extern "C++"` is the only option, as C code cannot call C++ code. Note that `extern "C++"` should be preferred over `extern` to allow users to `#include` the C++ header inside a `extern "C"` block (which is legal, although barely used).

Note that the current behavior is OK for C mode, but is incorrect for the C++ mode. As described in #1839, this incorrect behavior is diagnosed by compilers emitting warnings when `cdef public` functions return a C++ type (e.g. `std::vector`).
The test introduced in this PR checks that the current behavior for C mode (with both C and C++ compatibility) is preserved, and that the behavior for C++ mode is fixed.