### PR TITLE
Added documentation about the GIL

### DIFF
--- a/docs/src/quickstart/cythonize.rst
+++ b/docs/src/quickstart/cythonize.rst
@@ -143,7 +143,9 @@ Lines that translate to C code have a plus (``+``) in front
 and can be clicked to show the generated code.
 
 This report is invaluable when optimizing a function for speed,
-and for determining when to :ref:`release the GIL <nogil>`:
+and for determining when it is possible to :ref:`release the GIL <nogil>`
+(be aware that releasing the GIL is only useful under limited
+circumstances, see :ref:`cython_and_gil` for more details):
 in general, a ``nogil`` block may contain only "white" code.
 
 .. tabs::

--- a/docs/src/tutorial/pure.rst
+++ b/docs/src/tutorial/pure.rst
@@ -221,7 +221,10 @@ Managing the Global Interpreter Lock
     @cython.nogil
     @cython.cfunc
     def func_released_gil() -> cython.int:
-        # function with the GIL released
+        # function that can be run with the GIL released
+        
+  Note that the two uses differ: the context manager releases the GIL while the decorator marks that a
+  function *can* be run without the GIL. See :ref:`<cython_and_gil>` for more details.
 
 * ``cython.gil`` can be used as a context manager to replace the :keyword:`gil` keyword::
 

--- a/docs/src/userguide/index.rst
+++ b/docs/src/userguide/index.rst
@@ -26,6 +26,7 @@ Contents:
    numpy_tutorial
    numpy_ufuncs
    numpy_pythran
+   nogil
 
 Indices and tables
 ------------------

--- a/docs/src/userguide/nogil.rst
+++ b/docs/src/userguide/nogil.rst
@@ -1,0 +1,160 @@
+.. _cython_and_gil:
+
+Cython and the GIL
+==================
+
+Python has a global lock (:term:`the GIL <Global Interpreter Lock or GIL>`)
+to ensure that data related to the Python interpreter is not corrupted.
+It is *sometimes* to release this lock in Cython when you are not
+accessing Python data.
+
+There are two occasions when you may want to release the
+GIL:
+
+#. Using :ref:`Cython's parallelism mechanism <parallel>`. The contents of a ``prange`` loop for example are required to be ``nogil``.
+
+#. If you want other (external) Python threads to be able to run at the same time.
+
+    #. if you have a large computationally/IO-intensive block that doesn't need the GIL then it may be "polite" to release it, just to benefit users of your code who want to do multi-threading. However, this is mostly useful rather than necessary.
+
+    #. (very, very occasionally) it's sometimes useful to briefly release the GIL with a short with ``nogil: pass`` block. This is because Cython doesn't release it spontaneously (unlike Python) so if you're waiting on another Python thread to complete a task, this can avoid deadlocks. This sub-point probably doesn't apply to you unless you're compiling GUI code with Cython.
+
+If neither of these two points apply then you probably do not need to release the GIL. The sort of Cython 
+code that can run without the GIL (no calls to Python, purely C-level numeric operations)
+is often the sort of code that runs efficiently. This sometimes gives people the impression that the
+inverse is true and the trick is releasing the GIL, rather than the actual code they’re running.
+Don’t be misled by this -- your (single-threaded) code will run the same speed with or without the GIL.
+
+Marking functions as able to run without the GIL
+------------------------------------------------
+
+You can mark a whole function (either a Cython function or an :ref:`external function <nogil>`) as
+``nogil`` by appending this to the function signature or by using the ``@cython.nogil`` decorator:
+
+.. tabs::
+
+    .. group-tab:: Pure Python
+    
+        .. code-block:: python
+
+            @cython.nogil(True)
+            @cython.cfunc
+            @cython.noexcept
+            def some_func() -> None:
+            ...
+
+    .. group-tab:: Cython
+    
+        .. code-block:: cython
+    
+            cdef void some_func() noexcept nogil:
+                ....
+
+Be aware that this does not release the GIL when calling the function. It merely indicates that
+a function is suitable for use when the GIL is released. It is also fine to call these functions
+while holding the GIL.
+
+In this case we've marked the function as ``noexcept`` to indicate that it cannot raise a Python
+exception. Be aware that a function with an ``except *`` exception specification (typically functions
+returning ``void``) will be expensive to call because Cython will need to temporarily reacquire
+the GIL after every call to check the exception state. Most other exception specifications are
+cheap to handle in a ``nogil`` block since the GIL is only acquired if an exception is
+actually thrown.
+
+Releasing (and reacquiring) the GIL
+-----------------------------------
+
+To actually release the GIL you can use context managers
+
+.. tabs::
+
+    .. group-tab:: Pure Python
+    
+        .. code-block:: python
+        
+            with cython.nogil(True):
+                ...  # some code that runs without the GIL
+                with cython.gil:
+                    ...  # some code that runs with the GIL
+                ...  # some more code without the GIL
+            
+    .. group-tab:: Cython
+    
+        .. code-block:: cython
+    
+            with nogil:
+                ...  # some code that runs without the GIL
+                with gil:
+                    ...  # some code that runs with the GIL
+                ...  # some more code without the GIL
+            
+The ``with gil`` block is a useful trick to allow a small
+chunk of Python code to in a non-GIL block. Try not to use it
+too much since there is a cost to acquiring the GIL, and because these
+blocks cannot be parallelized.
+
+A function may be marked as ``with gil`` to ensure that the
+GIL is re-acquired then calling it. This is currently a Cython-only
+feature (no equivalent exists in pure-Python mode)::
+
+  cdef int some_func() with gil:
+      ...
+      
+Conditionally acquiring the GIL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It's possible to release the GIL based on a compile-time condition.
+This is most often used when working with :ref:`fusedtypes`
+
+.. tabs::
+
+    .. group-tab:: Pure Python
+    
+        .. code-block:: python
+    
+            with cython.nogil(some_type is object):
+                ...  # some code that runs without the GIL
+            
+    .. group-tab:: Cython
+    
+        .. code-block:: cython
+    
+            with nogil(some_type is object):
+                ...  # some code that runs without the GIL
+      
+Exceptions and the GIL
+----------------------
+
+A small number of "Python operations" may be performed in a ``nogil``
+block without needing to explicitly use ``with gil``. The main example
+is throwing exceptions. Here Cython knows that an exception will always
+require the GIL and so re-acquires it implicitly. Similarly, if
+a ``nogil`` function throws an exception, Cython is able to propagate
+it correctly without you needing to write explicit code to handle it.
+In most cases this is efficient since Cython is able to use the
+function's exception specification to check for an error, and then
+acquire the GIL only if needed, but ``except *`` functions are
+inefficient since Cython must always re-acquire the GIL.
+
+Don't use the GIL as a lock
+---------------------------
+
+It may be tempting to try to use the GIL for your own locking
+purposes and to say "the entire contents of a ``with gil`` block will
+run atomically since we hold the GIL". Don't do this!
+
+The GIL is only for the benefit of the interpreter, not for you.
+There are two issues here: 
+
+#. that future improvements in the Python interpreter may destroy 
+your "locking".
+
+#. Second, that the GIL can be released if any Python code is
+executed. The easiest way to run arbitrary Python code is to
+destroy a Python object that has a ``__del__`` function, but
+there are numerous other creative ways to do so, and it is
+almost impossible to know that you aren't going to trigger one
+of these.
+
+If you want a reliable lock then use the tools in the builtin
+``threading`` module.

