### PR TITLE
Add missing C++17/20 STL functions and methods

### DIFF
--- a/Cython/Includes/libcpp/map.pxd
+++ b/Cython/Includes/libcpp/map.pxd
@@ -121,6 +121,8 @@ cdef extern from "<map>" namespace "std" nogil:
         iterator upper_bound(const T&)
         const_iterator const_upper_bound "upper_bound"(const T&)
         #value_compare value_comp()
+        # C++20
+        bint contains(const key_type&)
 
     cdef cppclass multimap[T, U, COMPARE=*, ALLOCATOR=*]:
         ctypedef T key_type
@@ -239,3 +241,4 @@ cdef extern from "<map>" namespace "std" nogil:
         iterator upper_bound(const T&)
         const_iterator const_upper_bound "upper_bound"(const T&)
         #value_compare value_comp()
+        bint contains(const key_type&)

--- a/Cython/Includes/libcpp/map.pxd
+++ b/Cython/Includes/libcpp/map.pxd
@@ -122,7 +122,7 @@ cdef extern from "<map>" namespace "std" nogil:
         const_iterator const_upper_bound "upper_bound"(const T&)
         #value_compare value_comp()
         # C++20
-        bint contains(const key_type&)
+        bint contains(const T&)
 
     cdef cppclass multimap[T, U, COMPARE=*, ALLOCATOR=*]:
         ctypedef T key_type
@@ -241,4 +241,4 @@ cdef extern from "<map>" namespace "std" nogil:
         iterator upper_bound(const T&)
         const_iterator const_upper_bound "upper_bound"(const T&)
         #value_compare value_comp()
-        bint contains(const key_type&)
+        bint contains(const T&)

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -122,3 +122,13 @@ cdef extern from "<numeric>" namespace "std" nogil:
     ForwardIt2 transform_exclusive_scan[ExecutionPolicy, ForwardIt1, ForwardIt2, T, BinaryOperation, UnaryOperation](
         ExecutionPolicy&& policy, ForwardIt1 first, ForwardIt1 last, ForwardIt2 d_first, 
         T init, BinaryOperation binary_op, UnaryOperation unary_op)
+
+    # C++17
+    T gcd[T](T a, T b)
+    T lcm[T](T a, T b)
+
+    # C++20
+    T midpoint[T](T a, T b) except +
+    float lerp(float a, float b, float c) except +
+    double lerp(double a, double b, double c) except +
+    long double lerp(long double a, long double b, long double c) except +

--- a/Cython/Includes/libcpp/numeric.pxd
+++ b/Cython/Includes/libcpp/numeric.pxd
@@ -129,6 +129,3 @@ cdef extern from "<numeric>" namespace "std" nogil:
 
     # C++20
     T midpoint[T](T a, T b) except +
-    float lerp(float a, float b, float c) except +
-    double lerp(double a, double b, double c) except +
-    long double lerp(long double a, long double b, long double c) except +

--- a/Cython/Includes/libcpp/set.pxd
+++ b/Cython/Includes/libcpp/set.pxd
@@ -112,6 +112,8 @@ cdef extern from "<set>" namespace "std" nogil:
         iterator upper_bound(const T&)
         const_iterator const_upper_bound "upper_bound"(const T&)
         #value_compare value_comp()
+        # C++20
+        bint contains(const T&)
 
     cdef cppclass multiset[T]:
         ctypedef T value_type
@@ -222,3 +224,5 @@ cdef extern from "<set>" namespace "std" nogil:
         void swap(multiset&)
         iterator upper_bound(const T&)
         const_iterator const_upper_bound "upper_bound"(const T&)
+        # C++20
+        bint contains(const T&)

--- a/Cython/Includes/libcpp/string.pxd
+++ b/Cython/Includes/libcpp/string.pxd
@@ -251,6 +251,15 @@ cdef extern from "<string>" namespace "std" nogil:
         string substr(size_t pos) except +
         string substr()
 
+        # C++20
+        bint starts_with(char c) except +
+        bint starts_with(const char* s)
+        bint ends_with(char c) except +
+        bint ends_with(const char* s)
+        # C++23
+        #bint contains(char c) except +
+        #bint contains(const char* s)
+
         #string& operator= (const string&)
         #string& operator= (const char*)
         #string& operator= (char)

--- a/Cython/Includes/libcpp/string.pxd
+++ b/Cython/Includes/libcpp/string.pxd
@@ -257,8 +257,8 @@ cdef extern from "<string>" namespace "std" nogil:
         bint ends_with(char c) except +
         bint ends_with(const char* s)
         # C++23
