### PR TITLE
Distinguish api import functions from cython versions

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3840,14 +3840,18 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             if not condition:
                 code.putln("")  # start in new line
             code.putln("#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x050B0000")
-            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
+                objstruct, Naming.cy_version, objstruct))
             code.putln("#elif CYTHON_COMPILING_IN_LIMITED_API")
-            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
+                objstruct, Naming.cy_version, objstruct))
             code.putln("#else")
-            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (sizeof_objstruct, sizeof_objstruct))
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
+                sizeof_objstruct, Naming.cy_version, sizeof_objstruct))
             code.putln("#endif")
         else:
-            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT(%s),' % (objstruct, objstruct))
+            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
+                objstruct, Naming.cy_version, objstruct))
 
         # check_size
         if type.check_size and type.check_size in ('error', 'warn', 'ignore'):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -420,13 +420,13 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 sig = entry.type.signature_string()
                 h_code.putln(
                     'if (__Pyx_ImportFunction_%s(module, %s, (void (**)(void))&%s, "%s") < 0) goto bad;'
-                    % (Naming.cy_version, entry.name.as_c_string_literal(), cname, sig))
+                    % (Naming.cyversion, entry.name.as_c_string_literal(), cname, sig))
             for entry in api_vars:
                 cname = env.mangle(Naming.varptr_prefix_api, entry.name)
                 sig = entry.type.empty_declaration_code()
                 h_code.putln(
                     'if (__Pyx_ImportVoidPtr_%s(module, %s, (void **)&%s, "%s") < 0) goto bad;'
-                    % (Naming.cy_version, entry.name.as_c_string_literal(), cname, sig))
+                    % (Naming.cyversion, entry.name.as_c_string_literal(), cname, sig))
             with ModuleImportGenerator(h_code, imported_modules={env.qualified_name: 'module'}) as import_generator:
                 for entry in api_extension_types:
                     self.generate_type_import_call(entry.type, h_code, import_generator, error_code="goto bad;")
@@ -3714,7 +3714,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 signature = entry.type.empty_declaration_code()
                 code.putln(
                     'if (__Pyx_ImportVoidPtr_%s(%s, "%s", (void **)&%s, "%s") < 0) %s' % (
-                        Naming.cy_version,
+                        Naming.cyversion,
                         temp, entry.name, cname, signature,
                         code.error_goto(self.pos)))
             code.put_decref_clear(temp, py_object_type)
@@ -3740,7 +3740,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             for entry in entries:
                 code.putln(
                     'if (__Pyx_ImportFunction_%s(%s, %s, (void (**)(void))&%s, "%s") < 0) %s' % (
-                        Naming.cy_version,
+                        Naming.cyversion,
                         temp,
                         entry.name.as_c_string_literal(),
                         entry.cname,
@@ -3820,7 +3820,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         module = import_generator.imported_module(module_name, error_code)
         code.put('%s = __Pyx_ImportType_%s(%s, %s,' % (
             type.typeptr_cname,
-            Naming.cy_version,
+            Naming.cyversion,
             module,
             module_name))
 
@@ -3841,17 +3841,17 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("")  # start in new line
             code.putln("#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x050B0000")
             code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
-                objstruct, Naming.cy_version, objstruct))
+                objstruct, Naming.cyversion, objstruct))
             code.putln("#elif CYTHON_COMPILING_IN_LIMITED_API")
             code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
-                objstruct, Naming.cy_version, objstruct))
+                objstruct, Naming.cyversion, objstruct))
             code.putln("#else")
             code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
-                sizeof_objstruct, Naming.cy_version, sizeof_objstruct))
+                sizeof_objstruct, Naming.cyversion, sizeof_objstruct))
             code.putln("#endif")
         else:
             code.put('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
-                objstruct, Naming.cy_version, objstruct))
+                objstruct, Naming.cyversion, objstruct))
 
         # check_size
         if type.check_size and type.check_size in ('error', 'warn', 'ignore'):
