### PR TITLE
Replace deprecated functions

### DIFF
--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -39,32 +39,34 @@ static int __Pyx_main(int argc, wchar_t **argv)
     if (argc && argv)
         PySys_SetArgv(argc, argv);
 #else
-    PyStatus status;
+    {
+        PyStatus status;
 
-    PyConfig config;
-    PyConfig_InitPythonConfig(&config);
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
 
-    if (argc && argv) {
-        status = PyConfig_SetString(&config, &config.program_name, argv[0]);
+        if (argc && argv) {
+            status = PyConfig_SetString(&config, &config.program_name, argv[0]);
+            if (PyStatus_Exception(status)) {
+                PyConfig_Clear(&config);
+                return 1;
+            }
+
+            status = PyConfig_SetArgv(&config, argc, argv);
+            if (PyStatus_Exception(status)) {
+                PyConfig_Clear(&config);
+                return 1;
+            }
+        }
+
+        status = Py_InitializeFromConfig(&config);
         if (PyStatus_Exception(status)) {
             PyConfig_Clear(&config);
             return 1;
         }
 
-        status = PyConfig_SetArgv(&config, argc, argv);
-        if (PyStatus_Exception(status)) {
-            PyConfig_Clear(&config);
-            return 1;
-        }
-    }
-
-    status = Py_InitializeFromConfig(&config);
-    if (PyStatus_Exception(status)) {
         PyConfig_Clear(&config);
-        return 1;
     }
-
-    PyConfig_Clear(&config);
 #endif
 
     { /* init module '%(module_name)s' as '__main__' */

--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -23,8 +23,10 @@ static int __Pyx_main(int argc, wchar_t **argv)
     m = fpgetmask();
     fpsetmask(m & ~FP_X_OFL);
 #endif
+#if PY_VERSION_HEX < 0x03080000
     if (argc && argv)
         Py_SetProgramName(argv[0]);
+#endif
 
     #if PY_MAJOR_VERSION < 3
     if (PyImport_AppendInittab("%(module_name)s", init%(module_name)s) < 0) return 1;
@@ -32,9 +34,38 @@ static int __Pyx_main(int argc, wchar_t **argv)
     if (PyImport_AppendInittab("%(module_name)s", PyInit_%(module_name)s) < 0) return 1;
     #endif
 
+#if PY_VERSION_HEX < 0x03080000
     Py_Initialize();
     if (argc && argv)
         PySys_SetArgv(argc, argv);
+#else
+    PyStatus status;
+
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+
+    if (argc && argv) {
+        status = PyConfig_SetString(&config, &config.program_name, argv[0]);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            return 1;
+        }
+
+        status = PyConfig_SetArgv(&config, argc, argv);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            return 1;
+        }
+    }
+
+    status = Py_InitializeFromConfig(&config);
+    if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
+        return 1;
+    }
+
+    PyConfig_Clear(&config);
+#endif
 
     { /* init module '%(module_name)s' as '__main__' */
       PyObject* m = NULL;


### PR DESCRIPTION
`Py_SetProgramName` and `PySys_SetArgv` has been deprecated in Python 3.11

Fix #5134 (part) and #4895