### PR TITLE
Improve (and test) memoryview reference counting

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -76,7 +76,7 @@ cdef extern from *:
         pass
 
 cdef extern from *:
-    ctypedef int __pyx_atomic_int
+    ctypedef int __pyx_atomic_int_type
     {{memviewslice_name}} slice_copy_contig "__pyx_memoryview_copy_new_contig"(
                                  __Pyx_memviewslice *from_mvs,
                                  char *mode, int ndim,
@@ -317,21 +317,6 @@ cdef indirect_contiguous = Enum("<contiguous and indirect>")
 # 'follow' is implied when the first or last axis is ::1
 
 
-@cname('__pyx_align_pointer')
-cdef void *align_pointer(void *memory, size_t alignment) noexcept nogil:
-    "Align pointer memory on a given boundary"
-    cdef Py_intptr_t aligned_p = <Py_intptr_t> memory
-    cdef size_t offset
-
-    with cython.cdivision(True):
-        offset = aligned_p % alignment
-
-    if offset > 0:
-        aligned_p += alignment - offset
-
-    return <void *> aligned_p
-
-
 # pre-allocate thread locks for reuse
 ## note that this could be implemented in a more beautiful way in "normal" Cython,
 ## but this code gets merged into the user module and not everything works there.
@@ -352,8 +337,7 @@ cdef class memoryview:
     cdef PyThread_type_lock lock
     # the following array will contain a single __pyx_atomic int with
     # suitable alignment
-    cdef __pyx_atomic_int acquisition_count[2]
-    cdef __pyx_atomic_int *acquisition_count_aligned_p
+    cdef __pyx_atomic_int_type acquisition_count
     cdef Py_buffer view
     cdef int flags
     cdef bint dtype_is_object
@@ -383,8 +367,7 @@ cdef class memoryview:
         else:
             self.dtype_is_object = dtype_is_object
 
-        self.acquisition_count_aligned_p = <__pyx_atomic_int *> align_pointer(
-                  <void *> &self.acquisition_count[0], sizeof(__pyx_atomic_int))
+        assert <Py_intptr_t><void*>(&self.acquisition_count) % sizeof(__pyx_atomic_int_type) == 0
         self.typeinfo = NULL
 
     def __dealloc__(memoryview self):

--- a/tests/memoryview/parallel_refcounting_stress_test.pyx
+++ b/tests/memoryview/parallel_refcounting_stress_test.pyx
@@ -1,0 +1,68 @@
+# mode: run
+# tag: openmp
+
+from cython.parallel cimport prange
+cimport cython
+from random import randint, random
+
+include "../buffers/mockbuffers.pxi"
+
+# This test is designed to pick up concurrency errors in memoryview reference counting.
+# It won't be 100% reliable, but hopefully does enough memoryview reference counting in
+# parallel that we should see errors if it isn't thread-safe.
+# It has been verified to crash if the atomic reference counting is replace with non-atomic counting
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def refcounting_stress_test(int N):
+    """
+    >>> _ = refcounting_stress_test(5000)
+    acquired a
+    acquired b
+    acquired c
+    released a
+    released b
+    released c
+    """
+    selectors = [ randint(0, 3) for _ in range(N) ]
+    cdef int[::1] selectorsview = IntMockBuffer(None, selectors, (N,))
+    shape = (10, 3)
+    size = shape[0]*shape[1]
+    a = [ random() for _ in range(size) ]
+    b = [ random() for _ in range(size) ]
+    c = [ random() for _ in range(size) ]
+    cdef double[:,:] aview = DoubleMockBuffer("a", a, shape)
+    cdef double[:,:] bview = DoubleMockBuffer("b", b, shape)
+    cdef double[:,:] cview = DoubleMockBuffer("c", c, shape)
+
+    cdef int i
+    cdef double total = 0.0
+
+    for i in prange(N, nogil=True):
+        total += loopbody(aview, bview, cview, selectorsview[i])
+
+    # make "release" order predictable
+    del aview
+    del bview
+    del cview
+
+    return total
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef double loopbody(double[:,:] a, double[:,:] b, double[:,:] c, int selector) nogil:
+    cdef double[:,:] selected
+    cdef double[:] subslice
+    cdef double res = 0
+
+    if selector % 3 == 1:
+        selected = a
+    elif selector % 3 == 2:
+        selected = b
+    else:
+        selected = c
+
+    for i in range(selected.shape[0]):
+        subslice = selected[i, :]
+        res += subslice[0] + subslice[2]
+    return res


### PR DESCRIPTION
1. Avoid needing an indirection to align the atomic types. They should be aligned anyway, and this causes a notable slow-down.
2. Don't use "volatile" typedef - volatile doesn't guarantee anything about atomicity and isn't needed here.
3. Use explicit memory ordering. Won't make much difference on x86/x64 but may be faster on other architectures.
4. Add a stress-test to try to make sure we haven't messed up.

Closes https://github.com/cython/cython/issues/5509