### PR TITLE
Enhance `build_hex_version`

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -611,19 +611,23 @@ def raise_error_if_module_name_forbidden(full_module_name):
 
 def build_hex_version(version_string):
     """
-    Parse and translate '4.3a1' into the readable hex representation '0x040300A1' (like PY_VERSION_HEX).
+    Parse and translate public version identifier like '4.3a1' into the readable hex representation '0x040300A1' (like PY_VERSION_HEX).
+
+    SEE: https://peps.python.org/pep-0440/#public-version-identifiers
     """
-    # First, parse '4.12a1' into [4, 12, 0, 0xA01].
+    # Parse '4.12a1' into [4, 12, 0, 0xA01]
+    # And ignore .dev, .pre and .post segments
     digits = []
     release_status = 0xF0
-    for digit in re.split('(\D+)', version_string):
-        if digit in ('a', 'b', 'rc'):
-            release_status = {'a': 0xA0, 'b': 0xB0, 'rc': 0xC0}[digit]
+    for segment in re.split(r'(\D+)', version_string):
+        if segment in ('a', 'b', 'rc'):
+            release_status = {'a': 0xA0, 'b': 0xB0, 'rc': 0xC0}[segment]
             digits = (digits + [0, 0])[:3]  # 1.2a1 -> 1.2.0a1
-        elif digit in ('.dev', '.pre', '.post'):
-            break  # ignore '.dev0' / '.post0' in hex version
-        elif digit != '.':
-            digits.append(int(digit))
+        elif segment in ('.dev', '.pre', '.post'):
+            break  # break since those are the last segments
+        elif segment != '.':
+            digits.append(int(segment))
+
     digits = (digits + [0] * 3)[:4]
     digits[3] += release_status
 


### PR DESCRIPTION
I [though](https://github.com/cython/cython/pull/5208#issuecomment-1377285773) that at last I could bring some value here, but @scoder it too fast 069794816423948a3dd7cc3365cf969d44fc9326 ^-^
Well, I don't want to throw the refactoring out, so here it is