### PR TITLE
Do not attempt to write out a depfile on failure

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -527,7 +527,7 @@ def run_pipeline(source, options, full_module_name=None, context=None):
 
     err, enddata = Pipeline.run_pipeline(pipeline, source)
     context.teardown_errors(err, options, result)
-    if options.depfile:
+    if err is None and options.depfile:
         from ..Build.Dependencies import create_dependency_tree
         dependencies = create_dependency_tree(context).all_dependencies(result.main_source_file)
         Utils.write_depfile(result.c_file, result.main_source_file, dependencies)


### PR DESCRIPTION
This would be pretty useless as it cannot be used -- the output file does not exist either. But as it happens, on error, the output file is reset to None, so instead we triggered a python traceback while trying to write a depfile for `os.path.relpath(None, cwd)` that was written to `None+'.dep'`

Discovered when trying to help debug https://github.com/pandas-dev/pandas/pull/49115#issuecomment-1452775557