### PR TITLE
added include_dirs to numpy pythran docs

### DIFF
--- a/docs/src/userguide/numpy_pythran.rst
+++ b/docs/src/userguide/numpy_pythran.rst
@@ -31,10 +31,13 @@ Here is an example of a simple ``setup.py`` file using setuptools:
 
   from setuptools import setup
   from Cython.Build import cythonize
+  import numpy
+  import pythran
 
   setup(
       name = "My hello app",
-      ext_modules = cythonize('hello_pythran.pyx')
+      ext_modules = cythonize('hello_pythran.pyx'),
+      include_dirs = [numpy.get_include(), pythran.get_include()]
   )
 
 Then, with the following header in ``hello_pythran.pyx``:


### PR DESCRIPTION
Using the exemple in the documentation, I kept on getting the following error :

```
lib/lib_cython_serial.c:798:10: fatal error: pythonic/core.hpp: No such file or directory
  798 | #include "pythonic/core.hpp"
```
The setup process could not find the header files.

This pull request fixes this small flaw in the docs.