### PR TITLE
Fix AnnotationWriter for IndexNode with empty TupleNode

### DIFF
--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -644,7 +644,10 @@ class ExpressionWriter(TreeVisitor):
         self.visit(node.base)
         self.put(u"[")
         if isinstance(node.index, TupleNode):
-            self.emit_sequence(node.index)
+            if node.index.subexpr_nodes():
+                self.emit_sequence(node.index)
+            else:
+                self.put(u"()")
         else:
             self.visit(node.index)
         self.put(u"]")

--- a/tests/run/embedsignatures.pyx
+++ b/tests/run/embedsignatures.pyx
@@ -441,6 +441,7 @@ cdef class Foo:
     def m29(self, a: list(range(3))[0:1:1]): pass
     def m30(self, a: list(range(3))[7, 3:2:1, ...]): pass
     def m31(self, double[::1] a): pass
+    def m32(self, a: tuple[()]) -> tuple[tuple[()]]: pass
 
 __doc__ += ur"""
 >>> print(Foo.m00.__doc__)
@@ -538,4 +539,8 @@ Foo.m30(self, a: list(range(3))[7, 3:2:1, ...])
 
 >>> print(Foo.m31.__doc__)
 Foo.m31(self, double[::1] a)
+
+>>> print(Foo.m32.__doc__)
+Foo.m32(self, a: tuple[()]) -> tuple[tuple[()]]
+
 """


### PR DESCRIPTION
I hit this issue while adding argument annotations like `tuple[()]`. The annotation writer would emit `tuple[]`, which is invalid syntax. Despite the context being related to annotations, I believe the fix goes to the base `ExpressionWriter` class, so I did.