### PR TITLE
[0.29.x] IpythonMagic: Replace deprecated imp.load_dynamic() with importlib

### DIFF
--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -39,11 +39,12 @@ if sys.version_info < (3, 5):
     def load_dynamic(name, module_path):
         return imp.load_dynamic(name, module_path)
 else:
-    import importlib.util as _importlib_util
-    def load_dynamic(name, module_path):
-        spec = _importlib_util.spec_from_file_location(name, module_path)
-        module = _importlib_util.module_from_spec(spec)
-        # sys.modules[name] = module
+    import importlib.util
+    from importlib.machinery import ExtensionFileLoader
+
+    def load_dynamic(name, path):
+        spec = importlib.util.spec_from_file_location(name, loader=ExtensionFileLoader(name, path))
+        module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module
 

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -46,7 +46,6 @@ Parts of this code were taken from Cython.inline.
 
 from __future__ import absolute_import, print_function
 
-import imp
 import io
 import os
 import re
@@ -84,7 +83,7 @@ from IPython.utils.text import dedent
 
 from ..Shadow import __version__ as cython_version
 from ..Compiler.Errors import CompileError
-from .Inline import cython_inline
+from .Inline import cython_inline, load_dynamic
 from .Dependencies import cythonize
 
 
@@ -348,7 +347,7 @@ class CythonMagics(Magics):
             # Build failed and printed error message
             return None
 
-        module = imp.load_dynamic(module_name, module_path)
+        module = load_dynamic(module_name, module_path)
         self._import_all(module)
 
         if args.annotate:
@@ -411,7 +410,7 @@ class CythonMagics(Magics):
 
         # import and execute module code to generate profile
         so_module_path = os.path.join(lib_dir, pgo_module_name + self.so_ext)
-        imp.load_dynamic(pgo_module_name, so_module_path)
+        load_dynamic(pgo_module_name, so_module_path)
 
     def _cythonize(self, module_name, code, lib_dir, args, quiet=True):
         pyx_file = os.path.join(lib_dir, module_name + '.pyx')


### PR DESCRIPTION
Backport of #4941. Related to #5285.