### PR TITLE
Don't use unsupported GCC pragma's with Intel compilers

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -454,7 +454,7 @@ static CYTHON_INLINE PyObject * __Pyx_PyInt_FromSize_t(size_t ival) {
 
 // GCC diagnostic pragmas were introduced in GCC 4.6
 // Used to silence conversion warnings that are ok but cannot be avoided.
-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#if !defined(__INTEL_COMPILER) && defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #define __Pyx_HAS_GCC_DIAGNOSTIC
 #endif
 


### PR DESCRIPTION
The Intel compilers define `__GNUC__` but do not implement the warning pragma's used by Cython in `TypeConversion.c`. That results in a large amount of warnings like:
```
scipy/special/_ufuncs_cxx.cpython-310-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp(4940): warning #2282: unrecognized GCC pragma
  #pragma GCC diagnostic push
                         ^

scipy/special/_ufuncs_cxx.cpython-310-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp(4941): warning #2282: unrecognized GCC pragma
  #pragma GCC diagnostic ignored "-Wconversion"
                         ^

scipy/special/_ufuncs_cxx.cpython-310-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp(4945): warning #2282: unrecognized GCC pragma
  #pragma GCC diagnostic pop
```

Hence disable the use of these pragma's when we see an Intel compiler is used.