### PR TITLE
FIX: compilation of scipy, and pyzmq with py3.12.0a7+

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -141,7 +141,7 @@ static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject*);
   #define __Pyx_PyLong_CompactValueUnsigned(x)  (__Pyx_PyLong_Digits(x)[0])
   #define __Pyx_PyLong_DigitCount(x)  (((PyLongObject*)x)->long_value.lv_tag >> 3)  // (>> NON_SIZE_BITS)
   #define __Pyx_PyLong_SignedDigitCount(x)  \
-        ((1 - ((PyLongObject*)x)->long_value.lv_tag & 3) * (((PyLongObject*)x)->long_value.lv_tag >> 3))  // (>> NON_SIZE_BITS)
+        ((1 - (((PyLongObject*)x)->long_value.lv_tag & 3)) * (((PyLongObject*)x)->long_value.lv_tag >> 3))  // (>> NON_SIZE_BITS)
   #else  // Py < 3.12
   #define __Pyx_PyLong_IsNeg(x)  (Py_SIZE(x) < 0)
   #define __Pyx_PyLong_IsNonNeg(x)  (Py_SIZE(x) >= 0)
@@ -1042,7 +1042,8 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
             } else {
                 const digit* digits = __Pyx_PyLong_Digits(x);
                 assert(__Pyx_PyLong_DigitCount(x) > 1);
-                switch (__Pyx_PyLong_SignedDigitCount(x)) {
+                const Py_ssize_t size = __Pyx_PyLong_SignedDigitCount(x);
+                switch (size) {
                     {{for _size in (2, 3, 4)}}
                     {{for _case in (-_size, _size)}}
                     case {{_case}}:


### PR DESCRIPTION
This is a follow on to #5353 which makes scipy and pyzmq compile.

The compiler warned about the lack of parentheses which caused the `-` to be applied before the `&`.

The second change ensures that the value passed to the switch is a Py_ssize_t not an unsigned value.


In both cases the errors looked like:

```
FAILED: scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/meson-generated__ufuncs_cxx.cpp.o 
ccache c++ -Iscipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p -Iscipy/special -I../../scipy/special -I../../scipy/_lib/boost_math/include -Iscipy/_lib -I../../scipy/_lib -I../../scipy/_build_utils/src -I../../../../../home/tcaswell/.virtualenvs/bleeding/lib/python3.12/site-packages/numpy/core/include -I/home/tcaswell/.pybuild/bleeding/include/python3.12 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++14 -O2 -fpermissive -fPIC -Wno-cpp -DBOOST_MATH_STANDALONE=1 -MD -MQ scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/meson-generated__ufuncs_cxx.cpp.o -MF scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/meson-generated__ufuncs_cxx.cpp.o.d -o scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/meson-generated__ufuncs_cxx.cpp.o -c scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp: In function ‘long int __Pyx_PyInt_As_long(PyObject*)’:
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:1212:13: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
 1212 |         ((1 - ((PyLongObject*)x)->long_value.lv_tag & 3) * (((PyLongObject*)x)->long_value.lv_tag >> 3))  // (>> NON_SIZE_BITS)
      |           ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6384:25: note: in expansion of macro ‘__Pyx_PyLong_SignedDigitCount’
 6384 |                 switch (__Pyx_PyLong_SignedDigitCount(x)) {
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6385:27: error: narrowing conversion of ‘-2’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6385 |                     case -2:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6403:27: error: narrowing conversion of ‘-3’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6403 |                     case -3:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6421:27: error: narrowing conversion of ‘-4’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6421 |                     case -4:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp: In function ‘int __Pyx_PyInt_As_int(PyObject*)’:
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:1212:13: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
 1212 |         ((1 - ((PyLongObject*)x)->long_value.lv_tag & 3) * (((PyLongObject*)x)->long_value.lv_tag >> 3))  // (>> NON_SIZE_BITS)
      |           ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6587:25: note: in expansion of macro ‘__Pyx_PyLong_SignedDigitCount’
 6587 |                 switch (__Pyx_PyLong_SignedDigitCount(x)) {
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6588:27: error: narrowing conversion of ‘-2’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6588 |                     case -2:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6606:27: error: narrowing conversion of ‘-3’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6606 |                     case -3:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:6624:27: error: narrowing conversion of ‘-4’ from ‘int’ to ‘long unsigned int’ [-Wnarrowing]
 6624 |                     case -4:
      |                           ^
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp: In function ‘Py_ssize_t __Pyx_PyIndex_AsSsize_t(PyObject*)’:
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:1212:13: warning: suggest parentheses around ‘-’ in operand of ‘&’ [-Wparentheses]
 1212 |         ((1 - ((PyLongObject*)x)->long_value.lv_tag & 3) * (((PyLongObject*)x)->long_value.lv_tag >> 3))  // (>> NON_SIZE_BITS)
      |           ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
scipy/special/_ufuncs_cxx.cpython-312-x86_64-linux-gnu.so.p/_ufuncs_cxx.cpp:7143:31: note: in expansion of macro ‘__Pyx_PyLong_SignedDigitCount’
 7143 |       const Py_ssize_t size = __Pyx_PyLong_SignedDigitCount(b);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

I am not sure I fully understand what I am changing here, but I think I did what the compiler suggested.