### PR TITLE
Update numpy tutorial not to use deprecated/removed np.int

### DIFF
--- a/docs/examples/tutorial/numpy/convolve2.pyx
+++ b/docs/examples/tutorial/numpy/convolve2.pyx
@@ -6,24 +6,27 @@ import numpy as np
 
 # "cimport" is used to import special compile-time information
 # about the numpy module (this is stored in a file numpy.pxd which is
-# currently part of the Cython distribution).
-cimport numpy as np
+# distributed with Numpy).
+# Here we've used the name "cnp" to make it easier to understand what
+# comes from the cimported module and what comes from the imported module,
+# however you can use the same name for both if you wish.
+cimport numpy as cnp
 
 # It's necessary to call "import_array" if you use any part of the
 # numpy PyArray_* API. From Cython 3, accessing attributes like
 # ".shape" on a typed Numpy array use this API. Therefore we recommend
 # always calling "import_array" whenever you "cimport numpy"
-np.import_array()
+cnp.import_array()
 
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
 # type info object.
-DTYPE = np.int
+DTYPE = np.int64
 
 # "ctypedef" assigns a corresponding compile-time type to DTYPE_t. For
 # every type in the numpy module there's a corresponding compile-time
 # type with a _t-suffix.
-ctypedef np.int_t DTYPE_t
+ctypedef cnp.int64_t DTYPE_t
 
 # "def" can type its arguments but not have a return type. The type of the
 # arguments for a "def" function is checked at run-time when entering the
@@ -33,7 +36,7 @@ ctypedef np.int_t DTYPE_t
 # this has is to a) insert checks that the function arguments really are
 # NumPy arrays, and b) make some attribute access like f.shape[0] much
 # more efficient. (In this example this doesn't matter though.)
-def naive_convolve(np.ndarray f, np.ndarray g):
+def naive_convolve(cnp.ndarray f, cnp.ndarray g):
     if g.shape[0] % 2 != 1 or g.shape[1] % 2 != 1:
         raise ValueError("Only odd dimensions on filter supported")
     assert f.dtype == DTYPE and g.dtype == DTYPE

--- a/docs/examples/tutorial/numpy/convolve2.pyx
+++ b/docs/examples/tutorial/numpy/convolve2.pyx
@@ -58,7 +58,7 @@ def naive_convolve(cnp.ndarray f, cnp.ndarray g):
     cdef int tmid = tmax // 2
     cdef int xmax = vmax + 2 * smid
     cdef int ymax = wmax + 2 * tmid
-    cdef np.ndarray h = np.zeros([xmax, ymax], dtype=DTYPE)
+    cdef cnp.ndarray h = np.zeros([xmax, ymax], dtype=DTYPE)
     cdef int x, y, s, t, v, w
 
     # It is very important to type ALL your variables. You do not get any

--- a/docs/src/tutorial/numpy.rst
+++ b/docs/src/tutorial/numpy.rst
@@ -32,22 +32,22 @@ run a Python session to test both the Python version (imported from
 
     In [1]: import numpy as np
     In [2]: import convolve_py
-    In [3]: convolve_py.naive_convolve(np.array([[1, 1, 1]], dtype=np.int),
-    ...     np.array([[1],[2],[1]], dtype=np.int))
+    In [3]: convolve_py.naive_convolve(np.array([[1, 1, 1]], dtype=np.int64),
+    ...     np.array([[1],[2],[1]], dtype=np.int64))
     Out [3]:
     array([[1, 1, 1],
         [2, 2, 2],
         [1, 1, 1]])
     In [4]: import convolve1
-    In [4]: convolve1.naive_convolve(np.array([[1, 1, 1]], dtype=np.int),
-    ...     np.array([[1],[2],[1]], dtype=np.int))
+    In [4]: convolve1.naive_convolve(np.array([[1, 1, 1]], dtype=np.int64),
+    ...     np.array([[1],[2],[1]], dtype=np.int64))
     Out [4]:
     array([[1, 1, 1],
         [2, 2, 2],
         [1, 1, 1]])
     In [11]: N = 100
-    In [12]: f = np.arange(N*N, dtype=np.int).reshape((N,N))
-    In [13]: g = np.arange(81, dtype=np.int).reshape((9, 9))
+    In [12]: f = np.arange(N*N, dtype=np.int64).reshape((N,N))
+    In [13]: g = np.arange(81, dtype=np.int64).reshape((9, 9))
     In [19]: %timeit -n2 -r3 convolve_py.naive_convolve(f, g)
     2 loops, best of 3: 1.86 s per loop
     In [20]: %timeit -n2 -r3 convolve1.naive_convolve(f, g)
@@ -91,9 +91,9 @@ not provided then one-dimensional is assumed).
 These are the needed changes::
 
     ...
