### PR TITLE
Allow InterpretCompilerDirectives.visit_AnnotationNode to process nodes having no children

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1107,7 +1107,7 @@ class InterpretCompilerDirectives(CythonTransform):
         # for most transforms annotations are left unvisited (because they're unevaluated)
         # however, it is important to pick up compiler directives from them
         if node.expr:
-            self.visitchildren(node.expr)
+            self.visit(node.expr)
         return node
 
     def visit_NewExprNode(self, node):

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -368,6 +368,19 @@ cdef class ClassTurnOffTyping:
         return typeof(self.x), typeof(self.d), typeof(arg)
 
 
+from cython cimport int as cy_i
+
+
+def int_alias(a: cython.int, b: cy_i):
+    """
+    >>> int_alias(1, 2)
+    int
+    int
+    """
+    print(cython.typeof(a))
+    print(cython.typeof(b))
+
+
 _WARNINGS = """
 14:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 14:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.


### PR DESCRIPTION
Related to #5235
I discovered that the following code did not work with nodes having no child nodes, such as `NameNode`.
https://github.com/cython/cython/blob/0ffa7e91816a00a1694d1466aa91613b6708b244/Cython/Compiler/ParseTreeTransforms.py#L1106-L1111
```python
from cython cimport int as cy_i
cimport cython

def f(a: cython.int, b: cy_i):
    print(cython.typeof(a), cython.typeof(b))
```
(Code from #5235)
It caused the `NameNode` of `cy_i` to be ignored by `InterpretCompilerDirectives` when it was referenced by `node.expr`.