### PR TITLE
Make memoryviews with aliased types comformable

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -871,7 +871,7 @@ class MemoryViewSliceType(PyrexType):
         if dst_dtype.is_cv_qualified:
             dst_dtype = dst_dtype.cv_base_type
 
-        if src_dtype != dst_dtype:
+        if not src_dtype.same_as(dst_dtype):
             return False
 
         if src.ndim != dst.ndim:

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -1241,6 +1241,7 @@ match arr:
 
     return isinstance(<object>a, Sequence)
 
+
 ctypedef int aliasT
 def test_assignment_typedef():
     """

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -1240,3 +1240,17 @@ match arr:
         assert globs['res']
 
     return isinstance(<object>a, Sequence)
+
+ctypedef int aliasT
+def test_assignment_typedef():
+    """
+    >>> test_assignment_typedef()
+    1
+    2
+    """
+    cdef int[2] x
+    cdef aliasT[:] y
+    x[:] = [1, 2]
+    y = x
+    for v in y:
+        print(v)


### PR DESCRIPTION
Tentative fix for https://github.com/cython/cython/issues/5373