### PR TITLE
Restore 0.29.x handling of None fused memoryviews

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -432,7 +432,7 @@ class FusedCFuncDefNode(StatListNode):
                         __pyx_PyErr_Clear()
             """ % self.match)
 
-    def _buffer_checks(self, buffer_types, pythran_types, pyx_code, decl_code, env):
+    def _buffer_checks(self, buffer_types, pythran_types, pyx_code, decl_code, accept_none, env):
         """
         Generate Cython code to match objects to buffer specializations.
         First try to get a numpy dtype object and match it against the individual
@@ -488,6 +488,21 @@ class FusedCFuncDefNode(StatListNode):
         pyx_code.named_insertion_point("numpy_dtype_checks")
         self._buffer_check_numpy_dtype(pyx_code, buffer_types, pythran_types)
         pyx_code.dedent(2)
+
+        if accept_none:
+            # If None is acceptable, then Cython <3.0 matched None with the
+            # first type. This behaviour isn't ideal, but keep it for backwards
+            # compatibility. Better behaviour would be to see if subsequent
+            # arguments give a stronger match.
+            pyx_code.context.update(
+                specialized_type_name=buffer_types[0].specialization_string
+            )
+            pyx_code.put_chunk(
+                """
+                if arg is None:
+                    %s
+                    break
+                """ % self.match)
 
         # creating a Cython memoryview from a Python memoryview avoids the
         # need to get the buffer multiple times, and we can
@@ -730,7 +745,9 @@ class FusedCFuncDefNode(StatListNode):
                         self._fused_instance_checks(normal_types, pyx_code, env)
                     if buffer_types or pythran_types:
                         env.use_utility_code(Code.UtilityCode.load_cached("IsLittleEndian", "ModuleSetupCode.c"))
-                        self._buffer_checks(buffer_types, pythran_types, pyx_code, decl_code, env)
+                        self._buffer_checks(
+                            buffer_types, pythran_types, pyx_code, decl_code,
+                            arg.accept_none, env)
                     if has_object_fallback:
                         pyx_code.context.update(specialized_type_name='object')
                         pyx_code.putln(self.match)

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -324,7 +324,17 @@ def test_fused_memslice_dtype(cython.floating[:] array):
     double[:] double[:] 5.0 6.0
     >>> test_fused_memslice_dtype[cython.float](get_array(4, 'f'))
     float[:] float[:] 5.0 6.0
+
+    # None should evaluate to *something* (currently the first
+    # in the list, but this shouldn't be a hard requirement)
+    >>> test_fused_memslice_dtype(None)
+    float[:]
+    >>> test_fused_memslice_dtype[cython.double](None)
+    double[:]
     """
+    if array is None:
+        print cython.typeof(array)
+        return
     cdef cython.floating[:] otherarray = array[0:100:1]
     print cython.typeof(array), cython.typeof(otherarray), \
           array[5], otherarray[6]

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -333,7 +333,7 @@ def test_fused_memslice_dtype(cython.floating[:] array):
     double[:]
     """
     if array is None:
-        print cython.typeof(array)
+        print(cython.typeof(array))
         return
     cdef cython.floating[:] otherarray = array[0:100:1]
     print cython.typeof(array), cython.typeof(otherarray), \


### PR DESCRIPTION
Partial fix for #5297 - ideally I think we should do something cleverer, but this'd complicated memoryview dispatch significantly. This PR just restores the 0.29.x behaviour where None matches the first type.