### PR TITLE
Recognize `gil()`/`nogil()` arguments in pure python mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,18 +184,6 @@ jobs:
             # missing dependencies
             python-version: 3.6
             allowed_failure: true
-          - os: windows-2019
-            # TestInline
-            python-version: 3.8
-            allowed_failure: true
-          - os: windows-2019
-            # TestInline
-            python-version: "3.10"
-            allowed_failure: true
-          - os: windows-2019
-            # TestInline
-            python-version: "3.11"
-            allowed_failure: true
 
         exclude:
           # fails due to lack of a compatible compiler

--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -230,6 +230,7 @@ def cython_inline(code, get_type=unsafe_type,
             build_extension = _get_build_extension()
             cython_inline.so_ext = build_extension.get_ext_filename('')
 
+        lib_dir = os.path.abspath(lib_dir)
         module_path = os.path.join(lib_dir, module_name + cython_inline.so_ext)
 
         if not os.path.exists(lib_dir):
@@ -287,7 +288,11 @@ def __invoke(%(params)s):
             build_extension.build_lib  = lib_dir
             build_extension.run()
 
-        module = load_dynamic(module_name, module_path)
+        if sys.platform == 'win32' and sys.version_info >= (3, 8):
+            with os.add_dll_directory(os.path.abspath(lib_dir)):
+                module = load_dynamic(module_name, module_path)
+        else:
+            module = load_dynamic(module_name, module_path)
 
     _cython_inline_cache[orig_code, arg_sigs, key_hash] = module.__invoke
     arg_list = [kwds[arg] for arg in arg_names]

--- a/Cython/Build/Tests/TestInline.py
+++ b/Cython/Build/Tests/TestInline.py
@@ -18,39 +18,39 @@ global_value = 100
 class TestInline(CythonTest):
     def setUp(self):
         CythonTest.setUp(self)
-        self.test_kwds = dict(test_kwds)
+        self._call_kwds = dict(test_kwds)
         if os.path.isdir('TEST_TMP'):
             lib_dir = os.path.join('TEST_TMP','inline')
         else:
             lib_dir = tempfile.mkdtemp(prefix='cython_inline_')
-        self.test_kwds['lib_dir'] = lib_dir
+        self._call_kwds['lib_dir'] = lib_dir
 
     def test_simple(self):
-        self.assertEqual(inline("return 1+2", **self.test_kwds), 3)
+        self.assertEqual(inline("return 1+2", **self._call_kwds), 3)
 
     def test_types(self):
         self.assertEqual(inline("""
             cimport cython
             return cython.typeof(a), cython.typeof(b)
-        """, a=1.0, b=[], **self.test_kwds), ('double', 'list object'))
+        """, a=1.0, b=[], **self._call_kwds), ('double', 'list object'))
 
     def test_locals(self):
         a = 1
         b = 2
-        self.assertEqual(inline("return a+b", **self.test_kwds), 3)
+        self.assertEqual(inline("return a+b", **self._call_kwds), 3)
 
     def test_globals(self):
-        self.assertEqual(inline("return global_value + 1", **self.test_kwds), global_value + 1)
+        self.assertEqual(inline("return global_value + 1", **self._call_kwds), global_value + 1)
 
     def test_no_return(self):
         self.assertEqual(inline("""
             a = 1
             cdef double b = 2
             cdef c = []
-        """, **self.test_kwds), dict(a=1, b=2.0, c=[]))
+        """, **self._call_kwds), dict(a=1, b=2.0, c=[]))
 
     def test_def_node(self):
-        foo = inline("def foo(x): return x * x", **self.test_kwds)['foo']
+        foo = inline("def foo(x): return x * x", **self._call_kwds)['foo']
         self.assertEqual(foo(7), 49)
 
     def test_class_ref(self):
@@ -65,7 +65,7 @@ class TestInline(CythonTest):
         b = cy.declare(float, a)
         c = cy.declare(cy.pointer(cy.float), &b)
         return b
-        """, a=3, **self.test_kwds)
+        """, a=3, **self._call_kwds)
         self.assertEqual(type(b), float)
 
     def test_compiler_directives(self):
