### PR TITLE
Pin scikit-build version

### DIFF
--- a/test-requirements-27.txt
+++ b/test-requirements-27.txt
@@ -1,3 +1,4 @@
+scikit-build<0.16  # line-profiler dependency, 0.16 version dropped python 2 support
 attrs==20.3.0
 backports-abc==0.5
 backports.functools-lru-cache==1.6.3


### PR DESCRIPTION
scikit-build==0.16 drops python2 support.
