### PR TITLE
Fix C syntax error on windows

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2787,7 +2787,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             env.module_cname,
             Naming.pymoduledef_cname))
         module_state.putln("#else")
-        module_state.putln('static %s %s_static = {};' % (
+        module_state.putln('static %s %s_static = {0};' % (
             Naming.modulestate_cname,
             Naming.modulestateglobal_cname
         ))


### PR DESCRIPTION
Fix: https://github.com/cython/cython/issues/5169
Previous: https://github.com/cython/cython/pull/5170
PR to master as I realize the error is probably introduced in https://github.com/cython/cython/pull/5056, and has been merged into master. This should make it easier for this fix to be merged into other future branches that are still under development.