### PR TITLE
Fix clang warnings in ExtensionTypes.c

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2313,16 +2313,16 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 slot.right_slot.method_name,
             ))
 
-        overloads_left = int(bool(get_slot_method_cname(slot.left_slot.method_name)))
-        overloads_right = int(bool(get_slot_method_cname(slot.right_slot.method_name)))
+        overloads_left = bool(get_slot_method_cname(slot.left_slot.method_name))
+        overloads_right = bool(get_slot_method_cname(slot.right_slot.method_name))
         code.putln(
             TempitaUtilityCode.load_as_string(
                 "BinopSlot", "ExtensionTypes.c",
                 context={
                     "func_name": func_name,
                     "slot_name": slot.slot_name,
-                    "overloads_left": overloads_left,
-                    "overloads_right": overloads_right,
+                    "overloads_left": 'true' if overloads_left else 'false',
+                    "overloads_right": 'true' if overloads_right else 'false',
                     "call_left": call_slot_method(slot.left_slot.method_name, reverse=False),
                     "call_right": call_slot_method(slot.right_slot.method_name, reverse=True),
                     "type_cname": scope.parent_type.typeptr_cname,

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -523,6 +523,10 @@ __PYX_GOOD:
 
 /////////////// BinopSlot ///////////////
 
+#ifndef __cplusplus
+    #include <stdbool.h>
+#endif
+
 static CYTHON_INLINE PyObject *{{func_name}}_maybe_call_slot(PyTypeObject* type, PyObject *left, PyObject *right {{extra_arg_decl}}) {
     {{slot_type}} slot;
 #if CYTHON_USE_TYPE_SLOTS || PY_MAJOR_VERSION < 3 || CYTHON_COMPILING_IN_PYPY
@@ -534,7 +538,7 @@ static CYTHON_INLINE PyObject *{{func_name}}_maybe_call_slot(PyTypeObject* type,
 }
 
 static PyObject *{{func_name}}(PyObject *left, PyObject *right {{extra_arg_decl}}) {
-    int maybe_self_is_left, maybe_self_is_right = 0;
+    bool maybe_self_is_left, maybe_self_is_right = false;
     maybe_self_is_left = Py_TYPE(left) == Py_TYPE(right)
 #if CYTHON_USE_TYPE_SLOTS
             || (Py_TYPE(left)->tp_as_number && Py_TYPE(left)->tp_as_number->{{slot_name}} == &{{func_name}})
@@ -555,7 +559,7 @@ static PyObject *{{func_name}}(PyObject *left, PyObject *right {{extra_arg_decl}
             if (res != Py_NotImplemented) return res;
             Py_DECREF(res);
             // Don't bother calling it again.
-            maybe_self_is_right = 0;
+            maybe_self_is_right = false;
         }
         res = {{call_left}};
         if (res != Py_NotImplemented) return res;


### PR DESCRIPTION
Clang doesn't like it when integer constants are used as hardcoded booleans in an if test. A 'constant-logical-operand' warning is emitted.

If we change the variable types to bool and replace integers with true/false keywords the warnings go away.

fixes #5418