@@ -3862,7 +3862,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             raise RuntimeError("invalid value for check_size '%s' when compiling %s.%s" % (
                 type.check_size, module_name, type.name))
         code.put('__Pyx_ImportType_CheckSize_%s_%s);' % (
-            check_size.title(), Naming.cy_version))
+            check_size.title(), Naming.cyversion))
 
         code.putln(' if (!%s) %s' % (type.typeptr_cname, error_code))
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3850,7 +3850,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 sizeof_objstruct, Naming.cy_version, sizeof_objstruct))
             code.putln("#endif")
         else:
-            code.putln('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
+            code.put('sizeof(%s), __PYX_GET_STRUCT_ALIGNMENT_%s(%s),' % (
                 objstruct, Naming.cy_version, objstruct))
 
         # check_size
@@ -3861,7 +3861,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         else:
             raise RuntimeError("invalid value for check_size '%s' when compiling %s.%s" % (
                 type.check_size, module_name, type.name))
-        code.putln('__Pyx_ImportType_CheckSize_%s_%s);' % (
+        code.put('__Pyx_ImportType_CheckSize_%s_%s);' % (
             check_size.title(), Naming.cy_version))
 
         code.putln(' if (!%s) %s' % (type.typeptr_cname, error_code))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -403,7 +403,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     cname = env.mangle(Naming.varptr_prefix_api, entry.name)
                     h_code.putln("static %s = 0;" % type.declaration_code(cname))
                     h_code.putln("#define %s (*%s)" % (entry.name, cname))
-            h_code.put(UtilityCode.load_as_string("PyIdentifierFromString", "ImportExport.c")[0])
             if api_vars:
                 h_code.put(UtilityCode.load_as_string("VoidPtrImport", "ImportExport.c")[1])
             if api_funcs:
@@ -420,14 +419,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 cname = env.mangle(Naming.func_prefix_api, entry.name)
                 sig = entry.type.signature_string()
                 h_code.putln(
-                    'if (__Pyx_ImportFunction(module, %s, (void (**)(void))&%s, "%s") < 0) goto bad;'
-                    % (entry.name.as_c_string_literal(), cname, sig))
+                    'if (__Pyx_ImportFunction_%s(module, %s, (void (**)(void))&%s, "%s") < 0) goto bad;'
+                    % (Naming.cy_version, entry.name.as_c_string_literal(), cname, sig))
             for entry in api_vars:
                 cname = env.mangle(Naming.varptr_prefix_api, entry.name)
                 sig = entry.type.empty_declaration_code()
                 h_code.putln(
-                    'if (__Pyx_ImportVoidPtr(module, %s, (void **)&%s, "%s") < 0) goto bad;'
-                    % (entry.name.as_c_string_literal(), cname, sig))
+                    'if (__Pyx_ImportVoidPtr_%s(module, %s, (void **)&%s, "%s") < 0) goto bad;'
+                    % (Naming.cy_version, entry.name.as_c_string_literal(), cname, sig))
             with ModuleImportGenerator(h_code, imported_modules={env.qualified_name: 'module'}) as import_generator:
                 for entry in api_extension_types:
                     self.generate_type_import_call(entry.type, h_code, import_generator, error_code="goto bad;")
@@ -3714,7 +3713,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     cname = module.mangle(Naming.varptr_prefix, entry.name)
                 signature = entry.type.empty_declaration_code()
                 code.putln(
-                    'if (__Pyx_ImportVoidPtr(%s, "%s", (void **)&%s, "%s") < 0) %s' % (
+                    'if (__Pyx_ImportVoidPtr_%s(%s, "%s", (void **)&%s, "%s") < 0) %s' % (
+                        Naming.cy_version,
                         temp, entry.name, cname, signature,
                         code.error_goto(self.pos)))
             code.put_decref_clear(temp, py_object_type)
@@ -3739,7 +3739,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.put_gotref(temp, py_object_type)
             for entry in entries:
                 code.putln(
-                    'if (__Pyx_ImportFunction(%s, %s, (void (**)(void))&%s, "%s") < 0) %s' % (
+                    'if (__Pyx_ImportFunction_%s(%s, %s, (void (**)(void))&%s, "%s") < 0) %s' % (
+                        Naming.cy_version,
                         temp,
                         entry.name.as_c_string_literal(),
                         entry.cname,
@@ -3817,8 +3818,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             error_code = code.error_goto(error_pos)
 
         module = import_generator.imported_module(module_name, error_code)
-        code.put('%s = __Pyx_ImportType(%s, %s,' % (
+        code.put('%s = __Pyx_ImportType_%s(%s, %s,' % (
             type.typeptr_cname,
+            Naming.cy_version,
             module,
             module_name))
 
@@ -3855,7 +3857,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         else:
             raise RuntimeError("invalid value for check_size '%s' when compiling %s.%s" % (
                 type.check_size, module_name, type.name))
-        code.putln('__Pyx_ImportType_CheckSize_%s);' % check_size.title())
+        code.putln('__Pyx_ImportType_CheckSize_%s_%s);' % (
+            check_size.title(), Naming.cy_version))
 
         code.putln(' if (!%s) %s' % (type.typeptr_cname, error_code))
 

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -8,7 +8,7 @@
 from .. import __version__
 
 pyrex_prefix    = "__pyx_"
-cy_version = __version__.replace('.', '_')
+cyversion = __version__.replace('.', '_')
 
 
 codewriter_temp_prefix = pyrex_prefix + "t_"

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -5,8 +5,10 @@
 #   Prefixes for generating C names.
 #   Collected here to facilitate ensuring uniqueness.
 #
+from .. import __version__
 
 pyrex_prefix    = "__pyx_"
+cy_version = __version__.replace('.', '_')
 
 
 codewriter_temp_prefix = pyrex_prefix + "t_"

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -512,37 +512,37 @@ set_path:
 /////////////// TypeImport.proto ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportType_proto_$cy_version
-#define __PYX_HAVE_RT_ImportType_proto_$cy_version
+#ifndef __PYX_HAVE_RT_ImportType_proto_$cyversion
+#define __PYX_HAVE_RT_ImportType_proto_$cyversion
 
 #if __STDC_VERSION__ >= 201112L
 #include <stdalign.h>
 #endif
 
 #if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L
-#define __PYX_GET_STRUCT_ALIGNMENT_$cy_version(s) alignof(s)
+#define __PYX_GET_STRUCT_ALIGNMENT_$cyversion(s) alignof(s)
 #else
 // best guess at what the alignment could be since we can't measure it
-#define __PYX_GET_STRUCT_ALIGNMENT_$cy_version(s) sizeof(void*)
+#define __PYX_GET_STRUCT_ALIGNMENT_$cyversion(s) sizeof(void*)
 #endif
 
-enum __Pyx_ImportType_CheckSize_$cy_version {
-   __Pyx_ImportType_CheckSize_Error_$cy_version = 0,
-   __Pyx_ImportType_CheckSize_Warn_$cy_version = 1,
-   __Pyx_ImportType_CheckSize_Ignore_$cy_version = 2
+enum __Pyx_ImportType_CheckSize_$cyversion {
+   __Pyx_ImportType_CheckSize_Error_$cyversion = 0,
+   __Pyx_ImportType_CheckSize_Warn_$cyversion = 1,
+   __Pyx_ImportType_CheckSize_Ignore_$cyversion = 2
 };
 
-static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject* module, const char *module_name, const char *class_name, size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cy_version check_size);  /*proto*/
+static PyTypeObject *__Pyx_ImportType_$cyversion(PyObject* module, const char *module_name, const char *class_name, size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cyversion check_size);  /*proto*/
 
 #endif
 
 /////////////// TypeImport ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportType_$cy_version
-#define __PYX_HAVE_RT_ImportType_$cy_version
-static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *module_name, const char *class_name,
-    size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cy_version check_size)
+#ifndef __PYX_HAVE_RT_ImportType_$cyversion
+#define __PYX_HAVE_RT_ImportType_$cyversion
+static PyTypeObject *__Pyx_ImportType_$cyversion(PyObject *module, const char *module_name, const char *class_name,
+    size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cyversion check_size)
 {
     PyObject *result = 0;
     char warning[200];
@@ -604,7 +604,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
     }
     // varobjects almost have structs  between basicsize and basicsize + itemsize
     // but the struct isn't always one of the two limiting values
-    if (check_size == __Pyx_ImportType_CheckSize_Error_$cy_version &&
+    if (check_size == __Pyx_ImportType_CheckSize_Error_$cyversion &&
             ((size_t)basicsize > size || (size_t)(basicsize + itemsize) < size)) {
         PyErr_Format(PyExc_ValueError,
             "%.200s.%.200s size changed, may indicate binary incompatibility. "
@@ -612,7 +612,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
             module_name, class_name, size, basicsize, basicsize+itemsize);
         goto bad;
     }
-    else if (check_size == __Pyx_ImportType_CheckSize_Warn_$cy_version && (size_t)basicsize > size) {
+    else if (check_size == __Pyx_ImportType_CheckSize_Warn_$cyversion && (size_t)basicsize > size) {
         PyOS_snprintf(warning, sizeof(warning),
             "%s.%s size changed, may indicate binary incompatibility. "
             "Expected %zd from C header, got %zd from PyObject",
@@ -630,14 +630,14 @@ bad:
 /////////////// FunctionImport.proto ///////////////
 //@substitute: naming
 
-static int __Pyx_ImportFunction_$cy_version(PyObject *module, const char *funcname, void (**f)(void), const char *sig); /*proto*/
+static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcname, void (**f)(void), const char *sig); /*proto*/
 
 /////////////// FunctionImport ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportFunction_$cy_version
-#define __PYX_HAVE_RT_ImportFunction_$cy_version
-static int __Pyx_ImportFunction_$cy_version(PyObject *module, const char *funcname, void (**f)(void), const char *sig) {
+#ifndef __PYX_HAVE_RT_ImportFunction_$cyversion
+#define __PYX_HAVE_RT_ImportFunction_$cyversion
+static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcname, void (**f)(void), const char *sig) {
     PyObject *d = 0;
     PyObject *cobj = 0;
     union {
@@ -716,14 +716,14 @@ bad:
 /////////////// VoidPtrImport.proto ///////////////
 //@substitute: naming
 
-static int __Pyx_ImportVoidPtr_$cy_version(PyObject *module, const char *name, void **p, const char *sig); /*proto*/
+static int __Pyx_ImportVoidPtr_$cyversion(PyObject *module, const char *name, void **p, const char *sig); /*proto*/
 
 /////////////// VoidPtrImport ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportVoidPtr_$cy_version
-#define __PYX_HAVE_RT_ImportVoidPtr_$cy_version
-static int __Pyx_ImportVoidPtr_$cy_version(PyObject *module, const char *name, void **p, const char *sig) {
+#ifndef __PYX_HAVE_RT_ImportVoidPtr_$cyversion
+#define __PYX_HAVE_RT_ImportVoidPtr_$cyversion
+static int __Pyx_ImportVoidPtr_$cyversion(PyObject *module, const char *name, void **p, const char *sig) {
     PyObject *d = 0;
     PyObject *cobj = 0;
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -604,7 +604,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
     }
     // varobjects almost have structs  between basicsize and basicsize + itemsize
     // but the struct isn't always one of the two limiting values
-    if (check_size == __Pyx_ImportType_CheckSize_Error &&
+    if (check_size == __Pyx_ImportType_CheckSize_Error_%cy_version &&
             ((size_t)basicsize > size || (size_t)(basicsize + itemsize) < size)) {
         PyErr_Format(PyExc_ValueError,
             "%.200s.%.200s size changed, may indicate binary incompatibility. "
@@ -612,7 +612,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
             module_name, class_name, size, basicsize, basicsize+itemsize);
         goto bad;
     }
-    else if (check_size == __Pyx_ImportType_CheckSize_Warn && (size_t)basicsize > size) {
+    else if (check_size == __Pyx_ImportType_CheckSize_Warn_%cy_version && (size_t)basicsize > size) {
         PyOS_snprintf(warning, sizeof(warning),
             "%s.%s size changed, may indicate binary incompatibility. "
             "Expected %zd from C header, got %zd from PyObject",

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -1,14 +1,3 @@
-/////////////// PyIdentifierFromString.proto ///////////////
-
-#if !defined(__Pyx_PyIdentifier_FromString)
-#if PY_MAJOR_VERSION < 3
-  #define __Pyx_PyIdentifier_FromString(s) PyString_FromString(s)
-#else
-  #define __Pyx_PyIdentifier_FromString(s) PyUnicode_FromString(s)
-#endif
-#endif
-
-
 /////////////// ImportDottedModule.proto ///////////////
 
 static PyObject *__Pyx_ImportDottedModule(PyObject *name, PyObject *parts_tuple); /*proto*/
@@ -521,37 +510,39 @@ set_path:
 
 
 /////////////// TypeImport.proto ///////////////
+//@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportType_proto
-#define __PYX_HAVE_RT_ImportType_proto
+#ifndef __PYX_HAVE_RT_ImportType_proto_$cy_version
+#define __PYX_HAVE_RT_ImportType_proto_$cy_version
 
 #if __STDC_VERSION__ >= 201112L
 #include <stdalign.h>
 #endif
 
 #if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L
-#define __PYX_GET_STRUCT_ALIGNMENT(s) alignof(s)
+#define __PYX_GET_STRUCT_ALIGNMENT_$cy_version(s) alignof(s)
 #else
 // best guess at what the alignment could be since we can't measure it
-#define __PYX_GET_STRUCT_ALIGNMENT(s) sizeof(void*)
+#define __PYX_GET_STRUCT_ALIGNMENT_$cy_version(s) sizeof(void*)
 #endif
 
-enum __Pyx_ImportType_CheckSize {
-   __Pyx_ImportType_CheckSize_Error = 0,
-   __Pyx_ImportType_CheckSize_Warn = 1,
-   __Pyx_ImportType_CheckSize_Ignore = 2
+enum __Pyx_ImportType_CheckSize_$cy_version {
+   __Pyx_ImportType_CheckSize_Error_$cy_version = 0,
+   __Pyx_ImportType_CheckSize_Warn_$cy_version = 1,
+   __Pyx_ImportType_CheckSize_Ignore_$cy_version = 2
 };
 
-static PyTypeObject *__Pyx_ImportType(PyObject* module, const char *module_name, const char *class_name, size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize check_size);  /*proto*/
+static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject* module, const char *module_name, const char *class_name, size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cy_version check_size);  /*proto*/
 
 #endif
 
 /////////////// TypeImport ///////////////
+//@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportType
-#define __PYX_HAVE_RT_ImportType
-static PyTypeObject *__Pyx_ImportType(PyObject *module, const char *module_name, const char *class_name,
-    size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize check_size)
+#ifndef __PYX_HAVE_RT_ImportType_$cy_version
+#define __PYX_HAVE_RT_ImportType_$cy_version
+static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *module_name, const char *class_name,
+    size_t size, size_t alignment, enum __Pyx_ImportType_CheckSize_$cy_version check_size)
 {
     PyObject *result = 0;
     char warning[200];
@@ -637,15 +628,16 @@ bad:
 #endif
 
 /////////////// FunctionImport.proto ///////////////
+//@substitute: naming
 
-static int __Pyx_ImportFunction(PyObject *module, const char *funcname, void (**f)(void), const char *sig); /*proto*/
+static int __Pyx_ImportFunction_$cy_version(PyObject *module, const char *funcname, void (**f)(void), const char *sig); /*proto*/
 
 /////////////// FunctionImport ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportFunction
-#define __PYX_HAVE_RT_ImportFunction
-static int __Pyx_ImportFunction(PyObject *module, const char *funcname, void (**f)(void), const char *sig) {
+#ifndef __PYX_HAVE_RT_ImportFunction_$cy_version
+#define __PYX_HAVE_RT_ImportFunction_$cy_version
+static int __Pyx_ImportFunction_$cy_version(PyObject *module, const char *funcname, void (**f)(void), const char *sig) {
     PyObject *d = 0;
     PyObject *cobj = 0;
     union {
@@ -722,15 +714,16 @@ bad:
 }
 
 /////////////// VoidPtrImport.proto ///////////////
+//@substitute: naming
 
 static int __Pyx_ImportVoidPtr(PyObject *module, const char *name, void **p, const char *sig); /*proto*/
 
 /////////////// VoidPtrImport ///////////////
 //@substitute: naming
 
-#ifndef __PYX_HAVE_RT_ImportVoidPtr
-#define __PYX_HAVE_RT_ImportVoidPtr
-static int __Pyx_ImportVoidPtr(PyObject *module, const char *name, void **p, const char *sig) {
+#ifndef __PYX_HAVE_RT_ImportVoidPtr_$cy_version
+#define __PYX_HAVE_RT_ImportVoidPtr_$cy_version
+static int __Pyx_ImportVoidPtr_$cy_version(PyObject *module, const char *name, void **p, const char *sig) {
     PyObject *d = 0;
     PyObject *cobj = 0;
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -604,7 +604,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
     }
     // varobjects almost have structs  between basicsize and basicsize + itemsize
     // but the struct isn't always one of the two limiting values
-    if (check_size == __Pyx_ImportType_CheckSize_Error_%cy_version &&
+    if (check_size == __Pyx_ImportType_CheckSize_Error_$cy_version &&
             ((size_t)basicsize > size || (size_t)(basicsize + itemsize) < size)) {
         PyErr_Format(PyExc_ValueError,
             "%.200s.%.200s size changed, may indicate binary incompatibility. "
@@ -612,7 +612,7 @@ static PyTypeObject *__Pyx_ImportType_$cy_version(PyObject *module, const char *
             module_name, class_name, size, basicsize, basicsize+itemsize);
         goto bad;
     }
-    else if (check_size == __Pyx_ImportType_CheckSize_Warn_%cy_version && (size_t)basicsize > size) {
+    else if (check_size == __Pyx_ImportType_CheckSize_Warn_$cy_version && (size_t)basicsize > size) {
         PyOS_snprintf(warning, sizeof(warning),
             "%s.%s size changed, may indicate binary incompatibility. "
             "Expected %zd from C header, got %zd from PyObject",
@@ -716,7 +716,7 @@ bad:
 /////////////// VoidPtrImport.proto ///////////////
 //@substitute: naming
 
-static int __Pyx_ImportVoidPtr(PyObject *module, const char *name, void **p, const char *sig); /*proto*/
+static int __Pyx_ImportVoidPtr_$cy_version(PyObject *module, const char *name, void **p, const char *sig); /*proto*/
 
 /////////////// VoidPtrImport ///////////////
 //@substitute: naming


### PR DESCRIPTION
Fixes issue with changed signature for these functions between Cython releases (https://github.com/cython/cython/pull/5289#issuecomment-1509371606)