### PR TITLE
Use setuptools>60 for cpython3.12, skip unicode test on PyPy and 3.12+

### DIFF
--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -73,6 +73,9 @@ elif [[ $PYTHON_VERSION == "3."[45]* ]]; then
 elif [[ $PYTHON_VERSION == "pypy-2.7" ]]; then
   pip install wheel || exit 1
   pip install -r test-requirements-pypy27.txt || exit 1
+elif [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
+  python -m pip install wheel || exit 1
+  python -m pip install -r test-requirements-312.txt || exit 1
 else
   python -m pip install -U pip "setuptools<60" wheel || exit 1
 

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -x
+
 GCC_VERSION=${GCC_VERSION:=8}
 
 # Set up compilers

--- a/runtests.py
+++ b/runtests.py
@@ -499,6 +499,9 @@ VER_DEP_MODULES = {
                                          'run.pep557_dataclasses',  # dataclasses module
                                          'run.test_dataclasses',
                                          ]),
+    (3,11,999): (operator.gt, lambda x: x in ['run.py_unicode_strings',
+                                         ]),
+    
 }
 
 INCLUDE_DIRS = [ d for d in os.getenv('INCLUDE', '').split(os.pathsep) if d ]
@@ -2723,7 +2726,6 @@ def runtests(options, cmd_args, coverage=None):
             ('windows_bugs.txt', sys.platform == 'win32'),
             ('cygwin_bugs.txt', sys.platform == 'cygwin'),
             ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9)),
-            ('python_312.txt', sys.version_info >= (3, 12)),
         ]
 
         exclude_selectors += [

--- a/runtests.py
+++ b/runtests.py
@@ -2725,7 +2725,7 @@ def runtests(options, cmd_args, coverage=None):
             ('limited_api_bugs.txt', options.limited_api),
             ('windows_bugs.txt', sys.platform == 'win32'),
             ('cygwin_bugs.txt', sys.platform == 'cygwin'),
-            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9)),
+            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9))
         ]
 
         exclude_selectors += [

--- a/runtests.py
+++ b/runtests.py
@@ -2722,7 +2722,8 @@ def runtests(options, cmd_args, coverage=None):
             ('limited_api_bugs.txt', options.limited_api),
             ('windows_bugs.txt', sys.platform == 'win32'),
             ('cygwin_bugs.txt', sys.platform == 'cygwin'),
-            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9))
+            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9)),
+            ('python_312.txt', sys.version_info >= (3, 12)),
         ]
 
         exclude_selectors += [

--- a/test-requirements-312.txt
+++ b/test-requirements-312.txt
@@ -1,0 +1,4 @@
+numpy
+coverage
+pycodestyle
+setuptools

--- a/tests/pypy_implementation_detail_bugs.txt
+++ b/tests/pypy_implementation_detail_bugs.txt
@@ -46,3 +46,7 @@ run.cpp_classes_def
 memoryview_inplace_division
 run.pyarray
 run.array_cimport
+
+# relies on deprecated unicode APIs that will be removed in python3.12
+# exposing the underlying unicode buffer in PyPy is not thread-safe
+run.py_unicode_strings

--- a/tests/python_312.txt
+++ b/tests/python_312.txt
@@ -1,0 +1,2 @@
+# relies on deprecated unicode APIs that have been removed
+run.py_unicode_strings

--- a/tests/python_312.txt
+++ b/tests/python_312.txt
@@ -1,2 +1,0 @@
-# relies on deprecated unicode APIs that have been removed
-run.py_unicode_strings


### PR DESCRIPTION
See issue #5149. This skips the test that cannot run on 3.12+ and is problematic on PyPy. I think there should still be a warning somewhere if the APIs are used.

This also unpins setuptools for 3.12 so the tests can start.