### PR TITLE
Fix to-py conversion with duplicate enum values

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1728,7 +1728,7 @@ class CEnumDefNode(StatNode):
                 item.analyse_enum_declarations(scope, self.entry, next_int_enum_value)
                 if is_declared_enum:
                     next_int_enum_value = (
-                        item.entry.equivalent_enum_value or next_int_enum_value) + 1
+                        item.entry.enum_int_value or next_int_enum_value) + 1
 
     def analyse_expressions(self, env):
         return self
@@ -1761,7 +1761,7 @@ class CEnumDefItemNode(StatNode):
 
     child_attrs = ["value"]
 
-    def analyse_enum_declarations(self, env, enum_entry, incremental_enum_value):
+    def analyse_enum_declarations(self, env, enum_entry, incremental_int_value):
         if self.value:
             self.value = self.value.analyse_const_expression(env)
             if not self.value.type.is_int:
@@ -1780,17 +1780,17 @@ class CEnumDefItemNode(StatNode):
             create_wrapper=enum_entry.create_wrapper and enum_entry.name is None)
 
         # Use the incremental integer value unless we see an explicitly declared value.
-        enum_value = incremental_enum_value
+        enum_value = incremental_int_value
         if self.value:
             if self.value.is_literal:
                 enum_value = int(self.value.value)
             elif (self.value.is_name or self.value.is_attribute) and self.value.entry:
-                enum_value = self.value.entry.equivalent_enum_value
+                enum_value = self.value.entry.enum_int_value
             else:
                 # There is a value but we don't understand its integer value.
                 enum_value = None
         if enum_value is not None:
-            entry.equivalent_enum_value = enum_value
+            entry.enum_int_value = enum_value
 
         enum_entry.enum_values.append(entry)
         if enum_entry.name:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1722,7 +1722,7 @@ class CEnumDefNode(StatNode):
             # we can't see them.
             last_enum_value = 0 if self.visibility != 'extern' else None
             for item in self.items:
-                item.analyse_declarations(scope, self.entry, last_enum_value)
+                item.analyse_enum_declarations(scope, self.entry, last_enum_value)
                 value_entry = item.entry
                 last_enum_value = value_entry.equivalent_enum_value if self.visibility != 'extern' else None
                 if last_enum_value:
@@ -1759,7 +1759,7 @@ class CEnumDefItemNode(StatNode):
 
     child_attrs = ["value"]
 
-    def analyse_declarations(self, env, enum_entry, incremental_enum_value):
+    def analyse_enum_declarations(self, env, enum_entry, incremental_enum_value):
         if self.value:
             self.value = self.value.analyse_const_expression(env)
             if not self.value.type.is_int:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1727,8 +1727,8 @@ class CEnumDefNode(StatNode):
             for item in self.items:
                 item.analyse_enum_declarations(scope, self.entry, next_int_enum_value)
                 if is_declared_enum:
-                    next_int_enum_value = (
-                        item.entry.enum_int_value or next_int_enum_value) + 1
+                    next_int_enum_value = 1 + (
+                        item.entry.enum_int_value if item.entry.enum_int_value is not None else next_int_enum_value)
 
     def analyse_expressions(self, env):
         return self

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1723,7 +1723,7 @@ class CEnumDefNode(StatNode):
             last_enum_value = 0 if self.visibility != 'extern' else None
             for item in self.items:
                 value_entry = item.analyse_declarations(scope, self.entry, last_enum_value)
-                last_enum_value = value_entry.equivalent_enum_value
+                last_enum_value = value_entry.equivalent_enum_value if self.visibility != 'extern' else None
                 if last_enum_value:
                     last_enum_value += 1
 

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1257,8 +1257,8 @@ class SwitchTransform(Visitor.EnvTransform):
                 try:
                     value_entry = value.entry
                     if ((value_entry.type.is_enum or value_entry.type.is_cpp_enum)
-                            and value_entry.equivalent_enum_value is not None):
-                        value_for_seen = value_entry.equivalent_enum_value
+                            and value_entry.enum_int_value is not None):
+                        value_for_seen = value_entry.enum_int_value
                     else:
                         value_for_seen = value_entry.cname
                 except AttributeError:

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1256,7 +1256,7 @@ class SwitchTransform(Visitor.EnvTransform):
                 # final C value, but this is about the best we can do
                 try:
                     value_entry = value.entry
