### PR TITLE
Fix builtin bound classmethods

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2052,7 +2052,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
                 Py_DECREF(dict);
                 goto cleanup_failed;
             }
-            compiled = Py_CompileString("lambda ignore, *args, **kwds: method(*args, **kwds)",
+            compiled = Py_CompileString("lambda _, *args, **kwds: method(*args, **kwds)",
                                         "<bound_method_wrapper>", Py_eval_input);
             if (!compiled) {
                 Py_DECREF(dict);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2014,7 +2014,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
     } else
 #endif
     // bound classmethods need special treatment
-#if PY_MAJOR_VERSION >= 3
+#if PY_VERSION_HEX >= 0x03090000
     if (PyCFunction_CheckExact(method))
 #else
     if (PyCFunction_Check(method))

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2023,8 +2023,8 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
     if (PyCFunction_Check(method))
 #endif
     {
-        PyObject *self = NULL;
-        int self_found = 0;
+        PyObject *self;
+        int self_found;
 #if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_COMPILING_IN_PYPY
         self = PyObject_GetAttrString(method, "__self__");
         if (!self) {
@@ -2034,7 +2034,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
         self = PyCFunction_GET_SELF(method);
 #endif
         self_found = (self && self != Py_None);
-#if CYTHON_COMPILING_IN_LIMITED_API
+#if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_COMPILING_IN_PYPY
         Py_XDECREF(self);
 #endif
         if (self_found) {

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2014,7 +2014,10 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
     } else
 #endif
     // bound classmethods need special treatment
-#if PY_VERSION_HEX >= 0x03090000
+#if defined(CYTHON_COMPILING_IN_PYPY)
+    // In these functions are regular methods, so just do
+    // the self check
+#elif PY_VERSION_HEX >= 0x03090000
     if (PyCFunction_CheckExact(method))
 #else
     if (PyCFunction_Check(method))
@@ -2022,9 +2025,11 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
     {
         PyObject *self = NULL;
         int self_found = 0;
-#if CYTHON_COMPILING_IN_LIMITED_API
+#if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_COMPILING_IN_PYPY
         self = PyObject_GetAttrString(method, "__self__");
-        if (!self) goto cleanup_failed;
+        if (!self) {
+            PyErr_Clear();
+        }
 #else
         self = PyCFunction_GET_SELF(method);
 #endif

--- a/tests/run/bytearraymethods.pyx
+++ b/tests/run/bytearraymethods.pyx
@@ -287,3 +287,13 @@ cdef class BytearraySubtype(bytearray):
     """
     def _append(self, x):
         self.append(x)
+
+def fromhex(bytearray b):
+    """
+    https://github.com/cython/cython/issues/5051
+    Optimization of bound method calls was breaking classmethods
+    >>> fromhex(bytearray(b""))
+    """
+    if IS_PY3:
+        assert b.fromhex('2Ef0 F1f2  ') == b'.\xf0\xf1\xf2'
+    # method doesn't exist on Py2!

--- a/tests/run/bytesmethods.pyx
+++ b/tests/run/bytesmethods.pyx
@@ -11,6 +11,8 @@ SSIZE_T_MIN = PY_SSIZE_T_MIN
 b_a = b'a'
 b_b = b'b'
 
+import sys
+
 
 @cython.test_assert_path_exists(
     "//PythonCapiCallNode")
@@ -277,3 +279,13 @@ def literal_join(*args):
     result = b'|'.join(args)
     assert cython.typeof(result) == 'Python object', cython.typeof(result)
     return result
+
+def fromhex(bytes b):
+    """
+    https://github.com/cython/cython/issues/5051
+    Optimization of bound method calls was breaking classmethods
+    >>> fromhex(b"")
+    """
+    if sys.version_info[0] > 2:
+        assert b.fromhex('2Ef0 F1f2  ') == b'.\xf0\xf1\xf2'
+    # method doesn't exist on Py2!

--- a/tests/run/dict.pyx
+++ b/tests/run/dict.pyx
@@ -136,3 +136,17 @@ def dict_unpacking_not_for_arg_create_a_copy():
 
     print(sorted(call_once.items()))
     print(sorted(call_twice.items()))
+
+def from_keys_bound(dict d, val):
+    """
+    https://github.com/cython/cython/issues/5051
+    Optimization of bound method calls was breaking classmethods
+    >>> sorted(from_keys_bound({}, 100).items())
+    [('a', 100), ('b', 100)]
+    >>> sorted(from_keys_bound({}, None).items())
+    [('a', None), ('b', None)]
+    """
+    if val is not None:
+        return d.fromkeys(("a", "b"), val)
+    else:
+        return d.fromkeys(("a", "b"))


### PR DESCRIPTION
The general optimization for unpacking builtin method calls was breaking bound classmethods (with crashes on Py2 and wrong answers on Py3).

This PR adds code to handle it. The code is unlikely to be very fast, but my judgement is that this is a rare case and thus it's more important just to get it to work rather than to optimize this case.

Fixes #5051