### PR TITLE
Use Development release segment in public version identifiers

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -1,7 +1,7 @@
 # cython.* namespace for pure mode.
 from __future__ import absolute_import
 
-__version__ = "3.0.0a11"
+__version__ = "3.0.0a12.dev0"
 
 try:
     from __builtin__ import basestring


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/5204

As specified by PEP 440: https://peps.python.org/pep-0440/#public-version-identifiers