### PR TITLE
convert PyTypeObject struct initialization to C99 designated initializers

### DIFF
--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -353,81 +353,27 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_as_async = {
 #endif
 
 static PyTypeObject __pyx_AsyncGenType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    "async_generator",                          /* tp_name */
-    sizeof(__pyx_PyAsyncGenObject),             /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    (destructor)__Pyx_Coroutine_dealloc,        /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
+    .tp_name = "async_generator",
+    .tp_basicsize = sizeof(__pyx_PyAsyncGenObject),
+    .tp_dealloc = (destructor)__Pyx_Coroutine_dealloc,
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_as_async,                        /* tp_as_async */
-#else
-    0,                                          /*tp_reserved*/
+    .tp_as_async = &__Pyx_async_gen_as_async,
 #endif
-    (reprfunc)__Pyx_async_gen_repr,                   /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_HAVE_FINALIZE,               /* tp_flags */
-    0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_traverse,           /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /*tp_richcompare*/
-    offsetof(__pyx_CoroutineObject, gi_weakreflist), /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    __Pyx_async_gen_methods,                          /* tp_methods */
-    __Pyx_async_gen_memberlist,                       /* tp_members */
-    __Pyx_async_gen_getsetlist,                       /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
+    .tp_repr = (reprfunc)__Pyx_async_gen_repr,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_HAVE_FINALIZE,
+    .tp_traverse = (traverseproc)__Pyx_async_gen_traverse,
+#if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
+    .tp_richcompare = __Pyx_Coroutine_compare,
+#endif
+    .tp_weaklistoffset = offsetof(__pyx_CoroutineObject, gi_weakreflist),
+    .tp_methods = __Pyx_async_gen_methods,
+    .tp_members = __Pyx_async_gen_memberlist,
+    .tp_getset = __Pyx_async_gen_getsetlist,
 #if CYTHON_USE_TP_FINALIZE
-    0,                                  /*tp_del*/
+    .tp_finalize = __Pyx_Coroutine_del
 #else
-    __Pyx_Coroutine_del,                /*tp_del*/
-#endif
-    0,                                          /* tp_version_tag */
-#if CYTHON_USE_TP_FINALIZE
-    __Pyx_Coroutine_del,                        /* tp_finalize */
-#else
-    0,                                          /* tp_finalize */
-#endif
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                          /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                          /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                          /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
+    .tp_del = __Pyx_Coroutine_del
 #endif
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
@@ -632,74 +578,20 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_asend_as_async = {
 #endif
 
 static PyTypeObject __pyx__PyAsyncGenASendType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    "async_generator_asend",                    /* tp_name */
-    sizeof(__pyx_PyAsyncGenASend),                    /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)__Pyx_async_gen_asend_dealloc,        /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
+    .tp_name = "async_generator_asend",
+    .tp_basicsize = sizeof(__pyx_PyAsyncGenASend),
+    .tp_dealloc = (destructor)__Pyx_async_gen_asend_dealloc,
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_asend_as_async,                  /* tp_as_async */
-#else
-    0,                                          /*tp_reserved*/
+    .tp_as_async = &__Pyx_async_gen_asend_as_async,
 #endif
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_asend_traverse,  /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /*tp_richcompare*/
-    0,                                          /* tp_weaklistoffset */
-    PyObject_SelfIter,                          /* tp_iter */
-    (iternextfunc)__Pyx_async_gen_asend_iternext,     /* tp_iternext */
-    __Pyx_async_gen_asend_methods,                    /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
-    0,                                          /* tp_finalize */
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                          /*tp_vectorcall*/
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)__Pyx_async_gen_asend_traverse,
+#if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
+    .tp_richcompare = __Pyx_Coroutine_compare,
 #endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                          /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                          /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
-#endif
+    .tp_iter = PyObject_SelfIter,
+    .tp_iternext = (iternextfunc)__Pyx_async_gen_asend_iternext,
+    .tp_methods = __Pyx_async_gen_asend_methods
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
 
