### PR TITLE
Add a test for relative cimport within a submodule

### DIFF
--- a/tests/run/relative_cimport.srctree
+++ b/tests/run/relative_cimport.srctree
@@ -6,6 +6,7 @@ PYTHON -c "from pkg.a import test; assert test() == (5, 7)"
 PYTHON -c "from pkg.b import test; assert test() == (1, 2)"
 PYTHON -c "from pkg.b_py2 import test; assert test() == (1, 2)"
 PYTHON -c "from pkg.sub.c import test; assert test() == (1, 2)"
+PYTHON -c "from pkg.sub.d import test; assert test() == 3"
 
 ######## setup.py ########
 
@@ -25,9 +26,11 @@ setup(
 ######## pkg/a.pyx ########
 
 from .sub.reimport cimport myint
+from .sub cimport c
 
 cdef myint i = 5
 assert i == 5
+assert c.sum_func(1, 2) == 3
 
 from .sub cimport myint as pkg_myint
 
@@ -92,6 +95,19 @@ def test():
     obj.y = 2
     return (obj.x, obj.y)
 
+cdef int sum_func(int n, int m):
+    return n + m
+
+######## pkg/sub/c.pxd ########
+
+cdef int sum_func(int n, int m)
+
+######## pkg/sub/d.pyx ########
+
+from . cimport c
+
+def test():
+    return c.sum_func(1, 2)
 
 ######## pkg/sub/tdef.pxd ########
 
@@ -106,3 +122,4 @@ from .tdef cimport myint
 ######## pkg/sub/__init__.pxd ########
 
 from .tdef cimport myint
+from . cimport c


### PR DESCRIPTION
This test mirrors the structure of SciPy's `linalg.cython_blas`, `linalg.cython_lapack` and `special.cython_special` modules.

xref https://github.com/scipy/scipy/issues/17234#issuecomment-1471600772 for the relevant discussion on SciPy, and gh-4552 for the fix that made this work in `master`. Things are broken in 0.29.x for this `python runtests.py relative_cimport` (even before this addition, the gh-4552 fix wasn't backported):

<details>

```
$ python runtests.py relative_cimport
/home/rgommers/code/tmp/cython/runtests.py:2240: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  thread.setDaemon(True)  # Py2.6 ...
Python 3.10.9 | packaged by conda-forge | (main, Feb  2 2023, 20:20:04) [GCC 11.3.0]

Running tests against Cython 0.29.33 4574bae9897e87b437315b87a5af9d7fac5d5244 + uncommitted changes
Using Cython language level 2.
Backends: c,cpp

[-1] /home/rgommers/mambaforge/envs/scipy-dev/bin/python setup.py build_ext --inplace
Compiling pkg/a.pyx because it changed.
Compiling pkg/b.pyx because it changed.
Compiling pkg/b_py2.pyx because it changed.
Compiling pkg/sub/c.pyx because it changed.
Compiling pkg/sub/d.pyx because it changed.
[1/5] Cythonizing pkg/a.pyx

/home/rgommers/code/tmp/cython/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/rgommers/code/tmp/cython/TEST_TMP/run/relative_cimport/pkg/a.pxd
  tree = Parsing.p_module(s, pxd, full_module_name)

Error compiling Cython file:
------------------------------------------------------------
...

from .tdef cimport myint
^
------------------------------------------------------------

pkg/sub/__init__.pxd:2:0: 'pkg/tdef.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...

from .tdef cimport myint
^
------------------------------------------------------------

pkg/sub/__init__.pxd:2:0: 'pkg/tdef/myint.pxd' not found

Error compiling Cython file:
------------------------------------------------------------
...

from .tdef cimport myint
from . cimport c
^
------------------------------------------------------------

pkg/sub/__init__.pxd:3:0: 'pkg/c.pxd' not found

<etc>
```

</details>