@@ -109,4 +109,4 @@ class TestInline(CythonTest):
         a = numpy.ndarray((10, 20))
         a[0,0] = 10
         self.assertEqual(safe_type(a), 'numpy.ndarray[numpy.float64_t, ndim=2]')
-        self.assertEqual(inline("return a[0,0]", a=a, **self.test_kwds), 10.0)
+        self.assertEqual(inline("return a[0,0]", a=a, **self._call_kwds), 10.0)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3086,6 +3086,7 @@ class DefNode(FuncDefNode):
         if self.starstar_arg:
             error(self.starstar_arg.pos, "cdef function cannot have starstar argument")
         exception_value, exception_check = except_val or (None, False)
+        nogil = nogil or with_gil
 
         if cfunc is None:
             cfunc_args = []

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -410,7 +410,7 @@ directive_scopes = {  # defaults to available everywhere
 immediate_decorator_directives = {
     'cfunc', 'ccall', 'cclass', 'dataclasses.dataclass', 'ufunc',
     # function signature directives
-    'inline', 'exceptval', 'returns', 'nogil', 'with_gil',
+    'inline', 'exceptval', 'returns', 'with_gil',  # 'nogil',
     # class directives
     'freelist', 'no_gc', 'no_gc_clear', 'type_version_tag', 'final',
     'auto_pickle', 'internal', 'collection_type', 'total_ordering',

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -199,6 +199,7 @@ _directive_defaults = {
     'ccomplex' : False,  # use C99/C++ for complex types and arith
     'callspec' : "",
     'nogil' : False,
+    'gil' : False,
     'profile': False,
     'linetrace': False,
     'emit_code_comments': True,  # copy original source code into C code comments
@@ -322,7 +323,8 @@ directive_types = {
     'locals': dict,
     'final' : bool,  # final cdef classes and methods
     'collection_type': one_of('sequence'),
-    'nogil' : bool,
+    'nogil' : DEFER_ANALYSIS_OF_ARGUMENTS,
+    'gil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
     'binding' : bool,
@@ -358,6 +360,7 @@ directive_scopes = {  # defaults to available everywhere
     'final' : ('cclass', 'function'),
     'collection_type': ('cclass',),
     'nogil' : ('function', 'with statement'),
+    'gil' : ('function', 'with statement'),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -200,6 +200,7 @@ _directive_defaults = {
     'callspec' : "",
     'nogil' : False,
     'gil' : False,
+    'with_gil' : False,
     'profile': False,
     'linetrace': False,
     'emit_code_comments': True,  # copy original source code into C code comments
@@ -325,6 +326,7 @@ directive_types = {
     'collection_type': one_of('sequence'),
     'nogil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'gil' : DEFER_ANALYSIS_OF_ARGUMENTS,
+    'with_gil' : None,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
     'binding' : bool,
@@ -360,7 +362,8 @@ directive_scopes = {  # defaults to available everywhere
     'final' : ('cclass', 'function'),
     'collection_type': ('cclass',),
     'nogil' : ('function', 'with statement'),
-    'gil' : ('function', 'with statement'),
+    'gil' : ('with statement'),
+    'with_gil' : ('function',),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),
@@ -402,12 +405,12 @@ directive_scopes = {  # defaults to available everywhere
 }
 
 
-# a list of directives that (when used as a decorator) are only applied to
+# A list of directives that (when used as a decorator) are only applied to
 # the object they decorate and not to its children.
 immediate_decorator_directives = {
     'cfunc', 'ccall', 'cclass', 'dataclasses.dataclass', 'ufunc',
     # function signature directives
-    'inline', 'exceptval', 'returns',
+    'inline', 'exceptval', 'returns', 'nogil', 'with_gil',
     # class directives
     'freelist', 'no_gc', 'no_gc_clear', 'type_version_tag', 'final',
     'auto_pickle', 'internal', 'collection_type', 'total_ordering',

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1324,7 +1324,7 @@ class InterpretCompilerDirectives(CythonTransform):
                 for directive in new_directives:
                     if self.check_directive_scope(node.pos, directive[0], scope_name):
                         name, value = directive
-                        if name in ('gil', 'nogil', 'with_gil'):
+                        if name in ('nogil', 'with_gil'):
                             if value is None:
                                 value = True
                             else:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1325,11 +1325,10 @@ class InterpretCompilerDirectives(CythonTransform):
                     if self.check_directive_scope(node.pos, directive[0], scope_name):
                         name, value = directive
                         if name in ('gil', 'nogil', 'with_gil'):
-                            if not value:
+                            if value is None:
                                 value = True
                             else:
-                                kwds = value[1]
-                                args = value[0]
+                                args, kwds = value
                                 if kwds or len(args) != 1 or not isinstance(args[0], ExprNodes.BoolNode):
                                     raise PostParseError(dec.pos, 'The %s directive takes one compile-time boolean argument' % name)
                                 value = args[0].value

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -217,6 +217,7 @@ class _nogil(object):
 
 nogil = _nogil()
 gil = _nogil()
+with_gil = _nogil()  # Actually not a context manager, but compilation will give the right error.
 del _nogil
 
 

--- a/docs/examples/userguide/fusedtypes/conditional_gil.py
+++ b/docs/examples/userguide/fusedtypes/conditional_gil.py
@@ -1,0 +1,13 @@
+import cython
+
+double_or_object = cython.fused_type(cython.double, object)
+
+def increment(x: double_or_object):
+    with cython.nogil(double_or_object is not object):
+        # Same code handles both cython.double (GIL is released)
+        # and python object (GIL is not released).
+        x = x + 1
+    return x
+
+increment(5.0)  # GIL is released during increment
+increment(5)    # GIL is acquired during increment

--- a/docs/src/userguide/fusedtypes.rst
+++ b/docs/src/userguide/fusedtypes.rst
@@ -493,8 +493,6 @@ Conditional GIL Acquiring / Releasing
 Acquiring and releasing the GIL can be controlled by a condition
 which is known at compile time (see :ref:`gil_conditional`).
 
-.. Note:: Pure python mode currently does not support Conditional GIL Acquiring / Releasing. See Github issue :issue:`5113`.
-
 This is most useful when combined with fused types.
 A fused type function may have to handle both cython native types
 (e.g. cython.int or cython.double) and python types (e.g. object or bytes).
@@ -502,7 +500,15 @@ Conditional Acquiring / Releasing the GIL provides a method for running
 the same piece of code either with the GIL released (for cython native types)
 and with the GIL held (for python types):
 
-.. literalinclude:: ../../examples/userguide/fusedtypes/conditional_gil.pyx
+.. tabs::
+
+    .. group-tab:: Pure Python
+
+        .. literalinclude:: ../../examples/userguide/fusedtypes/conditional_gil.py
+
+    .. group-tab:: Cython
+
+        .. literalinclude:: ../../examples/userguide/fusedtypes/conditional_gil.pyx
 
 __signatures__
 ==============

--- a/tests/errors/pure_nogil_conditional.py
+++ b/tests/errors/pure_nogil_conditional.py
@@ -61,6 +61,13 @@ def nogil_keyworkd_arguments(x: cython.int) -> cython.int:
     with cython.nogil(kw=2):
         res = f_nogil(res)
 
+
+@cython.gil(True)
+@cython.cfunc
+def wrong_decorator() -> cython.int:
+    return 0
+
+
 _ERRORS = u"""
 22:14: Accessing Python global or builtin not allowed without gil
 22:19: Calling gil-requiring function not allowed without gil
@@ -78,4 +85,5 @@ _ERRORS = u"""
 46:16: Calling gil-requiring function not allowed without gil
 56:9: Compiler directive nogil accepts one positional argument.
 61:9: Compiler directive nogil accepts one positional argument.
+65:0: The gil compiler directive is not allowed in function scope
 """

--- a/tests/errors/pure_nogil_conditional.py
+++ b/tests/errors/pure_nogil_conditional.py
@@ -1,0 +1,81 @@
+# cython: remove_unreachable=False
+# mode: error
+import cython
+
+@cython.nogil
+@cython.cfunc
+def f_nogil(x: cython.int) -> cython.int:
+    y: cython.int
+    y = x + 10
+    return y
+
+
+def f_gil(x):
+    y = 0
+    y = x + 100
+    return y
+
+
+def illegal_gil_usage():
+    res: cython.int = 0
+    with cython.nogil(True):
+        res = f_gil(res)
+
+        with cython.nogil(True):
+            res = f_gil(res)
+
+    with cython.nogil(False):
+        res = f_nogil(res)
+
+
+def foo(a):
+    return a < 10
+
+
+def non_constant_condition(x: cython.int) -> cython.int:
+    res: cython.int = x
+    with cython.nogil(x < 10):
+        res = f_nogil(res)
+
+
+number_or_object = cython.fused_type(cython.float, cython.object)
+
+
+def fused_type(x: number_or_object):
+    with cython.nogil(number_or_object is object):
+        res = x + 1
+
+    # This should be fine
+    with cython.nogil(number_or_object is cython.float):
+        res = x + 1
+
+    return res
+
+def nogil_multiple_arguments(x: cython.int) -> cython.int:
+    res: cython.int = x
+    with cython.nogil(1, 2):
+        res = f_nogil(res)
+
+def nogil_keyworkd_arguments(x: cython.int) -> cython.int:
+    res: cython.int = x
+    with cython.nogil(kw=2):
+        res = f_nogil(res)
+
+_ERRORS = u"""
+22:14: Accessing Python global or builtin not allowed without gil
+22:19: Calling gil-requiring function not allowed without gil
+22:19: Coercion from Python not allowed without the GIL
+22:19: Constructing Python tuple not allowed without gil
+22:20: Converting to Python object not allowed without gil
+24:13: Trying to release the GIL while it was previously released.
+25:18: Accessing Python global or builtin not allowed without gil
+25:23: Calling gil-requiring function not allowed without gil
+25:23: Coercion from Python not allowed without the GIL
+25:23: Constructing Python tuple not allowed without gil
+25:24: Converting to Python object not allowed without gil
+37:24: Non-constant condition in a `with nogil(<condition>)` statement
+46:8: Assignment of Python object not allowed without gil
+46:16: Calling gil-requiring function not allowed without gil
+56:9: Compiler directive nogil accepts one positional argument.
+61:9: Compiler directive nogil accepts one positional argument.
+"""

--- a/tests/run/pure_nogil_conditional.pyx
+++ b/tests/run/pure_nogil_conditional.pyx
@@ -1,0 +1,231 @@
+# mode: run
+
+import cython
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+
+def test(int x):
+    """
+    >>> test(0)
+    110
+    """
+    with cython.nogil(True):
+        x = f_nogil(x)
+        with cython.gil(True):
+            x = f_gil(x)
+    return x
+
+
+@cython.nogil
+@cython.cfunc
+def f_nogil(x: cython.int) -> cython.int:
+    y: cython.int
+    y = x + 10
+    return y
+
+
+def f_gil(x):
+    y = 0
+    y = x + 100
+    return y
+
+
+@cython.nogil
+@cython.exceptval(check=False)
+@cython.cfunc
+def write_unraisable() -> cython.int:
+    with cython.gil:
+        raise ValueError()
+
+
+def test_unraisable():
+    """
+    >>> print(test_unraisable())  # doctest: +ELLIPSIS
+    ValueError
+    Exception...ignored...
+    """
+    import sys
+    old_stderr = sys.stderr
+    stderr = sys.stderr = StringIO()
+    try:
+        write_unraisable()
+    finally:
+        sys.stderr = old_stderr
+    return stderr.getvalue().strip()
+
+
+def test_nested():
+    """
+    >>> test_nested()
+    240
+    """
+    res: cython.int = 0
+
+    with cython.nogil(True):
+        res = f_nogil(res)
+        with cython.gil:
+            res = f_gil(res)
+            with cython.nogil:
+                res = f_nogil(res)
+
+        with cython.gil:
+            res = f_gil(res)
+            with cython.nogil(True):
+                res = f_nogil(res)
+            with cython.nogil:
+                res = f_nogil(res)
+
+    return res
+
+
+def test_try_finally():
+    """
+    >>> test_try_finally()
+    113
+    """
+    res: cython.int = 0
+
+    try:
+        with cython.nogil(True):
+            try:
+                res = f_nogil(res)
+                with cython.gil:
+                    try:
+                        res = f_gil(res)
+                    finally:
+                        res += 1
+            finally:
+                res = res + 1
+    finally:
+        res += 1
+
+    return res
+
+
+number_or_object = cython.fused_type(cython.int, cython.float, object)
+
+
+def test_fused(x: number_or_object) -> number_or_object:
+    """
+    >>> test_fused["int"](1)
+    2
+    >>> test_fused["float"](1.0)
+    2.0
+    >>> test_fused[object](1)
+    2
+    >>> test_fused[object](1.0)
+    2.0
+    """
+    res: number_or_object = x
+
+    with cython.nogil(number_or_object is not object):
+        res = res + 1
+
+    return res
+
+
+int_or_object = cython.fused_type(cython.int, object)
+
+
+def test_fused_object(x: int_or_object):
+    """
+    >>> import cython
+    >>> test_fused_object[object]("spam")
+    456
+    >>> test_fused_object["int"](1000)
+    1000
+    """
+    res: cython.int = 0
+
+    if int_or_object is object:
+        with cython.nogil(False):
+            res += len(x)
+
+        try:
+            with cython.nogil(int_or_object is object):
+                try:
+                    with cython.gil(int_or_object is object):
+                        res = f_gil(res)
+                    with cython.gil:
+                        res = f_gil(res)
+                    with cython.gil(False):
+                        res = f_nogil(res)
+
+                    with cython.gil(int_or_object is not object):
+                        res = f_nogil(res)
+                    with cython.nogil(False):
+                        res = f_nogil(res)
+
+                    res = f_nogil(res)
+                finally:
+                    res = res + 1
+
+            with cython.nogil(int_or_object is not object):
+                res = f_gil(res)
+
+            with cython.gil(int_or_object is not object):
+                res = f_gil(res)
+
+                with cython.nogil(int_or_object is object):
+                    res = f_nogil(res)
+
+        finally:
+            res += 1
+    else:
+        res = x
+
+    return res
+
+
+def test_fused_int(x: int_or_object):
+    """
+    >>> import cython
+    >>> test_fused_int[object]("spam")
+    4
+    >>> test_fused_int["int"](1000)
+    1452
+    """
+    res: cython.int = 0
+
+    if int_or_object is cython.int:
+        res += x
+
+        try:
+            with cython.nogil(int_or_object is cython.int):
+                try:
+                    with cython.gil(int_or_object is int):
+                        res = f_gil(res)
+                    with cython.gil:
+                        res = f_gil(res)
+                    with cython.gil(False):
+                        res = f_nogil(res)
+
+                    with cython.gil(int_or_object is not int):
+                        res = f_nogil(res)
+                    with cython.nogil(False):
+                        res = f_nogil(res)
+
+                    res = f_nogil(res)
+                finally:
+                    res = res + 1
+
+            with cython.nogil(int_or_object is not cython.int):
+                res = f_gil(res)
+
+            with cython.gil(int_or_object is not int):
+                res = f_gil(res)
+
+                with cython.nogil(int_or_object is int):
+                    res = f_nogil(res)
+
+        finally:
+            res += 1
+    else:
+        with cython.nogil(False):
+            res = len(x)
+
+    return res

--- a/tests/run/pure_nogil_conditional.pyx
+++ b/tests/run/pure_nogil_conditional.pyx
@@ -1,4 +1,5 @@
 # mode: run
+# tag: pure, nogil
 
 import cython
 
@@ -8,7 +9,7 @@ except ImportError:
     from io import StringIO
 
 
-def test(int x):
+def test(x: cython.int):
     """
     >>> test(0)
     110
@@ -32,6 +33,22 @@ def f_gil(x):
     y = 0
     y = x + 100
     return y
+
+
+@cython.with_gil
+@cython.cfunc
+def f_with_gil(x: cython.int) -> cython.int:
+    return x + len([1, 2] * x)
+
+
+def test_with_gil(x: cython.int):
+    """
+    >>> test_with_gil(3)
+    9
+    """
+    with cython.nogil:
+        result = f_with_gil(x)
+    return result
 
 
 @cython.nogil


### PR DESCRIPTION
Fixes #5113.

This is secondary attempt. Supersedes #5200. It tries to:

1. Raise an error when directive contains expression in all cases except `with gil()` or `with nogil()`. This maintains compatibility with current status quo
2. `try_to_parse_directive()` returns `optname, value` for all non-error cases, which ensures that it does not break code using this function.
