### PR TITLE
sync with NumPy 1.25

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Other changes
 -------------
 
 * The FAQ page was moved from the GitHub Wiki to the regular documentation.
+* ``np.long_t`` and ``np.ulong_t`` were removed, synching Cython with upstream
+  NumPy v1.25.0. The aliases were confusing since they could mean different
+  things on different platforms.
 
 
 3.0.0 beta 3 (2023-05-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Other changes
 -------------
 
 * The FAQ page was moved from the GitHub Wiki to the regular documentation.
+
 * ``np.long_t`` and ``np.ulong_t`` were removed, synching Cython with upstream
   NumPy v1.25.0. The aliases were confusing since they could mean different
   things on different platforms.

--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -758,11 +758,9 @@ ctypedef double complex complex128_t
 # The int types are mapped a bit surprising --
 # numpy.int corresponds to 'l' and numpy.long to 'q'
 ctypedef npy_long       int_t
-ctypedef npy_longlong   long_t
 ctypedef npy_longlong   longlong_t
 
 ctypedef npy_ulong      uint_t
-ctypedef npy_ulonglong  ulong_t
 ctypedef npy_ulonglong  ulonglong_t
 
 ctypedef npy_intp       intp_t

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -255,7 +255,6 @@ def inc1_object(np.ndarray[object] arr):
     arr[1] = o # unfortunately, += segfaults for objects
 
 def inc1_int_t(np.ndarray[np.int_t] arr):               arr[1] += 1
-# def inc1_long_t(np.ndarray[np.long_t] arr):             arr[1] += 1
 def inc1_longlong_t(np.ndarray[np.longlong_t] arr):     arr[1] += 1
 def inc1_float_t(np.ndarray[np.float_t] arr):           arr[1] += 1
 def inc1_double_t(np.ndarray[np.double_t] arr):         arr[1] += 1

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -255,7 +255,7 @@ def inc1_object(np.ndarray[object] arr):
     arr[1] = o # unfortunately, += segfaults for objects
 
 def inc1_int_t(np.ndarray[np.int_t] arr):               arr[1] += 1
-def inc1_long_t(np.ndarray[np.long_t] arr):             arr[1] += 1
+# def inc1_long_t(np.ndarray[np.long_t] arr):             arr[1] += 1
 def inc1_longlong_t(np.ndarray[np.longlong_t] arr):     arr[1] += 1
 def inc1_float_t(np.ndarray[np.float_t] arr):           arr[1] += 1
 def inc1_double_t(np.ndarray[np.double_t] arr):         arr[1] += 1


### PR DESCRIPTION
Numpy removed the confusing aliases for `np.long_t` and `np.ulong_t` in https://github.com/numpy/numpy/pull/22637. This was incorporated into yesterday's v1.25.0 release. This broke tests and CI here. 