### PR TITLE
Fix issues with partially optimized cascaded comparisons

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1835,6 +1835,8 @@ class CCodeWriter(object):
         return self.buffer.getvalue()
 
     def write(self, s):
+        if s.find("__Pyx_PyObject_IsTrue(__pyx_t_1)") != -1:
+            import pdb; pdb.set_trace()
         if '\n' in s:
             self._write_lines(s)
         else:

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1835,8 +1835,6 @@ class CCodeWriter(object):
         return self.buffer.getvalue()
 
     def write(self, s):
-        if s.find("__Pyx_PyObject_IsTrue(__pyx_t_1)") != -1:
-            import pdb; pdb.set_trace()
         if '\n' in s:
             self._write_lines(s)
         else:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -13405,7 +13405,7 @@ class PrimaryCmpNode(ExprNode, CmpNode):
                     if operand2 is not self.operand2:
                         self.coerced_operand2 = operand2
                 self.unify_cascade_type()
-            return self
+                return self
         # TODO: check if we can optimise parts of the cascade here
         return ExprNode.coerce_to_boolean(self, env)
 

--- a/tests/run/cascmp.pyx
+++ b/tests/run/cascmp.pyx
@@ -36,3 +36,69 @@ def const_cascade(x):
         1 <= 1 <= x <= 2 <= 3 > x <= 2 <= 2,
         1 <= 1 <= x <= 1 <= 1 <= x <= 2,
     )
+
+def eq_if_statement(a, b, c):
+    """
+    >>> eq_if_statement(1, 2, 3)
+    False
+    >>> eq_if_statement(2, 3, 4)
+    False
+    >>> eq_if_statement(1, 1, 2)
+    False
+    >>> eq_if_statement(1, "not an int", 2)
+    False
+    >>> eq_if_statement(2, 1, 1)
+    False
+    >>> eq_if_statement(1, 1, 1)
+    True
+    """
+    if 1 == a == b == c:
+        return True
+    else:
+        return False
+
+def eq_if_statement_semi_optimized(a, int b, int c):
+    """
+    Some but not all of the cascade ends up optimized
+    (probably not as much as should be). The test is mostly
+    that it keeps the types consistent throughout
+
+    >>> eq_if_statement_semi_optimized(1, 2, 3)
+    False
+    >>> eq_if_statement_semi_optimized(2, 3, 4)
+    False
+    >>> eq_if_statement_semi_optimized(1, 1, 2)
+    False
+    >>> eq_if_statement_semi_optimized("not an int", 1, 2)
+    False
+    >>> eq_if_statement_semi_optimized(2, 1, 1)
+    False
+    >>> eq_if_statement_semi_optimized(1, 1, 1)
+    True
+    """
+    if 1 == a == b == c == 1:
+        return True
+    else:
+        return False
+
+def eq_if_statement_semi_optimized2(a, b, c):
+    """
+    Here only "b==c" fails to optimize
+
+    >>> eq_if_statement_semi_optimized2(1, 2, 3)
+    False
+    >>> eq_if_statement_semi_optimized2(2, 3, 4)
+    False
+    >>> eq_if_statement_semi_optimized2(1, 1, 2)
+    False
+    >>> eq_if_statement_semi_optimized2(1, "not an int", 2)
+    False
+    >>> eq_if_statement_semi_optimized2(2, 1, 1)
+    False
+    >>> eq_if_statement_semi_optimized2(1, 1, 1)
+    True
+    """
+    if 1 == a == 1 == b == c:
+        return True
+    else:
+        return False


### PR DESCRIPTION
If a cascaded comparison is partially optimized (i.e. only some of the comparisons are optimized) then the result types must end up consistent all the way through. At the moment we select PyObject which probably isn't the most efficient option, but is the easiest to implement.

Fixes #5354