### PR TITLE
Fixed missed binop self types

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -965,8 +965,8 @@ class SlotTable(object):
 
             # Added in release 2.2
             # The following require the Py_TPFLAGS_HAVE_CLASS flag
-            BinopSlot(binaryfunc, "nb_floor_divide", "__floordiv__", method_name_to_slot),
-            BinopSlot(binaryfunc, "nb_true_divide", "__truediv__", method_name_to_slot),
+            BinopSlot(bf, "nb_floor_divide", "__floordiv__", method_name_to_slot),
+            BinopSlot(bf, "nb_true_divide", "__truediv__", method_name_to_slot),
             MethodSlot(ibinaryfunc, "nb_inplace_floor_divide", "__ifloordiv__", method_name_to_slot),
             MethodSlot(ibinaryfunc, "nb_inplace_true_divide", "__itruediv__", method_name_to_slot),
 
@@ -974,7 +974,7 @@ class SlotTable(object):
             MethodSlot(unaryfunc, "nb_index", "__index__", method_name_to_slot),
 
             # Added in release 3.5
-            BinopSlot(binaryfunc, "nb_matrix_multiply", "__matmul__", method_name_to_slot,
+            BinopSlot(bf, "nb_matrix_multiply", "__matmul__", method_name_to_slot,
                       ifdef="PY_VERSION_HEX >= 0x03050000"),
             MethodSlot(ibinaryfunc, "nb_inplace_matrix_multiply", "__imatmul__", method_name_to_slot,
                        ifdef="PY_VERSION_HEX >= 0x03050000"),

--- a/tests/run/binop_reverse_methods_GH2056.pyx
+++ b/tests/run/binop_reverse_methods_GH2056.pyx
@@ -30,6 +30,12 @@ class Base(object):
     'Base.__rpow__(Base(), 2, None)'
     >>> pow(Base(), 2, 100)
     'Base.__pow__(Base(), 2, 100)'
+    >>> Base() // 1
+    True
+    >>> set() // Base()
+    True
+
+    # version dependent tests for @ and / are external
     """
     implemented: cython.bint
 
@@ -66,6 +72,44 @@ class Base(object):
 
     def __repr__(self):
         return "%s()" % (self.__class__.__name__)
+
+    # The following methods were missed from the initial implementation
+    # that typed 'self'. These tests are a quick test to confirm that
+    # but not the full binop behaviour
+    def __matmul__(self, other):
+        return cython.typeof(self) == 'Base'
+
+    def __rmatmul__(self, other):
+        return cython.typeof(self) == 'Base'
+
+    def __truediv__(self, other):
+        return cython.typeof(self) == 'Base'
+
+    def __rtruediv__(self, other):
+        return cython.typeof(self) == 'Base'
+
+    def __floordiv__(self, other):
+        return cython.typeof(self) == 'Base'
+
+    def __rfloordiv__(self, other):
+        return cython.typeof(self) == 'Base'
+
+
+if sys.version_info >= (3, 5):
+    __doc__ += """
+    >>> Base() @ 1
+    True
+    >>> set() @ Base()
+    True
+    """
+
+if sys.version_info >= (3, 0):
+    __doc__ += """
+    >>> Base() / 1
+    True
+    >>> set() / Base()
+    True
+    """
 
 
 @cython.c_api_binop_methods(False)


### PR DESCRIPTION
`__matmul__`, `__truediv__`, `__floordiv__` all forgot to set the type of `self`.

Fixes #5067