### PR TITLE
fix compilation with language="C++" (wrong capitalization)

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -875,7 +875,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
 
                 if file not in m.sources:
                     # Old setuptools unconditionally replaces .pyx with .c/.cpp
-                    target_file = os.path.splitext(file)[0] + ('.cpp' if m.language == 'c++' else '.c')
+                    target_file = os.path.splitext(file)[0] + ('.cpp' if m.language.lower() == 'c++' else '.c')
                     try:
                         m.sources.remove(target_file)
                     except ValueError:
@@ -1035,7 +1035,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                 if m.np_pythran:
                     c_file = base + '.cpp'
                     options = pythran_options
-                elif m.language == 'c++':
+                elif m.language and m.language.lower() == 'c++':
                     c_file = base + '.cpp'
                     options = cpp_options
                 else:

--- a/tests/build/cpp_cythonize.srctree
+++ b/tests/build/cpp_cythonize.srctree
@@ -2,6 +2,7 @@
 
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import a; a.use_vector([1,2,3])"
+PYTHON -c "import b; b.use_vector([1,2,3])"
 
 ######## setup.py ########
 
@@ -16,6 +17,21 @@ setup(
 ######## a.pyx ########
 
 # distutils: language=c++
+
+from libcpp.vector cimport vector
+
+def use_vector(L):
+    try:
+        v = new vector[int]()
+        for a in L:
+            v.push_back(a)
+        return v.size()
+    finally:
+        del v
+
+######## b.pyx ########
+
+# distutils: language=C++
 
 from libcpp.vector cimport vector
 


### PR DESCRIPTION
tackle the very few places where `language` was compared to `"c++"` without forcing lower capitalization

extend an existing test rather than creating a new one.

closes #1226