-        #bint contains(char c) except +
-        #bint contains(const char* s)
+        bint contains(char c) except +
+        bint contains(const char* s)
 
         #string& operator= (const string&)
         #string& operator= (const char*)

--- a/Cython/Includes/libcpp/unordered_map.pxd
+++ b/Cython/Includes/libcpp/unordered_map.pxd
@@ -96,7 +96,7 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         size_t bucket_size(size_t)
         size_t bucket(const T&)
         # C++20
-        bint contains(const key_type&)
+        bint contains(const T&)
 
     cdef cppclass unordered_multimap[T, U, HASH=*, PRED=*, ALLOCATOR=*]:
         ctypedef T key_type
@@ -189,4 +189,4 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         size_t bucket_size(size_t)
         size_t bucket(const T&)
         # C++20
-        bint contains(const key_type&)
+        bint contains(const T&)

--- a/Cython/Includes/libcpp/unordered_map.pxd
+++ b/Cython/Includes/libcpp/unordered_map.pxd
@@ -95,6 +95,8 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         size_t max_bucket_count()
         size_t bucket_size(size_t)
         size_t bucket(const T&)
+        # C++20
+        bint contains(const key_type&)
 
     cdef cppclass unordered_multimap[T, U, HASH=*, PRED=*, ALLOCATOR=*]:
         ctypedef T key_type
@@ -186,3 +188,5 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         size_t max_bucket_count()
         size_t bucket_size(size_t)
         size_t bucket(const T&)
+        # C++20
+        bint contains(const key_type&)

--- a/Cython/Includes/libcpp/unordered_set.pxd
+++ b/Cython/Includes/libcpp/unordered_set.pxd
@@ -75,6 +75,8 @@ cdef extern from "<unordered_set>" namespace "std" nogil:
         size_t max_bucket_count()
         size_t bucket_size(size_t)
         size_t bucket(const T&)
+        # C++20
+        bint contains(const key_type&)
 
     cdef cppclass unordered_multiset[T,HASH=*,PRED=*,ALLOCATOR=*]:
         ctypedef T value_type
@@ -146,3 +148,5 @@ cdef extern from "<unordered_set>" namespace "std" nogil:
         size_t max_bucket_count()
         size_t bucket_size(size_t)
         size_t bucket(const T&)
+        # C++20
+        bint contains(const key_type&)

--- a/Cython/Includes/libcpp/unordered_set.pxd
+++ b/Cython/Includes/libcpp/unordered_set.pxd
@@ -76,7 +76,7 @@ cdef extern from "<unordered_set>" namespace "std" nogil:
         size_t bucket_size(size_t)
         size_t bucket(const T&)
         # C++20
-        bint contains(const key_type&)
+        bint contains(const T&)
 
     cdef cppclass unordered_multiset[T,HASH=*,PRED=*,ALLOCATOR=*]:
         ctypedef T value_type
@@ -149,4 +149,4 @@ cdef extern from "<unordered_set>" namespace "std" nogil:
         size_t bucket_size(size_t)
         size_t bucket(const T&)
         # C++20
-        bint contains(const key_type&)
+        bint contains(const T&)

--- a/tests/run/cpp_stl_associated_containers_contains_cpp20.pyx
+++ b/tests/run/cpp_stl_associated_containers_contains_cpp20.pyx
@@ -1,5 +1,7 @@
 # mode: run
-# tag: cpp, werror, cpp20
+# tag: cpp, cpp20
+
+# cython: language_level=3
 
 from libcpp.map cimport map, multimap
 from libcpp.set cimport set, multiset

