### PR TITLE
setup.py: Add project_urls for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -301,9 +301,9 @@ def run_build():
         project_urls={
             "Documentation": "https://cython.readthedocs.io/",
             "Donate": "https://cython.readthedocs.io/en/latest/src/donating.html",
-            "Source code": "https://github.com/cython/cython",
-            "Bug tracker": "https://github.com/cython/cython/issues",
-            "User group": "https://groups.google.com/g/cython-users",
+            "Source Code": "https://github.com/cython/cython",
+            "Bug Tracker": "https://github.com/cython/cython/issues",
+            "User Group": "https://groups.google.com/g/cython-users",
         },
 
         scripts=scripts,

--- a/setup.py
+++ b/setup.py
@@ -299,10 +299,11 @@ def run_build():
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
         project_urls={
-            'Documentation': 'https://cython.readthedocs.io/',
-            'Funding': 'https://cython.readthedocs.io/en/latest/src/donating.html',
-            'Source': 'https://github.com/cython/cython',
-            'Tracker': 'https://github.com/cython/cython/issues',
+            "Documentation": "https://cython.readthedocs.io/",
+            "Donate": "https://cython.readthedocs.io/en/latest/src/donating.html",
+            "Source code": "https://github.com/cython/cython",
+            "Bug tracker": "https://github.com/cython/cython/issues",
+            "User group": "https://groups.google.com/g/cython-users",
         },
 
         scripts=scripts,

--- a/setup.py
+++ b/setup.py
@@ -298,6 +298,12 @@ def run_build():
             "Topic :: Software Development :: Compilers",
             "Topic :: Software Development :: Libraries :: Python Modules"
         ],
+        project_urls={
+            'Documentation': 'https://cython.readthedocs.io/',
+            'Funding': 'https://cython.readthedocs.io/en/latest/src/donating.html',
+            'Source': 'https://github.com/cython/cython',
+            'Tracker': 'https://github.com/cython/cython/issues',
+        },
 
         scripts=scripts,
         packages=packages,


### PR DESCRIPTION
Add [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) dictionary to setup.py with URLs to the Cython documentation, funding, source code and bug tracker. This will add those URLs under the "Project links" section on https://pypi.org/project/cython, making it easy to find these resources directly from PyPI.