-    def naive_convolve(np.ndarray[DTYPE_t, ndim=2] f, np.ndarray[DTYPE_t, ndim=2] g):
+    def naive_convolve(cnp.ndarray[DTYPE_t, ndim=2] f, cnp.ndarray[DTYPE_t, ndim=2] g):
     ...
-    cdef np.ndarray[DTYPE_t, ndim=2] h = ...
+    cdef cnp.ndarray[DTYPE_t, ndim=2] h = ...
 
 Usage:
 
@@ -127,7 +127,7 @@ The array lookups are still slowed down by two factors:
         cimport cython
         @cython.boundscheck(False) # turn off bounds-checking for entire function
         @cython.wraparound(False)  # turn off negative index wrapping for entire function
-        def naive_convolve(np.ndarray[DTYPE_t, ndim=2] f, np.ndarray[DTYPE_t, ndim=2] g):
+        def naive_convolve(cnp.ndarray[DTYPE_t, ndim=2] f, cnp.ndarray[DTYPE_t, ndim=2] g):
         ...
 
 Now bounds checking is not performed (and, as a side-effect, if you ''do''
@@ -148,8 +148,8 @@ two examples with larger N:
     In [11]: %timeit -n3 -r100 convolve4.naive_convolve(f, g)
     3 loops, best of 100: 5.97 ms per loop
     In [12]: N = 1000
-    In [13]: f = np.arange(N*N, dtype=np.int).reshape((N,N))
-    In [14]: g = np.arange(81, dtype=np.int).reshape((9, 9))
+    In [13]: f = np.arange(N*N, dtype=np.int64).reshape((N,N))
+    In [14]: g = np.arange(81, dtype=np.int64).reshape((9, 9))
     In [17]: %timeit -n1 -r10 convolve3.naive_convolve(f, g)
     1 loops, best of 10: 1.16 s per loop
     In [18]: %timeit -n1 -r10 convolve4.naive_convolve(f, g)
@@ -187,12 +187,12 @@ It would be possible to do::
 
     def naive_convolve(object[DTYPE_t, ndim=2] f, ...):
 
-i.e. use :obj:`object` rather than :obj:`np.ndarray`. Under Python 3.0 this
+i.e. use :obj:`object` rather than :obj:`cnp.ndarray`. Under Python 3.0 this
 can allow your algorithm to work with any libraries supporting the buffer
 interface; and support for e.g. the Python Imaging Library may easily be added
 if someone is interested also under Python 2.x.
 
 There is some speed penalty to this though (as one makes more assumptions
-compile-time if the type is set to :obj:`np.ndarray`, specifically it is
+compile-time if the type is set to :obj:`cnp.ndarray`, specifically it is
 assumed that the data is stored in pure strided mode and not in indirect
 mode).

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -595,12 +595,12 @@ Coercion to NumPy
 Memoryview (and array) objects can be coerced to a NumPy ndarray, without having
 to copy the data. You can e.g. do::
 
-    cimport numpy as np
+    cimport numpy as cnp
     import numpy as np
 
-    numpy_array = np.asarray(<np.int32_t[:10, :10]> my_pointer)
+    numpy_array = np.asarray(<cnp.int32_t[:10, :10]> my_pointer)
 
-Of course, you are not restricted to using NumPy's type (such as ``np.int32_t``
+Of course, you are not restricted to using NumPy's type (such as ``cnp.int32_t``
 here), you can use any usable type.
 
 None Slices


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/5457