### PR TITLE
Fix ufunc GIL handling

### DIFF
--- a/Cython/Compiler/UFuncs.py
+++ b/Cython/Compiler/UFuncs.py
@@ -138,6 +138,9 @@ class UFuncConversion(object):
 
         ufunc_cname = self.global_scope.next_id(self.node.entry.name + "_ufunc_def")
 
+        outer_is_nogil = not (any(t.is_pyobject for t in arg_types) or
+            any(t.is_pyobject for t in out_types))
+
         context = dict(
             func_cname=ufunc_cname,
             in_types=arg_types,
@@ -145,6 +148,7 @@ class UFuncConversion(object):
             inline_func_call=self.node.entry.cname,
             inline_func_declaration=inline_func_decl,
             nogil=self.node.entry.type.nogil,
+            outer_is_nogil=outer_is_nogil,
         )
 
         code = CythonUtilityCode.load(

--- a/Cython/Compiler/UFuncs.py
+++ b/Cython/Compiler/UFuncs.py
@@ -138,7 +138,7 @@ class UFuncConversion(object):
 
         ufunc_cname = self.global_scope.next_id(self.node.entry.name + "_ufunc_def")
 
-        outer_is_nogil = not (any(t.is_pyobject for t in arg_types) or
+        will_be_called_without_gil = not (any(t.is_pyobject for t in arg_types) or
             any(t.is_pyobject for t in out_types))
 
         context = dict(
@@ -148,7 +148,7 @@ class UFuncConversion(object):
             inline_func_call=self.node.entry.cname,
             inline_func_declaration=inline_func_decl,
             nogil=self.node.entry.type.nogil,
-            outer_is_nogil=outer_is_nogil,
+            will_be_called_without_gil=will_be_called_without_gil,
         )
 
         code = CythonUtilityCode.load(

--- a/Cython/Utility/UFuncs.pyx
+++ b/Cython/Utility/UFuncs.pyx
@@ -8,7 +8,7 @@ cdef extern from *:
 
 # variable names have to come from tempita to avoid duplication
 @cname("{{func_cname}}")
-cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data) except * {{"nogil" if outer_is_nogil else ""}}:
+cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data) except * {{"nogil" if will_be_called_without_gil else ""}}:
     cdef npy_intp i
     cdef npy_intp n = dimensions[0]
     {{for idx, tp in enumerate(in_types)}}
@@ -23,7 +23,7 @@ cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp
     cdef npy_intp step_{{idx}} = steps[{{idx}}]
     {{endfor}}
 
-    {{"with gil" if (not nogil and outer_is_nogil) else "if True"}}:
+    {{"with gil" if (not nogil and will_be_called_without_gil) else "if True"}}:
         for i in range(n):
             {{for idx, tp in enumerate(in_types)}}
             {{if tp.is_pyobject}}

--- a/Cython/Utility/UFuncs.pyx
+++ b/Cython/Utility/UFuncs.pyx
@@ -8,7 +8,7 @@ cdef extern from *:
 
 # variable names have to come from tempita to avoid duplication
 @cname("{{func_cname}}")
-cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data) except *:
+cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data) except * {{"nogil" if outer_is_nogil else ""}}:
     cdef npy_intp i
     cdef npy_intp n = dimensions[0]
     {{for idx, tp in enumerate(in_types)}}
@@ -23,7 +23,7 @@ cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp
     cdef npy_intp step_{{idx}} = steps[{{idx}}]
     {{endfor}}
 
-    with nogil({{nogil}}):
+    {{"with gil" if (not nogil and outer_is_nogil) else "if True"}}:
         for i in range(n):
             {{for idx, tp in enumerate(in_types)}}
             {{if tp.is_pyobject}}

--- a/tests/run/ufunc.pyx
+++ b/tests/run/ufunc.pyx
@@ -10,6 +10,17 @@ int_arr_1d = np.arange(20, dtype=int)[::4]
 int_arr_2d = np.arange(500, dtype=int).reshape((50, -1))[5:8, 6:8]
 double_arr_1d = int_arr_1d.astype(np.double)
 double_arr_2d = int_arr_2d.astype(np.double)
+# Numpy has a cutoff at about 500 where it releases the GIL, so test some large arrays
+large_int_arr_1d = np.arange(1500, dtype=int)
+large_int_arr_2d = np.arange(1500*600, dtype=int).reshape((1500, -1))
+large_double_arr_1d = large_int_arr_1d.astype(np.double)
+large_double_arr_2d = large_int_arr_2d.astype(np.double)
+
+def dont_print(x):
+    """
+    For the large arrays, it's just a "don't crash" test
+    """
+    pass
 
 # it's fairly hard to test that nogil results in the GIL actually
 # being released unfortunately
@@ -29,6 +40,8 @@ def test_tripple_it():
     array([[168., 171.],
            [198., 201.],
            [228., 231.]])