--- a/tests/run/cpp_stl_associated_containers_contains_cpp20.pyx
+++ b/tests/run/cpp_stl_associated_containers_contains_cpp20.pyx
@@ -1,0 +1,104 @@
+# mode: run
+# tag: cpp, werror, cpp20
+
+from libcpp.map cimport map, multimap
+from libcpp.set cimport set, multiset
+from libcpp.unordered_map cimport unordered_map, unordered_multimap
+from libcpp.unordered_set cimport unordered_set, unordered_multiset
+
+def test_map_contains(vals, int key_to_find):
+    """
+    >>> test_map_contains([(1,100),(2,200),(3,300)], 3)
+    True
+    >>> test_map_contains([(1,100),(2,200),(3,300)], 4)
+    False
+    """
+    cdef map[int,int] m = map[int, int]()
+    for v in vals:
+        m.insert(v)
+    return m.contains(key_to_find)
+
+def test_unordered_map_contains(vals, int key_to_find):
+    """
+    >>> test_unordered_map_contains([(1,100),(2,200),(3,300)], 3)
+    True
+    >>> test_unordered_map_contains([(1,100),(2,200),(3,300)], 4)
+    False
+    """
+    cdef unordered_map[int,int] um = unordered_map[int, int]()
+    for v in vals:
+        um.insert(v)
+    return um.contains(key_to_find)
+
+def test_multimap_contains(vals, int key_to_find):
+    """
+    >>> test_multimap_contains([(1,100),(2,200),(3,300)], 3)
+    True
+    >>> test_multimap_contains([(1,100),(2,200),(3,300)], 4)
+    False
+    """
+    cdef multimap[int,int] mm = multimap[int, int]()
+    for v in vals:
+        mm.insert(v)
+    return mm.contains(key_to_find)
+
+def test_unordered_multimap_contains(vals, int key_to_find):
+    """
+    >>> test_unordered_multimap_contains([(1,100),(2,200),(3,300)], 3)
+    True
+    >>> test_unordered_multimap_contains([(1,100),(2,200),(3,300)], 4)
+    False
+    """
+    cdef unordered_multimap[int,int] umm = unordered_multimap[int, int]()
+    for v in vals:
+        umm.insert(v)
+    return umm.contains(key_to_find)
+
+
+def test_set_contains(vals, int val_to_find):
+    """
+    >>> test_set_contains([1, 2, 3], 3)
+    True
+    >>> test_set_contains([1, 2, 3], 4)
+    False
+    """
+    cdef set[int] s = set[int]()
+    for v in vals:
+        s.insert(v)
+    return s.contains(val_to_find)
+
+def test_unordered_set_contains(vals, int val_to_find):
+    """
+    >>> test_unordered_set_contains([1, 2, 3], 3)
+    True
+    >>> test_unordered_set_contains([1, 2, 3], 4)
+    False
+    """
+    cdef unordered_set[int] us = unordered_set[int]()
+    for v in vals:
+        us.insert(v)
+    return us.contains(val_to_find)
+
+def test_multiset_contains(vals, int val_to_find):
+    """
+    >>> test_multiset_contains([1, 2, 3], 3)
+    True
+    >>> test_multiset_contains([1, 2, 3], 4)
+    False
+    """
+    cdef multiset[int] ms = multiset[int]()
+    for v in vals:
+        ms.insert(v)
+    return ms.contains(val_to_find)
+
+def test_unordered_multiset_contains(vals, int val_to_find):
+    """
+    >>> test_unordered_multiset_contains([1, 2, 3], 3)
+    True
+    >>> test_unordered_multiset_contains([1, 2, 3], 4)
+    False
+    """
+    cdef unordered_multiset[int] ums = unordered_multiset[int]()
+    for v in vals:
+        ums.insert(v)
+    return ums.contains(val_to_find)

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -279,7 +279,7 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
 def test_gcd(int a, int b):
     """
     Test gcd
-    >>> test_gcd(2, 3)
+    >>> test_gcd(12, 18)
     6
     """
     return gcd[int](a, b)

--- a/tests/run/cpp_stl_numeric_ops_cpp17.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp17.pyx
@@ -3,7 +3,7 @@
 
 from libcpp.numeric cimport (reduce, transform_reduce, inclusive_scan, 
                              exclusive_scan, transform_inclusive_scan, 
-                             transform_exclusive_scan)
+                             transform_exclusive_scan, gcd, lcm)
 from libcpp.execution cimport seq
 from libcpp.vector cimport vector
 
@@ -275,3 +275,19 @@ def test_transform_exclusive_scan_with_execpolicy(vector[int] v, int init):
     cdef vector[int] out = vector[int](v.size())
     transform_exclusive_scan(seq, v.begin(), v.end(), out.begin(), init, add_integers, multiply_with_2)
     return out
+
+def test_gcd(int a, int b):
+    """
+    Test gcd
+    >>> test_gcd(2, 3)
+    6
+    """
+    return gcd[int](a, b)
+
+def test_lcm(int a, int b):
+    """
+    Test lcm
+    >>> test_lcm(45, 75)
+    225
+    """
+    return lcm[int](a, b)

--- a/tests/run/cpp_stl_numeric_ops_cpp20.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp20.pyx
@@ -21,12 +21,3 @@ def test_midpoint_float(float a, float b):
     """
     cdef float res = midpoint[float](a, b)
     return res
-
-def test_lerp(float a, float b, float t):
-    """
-    Test lerp for float
-    >>> test_lerp(1.0, 2.0, 0.5)
-    1.5
-    """
-    cdef float res = lerp(a, b, t)
-    return res

--- a/tests/run/cpp_stl_numeric_ops_cpp20.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp20.pyx
@@ -1,7 +1,7 @@
 # mode: run
 # tag: cpp, werror, cpp20
 
-from libcpp.numeric cimport midpoint, lerp
+from libcpp.numeric cimport midpoint
 
 def test_midpoint_integer(int a, int b):
     """

