### PR TITLE
Fix recursive repr on cdef dataclasses

### DIFF
--- a/Cython/Compiler/Dataclass.py
+++ b/Cython/Compiler/Dataclass.py
@@ -429,7 +429,7 @@ def generate_init_code(code, init, node, fields, kw_only):
 
 def generate_repr_code(code, repr, node, fields):
     """
-    The CPython implementation is just:
+    The core of the CPython implementation is just:
     ['return self.__class__.__qualname__ + f"(' +
                      ', '.join([f"{f.name}={{self.{f.name}!r}}"
                                 for f in fields]) +
@@ -437,18 +437,32 @@ def generate_repr_code(code, repr, node, fields):
 
     The only notable difference here is self.__class__.__qualname__ -> type(self).__name__
     which is because Cython currently supports Python 2.
+
+    However, it also has some guards for recursive repr invokations. In the standard
+    library implementation they're done with a wrapper decorator that captures a set
+    (with the set keyed by id and thread). Here we create a set as a thread local
+    variable and key only by id.
     """
     if not repr or node.scope.lookup("__repr__"):
         return
 
+    code.add_code_line("__pyx_recursive_repr_guard = __import__('threading').local()")
+    code.add_code_line("__pyx_recursive_repr_guard.running = set()")
     code.add_code_line("def __repr__(self):")
+    code.add_code_line("    key = id(self)")
+    code.add_code_line("    guard_set = self.__pyx_recursive_repr_guard.running")
+    code.add_code_line("    if key in guard_set: return '...'")
+    code.add_code_line("    guard_set.add(key)")
+    code.add_code_line("    try:")
     strs = [u"%s={self.%s!r}" % (name, name)
             for name, field in fields.items()
             if field.repr.value and not field.is_initvar]
     format_string = u", ".join(strs)
 
-    code.add_code_line(u'    name = getattr(type(self), "__qualname__", type(self).__name__)')
-    code.add_code_line(u"    return f'{name}(%s)'" % format_string)
+    code.add_code_line(u'        name = getattr(type(self), "__qualname__", type(self).__name__)')
+    code.add_code_line(u"        return f'{name}(%s)'" % format_string)
+    code.add_code_line("    finally:")
+    code.add_code_line("        guard_set.remove(key)")
 
 
 def generate_cmp_code(code, op, funcname, node, fields):

