### PR TITLE
Fix display error on Cython3.0 document on troubleshooting

### DIFF
--- a/docs/src/tutorial/embedding.rst
+++ b/docs/src/tutorial/embedding.rst
@@ -121,7 +121,7 @@ If your module imports anything (and possibly even if it doesn't) then it'll nee
 the Python path set so it knows where to look for modules. Unlikely the standalone
 interpreter, embedded Python doesn't set this up automatically.
 
-``PySys_SetPath(...)`` is the easiest way of doing this (just after ``Py_Initialize()`
+``PySys_SetPath(...)`` is the easiest way of doing this (just after ``Py_Initialize()``
 ideally). You could also use ``PySys_GetObject("path")`` and then append to the
 list that it returns.
 

--- a/docs/src/userguide/troubleshooting.rst
+++ b/docs/src/userguide/troubleshooting.rst
@@ -86,7 +86,7 @@ essentially disables all type-inference. Therefore it doesn't know the type of `
 Writing into extension types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``AttributeError``s can also happen when writing into a ``cdef class``, commonly in ``__init__``::
+``AttributeError`` can also happen when writing into a ``cdef class``, commonly in ``__init__``::
 
     cdef class Company:
         def __init__(self, staff):

--- a/docs/src/userguide/troubleshooting.rst
+++ b/docs/src/userguide/troubleshooting.rst
@@ -86,7 +86,7 @@ essentially disables all type-inference. Therefore it doesn't know the type of `
 Writing into extension types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``AttributeError`` can also happen when writing into a ``cdef class``, commonly in ``__init__``::
+``AttributeErrors`` can also happen when writing into a ``cdef class``, commonly in ``__init__``::
 
     cdef class Company:
         def __init__(self, staff):


### PR DESCRIPTION
This addition letter "s" cause error on displaying format.

Here is what it originally looks like:

![image](https://github.com/cython/cython/assets/31073262/365f2fec-d27b-4cf2-894e-b49fe6c54b27)

This is what you really mean:

<img width="719" alt="image" src="https://github.com/cython/cython/assets/31073262/d11c5c3c-c590-4040-8b52-40935ea2cff9">
