### PR TITLE
CmdLine: Fix regression when using the `--working` option.

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -215,7 +215,11 @@ def parse_command_line_raw(parser, args):
 def parse_command_line(args):
     parser = create_cython_argparser()
     arguments, sources = parse_command_line_raw(parser, args)
+
+    work_dir = getattr(arguments, 'working_path', '')
     for source in sources:
+        if work_dir and not os.path.isabs(source):
+            source = os.path.join(work_dir, source)
         if not os.path.exists(source):
             import errno
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), source)

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -20,7 +20,17 @@ unpatched_exists = os.path.exists
 
 def patched_exists(path):
     # avoid the Cython command raising a file not found error
-    if path in ('source.pyx', 'file.pyx', 'file1.pyx', 'file2.pyx', 'file3.pyx', 'foo.pyx', 'bar.pyx'):
+    if path in (
+        'source.pyx',
+        os.path.join('/work/dir', 'source.pyx'),
+        os.path.join('my_working_path', 'source.pyx'),
+        'file.pyx',
+        'file1.pyx',
+        'file2.pyx',
+        'file3.pyx',
+        'foo.pyx',
+        'bar.pyx',
+    ):
         return True
     return unpatched_exists(path)
 


### PR DESCRIPTION
Checking for the existence of source files must account for the user-specified working directory. 
If the source filename is not absolute,  prepend the working directory if specified, then perform the check.