### PR TITLE
Remove some additional sys.stderr prints

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -643,7 +643,7 @@ def compile_multiple(sources, options):
             out_of_date = context.c_file_out_of_date(source, output_filename)
             if (not timestamps) or out_of_date:
                 if verbose:
-                    sys.stderr.write("Compiling %s\n" % source)
+                    print("Compiling %s\n" % source)
                 result = run_pipeline(source, options,
                                       full_module_name=options.module_name,
                                       context=context)


### PR DESCRIPTION
Follow-up to https://github.com/cython/cython/pull/5505 - I think this one isn't an error either really.

(Although possibly might be most useful in the stderr stream. I'm not sure)