### PR TITLE
Fix regression in code generation order for cdef classes

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -651,7 +651,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 dfs(type_dict[v])
             result.append(u)
 
-        for key in type_order:
+        for key in reversed(type_order):
             dfs(type_dict[key])
 
         result.reverse()

--- a/tests/run/cdef_class_order.pyx
+++ b/tests/run/cdef_class_order.pyx
@@ -5,11 +5,33 @@ cdef class B
 cdef class A(object):
     cdef list dealloc1
 
+cdef class Y(X): pass
+cdef class X(C): pass
+cdef class C: pass
+
 cdef class B(A):
     cdef list dealloc2
+
+cdef class Z(A): pass
+
 
 def test():
     """
     >>> test()
+    A
+    B
+    C
+    X
+    Y
+    Z
     """
-    A(), B()
+    A(), B(), C(), X(), Y(), Z()
+    import sys
+    py_version = sys.version_info[:2]
+    if py_version >= (3, 7): # built-in dict is insertion-ordered
+        global_values = list(globals().values())
+    else:
+        global_values = [A, B, C, X, Y, Z]
+    for value in global_values:
+        if isinstance(value, type):
+            print(value.__name__)


### PR DESCRIPTION
Minor regression introduced in commit 1acc5b1634d34c2f26b4921068ac68372a9226d7 by @swolchok.

With this fix, cdef classes in mpi4py are emitted in the same order as Cython 0.29.x, classes are already ordered by inheritance int the source code, and IMHO that order should be preserved.

I've extended one of the tests to ensure that cdef classes are emitted in the order they appear in the Cython sources.
WITHOUT this fix, the added test would fail the following way:

```
Failed example:
    test()
Expected:
    A
    B
    C
    X
    Y
    Z
Got:
    C
    X
    Y
    A
    Z
    B
```