@@ -775,70 +667,11 @@ static PyType_Spec __pyx__PyAsyncGenWrappedValueType_spec = {
 #else /* CYTHON_USE_TYPE_SPECS */
 
 static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    "async_generator_wrapped_value",            /* tp_name */
-    sizeof(__pyx__PyAsyncGenWrappedValue),            /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)__Pyx_async_gen_wrapped_val_dealloc,  /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_as_async */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_wrapped_val_traverse,    /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
-    0,                                          /* tp_finalize */
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                          /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                          /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                          /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
-#endif
+    .tp_name = "async_generator_wrapped_value",
+    .tp_basicsize = sizeof(__pyx__PyAsyncGenWrappedValue),
+    .tp_dealloc = (destructor)__Pyx_async_gen_wrapped_val_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)__Pyx_async_gen_wrapped_val_traverse
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
 
@@ -1112,73 +945,20 @@ static __Pyx_PyAsyncMethodsStruct __Pyx_async_gen_athrow_as_async = {
 #endif
 
 static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    "async_generator_athrow",                   /* tp_name */
-    sizeof(__pyx_PyAsyncGenAThrow),                   /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    (destructor)__Pyx_async_gen_athrow_dealloc,       /* tp_dealloc */
-    0,                                          /* tp_vectorcall_offset */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
+    .tp_name = "async_generator_athrow",
+    .tp_basicsize = sizeof(__pyx_PyAsyncGenAThrow),
+    .tp_dealloc = (destructor)__Pyx_async_gen_athrow_dealloc,
 #if CYTHON_USE_ASYNC_SLOTS
-    &__Pyx_async_gen_athrow_as_async,                 /* tp_as_async */
-#else
-    0,                                          /*tp_reserved*/
+    .tp_as_async = &__Pyx_async_gen_athrow_as_async,
 #endif
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    0,                                          /* tp_doc */
-    (traverseproc)__Pyx_async_gen_athrow_traverse,    /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /*tp_richcompare*/
-    0,                                          /* tp_weaklistoffset */
-    PyObject_SelfIter,                          /* tp_iter */
-    (iternextfunc)__Pyx_async_gen_athrow_iternext,    /* tp_iternext */
-    __Pyx_async_gen_athrow_methods,                   /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    0,                                          /* tp_new */
-    0,                                          /* tp_free */
-    0,                                          /* tp_is_gc */
-    0,                                          /* tp_bases */
-    0,                                          /* tp_mro */
-    0,                                          /* tp_cache */
-    0,                                          /* tp_subclasses */
-    0,                                          /* tp_weaklist */
-    0,                                          /* tp_del */
-    0,                                          /* tp_version_tag */
-    0,                                          /* tp_finalize */
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                          /*tp_vectorcall*/
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_traverse = (traverseproc)__Pyx_async_gen_athrow_traverse,
+#if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
+    .tp_richcompare = __Pyx_Coroutine_compare,
 #endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                          /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                          /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
-#endif
+    .tp_iter = PyObject_SelfIter,
+    .tp_iternext = (iternextfunc)__Pyx_async_gen_athrow_iternext,
+    .tp_methods = __Pyx_async_gen_athrow_methods
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
 

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1538,72 +1538,18 @@ static PyType_Spec __pyx_CoroutineAwaitType_spec = {
 #else /* CYTHON_USE_TYPE_SPECS */
 
 static PyTypeObject __pyx_CoroutineAwaitType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "coroutine_wrapper", /*tp_name*/
-    sizeof(__pyx_CoroutineAwaitObject), /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __Pyx_CoroutineAwait_dealloc,/*tp_dealloc*/
-    0,                                  /*tp_print*/
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
-    0,                                  /*tp_as_async resp. tp_compare*/
-    0,                                  /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    0,                                  /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    0,                                  /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-    PyDoc_STR("A wrapper object implementing __await__ for coroutines."), /*tp_doc*/
-    (traverseproc) __Pyx_CoroutineAwait_traverse,   /*tp_traverse*/
-    (inquiry) __Pyx_CoroutineAwait_clear,           /*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    0,                                  /*tp_weaklistoffset*/
-    __Pyx_CoroutineAwait_self,          /*tp_iter*/
-    (iternextfunc) __Pyx_CoroutineAwait_Next, /*tp_iternext*/
-    __pyx_CoroutineAwait_methods,       /*tp_methods*/
-    0                         ,         /*tp_members*/
-    0                      ,            /*tp_getset*/
-    0,                                  /*tp_base*/
-    0,                                  /*tp_dict*/
-    0,                                  /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    0,                                  /*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "coroutine_wrapper",
+    .tp_basicsize = sizeof(__pyx_CoroutineAwaitObject),
+    .tp_dealloc = (destructor) __Pyx_CoroutineAwait_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_doc = PyDoc_STR("A wrapper object implementing __await__ for coroutines."),
+    .tp_traverse = (traverseproc) __Pyx_CoroutineAwait_traverse,
+    .tp_clear = (inquiry) __Pyx_CoroutineAwait_clear,
+    .tp_iter = __Pyx_CoroutineAwait_self,
+    .tp_iternext = (iternextfunc) __Pyx_CoroutineAwait_Next,
+    .tp_methods = __pyx_CoroutineAwait_methods,
 #if !CYTHON_COMPILING_IN_PYPY
-    __Pyx_CoroutineAwait_no_new,        /*tp_new*/
-#else
-    0,                                  /*tp_new*/
-#endif
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
-    0,                                  /*tp_del*/
-    0,                                  /*tp_version_tag*/
-    0,                                  /*tp_finalize*/
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
+    .tp_new = __Pyx_CoroutineAwait_no_new
 #endif
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
@@ -1686,91 +1632,31 @@ static PyType_Spec __pyx_CoroutineType_spec = {
 
 #if CYTHON_USE_ASYNC_SLOTS
 static __Pyx_PyAsyncMethodsStruct __pyx_Coroutine_as_async = {
-    __Pyx_Coroutine_await, /*am_await*/
-    0, /*am_aiter*/
-    0, /*am_anext*/
-#if PY_VERSION_HEX >= 0x030A00A3
-    0, /*am_send*/
-#endif
+    .am_await = __Pyx_Coroutine_await,
 };
 #endif
 
 static PyTypeObject __pyx_CoroutineType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "coroutine", /*tp_name*/
-    sizeof(__pyx_CoroutineObject),      /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __Pyx_Coroutine_dealloc,/*tp_dealloc*/
-    0,                                  /*tp_print*/
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "coroutine",
+    .tp_basicsize = sizeof(__pyx_CoroutineObject),
+    .tp_dealloc = (destructor) __Pyx_Coroutine_dealloc,
 #if CYTHON_USE_ASYNC_SLOTS
-    &__pyx_Coroutine_as_async,          /*tp_as_async (tp_reserved) - Py3 only! */
-#else
-    0,                                  /*tp_reserved*/
+    .tp_as_async = &__pyx_Coroutine_as_async,
 #endif
-    0,                                  /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    0,                                  /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    0,                                  /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE, /*tp_flags*/
-    0,                                  /*tp_doc*/
-    (traverseproc) __Pyx_Coroutine_traverse,   /*tp_traverse*/
-    0,                                  /*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    offsetof(__pyx_CoroutineObject, gi_weakreflist), /*tp_weaklistoffset*/
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE,
+    .tp_traverse = (traverseproc)__Pyx_Coroutine_traverse,
+#if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
+    .tp_richcompare = __Pyx_Coroutine_compare,
+#endif
+    .tp_weaklistoffset = offsetof(__pyx_CoroutineObject, gi_weakreflist),
     // no tp_iter() as iterator is only available through __await__()
-    0,                                  /*tp_iter*/
-    0,                                  /*tp_iternext*/
-    __pyx_Coroutine_methods,            /*tp_methods*/
-    __pyx_Coroutine_memberlist,         /*tp_members*/
-    __pyx_Coroutine_getsets,            /*tp_getset*/
-    0,                                  /*tp_base*/
-    0,                                  /*tp_dict*/
-    0,                                  /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    0,                                  /*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
-    0,                                  /*tp_new*/
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
+    .tp_methods = __pyx_Coroutine_methods,
+    .tp_members = __pyx_Coroutine_memberlist,
+    .tp_getset = __pyx_Coroutine_getsets,
 #if CYTHON_USE_TP_FINALIZE
-    0,                                  /*tp_del*/
+    .tp_finalize = __Pyx_Coroutine_del
 #else
-    __Pyx_Coroutine_del,                /*tp_del*/
-#endif
-    0,                                  /*tp_version_tag*/
-#if CYTHON_USE_TP_FINALIZE
-    __Pyx_Coroutine_del,                /*tp_finalize*/
-#else
-    0,                                  /*tp_finalize*/
-#endif
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
+    .tp_del = __Pyx_Coroutine_del
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
@@ -1847,75 +1733,29 @@ static PyType_Spec __pyx_IterableCoroutineType_spec = {
 #else /* CYTHON_USE_TYPE_SPECS */
 
 static PyTypeObject __pyx_IterableCoroutineType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "iterable_coroutine", /*tp_name*/
-    sizeof(__pyx_CoroutineObject),      /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __Pyx_Coroutine_dealloc,/*tp_dealloc*/
-    0,                                  /*tp_print*/
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "iterable_coroutine",
+    .tp_basicsize = sizeof(__pyx_CoroutineObject),
+    .tp_dealloc = (destructor) __Pyx_Coroutine_dealloc,
 #if CYTHON_USE_ASYNC_SLOTS
-    &__pyx_Coroutine_as_async,          /*tp_as_async (tp_reserved) - Py3 only! */
-#else
-    0,                                  /*tp_reserved*/
+    .tp_as_async = &__pyx_Coroutine_as_async,
 #endif
-    0,                                  /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    0,                                  /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    0,                                  /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE, /*tp_flags*/
-    0,                                  /*tp_doc*/
-    (traverseproc) __Pyx_Coroutine_traverse,   /*tp_traverse*/
-    0,                                  /*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    offsetof(__pyx_CoroutineObject, gi_weakreflist), /*tp_weaklistoffset*/
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE,
+    .tp_traverse = (traverseproc) __Pyx_Coroutine_traverse,
+#if CYTHON_USE_ASYNC_SLOTS && CYTHON_COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x030500B1
+    // in order to (mis-)use tp_reserved above, we must also implement tp_richcompare
+    .tp_richcompare = __Pyx_Coroutine_compare,
+#endif
+    .tp_weaklistoffset = offsetof(__pyx_CoroutineObject, gi_weakreflist),
     // enable iteration for legacy support of asyncio yield-from protocol
-    __Pyx_Coroutine_await,              /*tp_iter*/
-    (iternextfunc) __Pyx_Generator_Next, /*tp_iternext*/
-    __pyx_Coroutine_methods,            /*tp_methods*/
-    __pyx_Coroutine_memberlist,         /*tp_members*/
-    __pyx_Coroutine_getsets,            /*tp_getset*/
-    0,                                  /*tp_base*/
-    0,                                  /*tp_dict*/
-    0,                                  /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    0,                                  /*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
-    0,                                  /*tp_new*/
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
-    0,                                  /*tp_del*/
-    0,                                  /*tp_version_tag*/
-#if !CYTHON_COMPILING_IN_PYPY
-    __Pyx_Coroutine_del,                /*tp_finalize*/
-#endif
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
+    .tp_iter = __Pyx_Coroutine_await,
+    .tp_iternext = (iternextfunc) __Pyx_Generator_Next,
+    .tp_methods = __pyx_Coroutine_methods,
+    .tp_members = __pyx_Coroutine_memberlist,
+    .tp_getset = __pyx_Coroutine_getsets,
+#if PY_VERSION_HEX >= 0x030400a1
+    .tp_finalize = __Pyx_Coroutine_del
+#else
+    .tp_del = __Pyx_Coroutine_del
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */
@@ -1997,76 +1837,20 @@ static PyType_Spec __pyx_GeneratorType_spec = {
 #else /* CYTHON_USE_TYPE_SPECS */
 
 static PyTypeObject __pyx_GeneratorType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "generator", /*tp_name*/
-    sizeof(__pyx_CoroutineObject),      /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __Pyx_Coroutine_dealloc,/*tp_dealloc*/
-    0,                                  /*tp_print*/
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
-    0,                                  /*tp_as_async*/
-    0,                                  /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    0,                                  /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    0,                                  /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE, /*tp_flags*/
-    0,                                  /*tp_doc*/
-    (traverseproc) __Pyx_Coroutine_traverse,   /*tp_traverse*/
-    0,                                  /*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    offsetof(__pyx_CoroutineObject, gi_weakreflist), /*tp_weaklistoffset*/
-    0,                                  /*tp_iter*/
-    (iternextfunc) __Pyx_Generator_Next, /*tp_iternext*/
-    __pyx_Generator_methods,            /*tp_methods*/
-    __pyx_Generator_memberlist,         /*tp_members*/
-    __pyx_Generator_getsets,            /*tp_getset*/
-    0,                                  /*tp_base*/
-    0,                                  /*tp_dict*/
-    0,                                  /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    0,                                  /*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
-    0,                                  /*tp_new*/
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "generator",
+    .tp_basicsize = sizeof(__pyx_CoroutineObject),
+    .tp_dealloc = (destructor) __Pyx_Coroutine_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_HAVE_FINALIZE,
+    .tp_traverse = (traverseproc) __Pyx_Coroutine_traverse,
+    .tp_weaklistoffset = offsetof(__pyx_CoroutineObject, gi_weakreflist),
+    .tp_iternext = (iternextfunc) __Pyx_Generator_Next,
+    .tp_methods = __pyx_Generator_methods,
+    .tp_members = __pyx_Generator_memberlist,
+    .tp_getset = __pyx_Generator_getsets,
 #if CYTHON_USE_TP_FINALIZE
-    0,                                  /*tp_del*/
+    .tp_finalize = __Pyx_Coroutine_del
 #else
-    __Pyx_Coroutine_del,                /*tp_del*/
-#endif
-    0,                                  /*tp_version_tag*/
-#if CYTHON_USE_TP_FINALIZE
-    __Pyx_Coroutine_del,                /*tp_finalize*/
-#else
-    0,                                  /*tp_finalize*/
-#endif
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
+    .tp_del = __Pyx_Coroutine_del
 #endif
 };
 #endif /* CYTHON_USE_TYPE_SPECS */

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1059,81 +1059,33 @@ static PyType_Spec __pyx_CyFunctionType_spec = {
 #else /* CYTHON_USE_TYPE_SPECS */
 
 static PyTypeObject __pyx_CyFunctionType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "cython_function_or_method",  /*tp_name*/
-    sizeof(__pyx_CyFunctionObject),   /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __Pyx_CyFunction_dealloc, /*tp_dealloc*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "cython_function_or_method",
+    .tp_basicsize = sizeof(__pyx_CyFunctionObject),
+    .tp_dealloc = (destructor) __Pyx_CyFunction_dealloc,
 #if !CYTHON_METH_FASTCALL
-    0,                                  /*tp_print*/
 #elif CYTHON_BACKPORT_VECTORCALL
-    (printfunc)offsetof(__pyx_CyFunctionObject, func_vectorcall), /*tp_vectorcall_offset backported into tp_print*/
+    .tp_vectorcall_offset = (printfunc)offsetof(__pyx_CyFunctionObject, func_vectorcall),
 #else
-    offsetof(PyCFunctionObject, vectorcall), /*tp_vectorcall_offset*/
+    .tp_vectorcall_offset = offsetof(PyCFunctionObject, vectorcall),
 #endif
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
-    0,                                  /*tp_as_async*/
-    (reprfunc) __Pyx_CyFunction_repr,   /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    0,                                  /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    __Pyx_CyFunction_CallAsMethod,      /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
+    .tp_repr = (reprfunc) __Pyx_CyFunction_repr,
+    .tp_call = __Pyx_CyFunction_CallAsMethod,
+    .tp_flags = 
 #ifdef Py_TPFLAGS_METHOD_DESCRIPTOR
     Py_TPFLAGS_METHOD_DESCRIPTOR |
 #endif
 #if defined(_Py_TPFLAGS_HAVE_VECTORCALL) && CYTHON_METH_FASTCALL
     _Py_TPFLAGS_HAVE_VECTORCALL |
 #endif
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    0,                                  /*tp_doc*/
-    (traverseproc) __Pyx_CyFunction_traverse,   /*tp_traverse*/
-    (inquiry) __Pyx_CyFunction_clear,   /*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    offsetof(PyCFunctionObject, m_weakreflist),         /*tp_weaklistoffset*/
-    0,                                  /*tp_iter*/
-    0,                                  /*tp_iternext*/
-    __pyx_CyFunction_methods,           /*tp_methods*/
-    __pyx_CyFunction_members,           /*tp_members*/
-    __pyx_CyFunction_getsets,           /*tp_getset*/
-    0,                                  /*tp_base*/
-    0,                                  /*tp_dict*/
-    __Pyx_PyMethod_New,                 /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    offsetof(__pyx_CyFunctionObject, func_dict),/*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
-    0,                                  /*tp_new*/
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
-    0,                                  /*tp_del*/
-    0,                                  /*tp_version_tag*/
-    0,                                  /*tp_finalize*/
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
-#endif
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
+    .tp_traverse = (traverseproc) __Pyx_CyFunction_traverse,
+    .tp_clear = (inquiry) __Pyx_CyFunction_clear,
+    .tp_weaklistoffset = offsetof(PyCFunctionObject, m_weakreflist),
+    .tp_methods = __pyx_CyFunction_methods,
+    .tp_members = __pyx_CyFunction_members,
+    .tp_getset = __pyx_CyFunction_getsets,
+    .tp_descr_get = __Pyx_PyMethod_New,
+    .tp_dictoffset = offsetof(__pyx_CyFunctionObject, func_dict)
 };
 #endif  /* CYTHON_USE_TYPE_SPECS */
 
@@ -1579,70 +1531,19 @@ static PyMappingMethods __pyx_FusedFunction_mapping_methods = {
 };
 
 static PyTypeObject __pyx_FusedFunctionType_type = {
-    PyVarObject_HEAD_INIT(0, 0)
-    __PYX_TYPE_MODULE_PREFIX "fused_cython_function",  /*tp_name*/
-    sizeof(__pyx_FusedFunctionObject), /*tp_basicsize*/
-    0,                                  /*tp_itemsize*/
-    (destructor) __pyx_FusedFunction_dealloc, /*tp_dealloc*/
-    0,                                  /*tp_print*/
-    0,                                  /*tp_getattr*/
-    0,                                  /*tp_setattr*/
-    0,                                  /*tp_as_async*/
-    0,                                  /*tp_repr*/
-    0,                                  /*tp_as_number*/
-    0,                                  /*tp_as_sequence*/
-    &__pyx_FusedFunction_mapping_methods, /*tp_as_mapping*/
-    0,                                  /*tp_hash*/
-    (ternaryfunc) __pyx_FusedFunction_call, /*tp_call*/
-    0,                                  /*tp_str*/
-    0,                                  /*tp_getattro*/
-    0,                                  /*tp_setattro*/
-    0,                                  /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    0,                                  /*tp_doc*/
-    (traverseproc) __pyx_FusedFunction_traverse,   /*tp_traverse*/
-    (inquiry) __pyx_FusedFunction_clear,/*tp_clear*/
-    0,                                  /*tp_richcompare*/
-    0,                                  /*tp_weaklistoffset*/
-    0,                                  /*tp_iter*/
-    0,                                  /*tp_iternext*/
-    0,                                  /*tp_methods*/
-    __pyx_FusedFunction_members,        /*tp_members*/
-    __pyx_FusedFunction_getsets,           /*tp_getset*/
+    .tp_name = __PYX_TYPE_MODULE_PREFIX "fused_cython_function",
+    .tp_basicsize = sizeof(__pyx_FusedFunctionObject),
+    .tp_dealloc = (destructor) __pyx_FusedFunction_dealloc,
+    .tp_as_mapping = &__pyx_FusedFunction_mapping_methods,
+    .tp_call = (ternaryfunc) __pyx_FusedFunction_call,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
+    .tp_traverse = (traverseproc) __pyx_FusedFunction_traverse,
+    .tp_clear = (inquiry) __pyx_FusedFunction_clear,
+    .tp_members = __pyx_FusedFunction_members,
+    .tp_getset = __pyx_FusedFunction_getsets,
     // NOTE: tp_base may be changed later during module initialisation when importing CyFunction across modules.
-    &__pyx_CyFunctionType_type,         /*tp_base*/
-    0,                                  /*tp_dict*/
-    __pyx_FusedFunction_descr_get,      /*tp_descr_get*/
-    0,                                  /*tp_descr_set*/
-    0,                                  /*tp_dictoffset*/
-    0,                                  /*tp_init*/
-    0,                                  /*tp_alloc*/
-    0,                                  /*tp_new*/
-    0,                                  /*tp_free*/
-    0,                                  /*tp_is_gc*/
-    0,                                  /*tp_bases*/
-    0,                                  /*tp_mro*/
-    0,                                  /*tp_cache*/
-    0,                                  /*tp_subclasses*/
-    0,                                  /*tp_weaklist*/
-    0,                                  /*tp_del*/
-    0,                                  /*tp_version_tag*/
-    0,                                  /*tp_finalize*/
-#if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
-    0,                                  /*tp_vectorcall*/
-#endif
-#if __PYX_NEED_TP_PRINT_SLOT
-    0,                                  /*tp_print*/
-#endif
-#if PY_VERSION_HEX >= 0x030C0000
-    0,                                  /*tp_watched*/
-#endif
-#if PY_VERSION_HEX >= 0x030d00A4
-    0,                                          /*tp_versions_used*/
-#endif
-#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000
-    0,                                          /*tp_pypy_flags*/
-#endif
+    .tp_base = __pyx_CyFunctionType_type,
+    .tp_descr_get = __pyx_FusedFunction_descr_get
 };
 #endif
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1542,7 +1542,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
     .tp_members = __pyx_FusedFunction_members,
     .tp_getset = __pyx_FusedFunction_getsets,
     // NOTE: tp_base may be changed later during module initialisation when importing CyFunction across modules.
-    .tp_base = __pyx_CyFunctionType_type,
+    .tp_base = &__pyx_CyFunctionType_type,
     .tp_descr_get = __pyx_FusedFunction_descr_get
 };
 #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1064,7 +1064,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
     .tp_dealloc = (destructor) __Pyx_CyFunction_dealloc,
 #if !CYTHON_METH_FASTCALL
 #elif CYTHON_BACKPORT_VECTORCALL
-    .tp_vectorcall_offset = (printfunc)offsetof(__pyx_CyFunctionObject, func_vectorcall),
+    .tp_print = (printfunc)offsetof(__pyx_CyFunctionObject, func_vectorcall),
 #else
     .tp_vectorcall_offset = offsetof(PyCFunctionObject, vectorcall),
 #endif


### PR DESCRIPTION
This requires C99 compliant compilers, but reduces code size and may help future-proof the code.