### PR TITLE
Initialize return variables on C++

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2279,7 +2279,7 @@ class FuncDefNode(StatNode, BlockNode):
                 empty_decl_code = return_type.empty_declaration_code()
                 # C++ doesn't want names of the form '= struct foo()' so
                 # remove the struct
-                empty_decl_code = empty_decl_code.replace("struct ", "")
+                empty_decl_code = empty_decl_code.replace("struct ", "").replace("union ", "")
                 init_insertion_point.putln("")
                 init_insertion_point.putln("#ifdef __cplusplus")
                 init_insertion_point.putln("= %s()" % empty_decl_code)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2276,10 +2276,9 @@ class FuncDefNode(StatNode, BlockNode):
                 # For C, __Pyx_pretend_to_initialize() is sufficient (taking an address
                 # is enough to make returning a variable defined). For C++ this isn't
                 # true, and we genuinely have to make sure a variable is initialized.
-                empty_decl_code = return_type.empty_declaration_code()
                 # C++ doesn't want names of the form '= struct foo()' so
-                # remove the struct
-                empty_decl_code = empty_decl_code.replace("struct ", "").replace("union ", "")
+                # remove the "struct" with skip_c_tag
+                empty_decl_code = return_type.declaration_code("", skip_c_tag=True)
                 init_insertion_point.putln("")
                 init_insertion_point.putln("#ifdef __cplusplus")
                 init_insertion_point.putln("= %s()" % empty_decl_code)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3216,7 +3216,7 @@ class CFuncType(CType):
             and not (self.nogil and not rhs_type.nogil)
 
     def declaration_code(self, entity_code,
-                         for_display = 0, dll_linkage = None, pyrex = 0, 
+                         for_display = 0, dll_linkage = None, pyrex = 0,
                          skip_c_tag = False, with_calling_convention = 1):
         arg_decl_list = []
         for arg in self.args[:len(self.args)-self.optional_arg_count]:


### PR DESCRIPTION
rather than relying on __Pyx_pretend_to_initialize which isn't sufficient to avoid undefined behaviour there.

Fixes #5278