### PR TITLE
allow suggestions on AttributeError for PyPy in doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           - os: ubuntu-18.04
-            python-version: pypy-3.7
+            python-version: pypy-3.9
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           # Coverage

--- a/tests/run/py_classbody.py
+++ b/tests/run/py_classbody.py
@@ -8,7 +8,7 @@ class TestPyAttr(object):
     """
     >>> TestPyAttr.pyvar    # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    AttributeError: ...TestPyAttr...has no attribute 'pyvar'
+    AttributeError: ...TestPyAttr...has no attribute 'pyvar'...
     >>> TestPyAttr.pyval1
     3
     >>> TestPyAttr.pyval2
@@ -27,7 +27,7 @@ class TestCdefAttr(object):
     """
     >>> TestCdefAttr.cdefvar   # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    AttributeError: ...TestCdefAttr...has no attribute 'cdefvar'
+    AttributeError: ...TestCdefAttr...has no attribute 'cdefvar'...
     >>> TestCdefAttr.cdefval1
     11
 


### PR DESCRIPTION
PyPy will add a suggestion to AttributeError, so the error message becomes
```
AttributeError: type object 'TestCdefAttr' has no attribute 'cdefvar'. Did you mean: cdefval1?
```

instead of the CPython
```
AttributeError: type object 'TestCdefAttr' has no attribute 'cdefvar'
```

Adding an ellipsis suffix is enought to fix the error.