### PR TITLE
Update pypy in CI to released version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           - os: ubuntu-20.04
-            python-version: pypy-3.9-v7.3.12rc2
+            python-version: pypy-3.9-v7.3.12
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
           # Coverage


### PR DESCRIPTION
PyPy released a new version, so CI does not need to use a nightly.