### PR TITLE
Enhancements to autodoc/embedsignature

### DIFF
--- a/Cython/Compiler/AutoDocTransforms.py
+++ b/Cython/Compiler/AutoDocTransforms.py
@@ -66,28 +66,47 @@ class EmbedSignature(CythonTransform):
         # print(type(node).__name__, '-->', result)
         return result
 
-    def _fmt_arg(self, arg):
-        if arg.type is PyrexTypes.py_object_type or arg.is_self_arg:
-            doc = arg.name
-        else:
-            doc = arg.type.declaration_code(arg.name, for_display=1)
+    def _setup_format(self):
+        signature_format = self.current_directives['embedsignature.format']
+        self.is_format_c = signature_format == 'c'
+        self.is_format_python = signature_format == 'python'
+        self.is_format_clinic = signature_format == 'clinic'
 
+    def _fmt_arg(self, arg):
+        arg_doc = arg.name
+        annotation = None
+        defaultval = None
+        if arg.is_self_arg:
+            if self.is_format_clinic:
+                arg_doc = '$self'
+        elif arg.is_type_arg:
+            if self.is_format_clinic:
+                arg_doc = '$type'
+        elif self.is_format_c:
+            if arg.type is not PyrexTypes.py_object_type:
+                arg_doc = arg.type.declaration_code(arg.name, for_display=1)
+        elif self.is_format_python:
+            if not arg.annotation:
+                annotation = self._fmt_type(arg.type)
         if arg.annotation:
-            annotation = self._fmt_annotation(arg.annotation)
-            doc = doc + (': %s' % annotation)
-            if arg.default:
-                default = self._fmt_expr(arg.default)
-                doc = doc + (' = %s' % default)
-        elif arg.default:
-            default = self._fmt_expr(arg.default)
-            doc = doc + ('=%s' % default)
-        return doc
+            if not self.is_format_clinic:
+                annotation = self._fmt_annotation(arg.annotation)
+        if arg.default:
+            defaultval = self._fmt_expr(arg.default)
+        if annotation:
+            arg_doc = arg_doc + (': %s' % annotation)
+            if defaultval:
+                arg_doc = arg_doc + (' = %s' % defaultval)
+        elif defaultval:
+            arg_doc = arg_doc + ('=%s' % defaultval)
+        return arg_doc
 
     def _fmt_star_arg(self, arg):
         arg_doc = arg.name
         if arg.annotation:
-            annotation = self._fmt_annotation(arg.annotation)
-            arg_doc = arg_doc + (': %s' % annotation)
+            if not self.is_format_clinic:
+                annotation = self._fmt_annotation(arg.annotation)
+                arg_doc = arg_doc + (': %s' % annotation)
         return arg_doc
 
     def _fmt_arglist(self, args,
@@ -111,39 +130,62 @@ class EmbedSignature(CythonTransform):
             arglist.append('**%s' % arg_doc)
         return arglist
 
-    def _fmt_ret_type(self, ret):
-        if ret is PyrexTypes.py_object_type:
+    def _fmt_type(self, type):
+        if type is PyrexTypes.py_object_type:
             return None
-        else:
-            return ret.declaration_code("", for_display=1)
+        elif self.is_format_c:
+            code = type.declaration_code("", for_display=1)
+            return code
+        elif self.is_format_python:
+            annotation = None
+            if type.is_string:
+                annotation = self.current_directives['c_string_type']
+            elif type.is_numeric:
+                annotation = type.py_type_name()
+            if annotation is None:
+                code = type.declaration_code('', for_display=1)
+                annotation = code.replace(' ', '_').replace('*', 'p')
+            return annotation
+        return None
 
     def _fmt_signature(self, cls_name, func_name, args,
                        npoargs=0, npargs=0, pargs=None,
                        nkargs=0, kargs=None,
-                       return_expr=None,
-                       return_type=None, hide_self=False):
-        arglist = self._fmt_arglist(args,
-                                    npoargs, npargs, pargs,
-                                    nkargs, kargs,
-                                    hide_self=hide_self)
+                       return_expr=None, return_type=None,
+                       hide_self=False):
+        arglist = self._fmt_arglist(
+            args, npoargs, npargs, pargs, nkargs, kargs,
+            hide_self=hide_self,
+        )
         arglist_doc = ', '.join(arglist)
         func_doc = '%s(%s)' % (func_name, arglist_doc)
-        if cls_name:
+        if self.is_format_c and cls_name:
             func_doc = '%s.%s' % (cls_name, func_doc)
