### PR TITLE
Fix missing exported C function declarations with cimport_from_pyx enabled

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -929,8 +929,11 @@ class FusedCFuncDefNode(StatListNode):
             self.py_func.pymethdef_required = True
             self.fused_func_assignment.generate_function_definitions(env, code)
 
+        from . import Options
         for stat in self.stats:
-            if isinstance(stat, FuncDefNode) and stat.entry.used:
+            if (isinstance(stat, FuncDefNode)
+                and (stat.entry.used
+                     or (Options.cimport_from_pyx and not stat.entry.visibility == 'extern'))):
                 code.mark_pos(stat.pos)
                 stat.generate_function_definitions(env, code)
 

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -931,9 +931,8 @@ class FusedCFuncDefNode(StatListNode):
 
         from . import Options
         for stat in self.stats:
-            if (isinstance(stat, FuncDefNode)
-                and (stat.entry.used
-                     or (Options.cimport_from_pyx and not stat.entry.visibility == 'extern'))):
+            from_pyx = Options.cimport_from_pyx and not stat.entry.visibility == 'extern'
+            if isinstance(stat, FuncDefNode) and (stat.entry.used or from_pyx):
                 code.mark_pos(stat.pos)
                 stat.generate_function_definitions(env, code)
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1397,7 +1397,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_cfunction_declarations(self, env, code, definition):
         for entry in env.cfunc_entries:
-            if entry.used or (entry.visibility == 'public' or entry.api):
+            if (entry.used
+                    or entry.visibility == 'public'
+                    or entry.api
+                    or (Options.cimport_from_pyx and not entry.visibility == 'extern')):
                 generate_cfunction_declaration(entry, env, code, definition)
 
     def generate_variable_definitions(self, env, code):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1397,10 +1397,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_cfunction_declarations(self, env, code, definition):
         for entry in env.cfunc_entries:
+            from_pyx = Options.cimport_from_pyx and not entry.visibility == 'extern'
             if (entry.used
                     or entry.visibility == 'public'
                     or entry.api
-                    or (Options.cimport_from_pyx and not entry.visibility == 'extern')):
+                    or from_pyx):
                 generate_cfunction_declaration(entry, env, code, definition)
 
     def generate_variable_definitions(self, env, code):

--- a/tests/run/cimport_from_pyx.srctree
+++ b/tests/run/cimport_from_pyx.srctree
@@ -83,3 +83,18 @@ def cfuncOutside():
 
 cdef class ClassC:
     cdef int value
+
+######## d.pyx ########
+
+ctypedef fused fused_type:
+    long
+    double
+
+cdef fused_checker(fused_type i):
+    if fused_type is long:
+        return True
+    else:
+        return False
+
+def test():
+    return fused_checker(0)


### PR DESCRIPTION
Related to #5072.

This pull request attempts to fix the compilation errors that happen when the Cython compiler fails to generate the declarations of unused exported functions from `pyx` files with the `cimport_from_pyx` option on.
