### PR TITLE
Try to fix FakeReference on c++03

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -603,8 +603,8 @@ class __Pyx_FakeReference {
     // TODO(robertwb): Delegate all operators (or auto-generate unwrapping code where needed).
     template<typename U> bool operator ==(const U& other) const { return *ptr == other; }
     template<typename U> bool operator !=(const U& other) const { return *ptr != other; }
-    template<typename U=T> bool operator==(const __Pyx_FakeReference<U>& other) const { return *ptr == *other.ptr; }
-    template<typename U=T> bool operator!=(const __Pyx_FakeReference<U>& other) const { return *ptr != *other.ptr; }
+    template<typename U> bool operator==(const __Pyx_FakeReference<U>& other) const { return *ptr == *other.ptr; }
+    template<typename U> bool operator!=(const __Pyx_FakeReference<U>& other) const { return *ptr != *other.ptr; }
   private:
     T *ptr;
 };


### PR DESCRIPTION
Apparently default function template parameters aren't allowed (and they don't seem to be needed here anyway)

Hopefully fixes #5316