-        ret_doc = None
-        if return_expr:
-            ret_doc = self._fmt_annotation(return_expr)
-        elif return_type:
-            ret_doc = self._fmt_ret_type(return_type)
-        if ret_doc:
-            func_doc = '%s -> %s' % (func_doc, ret_doc)
+        if not self.is_format_clinic:
+            ret_doc = None
+            if return_expr:
+                ret_doc = self._fmt_annotation(return_expr)
+            elif return_type:
+                ret_doc = self._fmt_type(return_type)
+            if ret_doc:
+                func_doc = '%s -> %s' % (func_doc, ret_doc)
         return func_doc
 
     def _embed_signature(self, signature, node_doc):
+        if self.is_format_clinic and self.current_directives['binding']:
+            return node_doc
         if node_doc:
-            return "%s\n%s" % (signature, node_doc)
+            if self.is_format_clinic:
+                docfmt = "%s\n--\n\n%s"
+            else:
+                docfmt = "%s\n%s"
+            return docfmt % (signature, node_doc)
         else:
-            return signature
+            if self.is_format_clinic:
+                docfmt = "%s\n--\n\n"
+            else:
+                docfmt = "%s"
+            return docfmt % signature
 
     def __call__(self, node):
         if not Options.docstrings:
@@ -173,6 +215,7 @@ class EmbedSignature(CythonTransform):
     def visit_DefNode(self, node):
         if not self.current_directives['embedsignature']:
             return node
+        self._setup_format()
 
         is_constructor = False
         hide_self = False
@@ -180,8 +223,11 @@ class EmbedSignature(CythonTransform):
             is_constructor = self.class_node and node.name == '__init__'
             if not is_constructor:
                 return node
-            class_name, func_name = None, self.class_name
-            hide_self = True
+            class_name = None
+            func_name = node.name
+            if self.is_format_c:
+                func_name = self.class_name
+                hide_self = True
         else:
             class_name, func_name = self.class_name, node.name
 
@@ -195,11 +241,10 @@ class EmbedSignature(CythonTransform):
             return_expr=node.return_type_annotation,
             return_type=None, hide_self=hide_self)
         if signature:
-            if is_constructor:
+            if is_constructor and self.is_format_c:
                 doc_holder = self.class_node.entry.type.scope
             else:
                 doc_holder = node.entry
-
             if doc_holder.doc is not None:
                 old_doc = doc_holder.doc
             elif not is_constructor and getattr(node, 'py_func', None) is not None:
@@ -213,10 +258,11 @@ class EmbedSignature(CythonTransform):
         return node
 
     def visit_CFuncDefNode(self, node):
-        if not self.current_directives['embedsignature']:
-            return node
         if not node.overridable:  # not cpdef FOO(...):
             return node