-                    if (value_entry.type.is_enum or value_entry.type.is_cpp_enum
+                    if ((value_entry.type.is_enum or value_entry.type.is_cpp_enum)
                             and value_entry.equivalent_enum_value is not None):
                         value_for_seen = value_entry.equivalent_enum_value
                     else:

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1255,11 +1255,17 @@ class SwitchTransform(Visitor.EnvTransform):
                 # this isn't completely safe as we don't know the
                 # final C value, but this is about the best we can do
                 try:
-                    if value.entry.cname in seen:
-                        return True
+                    value_entry = value.entry
+                    if (value_entry.type.is_enum or value_entry.type.is_cpp_enum
+                            and value_entry.equivalent_enum_value is not None):
+                        value_for_seen = value_entry.equivalent_enum_value
+                    else:
+                        value_for_seen = value_entry.cname
                 except AttributeError:
                     return True  # play safe
-                seen.add(value.entry.cname)
+                if value_for_seen in seen:
+                    return True
+                seen.add(value_for_seen)
         return False
 
     def visit_IfStatNode(self, node):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4219,7 +4219,7 @@ class CppClassType(CType):
     def cpp_optional_check_for_null_code(self, cname):
         # only applies to c++ classes that are being declared as std::optional
         return "(%s.has_value())" % cname
-    
+
 
 class EnumMixin(object):
     """

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4226,7 +4226,7 @@ class EnumMixin(object):
     Common implementation details for C and C++ enums.
     """
 
-    def create_to_py_utility_code_implementation(self, env):
+    def create_enum_to_py_utility_code(self, env):
         from .UtilityCode import CythonUtilityCode
         self.to_py_function = "__Pyx_Enum_%s_to_py" % self.name
         if self.entry.scope != env.global_scope():
@@ -4309,7 +4309,7 @@ class CppScopedEnumType(CType, EnumMixin):
         if self.to_py_function is not None:
             return True
         if self.entry.create_wrapper:
-            self.create_to_py_utility_code_implementation(env)
+            self.create_enum_to_py_utility_code(env)
             return True
         if self.underlying_type.create_to_py_utility_code(env):
             # Using a C++11 lambda here, which is fine since
@@ -4459,7 +4459,7 @@ class CEnumType(CIntLike, CType, EnumMixin):
             return self.to_py_function
         if not self.entry.create_wrapper:
             return super(CEnumType, self).create_to_py_utility_code(env)
-        self.create_to_py_utility_code_implementation(env)
+        self.create_enum_to_py_utility_code(env)
         return True
 
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4236,7 +4236,7 @@ class EnumMixin(object):
 
         directives = CythonUtilityCode.filter_inherited_directives(
             env.global_scope().directives)
-        if any(value_entry.equivalent_enum_value is None for value_entry in self.entry.enum_values):
+        if any(value_entry.enum_int_value is None for value_entry in self.entry.enum_values):
             # We're at a high risk of making a switch statement with equal values in
             # (because we simply can't tell, and enums are often used like that).
             # So turn off the switch optimization to be safe.

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -165,7 +165,7 @@ class Entry(object):
     #                             or a string of "modulename.something.attribute"
     #                             Used for identifying imports from typing/dataclasses etc
     # pytyping_modifiers          Python type modifiers like "typing.ClassVar" but also "dataclasses.InitVar"
-    # equivalent_enum_value  None or int  If known, the int that corresponds to this enum value
+    # enum_int_value  None or int  If known, the int that corresponds to this enum value
 
     # TODO: utility_code and utility_code_definition serves the same purpose...
 
@@ -241,7 +241,7 @@ class Entry(object):
     is_cpp_optional = False
     known_standard_library_import = None
     pytyping_modifiers = None
-    equivalent_enum_value = None
+    enum_int_value = None
 
     def __init__(self, name, cname, type, pos = None, init = None):
         self.name = name

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -165,6 +165,7 @@ class Entry(object):
     #                             or a string of "modulename.something.attribute"
     #                             Used for identifying imports from typing/dataclasses etc
     # pytyping_modifiers          Python type modifiers like "typing.ClassVar" but also "dataclasses.InitVar"
+    # equivalent_enum_value  None or int  If known, the int that corresponds to this enum value
 
     # TODO: utility_code and utility_code_definition serves the same purpose...
 
@@ -240,6 +241,7 @@ class Entry(object):
     is_cpp_optional = False
     known_standard_library_import = None
     pytyping_modifiers = None
+    equivalent_enum_value = None
 
     def __init__(self, name, cname, type, pos = None, init = None):
         self.name = name

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -89,6 +89,30 @@ cdef enum cdefPyxDocEnum:
     """
     FIVE_AND_SEVEN = 5077
 
+cdef extern from *:
+    """
+    enum ExternHasDuplicates {
+        EX_DUP_A,
+        EX_DUP_B=EX_DUP_A,
+        EX_DUP_C=EX_DUP_A
+    };
+    """
+    # Cython doesn't know about the duplicates though
+    cpdef enum ExternHasDuplicates:
+        EX_DUP_A
+        EX_DUP_B
+        EX_DUP_C
+
+
+cpdef enum CyDefinedHasDuplicates1:
+    CY_DUP1_A
+    CY_DUP1_B = 0
+
+
+cpdef enum CyDefinedHasDuplicates2:
+    CY_DUP2_A
+    CY_DUP2_B = CY_DUP2_A
+
 
 def test_as_variable_from_cython():
     """
@@ -141,6 +165,33 @@ def to_from_py_conversion(PxdEnum val):
     C enums are commonly enough used as flags that it seems reasonable
     to allow it in Cython
     >>> to_from_py_conversion(RANK_1 | RANK_2) == (RANK_1 | RANK_2)
+    True
+    """
+    return val
+
+
+def to_from_py_conversion_with_duplicates1(ExternHasDuplicates val):
+    """
+    Mainly a compile-time test - we can't optimize to a switch here
+    >>> to_from_py_conversion_with_duplicates1(EX_DUP_A) == ExternHasDuplicates.EX_DUP_A
+    True
+    """
+    return val
+
+
+def to_from_py_conversion_with_duplicates2(CyDefinedHasDuplicates1 val):
+    """
+    Mainly a compile-time test - we can't optimize to a switch here
+    >>> to_from_py_conversion_with_duplicates2(CY_DUP1_A) == CyDefinedHasDuplicates1.CY_DUP1_A
+    True
+    """
+    return val
+
+
+def to_from_py_conversion_with_duplicates2(CyDefinedHasDuplicates2 val):
+    """
+    Mainly a compile-time test - we can't optimize to a switch here
+    >>> to_from_py_conversion_with_duplicates2(CY_DUP2_A) == CyDefinedHasDuplicates2.CY_DUP2_A
     True
     """
     return val

--- a/tests/run/cpdef_enums.pyx
+++ b/tests/run/cpdef_enums.pyx
@@ -113,6 +113,11 @@ cpdef enum CyDefinedHasDuplicates2:
     CY_DUP2_A
     CY_DUP2_B = CY_DUP2_A
 
+cpdef enum CyDefinedHasDuplicates3:
+    CY_DUP3_A = 1
+    CY_DUP3_B = 0
+    CY_DUP3_C  # = 1
+
 
 def test_as_variable_from_cython():
     """
@@ -192,6 +197,15 @@ def to_from_py_conversion_with_duplicates2(CyDefinedHasDuplicates2 val):
     """
     Mainly a compile-time test - we can't optimize to a switch here
     >>> to_from_py_conversion_with_duplicates2(CY_DUP2_A) == CyDefinedHasDuplicates2.CY_DUP2_A
+    True
+    """
+    return val
+
+
+def to_from_py_conversion_with_duplicates3(CyDefinedHasDuplicates3 val):
+    """
+    Mainly a compile-time test - we can't optimize to a switch here
+    >>> to_from_py_conversion_with_duplicates3(CY_DUP3_C) == CyDefinedHasDuplicates3.CY_DUP3_C
     True
     """
     return val


### PR DESCRIPTION
1. Where possible, track the equivalent integer value for an enum type as they're defined.
2. Use this to determine if the switch optimization can be used (if present)
3. If not present, disable the switch optimization for enum to py-enum conversion, since it's duplicates are pretty likely in this case.

Fixes #5400