### PR TITLE
Fix usage of __STDC_VERSION__ macro

### DIFF
--- a/Cython/Utility/Complex.c
+++ b/Cython/Utility/Complex.c
@@ -4,7 +4,7 @@
 #if !defined(CYTHON_CCOMPLEX)
   #if defined(__cplusplus)
     #define CYTHON_CCOMPLEX 1
-  #elif defined(_Complex_I) || (__STDC_VERSION__ >= 201112L && !defined(__STDC_NO_COMPLEX__))
+  #elif defined(_Complex_I) || ((defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_COMPLEX__))
     // <complex.h> should exist since C99, but only C11 defines a test to detect it
     #define CYTHON_CCOMPLEX 1
   #else

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -515,11 +515,11 @@ set_path:
 #ifndef __PYX_HAVE_RT_ImportType_proto_$cyversion
 #define __PYX_HAVE_RT_ImportType_proto_$cyversion
 
-#if __STDC_VERSION__ >= 201112L
+#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #include <stdalign.h>
 #endif
 
-#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L
+#if (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || __cplusplus >= 201103L
 #define __PYX_GET_STRUCT_ALIGNMENT_$cyversion(s) alignof(s)
 #else
 // best guess at what the alignment could be since we can't measure it

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2000,7 +2000,7 @@ static void __Pyx_FastGilFuncInit(void);
 
 #ifdef WITH_THREAD
   #ifndef CYTHON_THREAD_LOCAL
-    #if __STDC_VERSION__ >= 201112
+    #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112
       #define CYTHON_THREAD_LOCAL _Thread_local
     #elif defined(__GNUC__)
       #define CYTHON_THREAD_LOCAL __thread


### PR DESCRIPTION
Clang gets upset when an undefined macro is used