### PR TITLE
Fix named expression tests windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,20 @@ jobs:
             extra_hash: '-coverage'
 
           - os: windows-2019
+            # missing dependencies
+            python-version: 3.6
+            allowed_failure: true
+          - os: windows-2019
+            # TestInline
+            python-version: 3.8
+            allowed_failure: true
+          - os: windows-2019
+            # TestInline
+            python-version: 3.10
+            allowed_failure: true
+          - os: windows-2019
+            # TestInline
+            python-version: 3.11
             allowed_failure: true
 
           # MacOS sub-jobs

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -153,8 +153,11 @@ if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
   if [[ $CYTHON_COMPILE_ALL == "1" ]]; then
     SETUP_ARGS="$SETUP_ARGS --cython-compile-all"
   fi
+  # It looks like parallel build may be causing occasional link failures on Windows
+  # "with exit code 1158". DW isn't completely sure of this, but has disabled it in 
+  # the hope it helps
   SETUP_ARGS="$SETUP_ARGS
-    $(python -c 'import sys; print("-j5" if sys.version_info >= (3,5) else "")')"
+    $(python -c 'import sys; print("-j5" if sys.version_info >= (3,5) and not sys.platform.startswith("win") else "")')"
 
   CFLAGS=$BUILD_CFLAGS \
     python setup.py build_ext -i $SETUP_ARGS || exit 1

--- a/tests/run/cpp_extern.srctree
+++ b/tests/run/cpp_extern.srctree
@@ -14,6 +14,7 @@ PYTHON -c "from baz import test; test()"
 from Cython.Build import cythonize
 from Cython.Distutils.extension import Extension
 from distutils.core import setup
+import sys
 
 foo = Extension(
     "foo",
@@ -23,10 +24,16 @@ bar = Extension(
     "bar",
     ["bar.pyx", "bar1.c", "bar2.cpp"],
 )
+
+if sys.platform == "win32":
+    # escape the quotes on the command line
+    extern_c_definition = r'extern \"C\"'
+else:
+    extern_c_definition = 'extern "C"'
 baz = Extension(
     "baz",
     ["baz.pyx", "baz1.c", "baz2.cpp"],
-    define_macros = [("__PYX_EXTERN_C", 'extern "C"')],
+    define_macros = [("__PYX_EXTERN_C", extern_c_definition)],
 )
 
 setup(


### PR DESCRIPTION
Fixes named expression tests on Windows (I forgot that Windows filenames could contain ":")

Turns off allowed_failures on as many of the windows builds as possible

Fixes #5172