### PR TITLE
Fix annotation typing of Optional[tuple]

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4464,6 +4464,9 @@ class CTupleType(CType):
         self.exception_check = True
         self._convert_to_py_code = None
         self._convert_from_py_code = None
+        # equivalent_type must be set now because it isn't available at import time
+        from . import Builtin
+        self.equivalent_type = Builtin.tuple_type
 
     def __str__(self):
         return "(%s)" % ", ".join(str(c) for c in self.components)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4465,8 +4465,8 @@ class CTupleType(CType):
         self._convert_to_py_code = None
         self._convert_from_py_code = None
         # equivalent_type must be set now because it isn't available at import time
-        from . import Builtin
-        self.equivalent_type = Builtin.tuple_type
+        from .Builtin import tuple_type
+        self.equivalent_type = tuple_type
 
     def __str__(self):
         return "(%s)" % ", ".join(str(c) for c in self.components)

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -280,6 +280,15 @@ def test_use_typing_attributes_as_non_annotations():
     print(y1, str(y2) in allowed_optional_strings)
     print(z1, str(z2) in allowed_optional_strings)
 
+def test_optional_ctuple(x: typing.Optional[tuple[float]]):
+    """
+    Should not be a C-tuple (because these can't be optional
+    >>> test_optional_ctuple((1.0,))
+    tuple object
+    """
+    print(cython.typeof(x) + (" object" if not cython.compiled else ""))
+
+
 try:
     import numpy.typing as npt
     import numpy as np

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -282,7 +282,7 @@ def test_use_typing_attributes_as_non_annotations():
 
 def test_optional_ctuple(x: typing.Optional[tuple[float]]):
     """
-    Should not be a C-tuple (because these can't be optional
+    Should not be a C-tuple (because these can't be optional)
     >>> test_optional_ctuple((1.0,))
     tuple object
     """


### PR DESCRIPTION
Allow it to use a Py-tuple instead of a ctuple

Fixes https://github.com/cython/cython/issues/5263