### PR TITLE
Infer float in "safe" mode

### DIFF
--- a/Cython/Compiler/TypeInference.py
+++ b/Cython/Compiler/TypeInference.py
@@ -560,10 +560,12 @@ def safe_spanning_type(types, might_overflow, scope):
             return py_object_type
         else:
             return result_type
-    elif result_type is PyrexTypes.c_double_type:
+    elif (result_type is PyrexTypes.c_double_type or
+            result_type is PyrexTypes.c_float_type):
         # Python's float type is just a C double, so it's safe to use
-        # the C type instead
-        return result_type
+        # the C type instead. Similarly if given a C float, converting
+        # it to a C double will always behave like Python
+        return PyrexTypes.c_double_type
     elif result_type is PyrexTypes.c_bint_type:
         # find_spanning_type() only returns 'bint' for clean boolean
         # operations without other int types, so this is safe, too

--- a/Cython/Compiler/TypeInference.py
+++ b/Cython/Compiler/TypeInference.py
@@ -563,9 +563,9 @@ def safe_spanning_type(types, might_overflow, scope):
     elif (result_type is PyrexTypes.c_double_type or
             result_type is PyrexTypes.c_float_type):
         # Python's float type is just a C double, so it's safe to use
-        # the C type instead. Similarly if given a C float, converting
-        # it to a C double will always behave like Python
-        return PyrexTypes.c_double_type
+        # the C type instead. Similarly if given a C float, it leads to
+        # a small loss of precision vs Python but is otherwise the same
+        return result_type
     elif result_type is PyrexTypes.c_bint_type:
         # find_spanning_type() only returns 'bint' for clean boolean
         # operations without other int types, so this is safe, too

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -181,7 +181,7 @@ def test_tuple(a: typing.Tuple[cython.int, cython.float], b: typing.Tuple[cython
     >>> test_tuple((1, 1.0), (1, 1.0), (1, 1.0))
     int
     int
-    Python object
+    double
     Python object
     (int, float)
     tuple object
@@ -195,7 +195,10 @@ def test_tuple(a: typing.Tuple[cython.int, cython.float], b: typing.Tuple[cython
 
     print(cython.typeof(z))
     print("int" if cython.compiled and cython.typeof(x[0]) == "Python object" else cython.typeof(x[0]))  # FIXME: infer Python int
-    print(cython.typeof(p) if cython.compiled or cython.typeof(p) != 'float' else "Python object")  # FIXME: infer C double
+    if cython.compiled:
+        print(cython.typeof(p))
+    else:
+        print("double" if cython.typeof(p) == 'float' else cython.typeof(p))
     print(cython.typeof(x[1]) if cython.compiled or cython.typeof(p) != 'float' else "Python object")  # FIXME: infer C double
     print(cython.typeof(a) if cython.compiled or cython.typeof(a) != 'tuple' else "(int, float)")
     print(cython.typeof(x) + (" object" if not cython.compiled else ""))

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -181,7 +181,7 @@ def test_tuple(a: typing.Tuple[cython.int, cython.float], b: typing.Tuple[cython
     >>> test_tuple((1, 1.0), (1, 1.0), (1, 1.0))
     int
     int
-    double
+    float
     Python object
     (int, float)
     tuple object
@@ -198,7 +198,7 @@ def test_tuple(a: typing.Tuple[cython.int, cython.float], b: typing.Tuple[cython
     if cython.compiled:
         print(cython.typeof(p))
     else:
-        print("double" if cython.typeof(p) == 'float' else cython.typeof(p))
+        print('float' if cython.typeof(p) == 'float' else cython.typeof(p))
     print(cython.typeof(x[1]) if cython.compiled or cython.typeof(p) != 'float' else "Python object")  # FIXME: infer C double
     print(cython.typeof(a) if cython.compiled or cython.typeof(a) != 'tuple' else "(int, float)")
     print(cython.typeof(x) + (" object" if not cython.compiled else ""))

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -531,6 +531,12 @@ def safe_only():
     cdef int c_int = 1
     assert typeof(abs(c_int)) == "int", typeof(abs(c_int))
 
+    # float can be safely inferred to double
+    cdef float fl = 5.0
+    from_fl = fl
+    assert typeof(from_fl) == "double", typeof(from_fl)
+
+
 @infer_types(None)
 def safe_c_functions():
     """

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -531,10 +531,10 @@ def safe_only():
     cdef int c_int = 1
     assert typeof(abs(c_int)) == "int", typeof(abs(c_int))
 
-    # float can be safely inferred to double
+    # float can be inferred
     cdef float fl = 5.0
     from_fl = fl
-    assert typeof(from_fl) == "double", typeof(from_fl)
+    assert typeof(from_fl) == "float", typeof(from_fl)
 
 
 @infer_types(None)


### PR DESCRIPTION
~It currently infers to object, and double seems better than object.~

~I've picked "double" on the basis that this will always give the same precision answer as Python so it seems to match the semantics of "safe" mode better.~

Now does the simpler thing and just keeps it as a C float

Closes #5202