### PR TITLE
Disable parsing command line arguments

### DIFF
--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -44,6 +44,8 @@ static int __Pyx_main(int argc, wchar_t **argv)
 
         PyConfig config;
         PyConfig_InitPythonConfig(&config);
+        /* Disable parsing command line arguments */
+        config.parse_argv = 0;
 
         if (argc && argv) {
             status = PyConfig_SetString(&config, &config.program_name, argv[0]);

--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -44,7 +44,7 @@ static int __Pyx_main(int argc, wchar_t **argv)
 
         PyConfig config;
         PyConfig_InitPythonConfig(&config);
-        /* Disable parsing command line arguments */
+        // Disable parsing command line arguments
         config.parse_argv = 0;
 
         if (argc && argv) {


### PR DESCRIPTION
After #5210 parsing command line arguments turned on.

https://docs.python.org/3/c-api/init_config.html#c.PyConfig.parse_argv