+        if not self.current_directives['embedsignature']:
+            return node
+        self._setup_format()
 
         signature = self._fmt_signature(
             self.class_name, node.declarator.base.name,
@@ -239,16 +285,34 @@ class EmbedSignature(CythonTransform):
     def visit_PropertyNode(self, node):
         if not self.current_directives['embedsignature']:
             return node
+        self._setup_format()
 
         entry = node.entry
+        body = node.body
+        prop_name = entry.name
+        type_name = None
         if entry.visibility == 'public':
-            # property synthesised from a cdef public attribute
-            type_name = entry.type.declaration_code("", for_display=1)
-            if not entry.type.is_pyobject:
-                type_name = "'%s'" % type_name
-            elif entry.type.is_extension_type:
-                type_name = entry.type.module_name + '.' + type_name
-            signature = '%s: %s' % (entry.name, type_name)
+            if self.is_format_c:
+                # property synthesised from a cdef public attribute
+                type_name = entry.type.declaration_code("", for_display=1)
+                if not entry.type.is_pyobject:
+                    type_name = "'%s'" % type_name
+                elif entry.type.is_extension_type:
+                    type_name = entry.type.module_name + '.' + type_name
+            elif self.is_format_python:
+                type_name = self._fmt_type(entry.type)
+        if type_name is None:
+            for stat in body.stats:
+                if stat.name != '__get__':
+                    continue
+                if self.is_format_c:
+                    prop_name = '%s.%s' % (self.class_name, prop_name)
+                ret_annotation = stat.return_type_annotation
+                if ret_annotation:
+                    type_name = self._fmt_annotation(ret_annotation)
+        if type_name is not None :
+            signature = '%s: %s' % (prop_name, type_name)
             new_doc = self._embed_signature(signature, entry.doc)
-            entry.doc = EncodedString(new_doc)
+            if not self.is_format_clinic:
+                entry.doc = EncodedString(new_doc)
         return node

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -293,8 +293,12 @@ class FusedCFuncDefNode(StatListNode):
         """
         for specialized_type in normal_types:
             # all_numeric = all_numeric and specialized_type.is_numeric
+            py_type_name = specialized_type.py_type_name()
+            if py_type_name == 'int':
+                # Support Python 2 long
+                py_type_name = '(int, long)'
             pyx_code.context.update(
-                py_type_name=specialized_type.py_type_name(),
+                py_type_name=py_type_name,
                 specialized_type_name=specialized_type.specialization_string,
             )
             pyx_code.put_chunk(

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -182,7 +182,8 @@ _directive_defaults = {
     'boundscheck' : True,
     'nonecheck' : False,
     'initializedcheck' : True,
-    'embedsignature' : False,
+    'embedsignature': False,
+    'embedsignature.format': 'c',
     'auto_cpdef': False,
     'auto_pickle': None,
     'cdivision': False,  # was True before 0.12
@@ -344,6 +345,7 @@ directive_types = {
     'total_ordering': None,
     'dataclasses.dataclass': DEFER_ANALYSIS_OF_ARGUMENTS,
     'dataclasses.field': DEFER_ANALYSIS_OF_ARGUMENTS,
+    'embedsignature.format': one_of('c', 'clinic', 'python'),
 }
 
 for key, val in _directive_defaults.items():

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2006,7 +2006,7 @@ class CNumericType(CType):
 
     def py_type_name(self):
         if self.rank <= 4:
-            return "(int, long)"
+            return "int"
         return "float"
 
 

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -119,7 +119,8 @@ exceptval = lambda _=None, check=True: _EmptyDecoratorAndManager()
 overflowcheck = lambda _: _EmptyDecoratorAndManager()
 optimize = _Optimization()
 
-overflowcheck.fold = optimize.use_switch = \
+
+embedsignature.format = overflowcheck.fold = optimize.use_switch = \
     optimize.unpack_method_calls = lambda arg: _EmptyDecoratorAndManager()
 
 final = internal = type_version_tag = no_gc_clear = no_gc = total_ordering = _empty_decorator

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -865,12 +865,12 @@ Cython code.  Here is the list of currently supported directives:
     type).  The specific output and type mapping are experimental and
     may change over time.
     The ``clinic`` format generates signatures that are compatible
-    with those used with the CPython's Argument Clinic tool. The
+    with those understood by CPython's Argument Clinic tool. The
     CPython runtime strips these signatures from docstrings and
     translates them into a ``__text_signature__`` attribute. This is
     mainly useful when using ``binding=False``, since the Cython
-    functions generated with ``binding=True`` do not have a
-    ``__text_signature__`` attribute.
+    functions generated with ``binding=True`` do not have (nor need)
+    a ``__text_signature__`` attribute.
     Default is ``c``.
 
 ``cdivision`` (True / False)

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -854,6 +854,25 @@ Cython code.  Here is the list of currently supported directives:
     signature, which cannot otherwise be retrieved after
     compilation.  Default is False.
 
+``embedsignature.format`` (``c`` / ``python`` / ``clinic``)
+    If set to ``c``, Cython will generate signatures preserving
+    C type declarations and Python type annotations.
+    If set to ``python``, Cython will do a best attempt to use
+    pure-Python type annotations in embedded signatures. For arguments
+    without Python type annotations, the C type is mapped to the
+    closest Python type equivalent (e.g., C ``short`` is mapped to
+    Python ``int`` type and C ``double`` is mapped to Python ``float``
+    type).  The specific output and type mapping are experimental and
+    may change over time.
+    The ``clinic`` format generates signatures that are compatible
+    with those used with the CPython's Argument Clinic tool. The
+    CPython runtime strips these signatures from docstrings and
+    translates them into a ``__text_signature__`` attribute. This is
+    mainly useful when using ``binding=False``, since the Cython
+    functions generated with ``binding=True`` do not have a
+    ``__text_signature__`` attribute.
+    Default is ``c``.
+
 ``cdivision`` (True / False)
     If set to False, Cython will adjust the remainder and quotient
     operators C types to match those of Python ints (which differ when

--- a/tests/run/embedsignatures.pyx
+++ b/tests/run/embedsignatures.pyx
@@ -84,7 +84,7 @@ __doc__ = ur"""
     Existing string
 
     >>> print (Ext.m.__doc__)
-    Ext.m(self, a=u'spam')
+    Ext.m(self, a=u'spam', b='foo', c=b'bar')
 
     >>> print (Ext.n.__doc__)
     Ext.n(self, a: int, b: float = 1.0, *args: tuple, **kwargs: dict) -> (None, True)
@@ -268,7 +268,7 @@ cdef class Ext:
         """Existing string"""
         pass
 
-    def m(self, a=u'spam'):
+    def m(self, a=u'spam', b='foo', c=b'bar'):
         pass
 
     def n(self, a: int, b: float = 1.0, *args: tuple, **kwargs: dict) -> (None, True):
@@ -409,6 +409,7 @@ lambda_bar = lambda x: 20
 
 
 cdef class Foo:
+    def __init__(self, *args, **kwargs): pass
     def m00(self, a: None) ->  None: pass
     def m01(self, a: ...) ->  Ellipsis: pass
     def m02(self, a: True, b: False) ->  bool: pass
@@ -444,6 +445,10 @@ cdef class Foo:
     def m32(self, a: tuple[()]) -> tuple[tuple[()]]: pass
 
 __doc__ += ur"""
+>>> print(Foo.__doc__)
+Foo(*args, **kwargs)
+>>> assert Foo.__init__.__doc__ == type.__init__.__doc__
+
 >>> print(Foo.m00.__doc__)
 Foo.m00(self, a: None) -> None
 

--- a/tests/run/embedsignatures_clinic.pyx
+++ b/tests/run/embedsignatures_clinic.pyx
@@ -1,0 +1,126 @@
+# cython: embedsignature=True
+# cython: embedsignature.format=clinic
+# cython: annotation_typing=False
+# cython: binding=False
+# cython: c_string_type=bytearray
+# tag: py3only
+
+def f00(a, object b=42):
+    "f00 docstring"
+    pass
+
+def f01(unsigned int a: int, unsigned int b: int = 42, /, c=123):
+    "f01 docstring"
+    pass
+
+def f02(unsigned int a: float, *, unsigned int b: float = 42) -> tuple[int]:
+    "f02 docstring"
+    pass
+
+__doc__ = ur"""
+>>> print(f00.__doc__)
+f00 docstring
+>>> print(f00.__text_signature__)
+(a, b=42)
+
+>>> print(f01.__doc__)
+f01 docstring
+>>> print(f01.__text_signature__)
+(a, b=42, /, c=123)
+
+>>> print(f02.__doc__)
+f02 docstring
+>>> print(f02.__text_signature__)
+(a, *, b=42)
+
+"""
+
+
+cdef class Foo:
+    "Foo docstring"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        "init Foo"
+        pass
+
+    def m00(self, a, b=42, *args, c=123):
+        "m00 docstring"
+        pass
+
+    def m01(self, a, b=42, *, c=123, **kwargs):
+        "m01 docstring"
+        pass
+
+    @classmethod
+    def c00(cls, a):
+        "c00 docstring"
+        pass
+
+    @staticmethod
+    def s00(a):
+        "s00 docstring"
+        pass
+
+    cdef public long int p0
+    property p1:
+        "p1 docstring"
+        def __get__(self):
+            return 0
+    property p2:
+        "p2 docstring"
+        def __get__(self) -> int:
+            return 0
+    cdef public Foo p3
+
+
+__doc__ += ur"""
+>>> print(Foo.__doc__)
+Foo docstring
+>>> print(Foo.__init__.__doc__)
+init Foo
+>>> print(Foo.__init__.__text_signature__)
+($self, *args, **kwargs)
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.m00.__doc__)
+m00 docstring
+>>> print(Foo.m00.__text_signature__)
+($self, a, b=42, *args, c=123)
+
+>>> print(Foo.m01.__doc__)
+m01 docstring
+>>> print(Foo.m01.__text_signature__)
+($self, a, b=42, *, c=123, **kwargs)
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.c00.__doc__)
+c00 docstring
+>>> print(Foo.c00.__text_signature__)
+($type, a)
+
+>>> print(Foo.s00.__doc__)
+s00 docstring
+>>> print(Foo.s00.__text_signature__)
+(a)
+
+"""
+
+
+__doc__ += ur"""
+>>> print(Foo.p0.__doc__)
+None
+
+>>> print(Foo.p1.__doc__)
+p1 docstring
+
+>>> print(Foo.p2.__doc__)
+p2 docstring
+
+>>> print(Foo.p3.__doc__)
+None
+
+"""

--- a/tests/run/embedsignatures_python.pyx
+++ b/tests/run/embedsignatures_python.pyx
@@ -1,0 +1,280 @@
+# cython: embedsignature=True
+# cython: embedsignature.format=python
+# cython: annotation_typing=False
+# cython: c_string_type=bytearray
+
+cpdef object      f00(object a): return a
+cpdef long double f01(unsigned int a): return <double>a
+cpdef long double f02(unsigned int a: float): return <double>a
+
+__doc__ = ur"""
+>>> print(f00.__doc__)
+f00(a)
+
+>>> print(f01.__doc__)
+f01(a: int) -> float
+
+>>> print(f02.__doc__)
+f02(a: float) -> float
+
+"""
+
+
+cdef class Foo:
+    "Foo docstring"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        "init Foo"
+        pass
+
+    def m00(self, a): return a
+    def m01(self, unsigned int a): return a
+    def m02(self, unsigned int a: int): return a
+    def m03(self: Self, unsigned int a: int) -> float: return a
+    def m04(self, const char* a): return a
+    def m05(self, const char a[]): return a
+    def m06(self, const char* a: bytes) -> bytes: return a
+
+    @classmethod
+    def c00(cls, a): return a
+    @classmethod
+    def c01(type cls, unsigned int a): return a
+    @classmethod
+    def c02(cls: type[Foo], unsigned int a: int): return a
+    @classmethod
+    def c03(type cls: type[Foo], unsigned int a: int) -> float: return a
+
+    @staticmethod
+    def s00(a): return a
+    @staticmethod
+    def s01(unsigned int a): return a
+    @staticmethod
+    def s02(unsigned int a: int): return a
+    @staticmethod
+    def s03(unsigned int a: int) -> float: return a
+
+    cdef public long int p0
+    property p1:
+        """p1 docstring"""
+        def __get__(self):
+            return 0
+    property p2:
+        """p2 docstring"""
+        def __get__(self) -> int:
+            return 0
+    cdef public Foo p3
+
+
+__doc__ += ur"""
+>>> print(Foo.__doc__)
+Foo docstring
+>>> print(Foo.__init__.__doc__)
+__init__(self, *args: Any, **kwargs: Any) -> None
+init Foo
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.m00.__doc__)
+m00(self, a)
+
+>>> print(Foo.m01.__doc__)
+m01(self, a: int)
+
+>>> print(Foo.m02.__doc__)
+m02(self, a: int)
+
+>>> print(Foo.m03.__doc__)
+m03(self: Self, a: int) -> float
+
+>>> print(Foo.m04.__doc__)
+m04(self, a: bytearray)
+
+>>> print(Foo.m05.__doc__)
+m05(self, a: bytearray)
+
+>>> print(Foo.m06.__doc__)
+m06(self, a: bytes) -> bytes
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.c00.__doc__)
+c00(cls, a)
+
+>>> print(Foo.c01.__doc__)
+c01(cls, a: int)
+
+>>> print(Foo.c02.__doc__)
+c02(cls: type[Foo], a: int)
+
+>>> print(Foo.c03.__doc__)
+c03(cls: type[Foo], a: int) -> float
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.s00.__doc__)
+s00(a)
+
+>>> print(Foo.s01.__doc__)
+s01(a: int)
+
+>>> print(Foo.s02.__doc__)
+s02(a: int)
+
+>>> print(Foo.s03.__doc__)
+s03(a: int) -> float
+
+"""
+
+__doc__ += ur"""
+>>> print(Foo.p0.__doc__)
+p0: int
+
+>>> print(Foo.p1.__doc__)
+p1 docstring
+
+>>> print(Foo.p2.__doc__)
+p2: int
+p2 docstring
+
+>>> print(Foo.p3.__doc__)
+p3: Foo
+
+"""
+
+ctypedef long     long      LongLong
+ctypedef signed   long long LongLongSigned
+ctypedef unsigned long long LongLongUnsigned
+
+cdef class Bar:
+
+    cpdef          char       m00(self,          char       a): return a
+    cpdef signed   char       m01(self, signed   char       a): return a
+    cpdef unsigned char       m02(self, unsigned char       a): return a
+
+    cpdef          short      m10(self,          short      a): return a
+    cpdef signed   short      m11(self, signed   short      a): return a
+    cpdef unsigned short      m12(self, unsigned short      a): return a
+
+    cpdef          int        m20(self,          int        a): return a
+    cpdef signed   int        m21(self, signed   int        a): return a
+    cpdef unsigned int        m22(self, unsigned int        a): return a
+
+    cpdef          long       m30(self,          long       a): return a
+    cpdef signed   long       m31(self, signed   long       a): return a
+    cpdef unsigned long       m32(self, unsigned long       a): return a
+
+    cpdef          long long  m40(self,          long long  a): return a
+    cpdef signed   long long  m41(self, signed   long long  a): return a
+    cpdef unsigned long long  m42(self, unsigned long long  a): return a
+
+    cpdef LongLong            m43(self, LongLong            a): return a
+    cpdef LongLongSigned      m44(self, LongLongSigned      a): return a
+    cpdef LongLongUnsigned    m45(self, LongLongUnsigned    a): return a
+
+    cpdef float               m50(self, float               a): return a
+    cpdef double              m60(self, double              a): return a
+    cpdef long double         m70(self, long double         a): return a
+
+    cpdef float       complex m51(self, float       complex a): return a
+    cpdef double      complex m61(self, double      complex a): return a
+    cpdef long double complex m71(self, long double complex a): return a
+
+
+__doc__ += ur"""
+>>> print(Bar.m00.__doc__)
+m00(self, a: int) -> int
+
+>>> print(Bar.m01.__doc__)
+m01(self, a: int) -> int
+
+>>> print(Bar.m02.__doc__)
+m02(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m10.__doc__)
+m10(self, a: int) -> int
+
+>>> print(Bar.m11.__doc__)
+m11(self, a: int) -> int
+
+>>> print(Bar.m12.__doc__)
+m12(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m20.__doc__)
+m20(self, a: int) -> int
+
+>>> print(Bar.m21.__doc__)
+m21(self, a: int) -> int
+
+>>> print(Bar.m22.__doc__)
+m22(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m30.__doc__)
+m30(self, a: int) -> int
+
+>>> print(Bar.m31.__doc__)
+m31(self, a: int) -> int
+
+>>> print(Bar.m32.__doc__)
+m32(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m40.__doc__)
+m40(self, a: int) -> int
+
+>>> print(Bar.m41.__doc__)
+m41(self, a: int) -> int
+
+>>> print(Bar.m42.__doc__)
+m42(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m43.__doc__)
+m43(self, a: int) -> int
+
+>>> print(Bar.m44.__doc__)
+m44(self, a: int) -> int
+
+>>> print(Bar.m45.__doc__)
+m45(self, a: int) -> int
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m50.__doc__)
+m50(self, a: float) -> float
+
+>>> print(Bar.m60.__doc__)
+m60(self, a: float) -> float
+
+>>> print(Bar.m70.__doc__)
+m70(self, a: float) -> float
+
+"""
+
+__doc__ += ur"""
+>>> print(Bar.m51.__doc__)
+m51(self, a: complex) -> complex
+
+>>> print(Bar.m61.__doc__)
+m61(self, a: complex) -> complex
+
+>>> print(Bar.m71.__doc__)
+m71(self, a: complex) -> complex
+
+"""

--- a/tests/run/fused_types.pyx
+++ b/tests/run/fused_types.pyx
@@ -401,6 +401,37 @@ def test_cython_numeric(cython.numeric arg):
     """
     print cython.typeof(arg), arg
 
+
+cdef fused int_t:
+    int
+
+def test_pylong(int_t i):
+    """
+    >>> import cython
+    >>> try:    long = long # Python 2
+    ... except: long = int  # Python 3
+
+    >>> test_pylong[int](int(0))
+    int
+    >>> test_pylong[cython.int](int(0))
+    int
+    >>> test_pylong(int(0))
+    int
+
+    >>> test_pylong[int](long(0))
+    int
+    >>> test_pylong[cython.int](long(0))
+    int
+    >>> test_pylong(long(0))
+    int
+
+    >>> test_pylong[cython.long](0)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    KeyError: ...
+    """
+    print cython.typeof(i)
+
+
 cdef fused ints_t:
     int
     long


### PR DESCRIPTION
Add `embedsignature.pure` compiler directive to generate pure-Python type annotations compatible with type hinting syntax. This mostly amounts to:
* Not emitting C type declarations in signatures.
* Preferring explicit argument type annotations over C types.
* Mapping C type names to the closest Python type name.

See https://github.com/cython/cython/issues/3150