### PR TITLE
use pypy-3.9-v7.3.12rc2 instead of a nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           - os: ubuntu-20.04
-            python-version: pypy-3.9-nightly
+            python-version: pypy-3.9-v7.3.12rc2
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           # Coverage


### PR DESCRIPTION
PR #5429 changed CI to use pypy3.9 nightly in order to get a pypy-specific `_PyEval_GetAsyncGenFinalizer` and `_PyEval_GetAsyncGenFirstiter`. Using a nightly is unstable, since sometimes they are broken. It is better to use the latest v7.3.12rc2 which includes the needed changes for #5429. This PR is temporary, I expect the final release within a week or two.