### PR TITLE
Switch from deprecated `.setDaemon()`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2541,7 +2541,7 @@ def time_stamper_thread(interval=10):
             write('\n#### %s\n' % now())
 
     thread = threading.Thread(target=time_stamper, name='time_stamper')
-    thread.setDaemon(True)  # Py2 ...
+    thread.daemon = True
     thread.start()
     try:
         yield


### PR DESCRIPTION
`threading.Thread` supports enabling daemon mode through property `.daemon` begin from Python 2.6

Fix #5134 (part)