--- a/tests/run/cpp_stl_numeric_ops_cpp20.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp20.pyx
@@ -3,27 +3,30 @@
 
 from libcpp.numeric cimport midpoint, lerp
 
-def test_midpoint_integer(int a, int b)
+def test_midpoint_integer(int a, int b):
     """
     Test midpoint for integer types
     >>> test_midpoint_integer(2, 6)
     4
     """
-    return midpoint[int](a, b)
+    cdef int res = midpoint[int](a, b)
+    return res
 
 
-def test_midpoint_float(float a, float b)
+def test_midpoint_float(float a, float b):
     """
     Test midpoint for float
     >>> test_midpoint_float(2, 6)
-    3.35
+    4.0
     """
-    return midpoint[float](a, b)
+    cdef float res = midpoint[float](a, b)
+    return res
 
-def test_lerp(float a, float b, float t)
+def test_lerp(float a, float b, float t):
     """
     Test lerp for float
     >>> test_lerp(1.0, 2.0, 0.5)
     1.5
     """
-    return lerp[float](a, b, t)
+    cdef float res = lerp(a, b, t)
+    return res

--- a/tests/run/cpp_stl_numeric_ops_cpp20.pyx
+++ b/tests/run/cpp_stl_numeric_ops_cpp20.pyx
@@ -1,0 +1,29 @@
+# mode: run
+# tag: cpp, werror, cpp20
+
+from libcpp.numeric cimport midpoint, lerp
+
+def test_midpoint_integer(int a, int b)
+    """
+    Test midpoint for integer types
+    >>> test_midpoint_integer(2, 6)
+    4
+    """
+    return midpoint[int](a, b)
+
+
+def test_midpoint_float(float a, float b)
+    """
+    Test midpoint for float
+    >>> test_midpoint_float(2, 6)
+    3.35
+    """
+    return midpoint[float](a, b)
+
+def test_lerp(float a, float b, float t)
+    """
+    Test lerp for float
+    >>> test_lerp(1.0, 2.0, 0.5)
+    1.5
+    """
+    return lerp[float](a, b, t)

--- a/tests/run/cpp_stl_string_cpp20.pyx
+++ b/tests/run/cpp_stl_string_cpp20.pyx
@@ -9,7 +9,7 @@ b_F = b'F'
 b_abc = b"ABC"
 b_def = b"DEF"
 
-def test_string_starts_with_char(py_str):
+def test_string_starts_with_char(bytes py_str):
     """
     Test std::string.starts_with() with char type argument
     >>> test_string_starts_with_char(b'A')
@@ -22,7 +22,7 @@ def test_string_starts_with_char(py_str):
     return s.starts_with(c)
 
 
-def test_string_starts_with_cstr(py_str):
+def test_string_starts_with_cstr(bytes py_str):
     """
     Test std::string.starts_with() with c str type argument (char*)
     >>> test_string_starts_with_cstr(b"ABC")
@@ -35,7 +35,7 @@ def test_string_starts_with_cstr(py_str):
     return s.starts_with(c)
 
 
-def test_string_ends_with_char(py_str):
+def test_string_ends_with_char(bytes py_str):
     """
     Test std::string.ends_with() with char type argument
     >>> test_string_ends_with_char(b'F')
@@ -48,7 +48,7 @@ def test_string_ends_with_char(py_str):
     return s.ends_with(c)
 
 
-def test_string_ends_with_cstr(py_str):
+def test_string_ends_with_cstr(bytes py_str):
     """
     Test std::string.ends_with() with c str type argument (char*)
     >>> test_string_ends_with_cstr(b"DEF")

--- a/tests/run/cpp_stl_string_cpp20.pyx
+++ b/tests/run/cpp_stl_string_cpp20.pyx
@@ -2,60 +2,60 @@
 # tag: cpp, werror, cpp20
 
 from libcpp cimport bool
-from libcpp cimport string
+from libcpp.string cimport string
 
 b_A = b'A'
 b_F = b'F'
 b_abc = b"ABC"
 b_def = b"DEF"
 
-def test_string_starts_with_char(py_obj1):
+def test_string_starts_with_char(py_str):
     """
     Test std::string.starts_with() with char type argument
-    >>> test_string_starts_with_char(b_A)
+    >>> test_string_starts_with_char(b'A')
     True
-    >>> test_string_starts_with_char(b_F)
+    >>> test_string_starts_with_char(b'F')
     False
     """
