### PR TITLE
[0.29] fix depfile generation on Windows, across different drives

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -459,9 +459,14 @@ def write_depfile(target, source, dependencies):
     for fname in dependencies:
         fname = os.path.abspath(fname)
         if fname.startswith(src_base_dir):
-            paths.append(os.path.relpath(fname, cwd))
+            try:
+                newpath = os.path.relpath(fname, cwd)
+            except ValueError:
+                # if they are on different Windows drives, absolute is fine
+                newpath = fname
         else:
-            paths.append(fname)
+            newpath = fname
+        paths.append(newpath)
 
     depline = os.path.relpath(target, cwd) + ": \\\n  "
     depline += " \\\n  ".join(paths) + "\n"


### PR DESCRIPTION
Since its first implementation in commit 9db1fc39b31b7b3b2ed574a79f5f9fd980ee3be7, depfiles try to calculate relative paths for files relative to the project base dir. This usually worked, but fails when the output directory is being used from another Windows drive letter. This can happen for build systems that encourage out of source build directories. When that happens, the logical thing to do is to use an absolute path anyway. That's what those build systems do as well, so the resulting depfiles still align with the build system manifest.

(cherry picked from commit 038f94e9fd9e3b7ff279b3bd2627e974b94cb946)