### PR TITLE
Update Sharing C Functions example to hedge for strange use of Cython

### DIFF
--- a/docs/examples/userguide/sharing_declarations/volume.pyx
+++ b/docs/examples/userguide/sharing_declarations/volume.pyx
@@ -1,2 +1,2 @@
-cdef float cube(float x):
+cdef api float cube(float x):
     return x * x * x


### PR DESCRIPTION
Under Cython 0.29.34, the `__pyx_capi__` attribute and `volume_api.h` will not be generated unless the `cube` function is declared `api`.