### PR TITLE
Initialize array fields of struct with memcpy

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9266,7 +9266,7 @@ class DictNode(ExprNode):
                     code.putln('}')
             else:
                 if item.value.type.is_array:
-                    code.putln("memcpy(%s.%s, %s, sizeof %s);" % (
+                    code.putln("memcpy(%s.%s, %s, sizeof(%s));" % (
                             self.result(),
                             item.key.value,
                             item.value.result(),

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9265,10 +9265,17 @@ class DictNode(ExprNode):
                 if self.exclude_null_values:
                     code.putln('}')
             else:
-                code.putln("%s.%s = %s;" % (
-                        self.result(),
-                        item.key.value,
-                        item.value.result()))
+                if item.value.type.is_array:
+                    code.putln("memcpy(%s.%s, %s, sizeof %s);" % (
+                            self.result(),
+                            item.key.value,
+                            item.value.result(),
+                            item.value.result()))
+                else:
+                    code.putln("%s.%s = %s;" % (
+                            self.result(),
+                            item.key.value,
+                            item.value.result()))
             item.generate_disposal_code(code)
             item.free_temps(code)
 

--- a/tests/run/struct_conversion.pyx
+++ b/tests/run/struct_conversion.pyx
@@ -183,3 +183,14 @@ def test_struct_to_obj_cnames():
     {'x': 2}
     """
     return OverriddenCname(2)
+
+cdef struct ArrayFieldStruct:
+    int arr[4]
+
+def test_array_field_init():
+    """
+    >>> test_array_field_init()
+    [1, 2, 3, 4]
+    """
+    cdef ArrayFieldStruct s = ArrayFieldStruct([1, 2, 3, 4])
+    print(s.arr);


### PR DESCRIPTION
Related to #5178
Using `memcpy`, copy the content of an array into the array field of a `struct`.
