### PR TITLE
Fix faulty calls to Context

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -46,7 +46,8 @@ from ..Utils import (cached_function, cached_method, path_exists,
     safe_makedirs, copy_file_to_dir_if_newer, is_package_dir, write_depfile)
 from ..Compiler import Errors
 from ..Compiler.Main import Context
-from ..Compiler.Options import CompilationOptions, default_options
+from ..Compiler.Options import (CompilationOptions, default_options,
+    get_directive_defaults)
 
 join_path = cached_function(os.path.join)
 copy_once_if_newer = cached_function(copy_file_to_dir_if_newer)
@@ -731,7 +732,8 @@ def create_dependency_tree(ctx=None, quiet=False):
     global _dep_tree
     if _dep_tree is None:
         if ctx is None:
-            ctx = Context(["."], CompilationOptions(default_options))
+            ctx = Context(["."], get_directive_defaults(),
+                          options=CompilationOptions(default_options))
         _dep_tree = DependencyTree(ctx, quiet=quiet)
     return _dep_tree
 

--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -11,7 +11,8 @@ from distutils.command.build_ext import build_ext
 
 import Cython
 from ..Compiler.Main import Context
-from ..Compiler.Options import default_options
+from ..Compiler.Options import (default_options, CompilationOptions,
+    get_directive_defaults)
 
 from ..Compiler.Visitor import CythonTransform, EnvTransform
 from ..Compiler.ParseTreeTransforms import SkipDeclarations
@@ -68,7 +69,8 @@ class UnboundSymbols(EnvTransform, SkipDeclarations):
 def unbound_symbols(code, context=None):
     code = to_unicode(code)
     if context is None:
-        context = Context([], default_options)
+        context = Context([], get_directive_defaults(),
+                          options=CompilationOptions(default_options))
     from ..Compiler.ParseTreeTransforms import AnalyseDeclarationsTransform
     tree = parse_from_strings('(tree fragment)', code)
     for phase in Pipeline.create_pipeline(context, 'pyx'):
@@ -129,7 +131,11 @@ def _get_build_extension():
 
 @cached_function
 def _create_context(cython_include_dirs):
-    return Context(list(cython_include_dirs), default_options)
+    return Context(
+        list(cython_include_dirs),
+        get_directive_defaults(),
+        options=CompilationOptions(default_options)
+    )
 
 
 _cython_inline_cache = {}


### PR DESCRIPTION
which were mistakenly passing options instead of compiler directives.