### PR TITLE
Docs: Fix example in buffer user guide

### DIFF
--- a/docs/examples/userguide/buffer/matrix_with_buffer.pyx
+++ b/docs/examples/userguide/buffer/matrix_with_buffer.pyx
@@ -19,7 +19,7 @@ cdef class Matrix:
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         cdef Py_ssize_t itemsize = sizeof(self.v[0])
 
-        self.shape[0] = self.v.size() / self.ncols
+        self.shape[0] = self.v.size() // self.ncols
         self.shape[1] = self.ncols
 
         # Stride 1 is the distance, in bytes, between two items in a row;


### PR DESCRIPTION
Fixes following error:

```
$ cython -3 matrix_with_buffer.pyx

Error compiling Cython file:
------------------------------------------------------------
...
        self.v.resize(self.v.size() + self.ncols)

    def __getbuffer__(self, Py_buffer *buffer, int flags):
        cdef Py_ssize_t itemsize = sizeof(self.v[0])

        self.shape[0] = self.v.size() / self.ncols
                                      ^
------------------------------------------------------------
matrix_with_buffer.pyx:22:38: Cannot assign type 'double' to 'Py_ssize_t'
```
