### PR TITLE
Avoid deprecated Py_OptimizeFlag in Py3.12

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -477,7 +477,7 @@ def init_builtins():
 
     builtin_scope.declare_var(
         '__debug__', PyrexTypes.c_const_type(PyrexTypes.c_bint_type),
-        pos=None, cname='(!__pyx_get_Py_OptimizeFlag())', is_cdef=True)
+        pos=None, cname='__pyx_assertions_enabled()', is_cdef=True)
 
     global type_type, list_type, tuple_type, dict_type, set_type, frozenset_type
     global slice_type, bytes_type, str_type, unicode_type, basestring_type, bytearray_type

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -477,7 +477,7 @@ def init_builtins():
 
     builtin_scope.declare_var(
         '__debug__', PyrexTypes.c_const_type(PyrexTypes.c_bint_type),
-        pos=None, cname='(!Py_OptimizeFlag)', is_cdef=True)
+        pos=None, cname='(!__pyx_get_Py_OptimizeFlag())', is_cdef=True)
 
     global type_type, list_type, tuple_type, dict_type, set_type, frozenset_type
     global slice_type, bytes_type, str_type, unicode_type, basestring_type, bytearray_type

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6979,7 +6979,7 @@ class AssertStatNode(StatNode):
 
     def generate_execution_code(self, code):
         code.putln("#ifndef CYTHON_WITHOUT_ASSERTIONS")
-        code.putln("if (unlikely(!Py_OptimizeFlag)) {")
+        code.putln("if (unlikely(!__pyx_get_Py_OptimizeFlag())) {")
         code.mark_pos(self.pos)
         self.condition.generate_evaluation_code(code)
         code.putln(

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6978,8 +6978,10 @@ class AssertStatNode(StatNode):
         return self
 
     def generate_execution_code(self, code):
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("AssertionsEnabled", "Exceptions.c"))
         code.putln("#ifndef CYTHON_WITHOUT_ASSERTIONS")
-        code.putln("if (unlikely(!__pyx_get_Py_OptimizeFlag())) {")
+        code.putln("if (unlikely(__pyx_assertions_enabled())) {")
         code.mark_pos(self.pos)
         self.condition.generate_evaluation_code(code)
         code.putln(

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -6,6 +6,32 @@
 // __Pyx_GetException()
 
 
+/////////////// AssertionsEnabled.init ///////////////
+__Pyx_init_assertions_enabled();
+
+/////////////// AssertionsEnabled.proto ///////////////
+
+#define __Pyx_init_assertions_enabled()
+
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x02070600 && !defined(Py_OptimizeFlag)
+  #define __pyx_assertions_enabled() (1)
+#elif PY_VERSION_HEX < 0x03080000  ||  CYTHON_COMPILING_IN_PYPY  ||  defined(Py_LIMITED_API)
+  #define __pyx_assertions_enabled() (!Py_OptimizeFlag)
+#elif CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030900A6
+  // Py3.8+ has PyConfig from PEP 587, but only Py3.9 added read access to it.
+  // Py_OptimizeFlag is deprecated in Py3.12+
+  static int __pyx_assertions_enabled_flag;
+  #define __pyx_assertions_enabled() (__pyx_assertions_enabled_flag)
+
+  #undef __Pyx_init_assertions_enabled
+  static void __Pyx_init_assertions_enabled(void) {
+    __pyx_assertions_enabled_flag = ! _PyInterpreterState_GetConfig(__Pyx_PyThreadState_Current->interp)->optimization_level;
+  }
+#else
+  #define __pyx_assertions_enabled() (!Py_OptimizeFlag)
+#endif
+
+
 /////////////// ErrOccurredWithGIL.proto ///////////////
 static CYTHON_INLINE int __Pyx_ErrOccurredWithGIL(void); /* proto */
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -614,7 +614,15 @@ class __Pyx_FakeReference {
 /////////////// PythonCompatibility ///////////////
 
 #if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x02070600 && !defined(Py_OptimizeFlag)
-  #define Py_OptimizeFlag 0
+  #define __pyx_get_Py_OptimizeFlag() (0)
+#elif PY_VERSION_HEX < 0x03080000  ||  CYTHON_COMPILING_IN_PYPY  ||  defined(Py_LIMITED_API)
+  #define __pyx_get_Py_OptimizeFlag() (Py_OptimizeFlag)
+#elif CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030900A6
+  // Py3.8+ has PyConfig from PEP 587, but only Py3.9 added read access to it.
+  // Py_OptimizeFlag is deprecated in Py3.12+
+  #define __pyx_get_Py_OptimizeFlag() (_PyInterpreterState_GetConfig(__Pyx_PyThreadState_Current->interp)->optimization_level)
+#else
+  #define __pyx_get_Py_OptimizeFlag() (Py_OptimizeFlag)
 #endif
 
 #define __PYX_BUILD_PY_SSIZE_T "n"

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -613,18 +613,6 @@ class __Pyx_FakeReference {
 
 /////////////// PythonCompatibility ///////////////
 
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x02070600 && !defined(Py_OptimizeFlag)
-  #define __pyx_get_Py_OptimizeFlag() (0)
-#elif PY_VERSION_HEX < 0x03080000  ||  CYTHON_COMPILING_IN_PYPY  ||  defined(Py_LIMITED_API)
-  #define __pyx_get_Py_OptimizeFlag() (Py_OptimizeFlag)
-#elif CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030900A6
-  // Py3.8+ has PyConfig from PEP 587, but only Py3.9 added read access to it.
-  // Py_OptimizeFlag is deprecated in Py3.12+
-  #define __pyx_get_Py_OptimizeFlag() (_PyInterpreterState_GetConfig(__Pyx_PyThreadState_Current->interp)->optimization_level)
-#else
-  #define __pyx_get_Py_OptimizeFlag() (Py_OptimizeFlag)
-#endif
-
 #define __PYX_BUILD_PY_SSIZE_T "n"
 #define CYTHON_FORMAT_SSIZE_T "z"
 


### PR DESCRIPTION
Work around the deprecation of Py_OptimizeFlag in Py3.12 by reading the value from the interpreter's current PyConfig.

This is probably less efficient than was originally intended and makes assertions a little more costly.

See https://github.com/python/cpython/issues/99872