### PR TITLE
[0.29.x] Avoid using asyncio.get_event_loop

### DIFF
--- a/tests/run/asyncio_generators.srctree
+++ b/tests/run/asyncio_generators.srctree
@@ -24,14 +24,15 @@ setup(
 
 import from_asyncio_import
 import asyncio
+import sys
 from contextlib import closing
+new_event_loop = asyncio.new_event_loop if sys.version_info >= (3, 5) else asyncio.get_event_loop
 
 def runloop(task):
-    with closing(asyncio.new_event_loop()) as loop:
+    with closing(new_event_loop()) as loop:
         result = loop.run_until_complete(task())
         assert 3 == result, result
 
-import sys
 if sys.version_info < (3, 7):
     runloop(from_asyncio_import.wait3)
 
@@ -40,14 +41,15 @@ if sys.version_info < (3, 7):
 
 import import_asyncio
 import asyncio
+import sys
 from contextlib import closing
+new_event_loop = asyncio.new_event_loop if sys.version_info >= (3, 5) else asyncio.get_event_loop
 
 def runloop(task):
-    with closing(asyncio.new_event_loop()) as loop:
+    with closing(new_event_loop()) as loop:
         result = loop.run_until_complete(task())
         assert 3 == result, result
 
-import sys
 if sys.version_info < (3, 7):
     runloop(import_asyncio.wait3)
 
@@ -95,13 +97,20 @@ if ASYNCIO_SUPPORTS_COROUTINE:
 
 import sys
 import asyncio
-from contextlib import closing
+from contextlib import closing, contextmanager
+new_event_loop = asyncio.new_event_loop if sys.version_info >= (3, 5) else asyncio.get_event_loop
+if sys.version_info < (3, 5):
+    # don't close loop on Py 3.4
+    @contextmanager
+    def closing(o):
+        yield o
+
 
 ASYNCIO_SUPPORTS_COROUTINE = sys.version_info[:2] >= (3, 5)
 ASYNCIO_SUPPORTS_YIELD_FROM = sys.version_info[:2] < (3, 7)
 
 def runloop(task):
-    with closing(asyncio.new_event_loop()) as loop:
+    with closing(new_event_loop()) as loop:
         result = loop.run_until_complete(task())
         assert 3 == result, result
 
@@ -135,7 +144,7 @@ except ImportError:
     try:
         from collections import Generator
     except ImportError:
-        assert sys.version_info < (3,5), "Python 3.5+ should have collections.abc.Generator"
+        assert sys.version_info < (3, 5), "Python 3.5+ should have collections.abc.Generator"
         Generator = object  # easy win :)
 
 assert isinstance(from_asyncio_import.wait3(), Generator)
@@ -148,7 +157,7 @@ except ImportError:
     try:
         from collections import Awaitable
     except ImportError:
-        assert sys.version_info < (3,5), "Python 3.5+ should have collections.abc.Awaitable"
+        assert sys.version_info < (3, 5), "Python 3.5+ should have collections.abc.Awaitable"
         Awaitable = object  # easy win :)
 
 assert isinstance(async_def.wait3(), Awaitable)
@@ -159,7 +168,7 @@ except ImportError:
     try:
         from collections import Coroutine
     except ImportError:
-        assert sys.version_info < (3,5), "Python 3.5+ should have collections.abc.Coroutine"
+        assert sys.version_info < (3, 5), "Python 3.5+ should have collections.abc.Coroutine"
         Coroutine = object  # easy win :)
 
 assert isinstance(async_def.wait3(), Coroutine)

--- a/tests/run/asyncio_generators.srctree
+++ b/tests/run/asyncio_generators.srctree
@@ -24,11 +24,12 @@ setup(
 
 import from_asyncio_import
 import asyncio
+from contextlib import closing
 
 def runloop(task):
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(task())
-    assert 3 == result, result
+    with closing(asyncio.new_event_loop()) as loop:
+        result = loop.run_until_complete(task())
+        assert 3 == result, result
 
 import sys
 if sys.version_info < (3, 7):
@@ -39,11 +40,12 @@ if sys.version_info < (3, 7):
 
 import import_asyncio
 import asyncio
+from contextlib import closing
 
 def runloop(task):
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(task())
-    assert 3 == result, result
+    with closing(asyncio.new_event_loop()) as loop:
+        result = loop.run_until_complete(task())
+        assert 3 == result, result
 
 import sys
 if sys.version_info < (3, 7):
@@ -59,11 +61,12 @@ ASYNCIO_SUPPORTS_COROUTINE = sys.version_info[:2] >= (3, 5)
 if ASYNCIO_SUPPORTS_COROUTINE:
     import async_def
     import asyncio
+    from contextlib import closing
 
     def runloop(task):
-        loop = asyncio.get_event_loop()
-        result = loop.run_until_complete(task())
-        assert 3 == result, result
+        with closing(asyncio.new_event_loop()) as loop:
+            result = loop.run_until_complete(task())
+            assert 3 == result, result
 
     runloop(async_def.wait3)
 
@@ -77,12 +80,13 @@ ASYNCIO_SUPPORTS_COROUTINE = sys.version_info[:2] >= (3, 5)
 if ASYNCIO_SUPPORTS_COROUTINE:
     from async_def_future import await_future
     import asyncio
+    from contextlib import closing
 
     def runloop():
-        loop = asyncio.get_event_loop()
-        task, events, expected = await_future(loop)
-        result = loop.run_until_complete(task())
-        assert events == expected, 'expected %s, got %s' % (expected, events)
+        with closing(asyncio.new_event_loop()) as loop:
+            task, events, expected = await_future(loop)
+            result = loop.run_until_complete(task())
+            assert events == expected, 'expected %s, got %s' % (expected, events)
 
     runloop()
 
@@ -91,14 +95,15 @@ if ASYNCIO_SUPPORTS_COROUTINE:
 
 import sys
 import asyncio
+from contextlib import closing
 
 ASYNCIO_SUPPORTS_COROUTINE = sys.version_info[:2] >= (3, 5)
 ASYNCIO_SUPPORTS_YIELD_FROM = sys.version_info[:2] < (3, 7)
 
 def runloop(task):
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(task())
-    assert 3 == result, result
+    with closing(asyncio.new_event_loop()) as loop:
+        result = loop.run_until_complete(task())
+        assert 3 == result, result
 
 import import_asyncio
 if ASYNCIO_SUPPORTS_YIELD_FROM:

--- a/tests/run/py35_asyncio_async_def.srctree
+++ b/tests/run/py35_asyncio_async_def.srctree
@@ -24,7 +24,7 @@ from contextlib import closing
 async def main():
     await cy_test.say()
 
-with closing(asyncio.get_event_loop()) as loop:
+with closing(asyncio.new_event_loop()) as loop:
     print("Running Python coroutine ...")
     loop.run_until_complete(main())
 


### PR DESCRIPTION
The behaviour of creating a new event loop if one doesn't already exist was removed in Python 3.12 alpha and was allegedly deprecated before then.

Fixes #5183

Wants to be in 0.29.x and master