### PR TITLE
allow IS_UNSIGNED to handle const types

### DIFF
--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -699,10 +699,10 @@ def get_type_information_cname(code, dtype, maxdepth=None):
         flags = "0"
         is_unsigned = "0"
         if dtype is PyrexTypes.c_char_type:
-            is_unsigned = "IS_UNSIGNED(%s)" % declcode
+            is_unsigned = "__PYX_IS_UNSIGNED(%s)" % declcode
             typegroup = "'H'"
         elif dtype.is_int:
-            is_unsigned = "IS_UNSIGNED(%s)" % declcode
+            is_unsigned = "__PYX_IS_UNSIGNED(%s)" % declcode
             typegroup = "%s ? 'U' : 'I'" % is_unsigned
         elif complex_possible or dtype.is_complex:
             typegroup = "'C'"

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -54,6 +54,14 @@ static void __Pyx_RaiseBufferFallbackError(void) {
 /////////////// BufferFormatStructs.proto ///////////////
 //@proto_block: utility_code_proto_before_types
 
+#ifdef __cplusplus
+template<typename T>
+struct __PYX_IS_UNSIGNED_IMPL {static const bool value = T(0) < T(-1);};
+#define __PYX_IS_UNSIGNED(type) __PYX_IS_UNSIGNED_IMPL<type>::value
+#else
+#define __PYX_IS_UNSIGNED(type) (((type) -1) > 0)
+#endif
+
 /* Run-time type information about structs used with buffers */
 struct __Pyx_StructField_;
 

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -54,7 +54,7 @@ static void __Pyx_RaiseBufferFallbackError(void) {
 /////////////// BufferFormatStructs.proto ///////////////
 //@proto_block: utility_code_proto_before_types
 
-#define IS_UNSIGNED(type) (((type) -1) > 0)
+#define IS_UNSIGNED(type) ((type)(0) < (type)(-1))
 
 /* Run-time type information about structs used with buffers */
 struct __Pyx_StructField_;

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -54,14 +54,6 @@ static void __Pyx_RaiseBufferFallbackError(void) {
 /////////////// BufferFormatStructs.proto ///////////////
 //@proto_block: utility_code_proto_before_types
 
-#ifdef __cplusplus
-template<typename T>
-struct IS_UNSIGNED_IMPL {static const bool value = T(0) < T(-1);};
-#define IS_UNSIGNED(type) IS_UNSIGNED_IMPL<type>::value
-#else
-#define IS_UNSIGNED(type) (((type) -1) > 0)
-#endif
-
 /* Run-time type information about structs used with buffers */
 struct __Pyx_StructField_;
 

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -54,7 +54,13 @@ static void __Pyx_RaiseBufferFallbackError(void) {
 /////////////// BufferFormatStructs.proto ///////////////
 //@proto_block: utility_code_proto_before_types
 
-#define IS_UNSIGNED(type) ((type)(0) < (type)(-1))
+#ifdef __cplusplus
+template<typename T>
+struct IS_UNSIGNED_IMPL {static const bool value = T(0) < T(-1);};
+#define IS_UNSIGNED(type) IS_UNSIGNED_IMPL<type>::value
+#else
+#define IS_UNSIGNED(type) (((type) -1) > 0)
+#endif
 
 /* Run-time type information about structs used with buffers */
 struct __Pyx_StructField_;

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -34,7 +34,7 @@ static int __Pyx_check_twos_complement(void) {
 #ifdef __cplusplus
 template<typename T>
 struct __PYX_IS_UNSIGNED_IMPL {static const bool value = T(0) < T(-1);};
-#define __PYX_IS_UNSIGNED(type) IS_UNSIGNED_IMPL<type>::value
+#define __PYX_IS_UNSIGNED(type) __PYX_IS_UNSIGNED_IMPL<type>::value
 #else
 #define __PYX_IS_UNSIGNED(type) ((((type) -1) > 0))
 #endif

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -31,7 +31,7 @@ static int __Pyx_check_twos_complement(void) {
     }
 }
 
-#define __PYX_IS_UNSIGNED(type) ((((type) -1) > 0))
+#define __PYX_IS_UNSIGNED(type) ((type)(0) < (type)(-1))
 #define __PYX_SIGN_BIT(type)    ((((unsigned type) 1) << (sizeof(type) * 8 - 1)))
 #define __PYX_HALF_MAX(type)    ((((type) 1) << (sizeof(type) * 8 - 2)))
 #define __PYX_MIN(type)         ((__PYX_IS_UNSIGNED(type) ? (type) 0 : 0 - __PYX_HALF_MAX(type) - __PYX_HALF_MAX(type)))

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -31,7 +31,13 @@ static int __Pyx_check_twos_complement(void) {
     }
 }
 
-#define __PYX_IS_UNSIGNED(type) ((type)(0) < (type)(-1))
+#ifdef __cplusplus
+template<typename T>
+struct __PYX_IS_UNSIGNED_IMPL {static const bool value = T(0) < T(-1);};
+#define __PYX_IS_UNSIGNED(type) IS_UNSIGNED_IMPL<type>::value
+#else
+#define __PYX_IS_UNSIGNED(type) ((((type) -1) > 0))
+#endif
 #define __PYX_SIGN_BIT(type)    ((((unsigned type) 1) << (sizeof(type) * 8 - 1)))
 #define __PYX_HALF_MAX(type)    ((((type) 1) << (sizeof(type) * 8 - 2)))
 #define __PYX_MIN(type)         ((__PYX_IS_UNSIGNED(type) ? (type) 0 : 0 - __PYX_HALF_MAX(type) - __PYX_HALF_MAX(type)))


### PR DESCRIPTION
this adds support for constant types in the `IS_UNSIGNED` macro to fix #5301 without reducing const correctness.
This uses the same implementation used for the C++11 type_trait `std::is_unsigned`: https://en.cppreference.com/w/cpp/types/is_unsigned