### PR TITLE
Pin line_profiler version to <4

### DIFF
--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,4 @@
 jupyter
 pytest  # needed by IPython/Jupyter integration tests
-line_profiler
+line_profiler<4  # currently 4 appears to collect no profiling info
 setuptools<60


### PR DESCRIPTION
Ideally we'd work out why it isn't working, but for now it seems easiest to try to pin the version.