### PR TITLE
Remove unnecessary OrderedDict usage for CpdefEnums

### DIFF
--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -7,7 +7,7 @@ cdef extern from *:
 
 cdef object __Pyx_OrderedDict
 
-if PY_VERSION_HEX >= 0x03070000:
+if PY_VERSION_HEX >= 0x03060000:
     __Pyx_OrderedDict = dict
 else:
     from collections import OrderedDict as __Pyx_OrderedDict

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -50,11 +50,11 @@ if PY_VERSION_HEX >= 0x03040000:
 cdef dict __Pyx_globals = globals()
 if PY_VERSION_HEX >= 0x03040000:
     # create new IntEnum()
-    {{name}} = __Pyx_EnumBase('{{name}}', __Pyx_OrderedDict([
+    {{name}} = __Pyx_EnumBase('{{name}}', [
         {{for item in items}}
         ('{{item}}', {{item}}),
         {{endfor}}
-    ]))
+    ])
     {{if enum_doc is not None}}
     {{name}}.__doc__ = {{ repr(enum_doc) }}
     {{endif}}
@@ -75,11 +75,11 @@ cdef dict __Pyx_globals = globals()
 
 if PY_VERSION_HEX >= 0x03040000:
     # create new IntEnum()
-    __Pyx_globals["{{name}}"] = __Pyx_EnumBase('{{name}}', __Pyx_OrderedDict([
+    __Pyx_globals["{{name}}"] = __Pyx_EnumBase('{{name}}', [
         {{for item in items}}
         ('{{item}}', <{{underlying_type}}>({{name}}.{{item}})),
         {{endfor}}
-    ]))
+    ])
 
 else:
     __Pyx_globals["{{name}}"] = type('{{name}}', (__Pyx_EnumBase,), {})

--- a/Cython/Utility/CpdefEnums.pyx
+++ b/Cython/Utility/CpdefEnums.pyx
@@ -6,7 +6,11 @@ cdef extern from *:
     int PY_VERSION_HEX
 
 cdef object __Pyx_OrderedDict
-from collections import OrderedDict as __Pyx_OrderedDict
+
+if PY_VERSION_HEX >= 0x03070000:
+    __Pyx_OrderedDict = dict
+else:
+    from collections import OrderedDict as __Pyx_OrderedDict
 
 @cython.internal
 cdef class __Pyx_EnumMeta(type):


### PR DESCRIPTION
Since python 3.7, builtin dict is guaranteed to keep insertion order, so use dict on python 3.7 or later instead.

Stdlib enum.Enum supports an iterable of `(name, value)` even since python 3.4, so a list of `(name, value)` pairs is good enough.