+    >>> dont_print(tripple_it(large_int_arr_1d))
+    >>> dont_print(tripple_it(large_int_arr_2d))
     """
 
 @cython.ufunc
@@ -41,6 +54,8 @@ def test_to_the_power():
     True
     >>> np.allclose(to_the_power(1., double_arr_2d), np.ones_like(double_arr_2d))
     True
+    >>> dont_print(to_the_power(large_double_arr_1d, -large_double_arr_1d))
+    >>> dont_print(to_the_power(large_double_arr_2d, -large_double_arr_2d))
     """
 
 @cython.ufunc
@@ -56,6 +71,7 @@ def test_py_return_value():
     >>> py_return_value(double_arr_1d).dtype
     dtype('O')
     >>> py_return_value(-1.)  # returns None
+    >>> dont_print(py_return_value(large_double_arr_1d))
     """
 
 @cython.ufunc
@@ -66,6 +82,7 @@ def test_py_arg():
     """
     >>> py_arg(np.array([1, "2.0", 3.0], dtype=object))
     array([1., 2., 3.])
+    >>> dont_print(py_arg(np.array([1]*1200, dtype=object)))
     """
 
 @cython.ufunc
@@ -155,4 +172,32 @@ def test_nested_function():
     True
     >>> nested_function(-1.)
     -2.0
+    """
+
+@cython.ufunc
+cdef double can_throw(double x):
+    if x<0:
+        raise RuntimeError
+    return x
+
+def test_can_throw():
+    """
+    >>> arr = double_arr_1d.copy()
+    >>> arr[1] = -1.
+    >>> can_throw(arr)
+    Traceback (most recent call last):
+    ...
+    RuntimeError
+    >>> large_arr = large_double_arr_1d.copy()
+    >>> large_arr[-4] = -2.
+    >>> can_throw(large_arr)
+    Traceback (most recent call last):
+    ...
+    RuntimeError
+    >>> large_arr2d = large_double_arr_2d.copy()
+    >>> large_arr2d[100, 200] = -1.
+    >>> can_throw(large_arr2d)
+    Traceback (most recent call last):
+    ...
+    RuntimeError
     """

--- a/tests/run/ufunc.pyx
+++ b/tests/run/ufunc.pyx
@@ -16,32 +16,28 @@ large_int_arr_2d = np.arange(1500*600, dtype=int).reshape((1500, -1))
 large_double_arr_1d = large_int_arr_1d.astype(np.double)
 large_double_arr_2d = large_int_arr_2d.astype(np.double)
 
-def dont_print(x):
-    """
-    For the large arrays, it's just a "don't crash" test
-    """
-    pass
-
 # it's fairly hard to test that nogil results in the GIL actually
 # being released unfortunately
 @cython.ufunc
-cdef double tripple_it(long x) nogil:
-    """tripple_it doc"""
+cdef double triple_it(long x) nogil:
+    """triple_it doc"""
     return x*3.
 
-def test_tripple_it():
+def test_triple_it():
     """
     Ufunc also generates a signature so just look at the end
-    >>> tripple_it.__doc__.endswith('tripple_it doc')
+    >>> triple_it.__doc__.endswith('triple_it doc')
     True
-    >>> tripple_it(int_arr_1d)
+    >>> triple_it(int_arr_1d)
     array([ 0., 12., 24., 36., 48.])
-    >>> tripple_it(int_arr_2d)
+    >>> triple_it(int_arr_2d)
     array([[168., 171.],
            [198., 201.],
            [228., 231.]])
-    >>> dont_print(tripple_it(large_int_arr_1d))
-    >>> dont_print(tripple_it(large_int_arr_2d))
+
+    Treat the large arrays just as a "don't crash" test
+    >>> _ = triple_it(large_int_arr_1d)
+    >>> _ = triple_it(large_int_arr_2d)
     """
 
 @cython.ufunc
@@ -54,8 +50,8 @@ def test_to_the_power():
     True
     >>> np.allclose(to_the_power(1., double_arr_2d), np.ones_like(double_arr_2d))
     True
-    >>> dont_print(to_the_power(large_double_arr_1d, -large_double_arr_1d))
-    >>> dont_print(to_the_power(large_double_arr_2d, -large_double_arr_2d))
+    >>> _ = to_the_power(large_double_arr_1d, -large_double_arr_1d)
+    >>> _ = to_the_power(large_double_arr_2d, -large_double_arr_2d)
     """
 
 @cython.ufunc
@@ -71,7 +67,7 @@ def test_py_return_value():
     >>> py_return_value(double_arr_1d).dtype
     dtype('O')
     >>> py_return_value(-1.)  # returns None
-    >>> dont_print(py_return_value(large_double_arr_1d))
+    >>> _ = py_return_value(large_double_arr_1d)
     """
 
 @cython.ufunc
@@ -82,7 +78,7 @@ def test_py_arg():
     """
     >>> py_arg(np.array([1, "2.0", 3.0], dtype=object))
     array([1., 2., 3.])
-    >>> dont_print(py_arg(np.array([1]*1200, dtype=object)))
+    >>> _ = py_arg(np.array([1]*1200, dtype=object))
     """
 
 @cython.ufunc


### PR DESCRIPTION
It looks like Numpy releases the GIL for us (unless it's PyObject arguments), so we should assume that we don't have the GIL, and write code to regain it if needed, rather than assuming we need to release the GIL.

Fixes #5328