--- a/Tools/make_dataclass_tests.py
+++ b/Tools/make_dataclass_tests.py
@@ -130,6 +130,7 @@ skip_tests = frozenset(
         # not possible to add attributes on extension types
         ("TestCase", "test_post_init_classmethod"),
         # Bugs
+        # ====
         ("TestCase", "test_hash_field_rules"),  # compiler crash
         ("TestCase", "test_class_var"),  # not sure but compiler crash
         ("TestCase", "test_field_order"),  # invalid C code (__pyx_base?)
@@ -137,11 +138,6 @@ skip_tests = frozenset(
             "TestCase",
             "test_overwrite_fields_in_derived_class",
         ),  # invalid C code (__pyx_base?)
-        ("TestReplace", "test_recursive_repr"),  # recursion error
-        ("TestReplace", "test_recursive_repr_two_attrs"),  # recursion error
-        ("TestReplace", "test_recursive_repr_misc_attrs"),  # recursion error
-        ("TestReplace", "test_recursive_repr_indirection"),  # recursion error
-        ("TestReplace", "test_recursive_repr_indirection_two"),  # recursion error
         (
             "TestCase",
             "test_intermediate_non_dataclass",
@@ -231,12 +227,11 @@ class SubstituteNameString(ast.NodeTransformer):
             if node.value.find("<locals>") != -1:
                 import re
 
-                new_value = re.sub("[\w.]*<locals>", "", node.value)
+                new_value = new_value2 = re.sub("[\w.]*<locals>", "", node.value)
                 for key, value in self.substitutions.items():
-                    new_value2 = re.sub(f"(?<![\w])[.]{key}(?![\w])", value, new_value)
-                    if new_value != new_value2:
-                        node.value = new_value2
-                        break
+                    new_value2 = re.sub(f"(?<![\w])[.]{key}(?![\w])", value, new_value2)
+                if new_value != new_value2:
+                    node.value = new_value2
         return node
 
 

--- a/tests/run/test_dataclasses.pyx
+++ b/tests/run/test_dataclasses.pyx
@@ -548,6 +548,48 @@ class C_TestReplace_test_initvar_is_specified:
     def __post_init__(self, y):
         self.x *= y
 
+@dataclass
+@cclass
+class C_TestReplace_test_recursive_repr:
+    f: 'C'
+
+@dataclass
+@cclass
+class C_TestReplace_test_recursive_repr_two_attrs:
+    f: 'C'
+    g: 'C'
+
+@dataclass
+@cclass
+class C_TestReplace_test_recursive_repr_indirection:
+    f: 'D'
+
+@dataclass
+@cclass
+class D_TestReplace_test_recursive_repr_indirection:
+    f: 'C'
+
+@dataclass
+@cclass
+class C_TestReplace_test_recursive_repr_indirection_two:
+    f: 'D'
+
+@dataclass
+@cclass
+class D_TestReplace_test_recursive_repr_indirection_two:
+    f: 'E'
+
+@dataclass
+@cclass
+class E_TestReplace_test_recursive_repr_indirection_two:
+    f: 'C'
+
+@dataclass
+@cclass
+class C_TestReplace_test_recursive_repr_misc_attrs:
+    f: 'C'
+    g: int
+
 class CustomError(Exception):
     pass
 
@@ -1065,6 +1107,46 @@ class TestReplace(unittest.TestCase):
             replace(c, x=3)
         c = replace(c, x=3, y=5)
         self.assertEqual(c.x, 15)
+
+    def test_recursive_repr(self):
+        C = C_TestReplace_test_recursive_repr
+        c = C(None)
+        c.f = c
+        self.assertEqual(repr(c), 'C_TestReplace_test_recursive_repr(f=...)')
+
+    def test_recursive_repr_two_attrs(self):
+        C = C_TestReplace_test_recursive_repr_two_attrs
+        c = C(None, None)
+        c.f = c
+        c.g = c
+        self.assertEqual(repr(c), 'C_TestReplace_test_recursive_repr_two_attrs(f=..., g=...)')
+
+    def test_recursive_repr_indirection(self):
+        C = C_TestReplace_test_recursive_repr_indirection
+        D = D_TestReplace_test_recursive_repr_indirection
+        c = C(None)
+        d = D(None)
+        c.f = d
+        d.f = c
+        self.assertEqual(repr(c), 'C_TestReplace_test_recursive_repr_indirection(f=D_TestReplace_test_recursive_repr_indirection(f=...))')
+
+    def test_recursive_repr_indirection_two(self):
+        C = C_TestReplace_test_recursive_repr_indirection_two
+        D = D_TestReplace_test_recursive_repr_indirection_two
+        E = E_TestReplace_test_recursive_repr_indirection_two
+        c = C(None)
+        d = D(None)
+        e = E(None)
+        c.f = d
+        d.f = e
+        e.f = c
+        self.assertEqual(repr(c), 'C_TestReplace_test_recursive_repr_indirection_two(f=D_TestReplace_test_recursive_repr_indirection_two(f=E_TestReplace_test_recursive_repr_indirection_two(f=...)))')
+
+    def test_recursive_repr_misc_attrs(self):
+        C = C_TestReplace_test_recursive_repr_misc_attrs
+        c = C(None, 1)
+        c.f = c
+        self.assertEqual(repr(c), 'C_TestReplace_test_recursive_repr_misc_attrs(f=..., g=1)')
 
 class TestAbstract(unittest.TestCase):
     pass

--- a/tests/run/test_dataclasses.pyx
+++ b/tests/run/test_dataclasses.pyx
@@ -551,43 +551,43 @@ class C_TestReplace_test_initvar_is_specified:
 @dataclass
 @cclass
 class C_TestReplace_test_recursive_repr:
-    f: 'C'
+    f: object
 
 @dataclass
 @cclass
 class C_TestReplace_test_recursive_repr_two_attrs:
-    f: 'C'
-    g: 'C'
+    f: object
+    g: object
 
 @dataclass
 @cclass
 class C_TestReplace_test_recursive_repr_indirection:
-    f: 'D'
+    f: object
 
 @dataclass
 @cclass
 class D_TestReplace_test_recursive_repr_indirection:
-    f: 'C'
+    f: object
 
 @dataclass
 @cclass
 class C_TestReplace_test_recursive_repr_indirection_two:
-    f: 'D'
+    f: object
 
 @dataclass
 @cclass
 class D_TestReplace_test_recursive_repr_indirection_two:
-    f: 'E'
+    f: object
 
 @dataclass
 @cclass
 class E_TestReplace_test_recursive_repr_indirection_two:
-    f: 'C'
+    f: object
 
 @dataclass
 @cclass
 class C_TestReplace_test_recursive_repr_misc_attrs:
-    f: 'C'
+    f: object
     g: int
 
 class CustomError(Exception):


### PR DESCRIPTION
The dataclass module specifically guards repr from being invoked recursively. I use a slightly different method here to do the same thing.

Part of https://github.com/cython/cython/issues/4956