### PR TITLE
Relax `nogil_check()` of `SliceIndexNode` to support array initialisation

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5421,7 +5421,7 @@ class SliceIndexNode(ExprNode):
 
     def nogil_check(self, env):
         self.nogil = env.nogil
-        return super().nogil_check(env)
+        return super(SliceIndexNode, self).nogil_check(env)
 
     gil_message = "Slicing Python object"
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5417,7 +5417,7 @@ class SliceIndexNode(ExprNode):
                     base_type, MemoryView.get_axes_specs(env, [slice_node]))
         return None
 
-    nogil_check = Node.gil_error
+    # nogil_check is inherited from parent class
     gil_message = "Slicing Python object"
 
     get_slice_utility_code = TempitaUtilityCode.load(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5230,7 +5230,7 @@ class SliceIndexNode(ExprNode):
     #  start     ExprNode or None
     #  stop      ExprNode or None
     #  slice     ExprNode or None   constant slice object
-    #  nogil          bool                 used internally
+    #  nogil     bool               used internally
 
     subexprs = ['base', 'start', 'stop', 'slice']
     nogil = False

--- a/tests/errors/nogil.pyx
+++ b/tests/errors/nogil.pyx
@@ -102,6 +102,10 @@ cdef void slice_array() nogil:
         b = [1, 2, 3, 4]
     cdef int[4] a = b[:]
 
+cdef int[:] main() nogil:
+    cdef int[4] a = [1,2,3,4]
+    return a
+
 
 _ERRORS = u"""
 4:5: Function with Python return type cannot be declared nogil
@@ -177,4 +181,5 @@ _ERRORS = u"""
 
 103:21: Coercion from Python not allowed without the GIL
 103:21: Slicing Python object not allowed without gil
+107:11: Operation not allowed without gil
 """

--- a/tests/errors/nogil.pyx
+++ b/tests/errors/nogil.pyx
@@ -97,6 +97,11 @@ cdef int fstrings(int x, object obj) except -1 nogil:
     f"{x}"
     f"{obj}"
 
+cdef void slice_array() nogil:
+    with gil:
+        b = [1, 2, 3, 4]
+    cdef int[4] a = b[:]
+
 
 _ERRORS = u"""
 4:5: Function with Python return type cannot be declared nogil
@@ -169,4 +174,7 @@ _ERRORS = u"""
 97:6: String formatting not allowed without gil
 98:4: Discarding owned Python object not allowed without gil
 98:6: String formatting not allowed without gil
+
+103:21: Coercion from Python not allowed without the GIL
+103:21: Slicing Python object not allowed without gil
 """

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -170,6 +170,7 @@ def test_copy_array_exception(n):
     copy_array_exception(n)
     
 def test_copy_array_exception_nogil(n): 
+    """
     >>> test_copy_array_exception_nogil(20)
     Traceback (most recent call last):
         ...

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -115,11 +115,17 @@ cdef int copy_array() nogil:
     a[:] = [0, 1, 2, 3]
     return a[0] + a[1] + a[2] + a[3]
 
-cdef void copy_array2() nogil:
-    cdef double[16] x
-    cdef double[16] y
+cdef double copy_array2() nogil:
+    cdef double[4] x = [1.0, 3.0, 5.0, 7.0]
+    cdef double[4] y
     y[:] = x[:]
+    return y[0] + y[1] + y[2] + y[3]
+
+cdef double copy_array3() nogil:
+    cdef double[4] x = [2.0, 4.0, 6.0, 8.0]
+    cdef double[4] y
     y = x
+    return y[0] + y[1] + y[2] + y[3]
 
 def test_initalize_array():
     """
@@ -138,5 +144,13 @@ def test_copy_array():
 def test_copy_array2():
     """
     >>> test_copy_array2()
+    16.0
     """
     return copy_array2()
+
+def test_copy_array3():
+    """
+    >>> test_copy_array3()
+    20.0
+    """
+    return copy_array3()

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -167,4 +167,13 @@ def test_copy_array_exception(n):
         ...
     ValueError: Assignment to slice of wrong length, expected 5, got 20
     """
-    return copy_array_exception(n)
+    copy_array_exception(n)
+    
+def test_copy_array_exception_nogil(n): 
+    >>> test_copy_array_exception_nogil(20)
+    Traceback (most recent call last):
+        ...
+    ValueError: Assignment to slice of wrong length, expected 5, got 20
+    """
+    with nogil:
+        copy_array_exception(n)

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -104,3 +104,16 @@ def test_unraisable():
     finally:
         sys.stderr = old_stderr
     return stderr.getvalue().strip()
+
+
+cdef int initialize_array() nogil:
+    cdef int[4] a = [1, 2, 3, 4]
+    return a[0] + a[1] + a[2] + a[3]
+
+
+def test_array():
+    """
+    >>> test_array()
+    10
+    """
+    return initialize_array()

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -168,7 +168,7 @@ def test_copy_array_exception(n):
     ValueError: Assignment to slice of wrong length, expected 5, got 20
     """
     copy_array_exception(n)
-    
+
 def test_copy_array_exception_nogil(n): 
     """
     >>> test_copy_array_exception_nogil(20)
@@ -176,5 +176,6 @@ def test_copy_array_exception_nogil(n):
         ...
     ValueError: Assignment to slice of wrong length, expected 5, got 20
     """
+    cdef int cn = n
     with nogil:
-        copy_array_exception(n)
+        copy_array_exception(cn)

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -127,6 +127,11 @@ cdef double copy_array3() nogil:
     y = x
     return y[0] + y[1] + y[2] + y[3]
 
+cdef void copy_array_exception(int n) nogil:
+    cdef double[5] a = [1,2,3,4,5]
+    cdef double[6] b
+    b[:n] = a
+
 def test_initalize_array():
     """
     >>> test_initalize_array()
@@ -154,3 +159,12 @@ def test_copy_array3():
     20.0
     """
     return copy_array3()
+
+def test_copy_array_exception(n):
+    """
+    >>> test_copy_array_exception(20)
+    Traceback (most recent call last):
+        ...
+    ValueError: Assignment to slice of wrong length, expected 5, got 20
+    """
+    return copy_array_exception(n)

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -110,10 +110,33 @@ cdef int initialize_array() nogil:
     cdef int[4] a = [1, 2, 3, 4]
     return a[0] + a[1] + a[2] + a[3]
 
+cdef int copy_array() nogil:
+    cdef int[4] a
+    a[:] = [0, 1, 2, 3]
+    return a[0] + a[1] + a[2] + a[3]
 
-def test_array():
+cdef void copy_array2() nogil:
+    cdef double[16] x
+    cdef double[16] y
+    y[:] = x[:]
+    y = x
+
+def test_initalize_array():
     """
-    >>> test_array()
+    >>> test_initalize_array()
     10
     """
     return initialize_array()
+
+def test_copy_array():
+    """
+    >>> test_copy_array()
+    6
+    """
+    return copy_array()
+
+def test_copy_array2():
+    """
+    >>> test_copy_array2()
+    """
+    return copy_array2()


### PR DESCRIPTION
Fixes #3160
Fixes #1662
