### PR TITLE
Adjust error handling regex in Annotate.py to support html escaped characters

### DIFF
--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -315,7 +315,7 @@ _parse_code = re.compile((
     br'(?P<py_macro_api>Py[A-Z][a-z]+_[A-Z][A-Z_]+)|'
     br'(?P<py_c_api>Py[A-Z][a-z]+_[A-Z][a-z][A-Za-z_]*)'
     br')(?=\()|'       # look-ahead to exclude subsequent '(' from replacement
-    br'(?P<error_goto>(?:(?<=;) *if [^;]* +)?__PYX_ERR\([^)]+\))'
+    br'(?P<error_goto>(?:(?<=;) *if \(.*\) +)?__PYX_ERR\([^)]+\))'
 ).decode('ascii')).sub
 
 


### PR DESCRIPTION
Fixes #5462
