### PR TITLE
Added PyUnicode_AsUTF8AndSize to cpython imports

### DIFF
--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -357,8 +357,24 @@ cdef extern from *:
     # raised by the codec.
     bytes PyUnicode_EncodeUTF8(Py_UNICODE *s, Py_ssize_t size, char *errors)
 
-    # Encode a Unicode objects using UTF-8 and return the result as Python string object. Error handling is ``strict''. Return NULL if an exception was raised by the codec.
+    # Encode a Unicode objects using UTF-8 and return the result as Python bytes object. Error handling is ``strict''. Return NULL if an exception was raised by the codec.
     bytes PyUnicode_AsUTF8String(object unicode)
+
+
+    # Return a pointer to the UTF-8 encoding of the Unicode object,
+    # and store the size of the encoded representation (in bytes) in size.
+    # The size argument can be NULL; in this case no size will be stored.
+    # The returned buffer always has an extra null byte appended
+    # (not included in size), regardless of whether there are any
+    # other null code points.
+
+    # In the case of an error, NULL is returned with an exception set and
+    # no size is stored.
+
+    # This caches the UTF-8 representation of the string in the Unicode
+    # object, and subsequent calls will return a pointer to the same buffer.
+    # The caller is not responsible for deallocating the buffer
+    const char* PyUnicode_AsUTF8AndSize(object unicode, Py_ssize_t *size)
 
 # These are the UTF-16 codec APIs:
 


### PR DESCRIPTION
This is part of the Py_LIMITED_API. We have some use cases downstream in pandas where we import this from python - figured it would be better served as a natural cython import.

I wasn't sure where / how to test this, but happy to add that wherever in the repository. A simple program like this:

```python
import cython
from cpython.unicode cimport PyUnicode_AsUTF8AndSize

cpdef void foo():
    obj = "foo"
    i = 0
    data = PyUnicode_AsUTF8AndSize(obj, <Py_ssize_t *>&i)
    print(i)
```

Compiles and prints 3 as you'd expect and attempted assignment also fails:

```python
Error compiling Cython file:
------------------------------------------------------------
...
cpdef void foo():
    obj = "foo"
    i = 0
    data = PyUnicode_AsUTF8AndSize(obj, <Py_ssize_t *>&i)
    print(i)
    data[0] = "m"
        ^
------------------------------------------------------------

test.pyx:9:8: Assignment to const dereference
```