### PR TITLE
Add "unvisited_child_attrs" to help 3rd party tools

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1907,6 +1907,7 @@ class NewExprNode(AtomicExprNode):
     #
     # cppclass              node                 c++ class to create
 
+    unvisited_child_attrs = ['cppclass']
     type = None
 
     def infer_type(self, env):
@@ -10124,6 +10125,7 @@ class LambdaNode(InnerFunctionNode):
     # def_node      DefNode                the underlying function 'def' node
 
     child_attrs = ['def_node']
+    unvisited_child_attrs = ['args', 'result_expr']
 
     name = StringEncoding.EncodedString('<lambda>')
 
@@ -10910,6 +10912,7 @@ class TypecastNode(ExprNode):
     #  "type" directly and leave base_type and declarator to None
 
     subexprs = ['operand']
+    unvisited_child_attrs = ["base_type"]
     base_type = declarator = type = None
 
     def type_dependencies(self, env):
@@ -11077,6 +11080,7 @@ class CythonArrayNode(ExprNode):
     """
 
     subexprs = ['operand', 'shapes']
+    unvisited_child_attrs = ["base_type_node"]
 
     shapes = None
     is_temp = True
@@ -14402,6 +14406,7 @@ class AnnotationNode(ExprNode):
     # annotation is evaluated into a Python Object.
 
     subexprs = []
+    unvisited_child_attrs = ["expr"]
 
     # 'untyped' is set for fused specializations:
     # Once a fused function has been created we don't want

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -169,6 +169,11 @@ class Node(object):
     # Subset of attributes that are evaluated in the outer scope (e.g. function default arguments).
     outer_attrs = None
 
+    # Not used in Cython itself, but provided for the benefit of external tools (e.g. linters)
+    # to tell them about attrs that we don't want to visit in our own transforms for
+    # internal code-generation reasons.
+    unvisited_child_attrs = None
+
     cf_state = None
 
     # This may be an additional (or 'actual') type that will be checked when
@@ -1374,6 +1379,7 @@ class FusedTypeNode(CBaseTypeNode):
     """
 
     child_attrs = []
+    unvisited_child_attrs = ["types"]
 
     def analyse_declarations(self, env):
         type = self.analyse(env)
@@ -5213,6 +5219,7 @@ class CClassDefNode(ClassDefNode):
     #  buffer_defaults_pos
 
     child_attrs = ["body"]
+    unvisited_child_attrs = ["bases", "decorators"]
     buffer_defaults_node = None
     buffer_defaults_pos = None
     typedef_flag = False


### PR DESCRIPTION
A previous PR proposed some additions to child_attrs for things that appeared to be missing: https://github.com/cython/cython/pull/5239. Many of these were probably omitted for good practical reason I believe.

My proposal was to create a new attribute that lets third-party tools look up these attributes, but isn't used by Cython itself.