-    cdef char c = py_obj1
+    cdef char c = py_str[0]
     cdef string s = b"ABCDEF"
     return s.starts_with(c)
 
 
-def test_string_starts_with_cstr(py_obj1):
+def test_string_starts_with_cstr(py_str):
     """
     Test std::string.starts_with() with c str type argument (char*)
-    >>> test_string_starts_cstr(b_abc)
+    >>> test_string_starts_with_cstr(b"ABC")
     True
-    >>> test_string_starts_cstr(b_def)
+    >>> test_string_starts_with_cstr(b"DEF")
     False
     """
-    cdef char* c = py_obj1
+    cdef char* c = py_str
     cdef string s = b"ABCDEF"
     return s.starts_with(c)
 
 
-def test_string_ends_with_char(py_obj1):
+def test_string_ends_with_char(py_str):
     """
     Test std::string.ends_with() with char type argument
-    >>> test_string_ends_with_char(b_F)
+    >>> test_string_ends_with_char(b'F')
     True
-    >>> test_string_ends_with_char(b_A)
+    >>> test_string_ends_with_char(b'A')
     False
     """
-    cdef char c = py_obj1
+    cdef char c = py_str[0]
     cdef string s = b"ABCDEF"
     return s.ends_with(c)
 
 
-def test_string_ends_with_cstr(py_obj1):
+def test_string_ends_with_cstr(py_str):
     """
     Test std::string.ends_with() with c str type argument (char*)
-    >>> test_string_ends_with_cstr(b_def)
+    >>> test_string_ends_with_cstr(b"DEF")
     True
-    >>> test_string_ends_with_cstr(b_abc)
+    >>> test_string_ends_with_cstr(b"ABC")
     False
     """
-    cdef char* c = py_obj1
+    cdef char* c = py_str
     cdef string s = b"ABCDEF"
     return s.ends_with(c)

--- a/tests/run/cpp_stl_string_cpp20.pyx
+++ b/tests/run/cpp_stl_string_cpp20.pyx
@@ -1,0 +1,61 @@
+# mode: run
+# tag: cpp, werror, cpp20
+
+from libcpp cimport bool
+from libcpp cimport string
+
+b_A = b'A'
+b_F = b'F'
+b_abc = b"ABC"
+b_def = b"DEF"
+
+def test_string_starts_with_char(py_obj1):
+    """
+    Test std::string.starts_with() with char type argument
+    >>> test_string_starts_with_char(b_A)
+    True
+    >>> test_string_starts_with_char(b_F)
+    False
+    """
+    cdef char c = py_obj1
+    cdef string s = b"ABCDEF"
+    return s.starts_with(c)
+
+
+def test_string_starts_with_cstr(py_obj1):
+    """
+    Test std::string.starts_with() with c str type argument (char*)
+    >>> test_string_starts_cstr(b_abc)
+    True
+    >>> test_string_starts_cstr(b_def)
+    False
+    """
+    cdef char* c = py_obj1
+    cdef string s = b"ABCDEF"
+    return s.starts_with(c)
+
+
+def test_string_ends_with_char(py_obj1):
+    """
+    Test std::string.ends_with() with char type argument
+    >>> test_string_ends_with_char(b_F)
+    True
+    >>> test_string_ends_with_char(b_A)
+    False
+    """
+    cdef char c = py_obj1
+    cdef string s = b"ABCDEF"
+    return s.ends_with(c)
+
+
+def test_string_ends_with_cstr(py_obj1):
+    """
+    Test std::string.ends_with() with c str type argument (char*)
+    >>> test_string_ends_with_cstr(b_def)
+    True
+    >>> test_string_ends_with_cstr(b_abc)
+    False
+    """
+    cdef char* c = py_obj1
+    cdef string s = b"ABCDEF"
+    return s.ends_with(c)


### PR DESCRIPTION
Adds

- C++17 numeric's new [`gcd()`](https://en.cppreference.com/w/cpp/numeric/gcd) and [`lcm()`](https://en.cppreference.com/w/cpp/numeric/gcd) functions
- C++20 numeric's new [`midpoint()`](https://en.cppreference.com/w/cpp/numeric/midpoint) function
- C++20's new [`.contains()`](https://en.cppreference.com/w/cpp/container/map/contains) method for all associated STL containers (map, multimap, set, multiset, ...)
- C++20's new [`std::string::starts_with()`](https://en.cppreference.com/w/cpp/string/basic_string/starts_with) and [`std::string::ends_with()`](https://en.cppreference.com/w/cpp/string/basic_string/ends_with) methods