### PR TITLE
Prevent calling the dealloc slot of a non-GC base class with GC tracking enabled

### DIFF
--- a/tests/run/exttype_gc.pyx
+++ b/tests/run/exttype_gc.pyx
@@ -1,0 +1,38 @@
+# mode: run
+# tag: gc
+
+
+def create_obj(cls):
+    cls()  # create and discard
+
+
+cdef class BaseTypeNoGC:
+    pass
+
+
+cdef class ExtTypeGC(BaseTypeNoGC):
+    """
+    >>> create_obj(ExtTypeGC)
+    >>> create_obj(ExtTypeGC)
+    >>> create_obj(ExtTypeGC)
+
+    >>> class PyExtTypeGC(ExtTypeGC): pass
+    >>> create_obj(PyExtTypeGC)
+    >>> create_obj(PyExtTypeGC)
+    >>> create_obj(PyExtTypeGC)
+    """
+    cdef object attr
+
+
+cdef class ExtTypeNoGC(BaseTypeNoGC):
+    """
+    >>> create_obj(ExtTypeNoGC)
+    >>> create_obj(ExtTypeNoGC)
+    >>> create_obj(ExtTypeNoGC)
+
+    >>> class PyExtTypeNoGC(ExtTypeNoGC): pass
+    >>> create_obj(PyExtTypeNoGC)
+    >>> create_obj(PyExtTypeNoGC)
+    >>> create_obj(PyExtTypeNoGC)
+    """
+    cdef int x


### PR DESCRIPTION
This shows warnings in CPython (3.12) debug builds and can lead to crashes when GC triggers on an object while deallocating it. This is also an issue in 0.29.x, thus, needs to be backported.