### PR TITLE
wheel CI: Update cibuildwheel to v2.13.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,7 +74,7 @@ jobs:
           platforms: all
       
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.4
+        uses: pypa/cibuildwheel@v2.13.0
         env:
           # TODO: Build Cython with the compile-all flag?
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}


### PR DESCRIPTION
This commit updates cibuildwheel to v2.13.0 in the GitHub Actions wheel.yml CI workflow. cibuildwheel v2.13 adds CPython 3.12 support, under the prerelease flag CIBW_PRERELEASE_PYTHONS, among other this.

A small first step in solving https://github.com/cython/cython/issues/5467.

> ### [v2.13.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.13.0)
> ✨ Adds CPython 3.12 support, under the prerelease flag [CIBW_PRERELEASE_PYTHONS](https://cibuildwheel.readthedocs.io/en/stable/options/#prerelease-pythons). This version of cibuildwheel uses 3.12.0b1.
> 
> While CPython is in beta, the ABI can change, so your wheels might not be compatible with the final release. For this reason, we don't recommend distributing wheels until RC1, at which point 3.12 will be available in cibuildwheel without the flag.
> 
> ✨ Adds the ability to pass arguments to the container engine when the container is created, using the [CIBW_CONTAINER_ENGINE](https://cibuildwheel.readthedocs.io/en/stable/options/#container-engine) option.