--- a/docs/src/userguide/nogil.rst
+++ b/docs/src/userguide/nogil.rst
@@ -5,24 +5,33 @@ Cython and the GIL
 
 Python has a global lock (:term:`the GIL <Global Interpreter Lock or GIL>`)
 to ensure that data related to the Python interpreter is not corrupted.
-It is *sometimes* to release this lock in Cython when you are not
+It is *sometimes* useful to release this lock in Cython when you are not
 accessing Python data.
 
 There are two occasions when you may want to release the GIL:
 
-#. Using :ref:`Cython's parallelism mechanism <parallel>`. The contents of a ``prange`` loop for example are required to be ``nogil``.
+#. Using :ref:`Cython's parallelism mechanism <parallel>`. The contents of 
+   a ``prange`` loop for example are required to be ``nogil``.
 
 #. If you want other (external) Python threads to be able to run at the same time.
 
-    #. if you have a large computationally/IO-intensive block that doesn't need the GIL then it may be "polite" to release it, just to benefit users of your code who want to do multi-threading. However, this is mostly useful rather than necessary.
+    #. if you have a large computationally/IO-intensive block that doesn't need the
+       GIL then it may be "polite" to release it, just to benefit users of your code
+       who want to do multi-threading. However, this is mostly useful rather than necessary.
 
-    #. (very, very occasionally) in long-running Cython code that never calls into the Python interpreter, it can sometimes be useful to briefly release the GIL with a short ``with nogil: pass`` block. This is because Cython doesn't release it spontaneously (unlike the Python interpreter), so if you're waiting on another Python thread to complete a task, this can avoid deadlocks. This sub-point probably doesn't apply to you unless you're compiling GUI code with Cython.
+    #. (very, very occasionally) in long-running Cython code that never calls into the
+       Python interpreter, it can sometimes be useful to briefly release the GIL with a 
+       short ``with nogil: pass`` block. This is because Cython doesn't release it 
+       spontaneously (unlike the Python interpreter), so if you're waiting on another
+       Python thread to complete a task, this can avoid deadlocks. This sub-point
+       probably doesn't apply to you unless you're compiling GUI code with Cython.
 
-If neither of these two points apply then you probably do not need to release the GIL. The sort of Cython 
-code that can run without the GIL (no calls to Python, purely C-level numeric operations)
-is often the sort of code that runs efficiently. This sometimes gives people the impression that the
-inverse is true and the trick is releasing the GIL, rather than the actual code they’re running.
-Don’t be misled by this -- your (single-threaded) code will run the same speed with or without the GIL.
+If neither of these two points apply then you probably do not need to release the GIL.
+The sort of Cython code that can run without the GIL (no calls to Python, purely C-level
+numeric operations) is often the sort of code that runs efficiently. This sometimes
+gives people the impression that the inverse is true and the trick is releasing the GIL,
+rather than the actual code they’re running. Don’t be misled by this --
+your (single-threaded) code will run the same speed with or without the GIL.
 
 Marking functions as able to run without the GIL
 ------------------------------------------------


### PR DESCRIPTION
This was originally step 1 in trying to copy some of my own https://cython-guidelines.readthedocs.io content into the official docs. However, I noticed that we're actually missing quite a bit of information about the GIL and thought it'd be good to bring it together in one place. So most of this PR is new content rather than moved content.