### PR TITLE
Fix usage of _MSC_VER macro

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2129,7 +2129,7 @@ static void __Pyx_FastGilFuncInit(void) {
 
 ///////////////////// UtilityCodePragmas /////////////////////////
 
-#if _MSC_VER
+#ifdef _MSC_VER
 #pragma warning( push )
 /* Warning 4127: conditional expression is constant
  * Cython uses constant conditional expressions to allow in inline functions to be optimized at
@@ -2140,6 +2140,6 @@ static void __Pyx_FastGilFuncInit(void) {
 
 ///////////////////// UtilityCodePragmasEnd //////////////////////
 
-#if _MSV_VER
+#ifdef _MSC_VER
 #pragma warning( pop )  /* undo whatever Cython has done to warnings */
 #endif


### PR DESCRIPTION
Change #if to #ifdef so we don't get undefined macro warnings on non microsoft compilers.

Fix typo in macro.