### PR TITLE
Wheel CI: Update cibuildwheel to v2.11.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,7 +74,7 @@ jobs:
           platforms: all
       
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           # TODO: Build Cython with the compile-all flag?
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}


### PR DESCRIPTION
Updates cibuildwheel from [v.2.8.1](https://github.com/pypa/cibuildwheel/releases/tag/v2.8.1) to v2.11.2. The v2.8.1 release still used a Python 3.11 beta to build wheels (which aren't ABI stable (!)), [v2.11.2](https://github.com/pypa/cibuildwheel/releases/tag/v2.11.2) uses the stable Python 3.11.0 release.

Since [v2.11.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.11.0) cibuildwheel also allows building Windows Arm64 wheels (`-windows_arm64`). This could be interesting to look at (in another PR).