### PR TITLE
missing load_factor method on unordered_multimap

### DIFF
--- a/Cython/Includes/libcpp/unordered_map.pxd
+++ b/Cython/Includes/libcpp/unordered_map.pxd
@@ -182,6 +182,7 @@ cdef extern from "<unordered_map>" namespace "std" nogil:
         #value_compare value_comp()
         void max_load_factor(float)
         float max_load_factor()
+        float load_factor()
         void rehash(size_t)
         void reserve(size_t)
         size_t bucket_count()


### PR DESCRIPTION
See `unordered_map` above in the same file. Also https://en.cppreference.com/w/cpp/container/unordered_multimap/load_factor