### PR TITLE
raise AttributeError inside __getattr__

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -551,7 +551,6 @@ class CythonDotImportedFromElsewhere(object):
         sys.modules['cython.%s' % self.__name__] = mod
         return getattr(mod, attr)
 
-
 class CythonCImports(object):
     """
     Simplistic module mock to make cimports sort-of work in Python code.
@@ -567,8 +566,12 @@ class CythonCImports(object):
             raise AttributeError(item)
         try:
             return __import__(item)
-        except ModuleNotFoundError:
-            raise AttributeError(item) from None
+        except ImportError:
+            import sys
+            ex = AttributeError(item)
+            if sys.version_info >= (3, 0):
+                ex.__cause__ = None
+            raise ex
 
 
 import math, sys

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -565,7 +565,10 @@ class CythonCImports(object):
     def __getattr__(self, item):
         if item.startswith('__') and item.endswith('__'):
             raise AttributeError(item)
-        return __import__(item)
+        try:
+            return __import__(item)
+        except ModuleNotFoundError:
+            raise AttributeError(item) from None
 
 
 import math, sys

--- a/tests/run/test_shadow_error.py
+++ b/tests/run/test_shadow_error.py
@@ -1,4 +1,5 @@
-#tag: numpy
+# mode: run
+# tag: numpy, gh5411
 
 import pickle
 import numpy as np

--- a/tests/run/test_shadow_error.py
+++ b/tests/run/test_shadow_error.py
@@ -1,0 +1,13 @@
+#tag: numpy
+
+import pickle
+import numpy as np
+
+# This adds e.g
+# sys.modules['cython.cimports'] = CythonCImports('cython.cimports')
+from Cython import Shadow
+
+# This calls hasattr(CythonCImports, "add")
+add = pickle.loads(pickle.dumps(np.add))
+
+assert add is np.add


### PR DESCRIPTION
Fixes #5411, needed for using pickle with cython3 on NumPy

The basic premise is that a failure in `__getattr__` should raise an `AttributeError`