### PR TITLE
Recommend Cython 3 for pure-Python syntax

### DIFF
--- a/docs/src/two-syntax-variants-used
+++ b/docs/src/two-syntax-variants-used
@@ -16,3 +16,7 @@
       .. code-block:: python
 
           import cython
+          
+      If you use the pure Python syntax we strongly recommend you use a recent
+      Cython 3 release, since significant improvements have been made here
+      compared to the 0.29.x releases.


### PR DESCRIPTION
I know this is officially in the "Cython 3" documentation, but I think most users end up with this documentation. It'd be good to link the annotation typing mainly to Cython 3.