### PR TITLE
wheel CI: Always use latest minor version of cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@
 # not run on each push but only weekly and for releases.
 # Wheel builds can be triggered from the Actions page
 # (if you have the perms) on a commit to master.
-# 
+#
 # Alternatively, if you would like to trigger wheel builds
 # on a pull request, the labels that trigger builds are:
 # - Build System
@@ -66,15 +66,15 @@ jobs:
     steps:
       - name: Checkout Cython
         uses: actions/checkout@v3
-        
+
       - name: Set up QEMU
         if: contains(matrix.buildplat[1], '_aarch64')
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-      
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2
         env:
           # TODO: Build Cython with the compile-all flag?
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
@@ -138,7 +138,7 @@ jobs:
         with:
           name: pure-wheel
           path: ./dist/*.whl
-      
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
By removing the exact minor and patch version of the cibuildwheel action, it will always use the latest minor/patch version.

This ensures the latest Python versions are always used to build wheels.

Major version updates will be handled by #5110 for GitHub Actions.