### PR TITLE
PyPy < 3.10 needs tp_print

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1100,7 +1100,7 @@ class SlotTable(object):
             SyntheticSlot("tp_finalize", ["__del__"], "0", ifdef="PY_VERSION_HEX >= 0x030400a1",
                           used_ifdef="CYTHON_USE_TP_FINALIZE"),
             EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)"),
-            EmptySlot("tp_print", ifdef="CYTHON_NEED_TP_PRINT"),
+            EmptySlot("tp_print", ifdef="CYTHON_NEED_TP_PRINT == 1"),
             EmptySlot("tp_watched", ifdef="PY_VERSION_HEX >= 0x030C0000"),
             # PyPy specific extension - only here to avoid C compiler warnings.
             EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000"),

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1100,7 +1100,7 @@ class SlotTable(object):
             SyntheticSlot("tp_finalize", ["__del__"], "0", ifdef="PY_VERSION_HEX >= 0x030400a1",
                           used_ifdef="CYTHON_USE_TP_FINALIZE"),
             EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)"),
-            EmptySlot("tp_print", ifdef="CYTHON_NEED_TP_PRINT == 1"),
+            EmptySlot("tp_print", ifdef="__PYX_NEED_TP_PRINT_SLOT == 1"),
             EmptySlot("tp_watched", ifdef="PY_VERSION_HEX >= 0x030C0000"),
             # PyPy specific extension - only here to avoid C compiler warnings.
             EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000"),

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1100,7 +1100,7 @@ class SlotTable(object):
             SyntheticSlot("tp_finalize", ["__del__"], "0", ifdef="PY_VERSION_HEX >= 0x030400a1",
                           used_ifdef="CYTHON_USE_TP_FINALIZE"),
             EmptySlot("tp_vectorcall", ifdef="PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)"),
-            EmptySlot("tp_print", ifdef="PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000"),
+            EmptySlot("tp_print", ifdef="CYTHON_NEED_TP_PRINT"),
             EmptySlot("tp_watched", ifdef="PY_VERSION_HEX >= 0x030C0000"),
             # PyPy specific extension - only here to avoid C compiler warnings.
             EmptySlot("tp_pypy_flags", ifdef="CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX >= 0x03090000 && PY_VERSION_HEX < 0x030a0000"),

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -463,7 +463,7 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -738,7 +738,7 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -876,7 +876,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1220,7 +1220,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -463,7 +463,7 @@ static PyTypeObject __pyx_AsyncGenType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -738,7 +738,7 @@ static PyTypeObject __pyx__PyAsyncGenASendType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -876,7 +876,7 @@ static PyTypeObject __pyx__PyAsyncGenWrappedValueType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1220,7 +1220,7 @@ static PyTypeObject __pyx__PyAsyncGenAThrowType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                          /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                          /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1660,7 +1660,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1855,7 +1855,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -2006,7 +2006,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -2155,7 +2155,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1660,7 +1660,7 @@ static PyTypeObject __pyx_CoroutineAwaitType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1855,7 +1855,7 @@ static PyTypeObject __pyx_CoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -2006,7 +2006,7 @@ static PyTypeObject __pyx_IterableCoroutineType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -2155,7 +2155,7 @@ static PyTypeObject __pyx_GeneratorType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1045,7 +1045,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1573,7 +1573,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if CYTHON_NEED_TP_PRINT
+#if __PYX_NEED_TP_PRINT_SLOT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1045,7 +1045,7 @@ static PyTypeObject __pyx_CyFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000
@@ -1573,7 +1573,7 @@ static PyTypeObject __pyx_FusedFunctionType_type = {
 #if PY_VERSION_HEX >= 0x030800b1 && (!CYTHON_COMPILING_IN_PYPY || PYPY_VERSION_NUM >= 0x07030800)
     0,                                  /*tp_vectorcall*/
 #endif
-#if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+#if CYTHON_NEED_TP_PRINT
     0,                                  /*tp_print*/
 #endif
 #if PY_VERSION_HEX >= 0x030C0000

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -557,17 +557,9 @@
 #endif
 
 #if CYTHON_COMPILING_IN_PYPY == 1
-  #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x030A0000
-    #define CYTHON_NEED_TP_PRINT 1
-  #else
-    #define CYTHON_NEED_TP_PRINT 0
-  #endif
+  #define __PYX_NEED_TP_PRINT_SLOT  (PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x030A0000)
 #else
-  #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
-    #define CYTHON_NEED_TP_PRINT 1
-  #else
-    #define CYTHON_NEED_TP_PRINT 0
-  #endif
+  #define __PYX_NEED_TP_PRINT_SLOT  (PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000)
 #endif
 // reinterpret
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -556,7 +556,7 @@
   #define __PYX_IS_UNSIGNED(type) (((type)-1) > 0)
 #endif
 
-#ifdef CYTHON_COMPILING_IN_PYPY
+#if CYTHON_COMPILING_IN_PYPY == 1
   #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x030A0000
     #define CYTHON_NEED_TP_PRINT 1
   #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -556,6 +556,19 @@
   #define __PYX_IS_UNSIGNED(type) (((type)-1) > 0)
 #endif
 
+#ifdef CYTHON_COMPILING_IN_PYPY
+  #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x030A0000
+    #define CYTHON_NEED_TP_PRINT 1
+  #else
+    #define CYTHON_NEED_TP_PRINT 0
+  #endif
+#else
+  #if PY_VERSION_HEX >= 0x030800b4 && PY_VERSION_HEX < 0x03090000
+    #define CYTHON_NEED_TP_PRINT 1
+  #else
+    #define CYTHON_NEED_TP_PRINT 0
+  #endif
+#endif
 // reinterpret
 
 // TODO: refactor existing code to use those macros


### PR DESCRIPTION
Fixes #5436. PyPy < 3.10 still has a `tp_print` field, where CPython removed it for 3.9