### PR TITLE
Run GCC 11 tests with the most recent language standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,16 @@ jobs:
 
           # Ubuntu sub-jobs:
           # ================
-          # GCC 11
+          # GCC 11 (with latest language standards)
           - os: ubuntu-18.04
             python-version: 3.9
             backend: c
-            env: { GCC_VERSION: 11 }
+            env: { GCC_VERSION: 11, EXTRA_CFLAGS: "-std=c17" }
             extra_hash: "-gcc11"
           - os: ubuntu-18.04
             python-version: 3.9
             backend: cpp
-            env: { GCC_VERSION: 11 }
+            env: { GCC_VERSION: 11, EXTRA_CFLAGS: "-std=c++20" }
             extra_hash: "-gcc11"
           # compile all modules
           - os: ubuntu-18.04

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -594,8 +594,8 @@ class __Pyx_FakeReference {
     // TODO(robertwb): Delegate all operators (or auto-generate unwrapping code where needed).
     template<typename U> bool operator ==(const U& other) const { return *ptr == other; }
     template<typename U> bool operator !=(const U& other) const { return *ptr != other; }
-    bool operator==(const __Pyx_FakeReference& other) const { return *ptr == *other.ptr; }
-    bool operator!=(const __Pyx_FakeReference& other) const { return *ptr != *other.ptr; }
+    template<typename U=T> bool operator==(const __Pyx_FakeReference<U>& other) const { return *ptr == *other.ptr; }
+    template<typename U=T> bool operator!=(const __Pyx_FakeReference<U>& other) const { return *ptr != *other.ptr; }
   private:
     T *ptr;
 };

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -594,6 +594,8 @@ class __Pyx_FakeReference {
     // TODO(robertwb): Delegate all operators (or auto-generate unwrapping code where needed).
     template<typename U> bool operator ==(const U& other) const { return *ptr == other; }
     template<typename U> bool operator !=(const U& other) const { return *ptr != other; }
+    bool operator==(const __Pyx_FakeReference& other) const { return *ptr == *other.ptr; }
+    bool operator!=(const __Pyx_FakeReference& other) const { return *ptr != *other.ptr; }
   private:
     T *ptr;
 };

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -592,8 +592,8 @@ class __Pyx_FakeReference {
     T *operator&() { return ptr; }
     operator T&() { return *ptr; }
     // TODO(robertwb): Delegate all operators (or auto-generate unwrapping code where needed).
-    template<typename U> bool operator ==(U other) { return *ptr == other; }
-    template<typename U> bool operator !=(U other) { return *ptr != other; }
+    template<typename U> bool operator ==(const U& other) const { return *ptr == other; }
+    template<typename U> bool operator !=(const U& other) const { return *ptr != other; }
   private:
     T *ptr;
 };


### PR DESCRIPTION
It doesn't look like we're testing with a compiler using up-to-date language standards, and this meant we missed at least one bug recently:
https://github.com/cython/cython/pull/5029.

It seems like the GCC11 tests may as well double as "GCC11 with up-to-date language standards"