### PR TITLE
WIP: Unified release notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,27 @@ and `PEP-560`_ (Github issues :issue:`2753`, :issue:`3537`, :issue:`3764`) was a
 Related fixes
 ^^^^^^^^^^^^^
 
+* Generator expressions and comprehensions now look up their outer-most iterable
+  on creation, as Python does, and not later on start, as they did previously.
+  (Github issue :issue:`1159`)
+
+* C-API declarations for context variables in Python 3.7 were added.
+  Original patch by Zolisa Bleki.  (Github issue :issue:`2281`)
+
+* ``@cython.trashcan(True)`` can be used on an extension type to enable the
+  CPython :ref:`trashcan`. This allows deallocating deeply recursive objects
+  without overflowing the stack. Patch by Jeroen Demeyer.  (Github issue :issue:`2842`)
+
+* The long deprecated include files ``python_*``, ``stdio``, ``stdlib`` and
+  ``stl`` in ``Cython/Includes/Deprecated/`` were removed.  Use the ``libc.*``
+  and ``cpython.*`` pxd modules instead.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`2904`)
+
+* ``PyMem_[Raw]Calloc()`` was added to the ``cpython.mem`` declarations.
+  Note that the ``Raw`` versions are no longer #defined by Cython.  The previous
+  macros were not considered safe.
+  Patch by William Schwartz and David Woods.  (Github issue :issue:`3047`)
+
 * Unicode module names and imports are supported.
   Patch by David Woods.  (Github issue :issue:`3119`)
 
@@ -74,12 +95,56 @@ Related fixes
   were found to be broken in Python 3.8 and later.
   Patch by Marcel Stimberg.  (Github issue :issue:`3309`)
 
+* Cython avoids raising ``StopIteration`` in ``__next__`` methods when possible.
+  Patch by David Woods.  (Github issue :issue:`3447`)
+
+* ``__del__(self)`` on extension types now maps to ``tp_finalize`` in Python 3.
+  Original patch by ax487.  (Github issue :issue:`3612`)
+
+* A low-level inline function ``total_seconds(timedelta)`` was added to
+  ``cpython.datetime`` to bypass the Python method call.  Note that this function
+  is not guaranteed to give exactly the same results for very large time intervals.
+  Patch by Brock Mendel.  (Github issue :issue:`3616`)
+
+* A new module ``cpython.time`` was added with some low-level alternatives to
+  Python's ``time`` module.
+  Patch by Brock Mendel.  (Github issue :issue:`3767`)
+
+* Python's ``memoryview`` is now a known builtin type with optimised properties.
+  (Github issue :issue:`3798`)
+
+* The value ``PyBUF_MAX_NDIM`` was added to the ``cpython.buffer`` module.
+  Patch by John Kirkham.  (Github issue :issue:`3811`)
+
+* C-API declarations for ``cpython.fileobject`` were added.
+  Patch by Zackery Spytz.  (Github issue :issue:`3906`)
+
+* The signature of ``PyFloat_FromString()`` in ``cpython.float`` was changed
+  to match the signature in Py3.  It still has an automatic fallback for Py2.
+  (Github issue :issue:`3909`)
+
+* The internal CPython macro ``Py_ISSPACE()`` is no longer used.
+  Original patch by Andrew Jones.  (Github issue :issue:`4111`)
+
+* More C-API declarations for ``cpython.datetime``  were added.
+  Patch by Bluenix2.  (Github issue :issue:`4128`)
+
 * The generated C code failed to compile in CPython 3.11a4 and later.
   (Github issue :issue:`4500`)
+
+* Some old usages of the deprecated Python ``imp`` module were replaced with ``importlib``.
+  Patch by Matúš Valo.  (Github issue :issue:`4640`)
+
+* Context managers can be written in parentheses.
+  Patch by David Woods.  (Github issue :issue:`4814`)
 
 * The runtime size check for imported ``PyVarObject`` types was improved
   to reduce false positives and adapt to Python 3.11.
   Patch by David Woods.  (Github issues :issue:`4827`, :issue:`4894`)
+
+* The special methods ``__matmul__``, ``__truediv__``, ``__floordiv__`` failed to type
+  their ``self`` argument.
+  (Github issue :issue:`5067`)
 
 * ``cpdef`` enums no longer use ``OrderedDict`` but ``dict`` in Python 3.6 and later.
   Patch by GalaxySnail.  (Github issue :issue:`5180`)
@@ -99,6 +164,15 @@ Related fixes
 * The Python ``int`` handling code was adapted to make use of the new ``PyLong``
   internals in CPython 3.12.
   (Github issue :issue:`5353`)
+
+* The type ``cython.Py_hash_t`` is available in Python mode.
+
+* The names of Cython's internal types (functions, generator, coroutine, etc.)
+  are now qualified with the module name of the internal Cython module that is
+  used for sharing them across Cython implemented modules, for example
+  ``_cython_3_0a5.coroutine``.  This was done to avoid making them look like
+  homeless builtins, to help with debugging, and in order to avoid a CPython
+  warning according to https://bugs.python.org/issue20204
 
 Initial support for Limited API
 -------------------------------
@@ -647,9 +721,6 @@ Features added
   better supported.
   (Github issue :issue:`5058`)
 
-* Python's ``memoryview`` is now a known builtin type with optimised properties.
-  (Github issue :issue:`3798`)
-
 * The call-time dispatch for fused memoryview types is less slow.
   (Github issue :issue:`5073`)
 
@@ -674,10 +745,6 @@ Features added
 
 Bugs fixed
 ----------
-
-* Generator expressions and comprehensions now look up their outer-most iterable
-  on creation, as Python does, and not later on start, as they did previously.
-  (Github issue :issue:`1159`)
 
 * Calling bound classmethods of builtin types could fail trying to call the unbound method.
   (Github issue :issue:`5051`)
@@ -711,10 +778,6 @@ Bugs fixed
 * Nesting fused types in other fused types could fail to specialise the inner type.
   (Github issue :issue:`4725`)
 
-* The special methods ``__matmul__``, ``__truediv__``, ``__floordiv__`` failed to type
-  their ``self`` argument.
-  (Github issue :issue:`5067`)
-
 * Coverage analysis failed in projects with a separate source subdirectory.
   Patch by Sviatoslav Sydorenko and Ruben Vorderman.  (Github issue :issue:`3636`)
 
@@ -732,9 +795,6 @@ Bugs fixed
 
 * Relative imports failed in compiled ``__init__.py`` package modules.
   Patch by Matúš Valo.  (Github issue :issue:`3442`)
-
-* Some old usages of the deprecated Python ``imp`` module were replaced with ``importlib``.
-  Patch by Matúš Valo.  (Github issue :issue:`4640`)
 
 * The ``cython`` and ``cythonize`` commands ignored non-existing input files without error.
   Patch by Matúš Valo.  (Github issue :issue:`4629`)
@@ -791,12 +851,6 @@ Features added
   compile time dataclass generation capabilities to ``cdef`` classes (extension types).
   Patch by David Woods.  (Github issue :issue:`2903`).  ``kw_only`` dataclasses
   added by Yury Sokov.  (Github issue :issue:`4794`)
-
-* Context managers can be written in parentheses.
-  Patch by David Woods.  (Github issue :issue:`4814`)
-
-* Cython avoids raising ``StopIteration`` in ``__next__`` methods when possible.
-  Patch by David Woods.  (Github issue :issue:`3447`)
 
 * The ``cythonize`` and ``cython`` commands have a new option ``-M`` / ``--depfile``
   to generate ``.dep`` dependency files for the compilation unit.  This can be used
@@ -914,18 +968,10 @@ Features added
 * ``pyximport`` now uses ``cythonize()`` internally.
   Patch by Matúš Valo.  (Github issue :issue:`2304`)
 
-* ``__del__(self)`` on extension types now maps to ``tp_finalize`` in Python 3.
-  Original patch by ax487.  (Github issue :issue:`3612`)
-
 * An initial set of adaptations for GraalVM Python was implemented.  Note that
   this does not imply any general support for this target or that your code
   will work at all in this environment.  But testing should be possible now.
   Patch by David Woods.  (Github issue :issue:`4328`)
-
-* ``PyMem_[Raw]Calloc()`` was added to the ``cpython.mem`` declarations.
-  Note that the ``Raw`` versions are no longer #defined by Cython.  The previous
-  macros were not considered safe.
-  Patch by William Schwartz and David Woods.  (Github issue :issue:`3047`)
 
 Bugs fixed
 ----------
@@ -1062,10 +1108,6 @@ Bugs fixed
 * Python modules were not automatically recompiled when only their ``.pxd`` file changed.
   Patch by Golden Rockefeller.  (Github issue :issue:`1428`)
 
-* The signature of ``PyFloat_FromString()`` in ``cpython.float`` was changed
-  to match the signature in Py3.  It still has an automatic fallback for Py2.
-  (Github issue :issue:`3909`)
-
 * A compile error on MSVC was resolved.
   Patch by David Woods.  (Github issue :issue:`4202`)
 
@@ -1119,24 +1161,6 @@ Features added
 
 * Docstrings of ``cpdef`` enums are now copied to the enum class.
   Patch by matham.  (Github issue :issue:`3805`)
-
-* The type ``cython.Py_hash_t`` is available in Python mode.
-
-* C-API declarations for ``cpython.fileobject`` were added.
-  Patch by Zackery Spytz.  (Github issue :issue:`3906`)
-
-* C-API declarations for context variables in Python 3.7 were added.
-  Original patch by Zolisa Bleki.  (Github issue :issue:`2281`)
-
-* More C-API declarations for ``cpython.datetime``  were added.
-  Patch by Bluenix2.  (Github issue :issue:`4128`)
-
-* A new module ``cpython.time`` was added with some low-level alternatives to
-  Python's ``time`` module.
-  Patch by Brock Mendel.  (Github issue :issue:`3767`)
-
-* The value ``PyBUF_MAX_NDIM`` was added to the ``cpython.buffer`` module.
-  Patch by John Kirkham.  (Github issue :issue:`3811`)
 
 * "Declaration after use" is now an error for variables.
   Patch by David Woods.  (Github issue :issue:`3976`)
@@ -1203,9 +1227,6 @@ Bugs fixed
   be exposed in ``.pxd``  files.
   (Github issue :issue:`4106`)
 
-* The internal CPython macro ``Py_ISSPACE()`` is no longer used.
-  Original patch by Andrew Jones.  (Github issue :issue:`4111`)
-
 
 3.0.0 alpha 6 (2020-07-31)
 ==========================
@@ -1240,11 +1261,6 @@ Features added
   return types when no ``@exceptval()`` is defined.
   (Github issues :issue:`3625`, :issue:`3664`)
 
-* A low-level inline function ``total_seconds(timedelta)`` was added to
-  ``cpython.datetime`` to bypass the Python method call.  Note that this function
-  is not guaranteed to give exactly the same results for very large time intervals.
-  Patch by Brock Mendel.  (Github issue :issue:`3616`)
-
 * Type inference now understands that ``a, *b = x`` assigns a list to ``b``.
 
 * The Cython ``CodeWriter`` can now handle more syntax constructs.
@@ -1258,13 +1274,6 @@ Bugs fixed
 
 Other changes
 -------------
-
-* The names of Cython's internal types (functions, generator, coroutine, etc.)
-  are now qualified with the module name of the internal Cython module that is
-  used for sharing them across Cython implemented modules, for example
-  ``_cython_3_0a5.coroutine``.  This was done to avoid making them look like
-  homeless builtins, to help with debugging, and in order to avoid a CPython
-  warning according to https://bugs.python.org/issue20204
 
 3.0.0 alpha 5 (2020-05-19)
 ==========================
@@ -1408,10 +1417,6 @@ Features added
 * Reimports of already imported modules are substantially faster.
   (Github issue :issue:`2854`)
 
-* ``@cython.trashcan(True)`` can be used on an extension type to enable the
-  CPython :ref:`trashcan`. This allows deallocating deeply recursive objects
-  without overflowing the stack. Patch by Jeroen Demeyer.  (Github issue :issue:`2842`)
-
 * Inlined properties can be defined for external extension types.
   Patch by Matti Picus. (Github issue :issue:`2640`, redone later in :issue:`3571`)
 
@@ -1554,11 +1559,6 @@ Other changes
 * Source file fingerprinting now uses SHA-1 instead of MD5 since the latter
   tends to be slower and less widely supported these days.
   (Github issue :issue:`2790`)
-
-* The long deprecated include files ``python_*``, ``stdio``, ``stdlib`` and
-  ``stl`` in ``Cython/Includes/Deprecated/`` were removed.  Use the ``libc.*``
-  and ``cpython.*`` pxd modules instead.
-  Patch by Jeroen Demeyer.  (Github issue :issue:`2904`)
 
 * The search order for include files was changed. Previously it was
   ``include_directories``, ``Cython/Includes``, ``sys.path``. Now it is

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,64 +62,6 @@ and `PEP-560`_ (Github issues :issue:`2753`, :issue:`3537`, :issue:`3764`) was a
 .. _`PEP-590`: https://www.python.org/dev/peps/pep-0590
 .. _`PEP-614`: https://www.python.org/dev/peps/pep-0614
 
-Improved fidelity to Python semantics
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Cython 3.0.0 also aligns many semantics with Python 3, in particular:
-[TODO: more precise]
-* division
-* power operator
-* print
-* classes
-* types
-* subscripting
-
-Improvements in Pure Python mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Pure python mode gained many new features to be able to control
-most things that were usually only available in C. Examples:
-[TODO: improve]
-* with gil / nogil
-* etc.
-
-Initial support for Limited API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-[Text about the status of support for Limited API]
-
-* Preliminary support for the CPython's ``Py_LIMITED_API`` (stable ABI) is
-  available by setting the  ``CYTHON_LIMITED_API`` C macro.  Note that the
-  support is currently in an early stage and many features do not yet work.
-  You currently still have to define ``Py_LIMITED_API`` externally in order
-  to restrict the API usage.  This will change when the feature stabilises.
-  Patches by Eddie Elizondo and David Woods.  (Github issues :issue:`3223`,
-  :issue:`3311`, :issue:`3501`)
-
-* Limited API support was improved.
-  Patches by Matthias Braun.  (Github issues :issue:`3693`, :issue:`3707`)
-
-* ``_Py_TPFLAGS_HAVE_VECTORCALL`` was always set on extension types when using the limited API.
-  Patch by David Woods.  (Github issue :issue:`4453`)
-
-* Limited API C preprocessor warning is compatible with MSVC. Patch by
-  Victor Molina Garcia.  (Github issue :issue:`4826`)
-
-* The embedding code no longer calls deprecated C-API functions but uses the new ``PyConfig``
-  API instead on CPython versions that support it (3.8+).
-  Patch by Alexander Shadchin.  (Github issue :issue:`4895`)
-
-* Some C code issue were resolved for the Limited API target.
-  (Github issues :issue:`5264`, :issue:`5265`, :issue:`5266`)
-
-* Conversion of Python ints to C ``int128`` is now always supported, although slow
-  if dedicated C-API support is missing (``_PyLong_AsByteArray()``), specifically in
-  the Limited C-API.
-  (Github issue :issue:`5419`)
-
-* Custom buffer slot methods are now supported in the Limited C-API of Python 3.9+.
-  Patch by Lisandro Dalcin.  (Github issue :issue:`5422`)
-
 Related fixes
 ^^^^^^^^^^^^^
 
@@ -158,6 +100,66 @@ Related fixes
   internals in CPython 3.12.
   (Github issue :issue:`5353`)
 
+Initial support for Limited API
+-------------------------------
+
+[Text about the status of support for Limited API]
+
+Related fixes
+^^^^^^^^^^^^^
+
+* Preliminary support for the CPython's ``Py_LIMITED_API`` (stable ABI) is
+  available by setting the  ``CYTHON_LIMITED_API`` C macro.  Note that the
+  support is currently in an early stage and many features do not yet work.
+  You currently still have to define ``Py_LIMITED_API`` externally in order
+  to restrict the API usage.  This will change when the feature stabilises.
+  Patches by Eddie Elizondo and David Woods.  (Github issues :issue:`3223`,
+  :issue:`3311`, :issue:`3501`)
+
+* Limited API support was improved.
+  Patches by Matthias Braun.  (Github issues :issue:`3693`, :issue:`3707`)
+
+* ``_Py_TPFLAGS_HAVE_VECTORCALL`` was always set on extension types when using the limited API.
+  Patch by David Woods.  (Github issue :issue:`4453`)
+
+* Limited API C preprocessor warning is compatible with MSVC. Patch by
+  Victor Molina Garcia.  (Github issue :issue:`4826`)
+
+* The embedding code no longer calls deprecated C-API functions but uses the new ``PyConfig``
+  API instead on CPython versions that support it (3.8+).
+  Patch by Alexander Shadchin.  (Github issue :issue:`4895`)
+
+* Some C code issue were resolved for the Limited API target.
+  (Github issues :issue:`5264`, :issue:`5265`, :issue:`5266`)
+
+* Conversion of Python ints to C ``int128`` is now always supported, although slow
+  if dedicated C-API support is missing (``_PyLong_AsByteArray()``), specifically in
+  the Limited C-API.
+  (Github issue :issue:`5419`)
+
+* Custom buffer slot methods are now supported in the Limited C-API of Python 3.9+.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5422`)
+
+Improved fidelity to Python semantics
+-------------------------------------
+
+Cython 3.0.0 also aligns many semantics with Python 3, in particular:
+[TODO: more precise]
+* division
+* power operator
+* print
+* classes
+* types
+* subscripting
+
+Improvements in Pure Python mode
+--------------------------------
+
+Pure python mode gained many new features to be able to control
+most things that were usually only available in C. Examples:
+[TODO: improve]
+* with gil / nogil
+* etc.
 
 Code generation changes
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,7 +161,53 @@ Related fixes
 Interaction with numpy
 ----------------------
 
-[various]
+[Numpy now ships its own declarations, Cython does not use deprecated API anymore, ...]
+
+Related fixes
+^^^^^^^^^^^^^
+
+* Deprecated NumPy API usages were removed from ``numpy.pxd``.
+  Patch by Matti Picus.  (Github issue :issue:`3365`)
+
+* ``cython.inline()`` now sets the ``NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION``
+  C macro automatically when ``numpy`` is imported in the code, to avoid C compiler
+  warnings about deprecated NumPy C-API usage.
+
+* ``numpy.import_array()`` is automatically called if ``numpy`` has been cimported
+  and it has not been called in the module code.  This is intended as a hidden
+  fail-safe so user code should continue to call ``numpy.import_array``.
+  Patch by David Woods.  (Github issue :issue:`3524`)
+
+* The outdated getbuffer/releasebuffer implementations in the NumPy
+  declarations were removed so that buffers declared as ``ndarray``
+  now use the normal implementation in NumPy.
+
+* Several macros/functions declared in the NumPy API are now usable without
+  holding the GIL.
+
+* The ``numpy`` declarations were updated.
+  Patch by Brock Mendel.  (Github issue :issue:`3630`)
+
+* ``ndarray.shape`` failed to compile with Pythran and recent NumPy.
+  Patch by Serge Guelton.  (Github issue :issue:`3762`)
+
+* A C-level compatibility issue with recent NumPy versions was resolved.
+  Patch by David Woods.  (Github issue :issue:`4396`)
+
+* The generated modules no longer import NumPy internally when using
+  fused types but no memoryviews.
+  Patch by David Woods.  (Github issue :issue:`4935`)
+
+* A new function decorator ``@cython.ufunc`` automatically generates a (NumPy) ufunc that
+  applies the calculation function to an entire memoryview.
+  (Github issue :issue:`4758`)
+
+* Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
+  (Github issue :issue:`5328`)
+
+* ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
+  synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
+  since they could mean different things on different platforms.
 
 Exception handling
 ------------------
@@ -297,10 +343,6 @@ Other changes
 * The FAQ page was moved from the GitHub Wiki to the regular documentation
   to make it more visible.
 
-* ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
-  synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
-  since they could mean different things on different platforms.
-
 
 3.0.0 beta 3 (2023-05-24)
 =========================
@@ -418,9 +460,6 @@ Bugs fixed
 * ``from cython cimport … as …`` could lead to imported names not being found in annotations.
   Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5235`)
 
-* Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
-  (Github issue :issue:`5328`)
-
 * ``cimport_from_pyx`` could miss some declarations.
   Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5318`)
 
@@ -456,10 +495,6 @@ Bugs fixed
 
 Features added
 --------------
-
-* A new function decorator ``@cython.ufunc`` automatically generates a (NumPy) ufunc that
-  applies the calculation function to an entire memoryview.
-  (Github issue :issue:`4758`)
 
 * The ``**`` power operator now behaves more like in Python by returning the correct complex
   result if required by math.  A new ``cpow`` directive was added to turn on the previous
@@ -762,10 +797,6 @@ Bugs fixed
 * A work-around for StacklessPython < 3.8 was disabled in Py3.8 and later.
   (Github issue :issue:`4329`)
 
-* The generated modules no longer import NumPy internally when using
-  fused types but no memoryviews.
-  Patch by David Woods.  (Github issue :issue:`4935`)
-
 * Improve compatibility with forthcoming CPython 3.12 release.
 
 * Some C compiler warnings were fixed.
@@ -864,9 +895,6 @@ Bugs fixed
 
 * ``prange`` loops generated incorrect code when ``cpp_locals`` is enabled.
   Patch by David Woods.  (Github issue :issue:`4354`)
-
-* A C-level compatibility issue with recent NumPy versions was resolved.
-  Patch by David Woods.  (Github issue :issue:`4396`)
 
 * Decorators on inner functions were not evaluated in the right scope.
   Patch by David Woods.  (Github issue :issue:`4367`)
@@ -1124,9 +1152,6 @@ Bugs fixed
 * Modules with unicode names failed to build on Windows.
   Patch by David Woods.  (Github issue :issue:`4125`)
 
-* ``ndarray.shape`` failed to compile with Pythran and recent NumPy.
-  Patch by Serge Guelton.  (Github issue :issue:`3762`)
-
 * Casting to ctuples is now allowed.
   Patch by David Woods.  (Github issue :issue:`3808`)
 
@@ -1255,9 +1280,6 @@ Bugs fixed
 Other changes
 -------------
 
-* The ``numpy`` declarations were updated.
-  Patch by Brock Mendel.  (Github issue :issue:`3630`)
-
 * The names of Cython's internal types (functions, generator, coroutine, etc.)
   are now qualified with the module name of the internal Cython module that is
   used for sharing them across Cython implemented modules, for example
@@ -1274,9 +1296,6 @@ Features added
 * ``.pxd`` files can now be :ref:`versioned <versioning>` by adding an
   extension like "``.cython-30.pxd``" to prevent older Cython versions (than
   3.0 in this case) from picking them up.  (Github issue :issue:`3577`)
-
-* Several macros/functions declared in the NumPy API are now usable without
-  holding the GIL.
 
 * `libc.math` was extended to include all C99 function declarations.
   Patch by Dean Scarff.  (Github issue :issue:`3570`)
@@ -1295,10 +1314,6 @@ Bugs fixed
 * A reference leak when processing keyword arguments in Py2 was resolved,
   that appeared in 3.0a1.
   (Github issue :issue:`3578`)
-
-* The outdated getbuffer/releasebuffer implementations in the NumPy
-  declarations were removed so that buffers declared as ``ndarray``
-  now use the normal implementation in NumPy.
 
 * Includes all bug-fixes from the :ref:`0.29.18` release.
 
@@ -1388,11 +1403,6 @@ Features added
   eliminated at an earlier stage, which gives more freedom in writing
   replacement Python code.
   Patch by David Woods.  (Github issue :issue:`3507`)
-
-* ``numpy.import_array()`` is automatically called if ``numpy`` has been cimported
-  and it has not been called in the module code.  This is intended as a hidden
-  fail-safe so user code should continue to call ``numpy.import_array``.
-  Patch by David Woods.  (Github issue :issue:`3524`)
 
 * The Cython AST code serialiser class ``CodeWriter`` in ``Cython.CodeWriter``
   supports more syntax nodes.
@@ -1487,13 +1497,6 @@ Features added
   and Zackery Spytz.
   (Github issues :issue:`3468`, :issue:`3332`, :issue:`3202`, :issue:`3188`,
   :issue:`3179`, :issue:`2891`, :issue:`2826`, :issue:`2713`)
-
-* Deprecated NumPy API usages were removed from ``numpy.pxd``.
-  Patch by Matti Picus.  (Github issue :issue:`3365`)
-
-* ``cython.inline()`` now sets the ``NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION``
-  C macro automatically when ``numpy`` is imported in the code, to avoid C compiler
-  warnings about deprecated NumPy C-API usage.
 
 * The builtin ``abs()`` function can now be used on C numbers in nogil code.
   Patch by Elliott Sales de Andrade.  (Github issue :issue:`2748`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,14 +2,122 @@
 Cython Changelog
 ================
 
-3.0.0 (2023-0?-??)
-==================
+3.0.0 unified release notes
+===========================
+
+Cython 3.0.0 has been a very large effort that cleaned up many old warts,
+introduced many new features, and introduces a couple of intentional
+behaviour changes, even though the goal remained to stay compatible as
+much as possible with Cython 0.29.x. For details, see the `migration guide`_.
+
+.. _`migration guide`: https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html
+
+As the development was spread out over several years, a lot of things have
+happened in the meantime. Many crucial bugfixes and some features were
+backported to 0.29.x and are not strictly speaking "new" in Cyton 3.0.0.
+We mark affected lines below with †.
+
+Major themes in 3.0.0
+=====================
+
+Compatibility with Python
+-------------------------
+
+Since Cython 3.0.0 started development, CPython 3.8-3.11 were released.
+All these are supported in Cython, including experimental support for the
+in-development CPython 3.12. On the other end of the spectrum, support for
+Python 2.6 was dropped.
+
+Cython interacts very closely with the C-API of Python, which is where most
+of the adaptation work happens. Independently, Cython strives to be able to
+parse newer Python constructs for use with its `pure python`_ mode, which
+has been a focus. In short, this allows to compile a wider range of Python
+code into optimized C code.
+
+.. _`pure python`: https://cython.readthedocs.io/en/latest/src/tutorial/pure.html
+
+Implemented PEPs:
+
+* `PEP-3131`_: Supporting Non-ASCII Identifiers
+* `PEP-479`_: `generator_stop` (enabled by default for `language_level=3`)
+* `PEP-487`_: Simpler customisation of class creation
+* `PEP-563`_: Postponed Evaluation of Annotations
+* `PEP-570`_: Positional-Only Parameters
+* `PEP-572`_: Assignment Expressions (a.k.a. the walrus operator `:=`)
+* `PEP-590`_: Vectorcall protocol
+* `PEP-614`_: Relaxing Grammar Restrictions On Decorators
+
+Typing support in the sense of `PEP-484`_ and `PEP-560`_ was also improved.
+
+.. _`PEP-3131`: https://www.python.org/dev/peps/pep-3131
+.. _`PEP-479`: https://www.python.org/dev/peps/pep-0479
+.. _`PEP-484`: https://www.python.org/dev/peps/pep-0484
+.. _`PEP-487`: https://www.python.org/dev/peps/pep-0487
+.. _`PEP-560`: https://www.python.org/dev/peps/pep-0560
+.. _`PEP-563`: https://www.python.org/dev/peps/pep-0563
+.. _`PEP-570`: https://www.python.org/dev/peps/pep-0570
+.. _`PEP-572`: https://www.python.org/dev/peps/pep-0572
+.. _`PEP-590`: https://www.python.org/dev/peps/pep-0590
+.. _`PEP-614`: https://www.python.org/dev/peps/pep-0614
+
+Cython 3.0.0 also aligns many semantics with Python 3, in particular:
+[TODO: more precise]
+* division
+* power operator
+* print
+* classes
+* types
+* subscripting
+
+Furthermore, pure python mode gain many new features to be able to control
+most things that were usually only available in C. Examples:
+[TODO: improve]
+* with gil / nogil
+* etc.
+
+Also: Something about the limited API.
+
+Interaction with numpy
+----------------------
+
+[various]
+
+Exception handling
+------------------
+
+Cython 3.0.0 overhauled the exception handling by doing [XYZ]
+
+Compatibility with C
+--------------------
+
+[Various]
+
+Compatibility with C++
+----------------------
+
+[Lots]
+
+Commandline Interface
+---------------------
+
+[Various]
+
+Build integration
+-----------------
+
+[Various]
+
+Other changes
+-------------
+
+[Various]
 
 Bugs fixed
 ----------
 
 * Parser crash on hex/oct enum values.
   (Github issue :issue:`5524`)
+* ...
 
 
 3.0.0 rc 1 (2023-07-12)
@@ -1547,13 +1655,6 @@ Other changes
 
 * Support for Python 2.6 was removed.
 
-.. _`PEP-560`: https://www.python.org/dev/peps/pep-0560
-.. _`PEP-570`: https://www.python.org/dev/peps/pep-0570
-.. _`PEP-487`: https://www.python.org/dev/peps/pep-0487
-.. _`PEP-590`: https://www.python.org/dev/peps/pep-0590
-.. _`PEP-3131`: https://www.python.org/dev/peps/pep-3131
-.. _`PEP-563`: https://www.python.org/dev/peps/pep-0563
-.. _`PEP-479`: https://www.python.org/dev/peps/pep-0479
 
 3.0.0 (2023-0?-??)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -158,6 +158,22 @@ Related fixes
   internals in CPython 3.12.
   (Github issue :issue:`5353`)
 
+
+Code generation changes
+-----------------------
+
+[cdef dataclasses, total_ordering, numpy ufunc]
+
+Related fixes
+^^^^^^^^^^^^^
+
+* A new function decorator ``@cython.ufunc`` automatically generates a (NumPy) ufunc that
+  applies the calculation function to an entire memoryview.
+  (Github issue :issue:`4758`)
+
+* Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
+  (Github issue :issue:`5328`)
+
 Interaction with numpy
 ----------------------
 
@@ -197,13 +213,6 @@ Related fixes
 * The generated modules no longer import NumPy internally when using
   fused types but no memoryviews.
   Patch by David Woods.  (Github issue :issue:`4935`)
-
-* A new function decorator ``@cython.ufunc`` automatically generates a (NumPy) ufunc that
-  applies the calculation function to an entire memoryview.
-  (Github issue :issue:`4758`)
-
-* Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
-  (Github issue :issue:`5328`)
 
 * ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
   synching Cython with upstream NumPy v1.25.0.  The aliases were confusing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -325,6 +325,9 @@ Related fixes
   previous, unsafe behaviour.  This directive will eventually be removed in a later release.
   Patch by Matúš Valo.  (Github issue :issue:`5094`)
 
+* ``noexcept`` was not automatically applied to function pointer attributes in extern structs.
+  Patch by Matúš Valo.  (Github issue :issue:`5359`)
+
 * The code ``except +nogil`` (declaring a C++ exception handler function called ``nogil``)
   is now rejected because it is almost certainly a typo from ``except + nogil``.
   (Github issue :issue:`5430`)
@@ -442,6 +445,9 @@ Related fixes
 * Conversion from Python dict to C++ map now supports arbitrary Python mappings,
   not just dicts.
 
+* ``std::move()`` is now also called for temps during ``yield``.
+  Patch by Yu Feng.  (Github issue :issue:`4154`)
+
 * A new directive ``cpp_locals`` was added that allows local C++ variables to
   be lazily initialised (without default constructor), thus making them behave
   more like Python variables.
@@ -453,6 +459,9 @@ Related fixes
 
 * Code optimisations were not applied to methods of Cython implemented C++ classes.
   Patch by David Woods.  (Github issue :issue:`4212`)
+
+* Conversion from Python dicts to ``std::map`` was broken.
+  Patch by David Woods and Mikkel Skofelt.  (Github issues :issue:`4228`, :issue:`4231`)
 
 * Several issues with the new ``cpp_locals`` directive were resolved and
   its test coverage improved.
@@ -634,9 +643,6 @@ Bugs fixed
 
 * ``__qualname__`` and ``__module__`` were not available inside of class bodies.
   (Github issue :issue:`4447`)
-
-* ``noexcept`` was not automatically applied to function pointer attributes in extern structs.
-  Patch by Matúš Valo.  (Github issue :issue:`5359`)
 
 * Function signatures containing a type like `tuple[()]` could not be printed.
   Patch by Lisandro Dalcin.  (Github issue :issue:`5355`)
@@ -1095,9 +1101,6 @@ Bugs fixed
 * The dispatch code for binary operators to special methods could run into infinite recursion.
   Patch by David Woods.  (Github issue :issue:`4172`)
 
-* Conversion from Python dicts to ``std::map`` was broken.
-  Patch by David Woods and Mikkel Skofelt.  (Github issues :issue:`4231`, :issue:`4228`)
-
 * Attribute annotations in Python classes are now ignored, because they are
   just Python objects in a dict (as opposed to the fields of extension types).
   Patch by David Woods.  (Github issues :issue:`4196`, :issue:`4198`)
@@ -1146,9 +1149,6 @@ Features added
 
 * Self-documenting f-strings (``=``) were implemented.
   Patch by davfsa.  (Github issue :issue:`3796`)
-
-* ``std::move()`` is now also called for temps during ``yield``.
-  Patch by Yu Feng.  (Github issue :issue:`4154`)
 
 * ``asyncio.iscoroutinefunction()`` now recognises coroutine functions
   also when compiled by Cython.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -255,7 +255,146 @@ Compatibility with C
 Compatibility with C++
 ----------------------
 
-[Lots]
+[Text about forwarding references, ``cpp_locals``, ``std::move``]
+
+Related fixes
+^^^^^^^^^^^^^
+
+* Nested ``cppclass`` definitions are supported.
+  Patch by samaingw.  (Github issue :issue:`1218`)
+
+* ``cdef public`` functions used an incorrect linkage declaration in C++.
+  Patch by Maximilien Colange.  (Github issue :issue:`1839`)
+
+* Overloaded C++ static methods were lost.
+  Patch by Ashwin Srinath.  (Github :issue:`1851`)
+
+* Direct assignments to C++ references are now allowed.
+  Patch by David Woods.  (Github issue :issue:`1863`)
+
+* Templating C++ classes with memory view types lead to buggy code and is now rejected.
+  Patch by David Woods.  (Github issue :issue:`3085`)
+
+* C++ ``typeid()`` failed for fused types.
+  Patch by David Woods.  (Github issue :issue:`3203`)
+
+* The destructor is now called for fields in C++ structs.
+  Patch by David Woods.  (Github issue :issue:`3226`)
+
+* ``std::move()`` is now used in C++ mode for internal temp variables to
+  make them work without copying values.
+  Patch by David Woods.  (Github issues :issue:`3253`, :issue:`1612`)
+
+* The C++ ``typeid()`` function was allowed in C mode.
+  Patch by Celelibi.  (Github issue :issue:`3637`)
+
+* The construct ``for x in cpp_function_call()`` failed to compile.
+  Patch by David Woods.  (Github issue :issue:`3663`)
+
+* C++ references failed to compile when used as Python object indexes.
+  Patch by David Woods.  (Github issue :issue:`3754`)
+
+* A compile failure for C++ enums in Py3.4 / MSVC was resolved.
+  Patch by Ashwin Srinath.  (Github issue :issue:`3782`)
+
+* C++17 execution policies are supported in ``libcpp.algorithm``.
+  Patch by Ashwin Srinath.  (Github issue :issue:`3790`)
+
+* C++ iteration more safely stores the iterable in temporary variables.
+  Patch by Xavier.  (Github issue :issue:`3828`)
+
+* Cython compiled functions always provided a ``__self__`` attribute,
+  regardless of being used as a method or not.
+  Patch by David Woods.  (Github issue :issue:`4036`)
+
+* Nested C++ types were not usable through ctypedefs.
+  Patch by Vadim Pushtaev.  (Github issue :issue:`4039`)
+
+* Some C++ STL methods did not propagate exceptions.
+  Patch by Max Bachmann.  (Github issue :issue:`4079`)
+
+* More declarations for C++ string methods were added.
+
+* Converting C++ containers to Python lists uses less memory allocations.
+  Patch by Max Bachmann.  (Github issue :issue:`4081`)
+
+* Conversion from Python dict to C++ map now supports arbitrary Python mappings,
+  not just dicts.
+
+* A new directive ``cpp_locals`` was added that allows local C++ variables to
+  be lazily initialised (without default constructor), thus making them behave
+  more like Python variables.
+  Patch by David Woods.  (Github issue :issue:`4160`)
+
+* Generated utility code for C++ conversions no longer depends on several user
+  definable directives that may make it behave incorrectly.
+  Patch by David Woods.  (Github issue :issue:`4206`)
+
+* Code optimisations were not applied to methods of Cython implemented C++ classes.
+  Patch by David Woods.  (Github issue :issue:`4212`)
+
+* Several issues with the new ``cpp_locals`` directive were resolved and
+  its test coverage improved.
+  Patch by David Woods.  (Github issues :issue:`4265`, :issue:`4266`)
+
+* Declarations for ``libcpp.algorithms``, ``libcpp.set`` and ``libcpp.unordered_set``
+  were extended.
+  Patch by David Woods.  (Github issues :issue:`4271`, :issue:`4273`)
+
+* ``prange`` loops generated incorrect code when ``cpp_locals`` is enabled.
+  Patch by David Woods.  (Github issue :issue:`4354`)
+
+* C++ post-increment/-decrement operators were not correctly looked up on declared C++
+  classes, thus allowing Cython declarations to be missing for them and incorrect C++
+  code to be generated.
+  Patch by Max Bachmann.  (Github issue :issue:`4536`)
+
+* ``cpp_locals`` no longer have to be "assignable".
+  (Github issue :issue:`4558`)
+
+* C++ references did not work on fused types.
+  (Github issue :issue:`4717`)
+
+* Several C++ library declarations were added and fixed.
+  Patches by Dobatymo, account-login, Jonathan Helgert, Evgeny Yakimov, GalaxySnail, Max Bachmann.
+  (Github issues :issue:`4408`, :issue:`4419`, :issue:`4410`, :issue:`4395`,
+  :issue:`4423`, :issue:`4448`, :issue:`4462`, :issue:`3293`, :issue:`4522`,
+  :issue:`2171`, :issue:`4531`)
+
+* Some C++ and CPython library declarations were extended and fixed.
+  Patches by Max Bachmann, Till Hoffmann, Julien Jerphanion, Wenjun Si.
+  (Github issues :issue:`4530`, :issue:`4528`, :issue:`4710`, :issue:`4746`,
+  :issue:`4751`, :issue:`4818`, :issue:`4762`, :issue:`4910`)
+
+* Some C/C++ warnings were resolved.
+  Patches by Max Bachmann, Alexander Shadchin, at al.
+  (Github issues :issue:`5004`, :issue:`5005`, :issue:`5019`, :issue:`5029`, :issue:`5096`)
+
+* Declarations were added for the C++ bit operations, some other parts of C++20 and CPython APIs.
+  Patches by Jonathan Helgert, Dobatymo, William Ayd and Max Bachmann.
+  (Github issues :issue:`4962`, :issue:`5101`, :issue:`5157`, :issue:`5163`, :issue:`5257`)
+
+* ``reversed()`` can now be used together with C++ iteration.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5002`)
+
+* Fully qualified C++ names prefixed by a cimported module name could fail to compile.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5229`)
+
+* Cython generated C++ code accidentally used C++11 features in some cases.
+  (Github issue :issue:`5316`)
+
+* Some C++ warnings regarding ``const`` usage in internally generated utility code were resolved.
+  Patch by Max Bachmann.  (Github issue :issue:`5301`)
+
+* C++ declarations for ``<cmath>``, ``<numbers>`` and ``std::any`` were added.
+  Patches by Jonathan Helgert and Maximilien Colange.
+  (Github issues :issue:`5262`, :issue:`5309`, :issue:`5314`)
+
+* Reverse iteration in C++ no longer removes the ``const`` qualifier from the item type.
+  Patch by Isuru Fernando.  (Github issue :issue:`5478`)
+
+* C++ containers of item type ``bint`` could conflict with those of item type ``int``.
+  (Github issue :issue:`5516`)
 
 Commandline Interface
 ---------------------
@@ -302,12 +441,6 @@ Bugs fixed
 
 * Duplicate values in a ``cpdef`` enum could lead to invalid switch statements.
   (Github issue :issue:`5400`)
-
-* Reverse iteration in C++ no longer removes the ``const`` qualifier from the item type.
-  Patch by Isuru Fernando.  (Github issue :issue:`5478`)
-
-* C++ containers of item type ``bint`` could conflict with those of item type ``int``.
-  (Github issue :issue:`5516`)
 
 * With MSVC, Cython no longer enables C-Complex support by accident (which is not supported there).
   (Github issue :issue:`5512`)
@@ -437,10 +570,6 @@ Other changes
 Features added
 --------------
 
-* C++ declarations for ``<cmath>``, ``<numbers>`` and ``std::any`` were added.
-  Patches by Jonathan Helgert and Maximilien Colange.
-  (Github issues :issue:`5262`, :issue:`5309`, :issue:`5314`)
-
 Bugs fixed
 ----------
 
@@ -462,15 +591,6 @@ Bugs fixed
 
 * ``cimport_from_pyx`` could miss some declarations.
   Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5318`)
-
-* Fully qualified C++ names prefixed by a cimported module name could fail to compile.
-  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5229`)
-
-* Cython generated C++ code accidentally used C++11 features in some cases.
-  (Github issue :issue:`5316`)
-
-* Some C++ warnings regarding ``const`` usage in internally generated utility code were resolved.
-  Patch by Max Bachmann.  (Github issue :issue:`5301`)
 
 * With ``language_level=2``, imports of modules in packages could return the wrong module in Python 3.
   (Github issue :issue:`5308`)
@@ -533,27 +653,14 @@ Features added
 * C arrays can be initialised inside of nogil functions.
   Patch by Matúš Valo.  (Github issue :issue:`1662`)
 
-* ``reversed()`` can now be used together with C++ iteration.
-  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5002`)
-
 * Standard C/C++ atomic operations are now used for memory views, if available.
   (Github issue :issue:`4925`)
 
 * C11 ``complex.h`` is now properly detected.
   (Github issue :issue:`2513`)
 
-* Nested ``cppclass`` definitions are supported.
-  Patch by samaingw.  (Github issue :issue:`1218`)
-
-* ``cpp_locals`` no longer have to be "assignable".
-  (Github issue :issue:`4558`)
-
 * ``cythonize --help`` now also prints information about the supported environment variables.
   Patch by Matúš Valo.  (Github issue :issue:`1711`)
-
-* Declarations were added for the C++ bit operations, some other parts of C++20 and CPython APIs.
-  Patches by Jonathan Helgert, Dobatymo, William Ayd and Max Bachmann.
-  (Github issues :issue:`4962`, :issue:`5101`, :issue:`5157`, :issue:`5163`, :issue:`5257`)
 
 Bugs fixed
 ----------
@@ -598,20 +705,6 @@ Bugs fixed
 
 * ``cdef public`` functions declared in .pxd files could use an incorrectly mangled C name.
   Patch by EpigeneMax.  (Github issue :issue:`2940`)
-
-* ``cdef public`` functions used an incorrect linkage declaration in C++.
-  Patch by Maximilien Colange.  (Github issue :issue:`1839`)
-
-* C++ post-increment/-decrement operators were not correctly looked up on declared C++
-  classes, thus allowing Cython declarations to be missing for them and incorrect C++
-  code to be generated.
-  Patch by Max Bachmann.  (Github issue :issue:`4536`)
-
-* C++ iteration more safely stores the iterable in temporary variables.
-  Patch by Xavier.  (Github issue :issue:`3828`)
-
-* C++ references did not work on fused types.
-  (Github issue :issue:`4717`)
 
 * The module state struct was not initialised in correct C (before C23), leading to
   compile errors on Windows.
@@ -669,10 +762,6 @@ Bugs fixed
 * ``setup.cfg`` was missing from the source distribution.
   (Github issue :issue:`5199`)
 
-* Some C/C++ warnings were resolved.
-  Patches by Max Bachmann, Alexander Shadchin, at al.
-  (Github issues :issue:`5004`, :issue:`5005`, :issue:`5019`, :issue:`5029`, :issue:`5096`)
-
 * Intel C compilers could complain about unsupported gcc pragmas.
   Patch by Ralf Gommers.  (Github issue :issue:`5052`)
 
@@ -720,11 +809,6 @@ Features added
 
 * Cython avoids raising ``StopIteration`` in ``__next__`` methods when possible.
   Patch by David Woods.  (Github issue :issue:`3447`)
-
-* Some C++ and CPython library declarations were extended and fixed.
-  Patches by Max Bachmann, Till Hoffmann, Julien Jerphanion, Wenjun Si.
-  (Github issues :issue:`4530`, :issue:`4528`, :issue:`4710`, :issue:`4746`,
-  :issue:`4751`, :issue:`4818`, :issue:`4762`, :issue:`4910`)
 
 * The ``cythonize`` and ``cython`` commands have a new option ``-M`` / ``--depfile``
   to generate ``.dep`` dependency files for the compilation unit.  This can be used
@@ -854,12 +938,6 @@ Features added
 * ``__del__(self)`` on extension types now maps to ``tp_finalize`` in Python 3.
   Original patch by ax487.  (Github issue :issue:`3612`)
 
-* Conversion from Python dict to C++ map now supports arbitrary Python mappings,
-  not just dicts.
-
-* Direct assignments to C++ references are now allowed.
-  Patch by David Woods.  (Github issue :issue:`1863`)
-
 * An initial set of adaptations for GraalVM Python was implemented.  Note that
   this does not imply any general support for this target or that your code
   will work at all in this environment.  But testing should be possible now.
@@ -893,9 +971,6 @@ Bugs fixed
 * Fused typed default arguments generated incorrect code.
   Patch by David Woods.  (Github issue :issue:`4413`)
 
-* ``prange`` loops generated incorrect code when ``cpp_locals`` is enabled.
-  Patch by David Woods.  (Github issue :issue:`4354`)
-
 * Decorators on inner functions were not evaluated in the right scope.
   Patch by David Woods.  (Github issue :issue:`4367`)
 
@@ -920,15 +995,6 @@ Bugs fixed
 
 * Default values for memory views arguments were not properly supported.
   Patch by Corentin Cadiou.  (Github issue :issue:`4313`)
-
-* Templating C++ classes with memory view types lead to buggy code and is now rejected.
-  Patch by David Woods.  (Github issue :issue:`3085`)
-
-* Several C++ library declarations were added and fixed.
-  Patches by Dobatymo, account-login, Jonathan Helgert, Evgeny Yakimov, GalaxySnail, Max Bachmann.
-  (Github issues :issue:`4408`, :issue:`4419`, :issue:`4410`, :issue:`4395`,
-  :issue:`4423`, :issue:`4448`, :issue:`4462`, :issue:`3293`, :issue:`4522`,
-  :issue:`2171`, :issue:`4531`)
 
 * Some compiler problems and warnings were resolved.
   Patches by David Woods, 0dminnimda, Nicolas Pauss and others.
@@ -966,24 +1032,12 @@ Other changes
 Features added
 --------------
 
-* Declarations for ``libcpp.algorithms``, ``libcpp.set`` and ``libcpp.unordered_set``
-  were extended.
-  Patch by David Woods.  (Github issues :issue:`4271`, :issue:`4273`)
-
 * ``cygdb`` has a new option ``--skip-interpreter`` that allows using a different
   Python runtime than the one used to generate the debugging information.
   Patch by Alessandro Molina.  (Github issue :issue:`4186`)
 
 Bugs fixed
 ----------
-
-* Several issues with the new ``cpp_locals`` directive were resolved and
-  its test coverage improved.
-  Patch by David Woods.  (Github issues :issue:`4266`, :issue:`4265`)
-
-* Generated utility code for C++ conversions no longer depends on several user
-  definable directives that may make it behave incorrectly.
-  Patch by David Woods.  (Github issue :issue:`4206`)
 
 * A reference counting bug in the new ``@cython.total_ordering`` decorator was fixed.
 
@@ -1007,14 +1061,6 @@ Features added
   implement all comparison operators, similar to ``functools.total_ordering``.
   Patch by Spencer Brown.  (Github issue :issue:`2090`)
 
-* A new directive ``cpp_locals`` was added that allows local C++ variables to
-  be lazily initialised (without default constructor), thus making them behave
-  more like Python variables.
-  Patch by David Woods.  (Github issue :issue:`4160`)
-
-* C++17 execution policies are supported in ``libcpp.algorithm``.
-  Patch by Ashwin Srinath.  (Github issue :issue:`3790`)
-
 * New C feature flags: ``CYTHON_USE_MODULE_STATE``, ``CYTHON_USE_TYPE_SPECS``
   Both are currently considered experimental.
   (Github issue :issue:`3611`)
@@ -1027,9 +1073,6 @@ Bugs fixed
 
 * The dispatch code for binary operators to special methods could run into infinite recursion.
   Patch by David Woods.  (Github issue :issue:`4172`)
-
-* Code optimisations were not applied to methods of Cython implemented C++ classes.
-  Patch by David Woods.  (Github issue :issue:`4212`)
 
 * Conversion from Python dicts to ``std::map`` was broken.
   Patch by David Woods and Mikkel Skofelt.  (Github issues :issue:`4231`, :issue:`4228`)
@@ -1087,9 +1130,6 @@ Features added
 * Self-documenting f-strings (``=``) were implemented.
   Patch by davfsa.  (Github issue :issue:`3796`)
 
-* The destructor is now called for fields in C++ structs.
-  Patch by David Woods.  (Github issue :issue:`3226`)
-
 * ``std::move()`` is now also called for temps during ``yield``.
   Patch by Yu Feng.  (Github issue :issue:`4154`)
 
@@ -1101,9 +1141,6 @@ Features added
   Patch by Egor Dranischnikow.  (Github issue :issue:`3751`)
 
 * ``float(…)`` is optimised for string arguments (str/bytes/bytearray).
-
-* Converting C++ containers to Python lists uses less memory allocations.
-  Patch by Max Bachmann.  (Github issue :issue:`4081`)
 
 * Docstrings of ``cpdef`` enums are now copied to the enum class.
   Patch by matham.  (Github issue :issue:`3805`)
@@ -1128,8 +1165,6 @@ Features added
 
 * "Declaration after use" is now an error for variables.
   Patch by David Woods.  (Github issue :issue:`3976`)
-
-* More declarations for C++ string methods were added.
 
 * Cython now detects when existing output files were not previously generated
   by itself and refuses to overwrite them.  It is a common mistake to name
@@ -1161,16 +1196,6 @@ Bugs fixed
 * Literal list assignments to pointer variables declared in PEP-526
   notation failed to compile.
 
-* Nested C++ types were not usable through ctypedefs.
-  Patch by Vadim Pushtaev.  (Github issue :issue:`4039`)
-
-* Overloaded C++ static methods were lost.
-  Patch by Ashwin Srinath.  (Github :issue:`1851`)
-
-* Cython compiled functions always provided a ``__self__`` attribute,
-  regardless of being used as a method or not.
-  Patch by David Woods.  (Github issue :issue:`4036`)
-
 * Calls to ``.__class__()`` of a known extension type failed.
   Patch by David Woods.  (Github issue :issue:`3954`)
 
@@ -1189,12 +1214,6 @@ Bugs fixed
 
 * Some C compiler warninge were resolved.
   Patches by Max Bachmann.  (Github issue :issue:`4053`, :issue:`4059`, :issue:`4054`, :issue:`4148`, :issue:`4162`)
-
-* A compile failure for C++ enums in Py3.4 / MSVC was resolved.
-  Patch by Ashwin Srinath.  (Github issue :issue:`3782`)
-
-* Some C++ STL methods did not propagate exceptions.
-  Patch by Max Bachmann.  (Github issue :issue:`4079`)
 
 * An unsupported C-API call in PyPy was fixed.
   Patch by Max Bachmann.  (Github issue :issue:`4055`)
@@ -1262,15 +1281,6 @@ Features added
 
 Bugs fixed
 ----------
-
-* The construct ``for x in cpp_function_call()`` failed to compile.
-  Patch by David Woods.  (Github issue :issue:`3663`)
-
-* C++ references failed to compile when used as Python object indexes.
-  Patch by David Woods.  (Github issue :issue:`3754`)
-
-* The C++ ``typeid()`` function was allowed in C mode.
-  Patch by Celelibi.  (Github issue :issue:`3637`)
 
 * ``repr()`` was assumed to return ``str`` instead of ``unicode`` with ``language_level=3``.
   (Github issue :issue:`3736`)
@@ -1395,10 +1405,6 @@ Bugs fixed
 Features added
 --------------
 
-* ``std::move()`` is now used in C++ mode for internal temp variables to
-  make them work without copying values.
-  Patch by David Woods.  (Github issues :issue:`3253`, :issue:`1612`)
-
 * Conditional blocks in Python code that depend on ``cython.compiled`` are
   eliminated at an earlier stage, which gives more freedom in writing
   replacement Python code.
@@ -1417,9 +1423,6 @@ Bugs fixed
   are now new-style (type) classes also in Py2.  Previously, they were created
   as old-style (non-type) classes.
   (Github issue :issue:`3530`)
-
-* C++ ``typeid()`` failed for fused types.
-  Patch by David Woods.  (Github issue :issue:`3203`)
 
 * ``__arg`` argument names in methods were not mangled with the class name.
   Patch by David Woods.  (Github issue :issue:`1382`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -259,7 +259,7 @@ and the code. Dataclasses have gained an extension type equivalent that implemen
 the dataclass features in C code.  Similarly, the ``@functools.total_ordering``
 decorator to an extension type will implement the comparison functions in C.
 
-FInally, NumPy ufuncs can be generated from simple computation functions with the
+Finally, NumPy ufuncs can be generated from simple computation functions with the
 new ``@cython.ufunc`` decorator.
 
 Related fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,18 +36,20 @@ code into optimized C code.
 
 .. _`pure python`: https://cython.readthedocs.io/en/latest/src/tutorial/pure.html
 
-Implemented PEPs:
+Implemented PEPs
+^^^^^^^^^^^^^^^^
 
-* `PEP-3131`_: Supporting Non-ASCII Identifiers
-* `PEP-479`_: `generator_stop` (enabled by default for `language_level=3`)
-* `PEP-487`_: Simpler customisation of class creation
-* `PEP-563`_: Postponed Evaluation of Annotations
-* `PEP-570`_: Positional-Only Parameters
-* `PEP-572`_: Assignment Expressions (a.k.a. the walrus operator `:=`)
-* `PEP-590`_: Vectorcall protocol
-* `PEP-614`_: Relaxing Grammar Restrictions On Decorators
+* `PEP-3131`_: Supporting Non-ASCII Identifiers (Github issue :issue:`2601`)
+* `PEP-479`_: `generator_stop` (enabled by default for `language_level=3`) (Github issue :issue:`2580`)
+* `PEP-487`_: Simpler customisation of class creation (Github issue :issue:`2781`)
+* `PEP-563`_: Postponed Evaluation of Annotations (Github issue :issue:`3285`)
+* `PEP-570`_: Positional-Only Parameters (Github issue :issue:`2915`)
+* `PEP-572`_: Assignment Expressions (a.k.a. the walrus operator `:=`) (Github issue :issue:`2636`)
+* `PEP-590`_: Vectorcall protocol (Github issue :issue:`2263`)
+* `PEP-614`_: Relaxing Grammar Restrictions On Decorators (Github issue :issue:`4570`)
 
-Typing support in the sense of `PEP-484`_ and `PEP-560`_ was also improved.
+Typing support in the sense of `PEP-484`_ (Github issues :issue:`3949`, :issue:`4243`)
+and `PEP-560`_ (Github issues :issue:`2753`, :issue:`3537`, :issue:`3764`) was also improved.
 
 .. _`PEP-3131`: https://www.python.org/dev/peps/pep-3131
 .. _`PEP-479`: https://www.python.org/dev/peps/pep-0479
@@ -60,6 +62,9 @@ Typing support in the sense of `PEP-484`_ and `PEP-560`_ was also improved.
 .. _`PEP-590`: https://www.python.org/dev/peps/pep-0590
 .. _`PEP-614`: https://www.python.org/dev/peps/pep-0614
 
+Improved fidelity to Python semantics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Cython 3.0.0 also aligns many semantics with Python 3, in particular:
 [TODO: more precise]
 * division
@@ -69,13 +74,89 @@ Cython 3.0.0 also aligns many semantics with Python 3, in particular:
 * types
 * subscripting
 
-Furthermore, pure python mode gain many new features to be able to control
+Improvements in Pure Python mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pure python mode gained many new features to be able to control
 most things that were usually only available in C. Examples:
 [TODO: improve]
 * with gil / nogil
 * etc.
 
-Also: Something about the limited API.
+Initial support for Limited API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+[Text about the status of support for Limited API]
+
+* Preliminary support for the CPython's ``Py_LIMITED_API`` (stable ABI) is
+  available by setting the  ``CYTHON_LIMITED_API`` C macro.  Note that the
+  support is currently in an early stage and many features do not yet work.
+  You currently still have to define ``Py_LIMITED_API`` externally in order
+  to restrict the API usage.  This will change when the feature stabilises.
+  Patches by Eddie Elizondo and David Woods.  (Github issues :issue:`3223`,
+  :issue:`3311`, :issue:`3501`)
+
+* Limited API support was improved.
+  Patches by Matthias Braun.  (Github issues :issue:`3693`, :issue:`3707`)
+
+* ``_Py_TPFLAGS_HAVE_VECTORCALL`` was always set on extension types when using the limited API.
+  Patch by David Woods.  (Github issue :issue:`4453`)
+
+* Limited API C preprocessor warning is compatible with MSVC. Patch by
+  Victor Molina Garcia.  (Github issue :issue:`4826`)
+
+* The embedding code no longer calls deprecated C-API functions but uses the new ``PyConfig``
+  API instead on CPython versions that support it (3.8+).
+  Patch by Alexander Shadchin.  (Github issue :issue:`4895`)
+
+* Some C code issue were resolved for the Limited API target.
+  (Github issues :issue:`5264`, :issue:`5265`, :issue:`5266`)
+
+* Conversion of Python ints to C ``int128`` is now always supported, although slow
+  if dedicated C-API support is missing (``_PyLong_AsByteArray()``), specifically in
+  the Limited C-API.
+  (Github issue :issue:`5419`)
+
+* Custom buffer slot methods are now supported in the Limited C-API of Python 3.9+.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5422`)
+
+Related fixes
+^^^^^^^^^^^^^
+
+* Unicode module names and imports are supported.
+  Patch by David Woods.  (Github issue :issue:`3119`)
+
+* ``PyEval_InitThreads()`` is no longer used in Py3.7+ where it is a no-op.
+
+* The ``Tempita`` module no longer contains HTML processing capabilities, which
+  were found to be broken in Python 3.8 and later.
+  Patch by Marcel Stimberg.  (Github issue :issue:`3309`)
+
+* The generated C code failed to compile in CPython 3.11a4 and later.
+  (Github issue :issue:`4500`)
+
+* The runtime size check for imported ``PyVarObject`` types was improved
+  to reduce false positives and adapt to Python 3.11.
+  Patch by David Woods.  (Github issues :issue:`4827`, :issue:`4894`)
+
+* ``cpdef`` enums no longer use ``OrderedDict`` but ``dict`` in Python 3.6 and later.
+  Patch by GalaxySnail.  (Github issue :issue:`5180`)
+
+* Several problems with CPython 3.12 were resolved.
+  (Github issue :issue:`5238`)
+
+* Very long Python integer constants could exceed the maximum C name length of MSVC.
+  Patch by 0dminnimda.  (Github issue :issue:`5290`)
+
+* The exception handling code was adapted to CPython 3.12.
+  (Github issue :issue:`5442`)
+
+* The dataclass implementation was adapted to support Python 3.12.
+  (Github issue :issue:`5346`)
+
+* The Python ``int`` handling code was adapted to make use of the new ``PyLong``
+  internals in CPython 3.12.
+  (Github issue :issue:`5353`)
 
 Interaction with numpy
 ----------------------
@@ -197,26 +278,8 @@ Other changes
 Features added
 --------------
 
-* Custom buffer slot methods are now supported in the Limited C-API of Python 3.9+.
-  Patch by Lisandro Dalcin.  (Github issue :issue:`5422`)
-
 * The ``extern "C"`` and ``extern "C++"`` markers that Cython generates for
   ``public`` functions can now be controlled by setting the C macro ``CYTHON_EXTERN_C``.
-
-* The Python ``int`` handling code was adapted to make use of the new ``PyLong``
-  internals in CPython 3.12.
-  (Github issue :issue:`5353`)
-
-* Conversion of Python ints to C ``int128`` is now always supported, although slow
-  if dedicated C-API support is missing (``_PyLong_AsByteArray()``), specifically in
-  the Limited C-API.
-  (Github issue :issue:`5419`)
-
-* The exception handling code was adapted to CPython 3.12.
-  (Github issue :issue:`5442`)
-
-* The dataclass implementation was adapted to support Python 3.12.
-  (Github issue :issue:`5346`)
 
 * The normal ``@dataclasses.dataclass`` and ``@functools.total_ordering`` decorators
   can now be used on extension types.  Using the corresponding ``@cython.*`` decorator
@@ -332,9 +395,6 @@ Bugs fixed
 * Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
   (Github issue :issue:`5328`)
 
-* Very long Python integer constants could exceed the maximum C name length of MSVC.
-  Patch by 0dminnimda.  (Github issue :issue:`5290`)
-
 * ``cimport_from_pyx`` could miss some declarations.
   Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5318`)
 
@@ -361,9 +421,6 @@ Bugs fixed
 
 * Some issues with ``depfile`` generation were resolved.
   Patches by Eli Schwartz.  (Github issues :issue:`5279`, :issue:`5291`)
-
-* Some C code issue were resolved for the Limited API target.
-  (Github issues :issue:`5264`, :issue:`5265`, :issue:`5266`)
 
 * The C code shown in the annotated HTML output could lack the last C code line(s).
 
@@ -418,10 +475,6 @@ Features added
   both Python and C semantics of enums.
   (Github issue :issue:`2732`)
 
-* `PEP-614 <https://peps.python.org/pep-0614/>`_:
-  decorators can now be arbitrary Python expressions.
-  (Github issue :issue:`4570`)
-
 * ``cpdef`` enums can now be pickled.
   (Github issue :issue:`5120`)
 
@@ -470,9 +523,6 @@ Bugs fixed
 
 * ``int(Py_UCS4)`` returned the code point instead of the parsed digit value.
   (Github issue :issue:`5216`)
-
-* Several problems with CPython 3.12 were resolved.
-  (Github issue :issue:`5238`)
 
 * The C ``float`` type was not inferred on assignments.
   (Github issue :issue:`5234`)
@@ -541,9 +591,6 @@ Bugs fixed
 * Some issues with Cython ``@dataclass`` arguments, hashing, inheritance and ``repr()``
   were resolved.  (Github issues :issue:`4956`, :issue:`5046`)
 
-* ``cpdef`` enums no longer use ``OrderedDict`` but ``dict`` in Python 3.6 and later.
-  Patch by GalaxySnail.  (Github issue :issue:`5180`)
-
 * Larger numbers of extension types with multiple subclasses could take very long to compile.
   Patch by Scott Wolchok.  (Github issue :issue:`5139`)
 
@@ -577,10 +624,6 @@ Bugs fixed
   Patches by Max Bachmann, Alexander Shadchin, at al.
   (Github issues :issue:`5004`, :issue:`5005`, :issue:`5019`, :issue:`5029`, :issue:`5096`)
 
-* The embedding code no longer calls deprecated C-API functions but uses the new ``PyConfig``
-  API instead on CPython versions that support it (3.8+).
-  Patch by Alexander Shadchin.  (Github issue :issue:`4895`)
-
 * Intel C compilers could complain about unsupported gcc pragmas.
   Patch by Ralf Gommers.  (Github issue :issue:`5052`)
 
@@ -606,10 +649,6 @@ Other changes
 * Wheels now include a compiled parser again, which increases their size a little
   but gives about a 10% speed-up when running Cython.
 
-* The ``Tempita`` module no longer contains HTML processing capabilities, which
-  were found to be broken in Python 3.8 and later.
-  Patch by Marcel Stimberg.  (Github issue :issue:`3309`)
-
 * The Emacs Cython mode file ``cython-mode.el`` is now maintained in a separate repo:
   https://github.com/cython/emacs-cython-mode
 
@@ -626,10 +665,6 @@ Features added
   compile time dataclass generation capabilities to ``cdef`` classes (extension types).
   Patch by David Woods.  (Github issue :issue:`2903`).  ``kw_only`` dataclasses
   added by Yury Sokov.  (Github issue :issue:`4794`)
-
-* Named expressions (PEP 572) aka. assignment expressions (aka. the walrus operator
-  ``:=``) were implemented.
-  Patch by David Woods.  (Github issue :issue:`2636`)
 
 * Context managers can be written in parentheses.
   Patch by David Woods.  (Github issue :issue:`4814`)
@@ -708,9 +743,6 @@ Bugs fixed
 * ``pyximport`` failed for long filenames on Windows.
   Patch by Matti Picus.  (Github issue :issue:`4630`)
 
-* The generated C code failed to compile in CPython 3.11a4 and later.
-  (Github issue :issue:`4500`)
-
 * A case of undefined C behaviour was resolved in the list slicing code.
   Patch by Richard Barnes.  (Github issue :issue:`4734`)
 
@@ -723,18 +755,11 @@ Bugs fixed
   compatible exception specifications.  Patches by David Woods.
   (Github issues :issue:`4770`, :issue:`4689`)
 
-* The runtime size check for imported ``PyVarObject`` types was improved
-  to reduce false positives and adapt to Python 3.11.
-  Patch by David Woods.  (Github issues :issue:`4827`, :issue:`4894`)
-
 * The generated modules no longer import NumPy internally when using
   fused types but no memoryviews.
   Patch by David Woods.  (Github issue :issue:`4935`)
 
 * Improve compatibility with forthcoming CPython 3.12 release.
-
-* Limited API C preprocessor warning is compatible with MSVC. Patch by
-  Victor Molina Garcia.  (Github issue :issue:`4826`)
 
 * Some C compiler warnings were fixed.
   Patch by mwtian.  (Github issue :issue:`4831`)
@@ -883,9 +908,6 @@ Bugs fixed
 * An endless loop in ``cython-mode.el`` was resolved.
   Patch by Johannes Mueller.  (Github issue :issue:`3218`)
 
-* ``_Py_TPFLAGS_HAVE_VECTORCALL`` was always set on extension types when using the limited API.
-  Patch by David Woods.  (Github issue :issue:`4453`)
-
 * Some compatibility issues with PyPy were resolved.
   Patches by Max Bachmann, Matti Picus.
   (Github issues :issue:`4454`, :issue:`4477`, :issue:`4478`, :issue:`4509`, :issue:`4517`)
@@ -974,9 +996,6 @@ Bugs fixed
 * Code optimisations were not applied to methods of Cython implemented C++ classes.
   Patch by David Woods.  (Github issue :issue:`4212`)
 
-* The special ``cython`` module was not always detected in PEP-484 type annotations.
-  Patch by David Woods.  (Github issue :issue:`4243`)
-
 * Conversion from Python dicts to ``std::map`` was broken.
   Patch by David Woods and Mikkel Skofelt.  (Github issues :issue:`4231`, :issue:`4228`)
 
@@ -1029,12 +1048,6 @@ Features added
   imported module name with ``cython.cimports.``, e.g.
   ``from cython.cimports.libc.math import sin``.
   (GIthub issue :issue:`4190`)
-
-* ``__class_getitem__`` (`PEP-560`_) is supported for cdef classes.
-  Patch by Kmol Yuan.  (Github issue :issue:`3764`)
-
-* ``__mro_entries__`` (`PEP-560`_) is supported for Python classes.
-  Patch by David Woods.  (Github issue :issue:`3537`)
 
 * ``cython.array`` supports simple, non-strided views.
   (Github issue :issue:`3775`)
@@ -1160,9 +1173,6 @@ Bugs fixed
 * The Cython ``CodeWriter`` mishandled no-argument ``return`` statements.
   Patch by Tao He.  (Github issue :issue:`3795`)
 
-* ``complex`` wasn't supported in PEP-484 type annotations.
-  Patch by David Woods.  (Github issue :issue:`3949`)
-
 * Default arguments of methods were not exposed for introspection.
   Patch by Vladimir Matveev.  (Github issue :issue:`4061`)
 
@@ -1217,9 +1227,6 @@ Features added
   Patch by Brock Mendel.  (Github issue :issue:`3616`)
 
 * Type inference now understands that ``a, *b = x`` assigns a list to ``b``.
-
-* Limited API support was improved.
-  Patches by Matthias Braun.  (Github issues :issue:`3693`, :issue:`3707`)
 
 * The Cython ``CodeWriter`` can now handle more syntax constructs.
   Patch by Tao He.  (Github issue :issue:`3514`)
@@ -1333,8 +1340,6 @@ Bugs fixed
   could generate invalid C code.
   (Github issue :issue:`3558`)
 
-* ``PyEval_InitThreads()`` is no longer used in Py3.7+ where it is a no-op.
-
 * Parallel builds of Cython itself (``setup.py build_ext -j N``) failed on Windows.
 
 Other changes
@@ -1374,12 +1379,6 @@ Features added
 * ``std::move()`` is now used in C++ mode for internal temp variables to
   make them work without copying values.
   Patch by David Woods.  (Github issues :issue:`3253`, :issue:`1612`)
-
-* ``__class_getitem__`` is supported for types on item access (`PEP-560`_).
-  Patch by msg555.  (Github issue :issue:`2753`)
-
-* The simplified Py3.6 customisation of class creation is implemented (`PEP-487`_).
-  (Github issue :issue:`2781`)
 
 * Conditional blocks in Python code that depend on ``cython.compiled`` are
   eliminated at an earlier stage, which gives more freedom in writing
@@ -1430,26 +1429,6 @@ Bugs fixed
 Features added
 --------------
 
-* Cython functions now use the `PEP-590`_ vectorcall protocol in Py3.7+.
-  Patch by Jeroen Demeyer.  (Github issue :issue:`2263`)
-
-* Unicode identifiers are supported in Cython code (`PEP-3131`_).
-  Patch by David Woods.  (Github issue :issue:`2601`)
-
-* Unicode module names and imports are supported.
-  Patch by David Woods.  (Github issue :issue:`3119`)
-
-* Annotations are no longer parsed, keeping them as strings following `PEP-563`_.
-  Patch by David Woods.  (Github issue :issue:`3285`)
-
-* Preliminary support for the CPython's ``Py_LIMITED_API`` (stable ABI) is
-  available by setting the  ``CYTHON_LIMITED_API`` C macro.  Note that the
-  support is currently in an early stage and many features do not yet work.
-  You currently still have to define ``Py_LIMITED_API`` externally in order
-  to restrict the API usage.  This will change when the feature stabilises.
-  Patches by Eddie Elizondo and David Woods.  (Github issues :issue:`3223`,
-  :issue:`3311`, :issue:`3501`)
-
 * The dispatch to fused functions is now linear in the number of arguments,
   which makes it much faster, often 2x or more, and several times faster for
   larger fused types with many specialisations.
@@ -1464,9 +1443,6 @@ Features added
 
 * Reimports of already imported modules are substantially faster.
   (Github issue :issue:`2854`)
-
-* Positional-only arguments are supported in Python functions (`PEP-570`_).
-  Patch by Josh Tobin.  (Github issue :issue:`2915`)
 
 * The ``volatile`` C modifier is supported in Cython code.
   Patch by Jeroen Demeyer.  (Github issue :issue:`1667`)
@@ -1517,9 +1493,6 @@ Features added
 
 * The builtin ``abs()`` function can now be used on C numbers in nogil code.
   Patch by Elliott Sales de Andrade.  (Github issue :issue:`2748`)
-
-* `PEP-479`_ (``generator_stop``) is now enabled by default with language level 3.
-  (Github issue :issue:`2580`)
 
 * The ``cython.view.array`` type supports inheritance.
   Patch by David Woods.  (Github issue :issue:`3413`)
@@ -1652,8 +1625,6 @@ Other changes
 
 * Binary Linux wheels now follow the manylinux2010 standard.
   Patch by Alexey Stepanov.  (Github issue :issue:`3355`)
-
-* Support for Python 2.6 was removed.
 
 
 3.0.0 (2023-0?-??)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1555,6 +1555,1559 @@ Other changes
 .. _`PEP-563`: https://www.python.org/dev/peps/pep-0563
 .. _`PEP-479`: https://www.python.org/dev/peps/pep-0479
 
+3.0.0 (2023-0?-??)
+==================
+
+Bugs fixed
+----------
+
+* Parser crash on hex/oct enum values.
+  (Github issue :issue:`5524`)
+
+
+3.0.0 rc 1 (2023-07-12)
+=======================
+
+Features added
+--------------
+
+* ``with gil`` and ``with nogil(flag)`` now accept their flag argument also in Python code.
+  Patch by Matúš Valo.  (Github issue :issue:`5113`)
+
+* A new decorator ``@cython.with_gil`` is available in Python code to match the ``with gil``
+  function declaration in Cython syntax.
+
+* Assigning a list to a ctuple is slightly faster.
+
+Bugs fixed
+----------
+
+* The reference counting of memory views involved useless overhead.
+  (Github issue :issue:`5510`)
+
+* Duplicate values in a ``cpdef`` enum could lead to invalid switch statements.
+  (Github issue :issue:`5400`)
+
+* Handling freshly raised exceptions that didn't have a traceback yet could crash.
+  (Github issue :issue:`5495`)
+
+* Reverse iteration in C++ no longer removes the ``const`` qualifier from the item type.
+  Patch by Isuru Fernando.  (Github issue :issue:`5478`)
+
+* C++ containers of item type ``bint`` could conflict with those of item type ``int``.
+  (Github issue :issue:`5516`)
+
+* With MSVC, Cython no longer enables C-Complex support by accident (which is not supported there).
+  (Github issue :issue:`5512`)
+
+* The Python implementation of ``cimport cython.cimports…`` could raise an ``ImportError``
+  instead of an ``AttributeError`` when looking up package variable names.
+  Patch by Matti Picus.  (Github issue :issue:`5411`)
+
+* Passing a language level and directives on the command line lost the language level setting.
+  Patch by Matúš Valo.  (Github issue :issue:`5484`)
+
+* Some typedef declarations for libc function types were fixed.
+  (Github issue :issue:`5498`)
+
+* Some C compiler warnings and errors in CPython 3.12 were resolved.
+
+* The deprecated ``_PyGC_FINALIZED()`` C-API macro is no longer used.
+  Patch by Thomas Caswell and Matúš Valo.  (Github issue :issue:`5481`)
+
+* A compile error when using ``__debug__`` was resolved.
+
+* A module loading problem with ``cython.inline()`` on Windows was resolved.
+
+* ``cython --version`` now prints the version to stdout instead of stderr.
+  (Github issue :issue:`5504`)
+
+* Includes all bug-fixes and features from the 0.29 maintenance branch
+  up to the :ref:`0.29.36` release.
+
+Other changes
+-------------
+
+* The FAQ page was moved from the GitHub Wiki to the regular documentation
+  to make it more visible.
+
+* ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
+  synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
+  since they could mean different things on different platforms.
+
+
+3.0.0 beta 3 (2023-05-24)
+=========================
+
+Features added
+--------------
+
+* Custom buffer slot methods are now supported in the Limited C-API of Python 3.9+.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5422`)
+
+* The ``extern "C"`` and ``extern "C++"`` markers that Cython generates for
+  ``public`` functions can now be controlled by setting the C macro ``CYTHON_EXTERN_C``.
+
+* The Python ``int`` handling code was adapted to make use of the new ``PyLong``
+  internals in CPython 3.12.
+  (Github issue :issue:`5353`)
+
+* Conversion of Python ints to C ``int128`` is now always supported, although slow
+  if dedicated C-API support is missing (``_PyLong_AsByteArray()``), specifically in
+  the Limited C-API.
+  (Github issue :issue:`5419`)
+
+* The exception handling code was adapted to CPython 3.12.
+  (Github issue :issue:`5442`)
+
+* The dataclass implementation was adapted to support Python 3.12.
+  (Github issue :issue:`5346`)
+
+* The normal ``@dataclasses.dataclass`` and ``@functools.total_ordering`` decorators
+  can now be used on extension types.  Using the corresponding ``@cython.*`` decorator
+  will automatically turn a Python class into an extension type (no need for ``@cclass``).
+  (Github issue :issue:`5292`)
+
+* Multiplying a sequence by a C integer avoids creating and intermediate Python integer.
+
+* ctuples can now be assigned from arbitrary sequences, not just Python tuples.
+
+* A new directive ``embedsignature.format`` was added to select the format of the
+  docstring embedded signatures between ``python``, ``c`` and argument ``clinic``.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5415`)
+
+* Some invalid directive usages are now detected and rejected, e.g. using ``@ccall``
+  together with ``@cfunc``, and applying ``@cfunc`` to a ``@ufunc``.  Cython also
+  warns now when a directive is applied needlessly.
+  (Github issue :issue:`5399` et al.)
+
+* Unicode identifier names now allow all letters defined in CPython 3.12.
+
+Bugs fixed
+----------
+
+* Some C compile failures in CPython 3.12.0a6/a7 were resolved.
+
+* Cascaded comparisons between integer constants and Python types could fail to compile.
+  (Github issue :issue:`5354`)
+
+* The internal macro ``__PYX_IS_UNSIGNED`` was accidentally duplicated in beta 2
+  which lead to C compile errors.
+  Patch by 0dminnimda.  (Github issue :issue:`5356`)
+
+* Memoryviews with typedef item types could fail to match the non-typedef item types.
+  Patch by Yue Yang.  (Github issue :issue:`5373`)
+
+* Fused memory views could raise a ``TypeError`` instead of a ``ValueError`` on creation.
+  Patch by Matúš Valo.  (Github issue :issue:`5401`)
+
+* Cython could crash when finding import files with dots in their names.
+  Patch by Matúš Valo.  (Github issue :issue:`5396`)
+
+* Selecting a context manager in parentheses and then calling it directly failed to parse.
+  (Github issue :issue:`5403`)
+
+* ``__qualname__`` and ``__module__`` were not available inside of class bodies.
+  (Github issue :issue:`4447`)
+
+* ``noexcept`` was not automatically applied to function pointer attributes in extern structs.
+  Patch by Matúš Valo.  (Github issue :issue:`5359`)
+
+* Function signatures containing a type like `tuple[()]` could not be printed.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5355`)
+
+* Extension type hierarchies were generated in the wrong order, thus leading to compile issues.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5395`)
+
+* Using the ``--working`` option could lead to sources not being found.
+  Patch by Lisandro Dalcin.  (Github issue :issue:`5365`)
+
+* Some C compiler warnings were resolved.
+  Patches by Matt Tyson, Lisandro Dalcin, Philipp Wagner, Matti Picus et al.
+  (Github issues :issue:`5417`, :issue:`5418`, :issue:`5421`, :issue:`5437`, :issue:`5438`, :issue:`5443`)
+
+* Includes all bug-fixes and features from the 0.29 maintenance branch
+  up to the :ref:`0.29.35` release.
+
+Other changes
+-------------
+
+* For-loops now release the internal reference to their list/tuple iterable before
+  instead of after the ``else:`` clause.  This probably has no practical impact.
+  (Github issue :issue:`5347`)
+
+* Simple tuple types like ``(int, int)`` are no longer accepted in Python annotations
+  and require the Python notation instead (e.g. ``tuple[cython.int, cython.int]``).
+  (Github issue :issue:`5397`)
+
+* The code ``except +nogil`` (declaring a C++ exception handler function called ``nogil``)
+  is now rejected because it is almost certainly a typo from ``except + nogil``.
+  (Github issue :issue:`5430`)
+
+
+3.0.0 beta 2 (2023-03-27)
+=========================
+
+Features added
+--------------
+
+* C++ declarations for ``<cmath>``, ``<numbers>`` and ``std::any`` were added.
+  Patches by Jonathan Helgert and Maximilien Colange.
+  (Github issues :issue:`5262`, :issue:`5309`, :issue:`5314`)
+
+Bugs fixed
+----------
+
+* Unintended internal exception handling lead to a visible performance regression
+  for ``nogil`` memoryview code in 3.0.0b1.
+  (Github issue :issue:`5324`)
+
+* ``None`` default arguments for arguments with fused memoryview types could select a different
+  implementation in 3.0 than in 0.29.x.  The selection behaviour is generally considered
+  suboptimal but was at least reverted to the old behaviour for now.
+  (Github issue :issue:`5297`)
+
+* The new complex vs. floating point behaviour of the ``**`` power operator accidentally
+  added a dependency on the GIL, which was really only required on failures.
+  (Github issue :issue:`5287`)
+
+* ``from cython cimport … as …`` could lead to imported names not being found in annotations.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5235`)
+
+* Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
+  (Github issue :issue:`5328`)
+
+* Very long Python integer constants could exceed the maximum C name length of MSVC.
+  Patch by 0dminnimda.  (Github issue :issue:`5290`)
+
+* ``cimport_from_pyx`` could miss some declarations.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5318`)
+
+* Fully qualified C++ names prefixed by a cimported module name could fail to compile.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5229`)
+
+* Cython generated C++ code accidentally used C++11 features in some cases.
+  (Github issue :issue:`5316`)
+
+* Some C++ warnings regarding ``const`` usage in internally generated utility code were resolved.
+  Patch by Max Bachmann.  (Github issue :issue:`5301`)
+
+* With ``language_level=2``, imports of modules in packages could return the wrong module in Python 3.
+  (Github issue :issue:`5308`)
+
+* ``typing.Optional`` could fail on tuple types.
+  (Github issue :issue:`5263`)
+
+* Auto-generated utility code didn't always have all required user defined types available.
+  (Github issue :issue:`5269`)
+
+* Type checks for Python's ``memoryview`` type generated incorrect C code.
+  (Github issues :issue:`5268`, :issue:`5270`)
+
+* Some issues with ``depfile`` generation were resolved.
+  Patches by Eli Schwartz.  (Github issues :issue:`5279`, :issue:`5291`)
+
+* Some C code issue were resolved for the Limited API target.
+  (Github issues :issue:`5264`, :issue:`5265`, :issue:`5266`)
+
+* The C code shown in the annotated HTML output could lack the last C code line(s).
+
+
+3.0.0 beta 1 (2023-02-25)
+=========================
+
+Features added
+--------------
+
+* Cython implemented C functions now propagate exceptions by default, rather than
+  swallowing them in non-object returning function if the user forgot to add an
+  ``except`` declaration to the signature.  This was a long-standing source of bugs,
+  but can require adding the ``noexcept`` declaration to existing functions if
+  exception propagation is really undesired.
+  (Github issue :issue:`4280`)
+
+* To opt out of the new, safer exception handling behaviour, legacy code can set the new
+  directive ``legacy_implicit_noexcept=True`` for a transition period to keep the
+  previous, unsafe behaviour.  This directive will eventually be removed in a later release.
+  Patch by Matúš Valo.  (Github issue :issue:`5094`)
+
+* A new function decorator ``@cython.ufunc`` automatically generates a (NumPy) ufunc that
+  applies the calculation function to an entire memoryview.
+  (Github issue :issue:`4758`)
+
+* The ``**`` power operator now behaves more like in Python by returning the correct complex
+  result if required by math.  A new ``cpow`` directive was added to turn on the previous
+  C-like behaviour.
+  (Github issue :issue:`4936`)
+
+* The special ``__*pow__`` methods now support the 2- and 3-argument variants.
+  (Github issue :issue:`5160`)
+
+* Unknown type annotations (e.g. because of typos) now emit a warning at compile time.
+  Patch by Matúš Valo.  (Github issue :issue:`5070`)
+
+* Subscripted builtin types in type declarations (like ``list[float]``) are now
+  better supported.
+  (Github issue :issue:`5058`)
+
+* Python's ``memoryview`` is now a known builtin type with optimised properties.
+  (Github issue :issue:`3798`)
+
+* The call-time dispatch for fused memoryview types is less slow.
+  (Github issue :issue:`5073`)
+
+* Integer comparisons avoid Python coercions if possible.
+  (Github issue :issue:`4821`)
+
+* The Python Enum of a ``cpdef enum`` now inherits from ``IntFlag`` to better match
+  both Python and C semantics of enums.
+  (Github issue :issue:`2732`)
+
+* `PEP-614 <https://peps.python.org/pep-0614/>`_:
+  decorators can now be arbitrary Python expressions.
+  (Github issue :issue:`4570`)
+
+* ``cpdef`` enums can now be pickled.
+  (Github issue :issue:`5120`)
+
+* Bound C methods can now coerce to Python objects.
+  (Github issues :issue:`4890`, :issue:`5062`)
+
+* C arrays can be initialised inside of nogil functions.
+  Patch by Matúš Valo.  (Github issue :issue:`1662`)
+
+* ``reversed()`` can now be used together with C++ iteration.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5002`)
+
+* Standard C/C++ atomic operations are now used for memory views, if available.
+  (Github issue :issue:`4925`)
+
+* C11 ``complex.h`` is now properly detected.
+  (Github issue :issue:`2513`)
+
+* Nested ``cppclass`` definitions are supported.
+  Patch by samaingw.  (Github issue :issue:`1218`)
+
+* ``cpp_locals`` no longer have to be "assignable".
+  (Github issue :issue:`4558`)
+
+* ``cythonize --help`` now also prints information about the supported environment variables.
+  Patch by Matúš Valo.  (Github issue :issue:`1711`)
+
+* Declarations were added for the C++ bit operations, some other parts of C++20 and CPython APIs.
+  Patches by Jonathan Helgert, Dobatymo, William Ayd and Max Bachmann.
+  (Github issues :issue:`4962`, :issue:`5101`, :issue:`5157`, :issue:`5163`, :issue:`5257`)
+
+Bugs fixed
+----------
+
+* Generator expressions and comprehensions now look up their outer-most iterable
+  on creation, as Python does, and not later on start, as they did previously.
+  (Github issue :issue:`1159`)
+
+* Type annotations for Python ``int`` rejected ``long`` under Py2 in the alpha-11 release.
+  They are now ignored again (as always before) when ``language_level=2``, and accept
+  both ``int`` and ``long`` in Py2 (and only ``int`` in Py3) otherwise.
+  (Github issue :issue:`4944`)
+
+* Calling bound classmethods of builtin types could fail trying to call the unbound method.
+  (Github issue :issue:`5051`)
+
+* ``int(Py_UCS4)`` returned the code point instead of the parsed digit value.
+  (Github issue :issue:`5216`)
+
+* Several problems with CPython 3.12 were resolved.
+  (Github issue :issue:`5238`)
+
+* The C ``float`` type was not inferred on assignments.
+  (Github issue :issue:`5234`)
+
+* Memoryviews with ``object`` item type were not supported in Python type declarations.
+  (Github issue :issue:`4907`)
+
+* Iterating over memoryviews in generator expressions could leak a buffer reference.
+  (Github issue :issue:`4968`)
+
+* Memory views and the internal Cython array type now identify as ``collections.abc.Sequence``
+  by setting the ``Py_TPFLAGS_SEQUENCE`` type flag directly.
+  (Github issue :issue:`5187`)
+
+* ``__del__`` finaliser methods were not always called if they were only inherited.
+  (Github issue :issue:`4995`)
+
+* Extension types are now explicitly marked as immutable types to prevent them from
+  being considered mutable.
+  Patch by Max Bachmann.  (Github issue :issue:`5023`)
+
+* ``const`` types could not be returned from functions.
+  Patch by Mike Graham.  (Github issue :issue:`5135`)
+
+* ``cdef public`` functions declared in .pxd files could use an incorrectly mangled C name.
+  Patch by EpigeneMax.  (Github issue :issue:`2940`)
+
+* ``cdef public`` functions used an incorrect linkage declaration in C++.
+  Patch by Maximilien Colange.  (Github issue :issue:`1839`)
+
+* C++ post-increment/-decrement operators were not correctly looked up on declared C++
+  classes, thus allowing Cython declarations to be missing for them and incorrect C++
+  code to be generated.
+  Patch by Max Bachmann.  (Github issue :issue:`4536`)
+
+* C++ iteration more safely stores the iterable in temporary variables.
+  Patch by Xavier.  (Github issue :issue:`3828`)
+
+* C++ references did not work on fused types.
+  (Github issue :issue:`4717`)
+
+* The module state struct was not initialised in correct C (before C23), leading to
+  compile errors on Windows.
+  Patch by yudonglin.  (Github issue :issue:`5169`)
+
+* Structs that contained an array field resulted in incorrect C code.  Their initialisation
+  now uses ``memcpy()``.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5178`)
+
+* Nesting fused types in other fused types could fail to specialise the inner type.
+  (Github issue :issue:`4725`)
+
+* The special methods ``__matmul__``, ``__truediv__``, ``__floordiv__`` failed to type
+  their ``self`` argument.
+  (Github issue :issue:`5067`)
+
+* Coverage analysis failed in projects with a separate source subdirectory.
+  Patch by Sviatoslav Sydorenko and Ruben Vorderman.  (Github issue :issue:`3636`)
+
+* The ``annotation_typing`` directive was missing in pure Python mode.
+  Patch by 0dminnimda.  (Github issue :issue:`5194`)
+
+* The ``@dataclass`` directive was accidentally inherited by methods and subclasses.
+  (Github issue :issue:`4953`)
+
+* Some issues with Cython ``@dataclass`` arguments, hashing, inheritance and ``repr()``
+  were resolved.  (Github issues :issue:`4956`, :issue:`5046`)
+
+* ``cpdef`` enums no longer use ``OrderedDict`` but ``dict`` in Python 3.6 and later.
+  Patch by GalaxySnail.  (Github issue :issue:`5180`)
+
+* Larger numbers of extension types with multiple subclasses could take very long to compile.
+  Patch by Scott Wolchok.  (Github issue :issue:`5139`)
+
+* Relative imports failed in compiled ``__init__.py`` package modules.
+  Patch by Matúš Valo.  (Github issue :issue:`3442`)
+
+* Some old usages of the deprecated Python ``imp`` module were replaced with ``importlib``.
+  Patch by Matúš Valo.  (Github issue :issue:`4640`)
+
+* The ``cython`` and ``cythonize`` commands ignored non-existing input files without error.
+  Patch by Matúš Valo.  (Github issue :issue:`4629`)
+
+* Invalid and misspelled ``cython.*`` module names were not reported as errors.
+  (Github issue :issue:`4947`)
+
+* Unused ``**kwargs`` arguments did not show up in ``locals()``.
+  (Github issue :issue:`4899`)
+
+* Extended glob paths with ``/**/`` and ``\**\`` for finding source files failed on Windows.
+
+* Annotated HTML generation was missing newlines in 3.0.0a11.
+  (Github issue :issue:`4945`)
+
+* Some parser issues were resolved.
+  (Github issue :issue:`4992`)
+
+* ``setup.cfg`` was missing from the source distribution.
+  (Github issue :issue:`5199`)
+
+* Some C/C++ warnings were resolved.
+  Patches by Max Bachmann, Alexander Shadchin, at al.
+  (Github issues :issue:`5004`, :issue:`5005`, :issue:`5019`, :issue:`5029`, :issue:`5096`)
+
+* The embedding code no longer calls deprecated C-API functions but uses the new ``PyConfig``
+  API instead on CPython versions that support it (3.8+).
+  Patch by Alexander Shadchin.  (Github issue :issue:`4895`)
+
+* Intel C compilers could complain about unsupported gcc pragmas.
+  Patch by Ralf Gommers.  (Github issue :issue:`5052`)
+
+* Includes all bug-fixes and features from the 0.29 maintenance branch
+  up to the :ref:`0.29.33` release.
+
+Other changes
+-------------
+
+* The undocumented, untested and apparently useless syntax
+  ``from somemodule cimport class/struct/union somename`` was removed.  The type
+  modifier is not needed here and a plain ``cimport`` of the name will do.
+  (Github issue :issue:`4904`)
+
+* C-style array declarations (``cdef int a[4]``) are now (silently) deprecated in
+  favour of the Java-style ``cdef int[4] a`` form.  The latter was always available
+  and the Python type declaration syntax already used it exclusively (``a: int[4]``).
+  Patch by Matúš Valo.  (Github issue :issue:`5248`)
+
+* The wheel building process was migrated to use the ``cibuildwheel`` tool.
+  Patch by Thomas Li.  (Github issue :issue:`4736`)
+
+* Wheels now include a compiled parser again, which increases their size a little
+  but gives about a 10% speed-up when running Cython.
+
+* The ``Tempita`` module no longer contains HTML processing capabilities, which
+  were found to be broken in Python 3.8 and later.
+  Patch by Marcel Stimberg.  (Github issue :issue:`3309`)
+
+* The Emacs Cython mode file ``cython-mode.el`` is now maintained in a separate repo:
+  https://github.com/cython/emacs-cython-mode
+
+* Cython now uses a ``.dev0`` version suffix for unreleased source installations.
+
+
+3.0.0 alpha 11 (2022-07-31)
+===========================
+
+Features added
+--------------
+
+* A new decorator ``@cython.dataclasses.dataclass`` was implemented that provides
+  compile time dataclass generation capabilities to ``cdef`` classes (extension types).
+  Patch by David Woods.  (Github issue :issue:`2903`).  ``kw_only`` dataclasses
+  added by Yury Sokov.  (Github issue :issue:`4794`)
+
+* Named expressions (PEP 572) aka. assignment expressions (aka. the walrus operator
+  ``:=``) were implemented.
+  Patch by David Woods.  (Github issue :issue:`2636`)
+
+* Context managers can be written in parentheses.
+  Patch by David Woods.  (Github issue :issue:`4814`)
+
+* Cython avoids raising ``StopIteration`` in ``__next__`` methods when possible.
+  Patch by David Woods.  (Github issue :issue:`3447`)
+
+* Some C++ and CPython library declarations were extended and fixed.
+  Patches by Max Bachmann, Till Hoffmann, Julien Jerphanion, Wenjun Si.
+  (Github issues :issue:`4530`, :issue:`4528`, :issue:`4710`, :issue:`4746`,
+  :issue:`4751`, :issue:`4818`, :issue:`4762`, :issue:`4910`)
+
+* The ``cythonize`` and ``cython`` commands have a new option ``-M`` / ``--depfile``
+  to generate ``.dep`` dependency files for the compilation unit.  This can be used
+  by external build tools to track these dependencies.
+  The ``cythonize`` option was already available in Cython :ref:`0.29.27`.
+  Patches by Evgeni Burovski and Eli Schwartz.  (Github issue :issue:`1214`)
+
+* ``cythonize()`` and the corresponding CLI command now regenerate the output files
+  also when they already exist but were generated by a different Cython version.
+
+* Memory views and the internal Cython array type now identify as ``collections.abc.Sequence``.
+  Patch by David Woods.  (Github issue :issue:`4817`)
+
+* Cython generators and coroutines now identify as ``CO_ASYNC_GENERATOR``,
+  ``CO_COROUTINE`` and ``CO_GENERATOR`` accordingly.
+  (Github issue :issue:`4902`)
+
+* Memory views can use atomic CPU instructions instead of locks in more cases.
+  Patch by Sam Gross.  (Github issue :issue:`4912`)
+
+* The environment variable ``CYTHON_FORCE_REGEN=1`` can be used to force ``cythonize``
+  to regenerate the output files regardless of modification times and changes.
+
+* A new Cython build option ``--cython-compile-minimal`` was added to compile only a
+  smaller set of Cython's own modules, which can be used to reduce the package
+  and install size.
+
+* Improvements to ``PyTypeObject`` definitions in pxd wrapping of libpython.
+  Patch by John Kirkham. (Github issue :issue:`4699`)
+
+
+Bugs fixed
+----------
+
+* Decorators like ``@cfunc`` and ``@ccall`` could leak into nested functions and classes.
+  Patch by David Woods.  (Github issue :issue:`4092`)
+
+* Exceptions within for-loops that run over memoryviews could lead to a ref-counting error.
+  Patch by David Woods.  (Github issue :issue:`4662`)
+
+* Using memoryview arguments in closures of inner functions could lead to ref-counting errors.
+  Patch by David Woods.  (Github issue :issue:`4798`)
+
+* Several optimised string methods failed to accept ``None`` as arguments to their options.
+  Test patch by Kirill Smelkov.  (Github issue :issue:`4737`)
+
+* A regression in 3.0.0a10 was resolved that prevented property setter methods from
+  having the same name as their value argument.
+  Patch by David Woods.  (Github issue :issue:`4836`)
+
+* Typedefs for the ``bint`` type did not always behave like ``bint``.
+  Patch by Nathan Manville and 0dminnimda.  (Github issue :issue:`4660`)
+
+* The return type of a fused function is no longer ignored for function pointers,
+  since it is relevant when passing them e.g. as argument into other fused functions.
+  Patch by David Woods.  (Github issue :issue:`4644`)
+
+* The ``__self__`` attribute of fused functions reports its availability correctly
+  with ``hasattr()``.  Patch by David Woods.
+  (Github issue :issue:`4808`)
+
+* ``pyximport`` no longer uses the deprecated ``imp`` module.
+  Patch by Matúš Valo.  (Github issue :issue:`4560`)
+
+* ``pyximport`` failed for long filenames on Windows.
+  Patch by Matti Picus.  (Github issue :issue:`4630`)
+
+* The generated C code failed to compile in CPython 3.11a4 and later.
+  (Github issue :issue:`4500`)
+
+* A case of undefined C behaviour was resolved in the list slicing code.
+  Patch by Richard Barnes.  (Github issue :issue:`4734`)
+
+* Using the Limited API could report incorrect line numbers in tracebacks.
+
+* A work-around for StacklessPython < 3.8 was disabled in Py3.8 and later.
+  (Github issue :issue:`4329`)
+
+* Improve conversion between function pointers with non-identical but
+  compatible exception specifications.  Patches by David Woods.
+  (Github issues :issue:`4770`, :issue:`4689`)
+
+* The runtime size check for imported ``PyVarObject`` types was improved
+  to reduce false positives and adapt to Python 3.11.
+  Patch by David Woods.  (Github issues :issue:`4827`, :issue:`4894`)
+
+* The generated modules no longer import NumPy internally when using
+  fused types but no memoryviews.
+  Patch by David Woods.  (Github issue :issue:`4935`)
+
+* Improve compatibility with forthcoming CPython 3.12 release.
+
+* Limited API C preprocessor warning is compatible with MSVC. Patch by
+  Victor Molina Garcia.  (Github issue :issue:`4826`)
+
+* Some C compiler warnings were fixed.
+  Patch by mwtian.  (Github issue :issue:`4831`)
+
+* The parser allowed some invalid spellings of ``...``.
+  Patch by 0dminnimda.  (Github issue :issue:`4868`)
+
+* Includes all bug-fixes and features from the 0.29 maintenance branch
+  up to the :ref:`0.29.32` release.
+
+Other changes
+-------------
+
+* When using type annotations, ``func(x: list)`` or ``func(x: ExtType)`` (and other
+  Python builtin or extension types) no longer allow ``None`` as input argument to ``x``.
+  This is consistent with the normal typing semantics in Python, and was a common gotcha
+  for users who did not expect ``None`` to be allowed as input.  To allow ``None``, use
+  ``typing.Optional`` as in ``func(x: Optional[list])``.  ``None`` is also automatically
+  allowed when it is used as default argument, i.e. ``func(x: list = None)``.
+  ``int`` and ``float`` are now also recognised in type annotations and restrict the
+  value type at runtime.  They were previously ignored.
+  Note that, for backwards compatibility reasons, the new behaviour does not apply when using
+  Cython's C notation, as in ``func(list x)``.  Here, ``None`` is still allowed, as always.
+  Also, the ``annotation_typing`` directive can now be enabled and disabled more finely
+  within the module.
+  (Github issues :issue:`3883`, :issue:`2696`, :issue:`4669`, :issue:`4606`, :issue:`4886`)
+
+* The compile-time ``DEF`` and ``IF`` statements are deprecated and generate a warning.
+  They should be replaced with normal constants, code generation or C macros.
+  (Github issue :issue:`4310`)
+
+* Reusing an extension type attribute name as a method name is now an error.
+  Patch by 0dminnimda.  (Github issue :issue:`4661`)
+
+* Improve compatibility between classes pickled in Cython 3.0 and 0.29.x
+  by accepting MD5, SHA-1 and SHA-256 checksums.
+  (Github issue :issue:`4680`)
+
+
+3.0.0 alpha 10 (2022-01-06)
+===========================
+
+Features added
+--------------
+
+* ``Cython.Distutils.build_ext`` now uses ``cythonize()`` internally (previously
+  known as ``new_build_ext``), while still supporting the options that were
+  available in the old implementation (``old_build_ext``).
+  Patch by Matúš Valo.  (Github issue :issue:`3541`)
+
+* ``pyximport`` now uses ``cythonize()`` internally.
+  Patch by Matúš Valo.  (Github issue :issue:`2304`)
+
+* ``__del__(self)`` on extension types now maps to ``tp_finalize`` in Python 3.
+  Original patch by ax487.  (Github issue :issue:`3612`)
+
+* Conversion from Python dict to C++ map now supports arbitrary Python mappings,
+  not just dicts.
+
+* Direct assignments to C++ references are now allowed.
+  Patch by David Woods.  (Github issue :issue:`1863`)
+
+* An initial set of adaptations for GraalVM Python was implemented.  Note that
+  this does not imply any general support for this target or that your code
+  will work at all in this environment.  But testing should be possible now.
+  Patch by David Woods.  (Github issue :issue:`4328`)
+
+* ``PyMem_[Raw]Calloc()`` was added to the ``cpython.mem`` declarations.
+  Note that the ``Raw`` versions are no longer #defined by Cython.  The previous
+  macros were not considered safe.
+  Patch by William Schwartz and David Woods.  (Github issue :issue:`3047`)
+
+Bugs fixed
+----------
+
+* Circular imports of compiled modules could fail needlessly even when the import
+  could already be resolved from ``sys.modules``.
+  Patch by Syam Gadde.  (Github issue :issue:`4390`)
+
+* The GIL can now safely be released inside of ``nogil`` functions (which may actually
+  be called with the GIL held at runtime).
+  Patch by David Woods.  (Github issue :issue:`4137`)
+
+* Type errors when passing memory view arguments could leak buffer references.
+  Patch by David Woods.  (Github issue :issue:`4296`)
+
+* Cython did not type the ``self`` argument in special binary methods.
+  Patch by David Woods.  (Github issue :issue:`4434`)
+
+* An incompatibility with recent coverage.py versions was resolved.
+  Patch by David Woods.  (Github issue :issue:`4440`)
+
+* Fused typed default arguments generated incorrect code.
+  Patch by David Woods.  (Github issue :issue:`4413`)
+
+* ``prange`` loops generated incorrect code when ``cpp_locals`` is enabled.
+  Patch by David Woods.  (Github issue :issue:`4354`)
+
+* A C-level compatibility issue with recent NumPy versions was resolved.
+  Patch by David Woods.  (Github issue :issue:`4396`)
+
+* Decorators on inner functions were not evaluated in the right scope.
+  Patch by David Woods.  (Github issue :issue:`4367`)
+
+* Very early errors during module initialisation could lead to crashes.
+  Patch by David Woods.  (Github issue :issue:`4377`)
+
+* Fused functions were binding unnecessarily, which prevented them from being pickled.
+  Patch by David Woods.  (Github issue :issue:`4370`)
+
+* Some constant tuples containing strings were not deduplicated.
+  Patch by David Woods.  (Github issue :issue:`4353`)
+
+* Unsupported decorators on cdef functions were not rejected in recent releases.
+  Patch by David Woods.  (Github issue :issue:`4322`)
+
+* The excess arguments in a for-in-range loop with more than 3 arguments to `range()`
+  were silently ignored.
+  Original patch by Max Bachmann. (Github issue :issue:`4550`)
+
+* Python object types were not allowed as ``->`` return type annotations.
+  Patch by Matúš Valo.  (Github issue :issue:`4433`)
+
+* Default values for memory views arguments were not properly supported.
+  Patch by Corentin Cadiou.  (Github issue :issue:`4313`)
+
+* Templating C++ classes with memory view types lead to buggy code and is now rejected.
+  Patch by David Woods.  (Github issue :issue:`3085`)
+
+* Several C++ library declarations were added and fixed.
+  Patches by Dobatymo, account-login, Jonathan Helgert, Evgeny Yakimov, GalaxySnail, Max Bachmann.
+  (Github issues :issue:`4408`, :issue:`4419`, :issue:`4410`, :issue:`4395`,
+  :issue:`4423`, :issue:`4448`, :issue:`4462`, :issue:`3293`, :issue:`4522`,
+  :issue:`2171`, :issue:`4531`)
+
+* Some compiler problems and warnings were resolved.
+  Patches by David Woods, 0dminnimda, Nicolas Pauss and others.
+  (Github issues :issue:`4317`, :issue:`4324`, :issue:`4361`, :issue:`4357`)
+
+* The ``self`` argument of static methods in .pxd files was incorrectly typed.
+  Patch by David Woods.  (Github issue :issue:`3174`)
+
+* A name collision when including multiple generated API header files was resolved.
+  Patch by David Woods.  (Github issue :issue:`4308`)
+
+* An endless loop in ``cython-mode.el`` was resolved.
+  Patch by Johannes Mueller.  (Github issue :issue:`3218`)
+
+* ``_Py_TPFLAGS_HAVE_VECTORCALL`` was always set on extension types when using the limited API.
+  Patch by David Woods.  (Github issue :issue:`4453`)
+
+* Some compatibility issues with PyPy were resolved.
+  Patches by Max Bachmann, Matti Picus.
+  (Github issues :issue:`4454`, :issue:`4477`, :issue:`4478`, :issue:`4509`, :issue:`4517`)
+
+* A compiler crash when running Cython thread-parallel from distutils was resolved.
+  (Github issue :issue:`4503`)
+
+* Includes all bug-fixes from the :ref:`0.29.26` release.
+
+Other changes
+-------------
+
+* A warning was added when ``__defaults__`` or ``__kwdefaults__`` of Cython compiled
+  functions were re-assigned, since this does not current have an effect.
+  Patch by David Woods.  (Github issue :issue:`2650`)
+
+
+3.0.0 alpha 9 (2021-07-21)
+==========================
+
+Features added
+--------------
+
+* Declarations for ``libcpp.algorithms``, ``libcpp.set`` and ``libcpp.unordered_set``
+  were extended.
+  Patch by David Woods.  (Github issues :issue:`4271`, :issue:`4273`)
+
+* ``cygdb`` has a new option ``--skip-interpreter`` that allows using a different
+  Python runtime than the one used to generate the debugging information.
+  Patch by Alessandro Molina.  (Github issue :issue:`4186`)
+
+Bugs fixed
+----------
+
+* Several issues with the new ``cpp_locals`` directive were resolved and
+  its test coverage improved.
+  Patch by David Woods.  (Github issues :issue:`4266`, :issue:`4265`)
+
+* Generated utility code for C++ conversions no longer depends on several user
+  definable directives that may make it behave incorrectly.
+  Patch by David Woods.  (Github issue :issue:`4206`)
+
+* A reference counting bug in the new ``@cython.total_ordering`` decorator was fixed.
+
+* Includes all bug-fixes from the :ref:`0.29.24` release.
+
+Other changes
+-------------
+
+* Parts of the documentation were (and are being) rewritten to show the
+  Cython language syntax next to the equivalent Python syntax.
+  Patches by 0dminnimda and Matúš Valo.  (Github issue :issue:`4187`)
+
+
+3.0.0 alpha 8 (2021-07-02)
+==========================
+
+Features added
+--------------
+
+* A ``@cython.total_ordering`` decorator has been added to automatically
+  implement all comparison operators, similar to ``functools.total_ordering``.
+  Patch by Spencer Brown.  (Github issue :issue:`2090`)
+
+* A new directive ``cpp_locals`` was added that allows local C++ variables to
+  be lazily initialised (without default constructor), thus making them behave
+  more like Python variables.
+  Patch by David Woods.  (Github issue :issue:`4160`)
+
+* C++17 execution policies are supported in ``libcpp.algorithm``.
+  Patch by Ashwin Srinath.  (Github issue :issue:`3790`)
+
+* New C feature flags: ``CYTHON_USE_MODULE_STATE``, ``CYTHON_USE_TYPE_SPECS``
+  Both are currently considered experimental.
+  (Github issue :issue:`3611`)
+
+* ``[...] * N`` is optimised for C integer multipliers ``N``.
+  (Github issue :issue:`3922`)
+
+Bugs fixed
+----------
+
+* The dispatch code for binary operators to special methods could run into infinite recursion.
+  Patch by David Woods.  (Github issue :issue:`4172`)
+
+* Code optimisations were not applied to methods of Cython implemented C++ classes.
+  Patch by David Woods.  (Github issue :issue:`4212`)
+
+* The special ``cython`` module was not always detected in PEP-484 type annotations.
+  Patch by David Woods.  (Github issue :issue:`4243`)
+
+* Conversion from Python dicts to ``std::map`` was broken.
+  Patch by David Woods and Mikkel Skofelt.  (Github issues :issue:`4231`, :issue:`4228`)
+
+* The exception handling annotation ``except +*`` was broken.
+  Patch by David Woods.  (Github issues :issue:`3065`, :issue:`3066`)
+
+* Attribute annotations in Python classes are now ignored, because they are
+  just Python objects in a dict (as opposed to the fields of extension types).
+  Patch by David Woods.  (Github issues :issue:`4196`, :issue:`4198`)
+
+* An unnecessary slow-down at import time was removed from ``Cython.Distutils``.
+  Original patch by Anthony Sottile.  (Github issue :issue:`4224`)
+
+* Python modules were not automatically recompiled when only their ``.pxd`` file changed.
+  Patch by Golden Rockefeller.  (Github issue :issue:`1428`)
+
+* The signature of ``PyFloat_FromString()`` in ``cpython.float`` was changed
+  to match the signature in Py3.  It still has an automatic fallback for Py2.
+  (Github issue :issue:`3909`)
+
+* A compile error on MSVC was resolved.
+  Patch by David Woods.  (Github issue :issue:`4202`)
+
+* A C compiler warning in PyPy3 regarding ``PyEval_EvalCode()`` was resolved.
+
+* Directives starting with ``optimization.*`` in pure Python mode were incorrectly named.
+  It should have been ``optimize.*``.
+  Patch by David Woods.  (Github issue :issue:`4258`)
+
+Other changes
+-------------
+
+* Variables can no longer be declared with ``cpdef``.
+  Patch by David Woods.  (Github issue :issue:`887`)
+
+* Support for the now unsupported Pyston V1 was removed in favour of Pyston V2.
+  Patch by Marius Wachtler.  (Github issue :issue:`4211`)
+
+* The ``Cython.Build.BuildExecutable`` tool no longer executes the program automatically.
+  Use ``cythonrun`` for that.
+
+
+3.0.0 alpha 7 (2021-05-24)
+==========================
+
+Features added
+--------------
+
+* A ``cimport`` is now supported in pure Python code by prefixing the
+  imported module name with ``cython.cimports.``, e.g.
+  ``from cython.cimports.libc.math import sin``.
+  (GIthub issue :issue:`4190`)
+
+* ``__class_getitem__`` (`PEP-560`_) is supported for cdef classes.
+  Patch by Kmol Yuan.  (Github issue :issue:`3764`)
+
+* ``__mro_entries__`` (`PEP-560`_) is supported for Python classes.
+  Patch by David Woods.  (Github issue :issue:`3537`)
+
+* ``cython.array`` supports simple, non-strided views.
+  (Github issue :issue:`3775`)
+
+* Self-documenting f-strings (``=``) were implemented.
+  Patch by davfsa.  (Github issue :issue:`3796`)
+
+* The destructor is now called for fields in C++ structs.
+  Patch by David Woods.  (Github issue :issue:`3226`)
+
+* ``std::move()`` is now also called for temps during ``yield``.
+  Patch by Yu Feng.  (Github issue :issue:`4154`)
+
+* ``asyncio.iscoroutinefunction()`` now recognises coroutine functions
+  also when compiled by Cython.
+  Patch by Pedro Marques da Luz.  (Github issue :issue:`2273`)
+
+* C compiler warnings and errors are now shown in Jupyter notebooks.
+  Patch by Egor Dranischnikow.  (Github issue :issue:`3751`)
+
+* ``float(…)`` is optimised for string arguments (str/bytes/bytearray).
+
+* Converting C++ containers to Python lists uses less memory allocations.
+  Patch by Max Bachmann.  (Github issue :issue:`4081`)
+
+* Docstrings of ``cpdef`` enums are now copied to the enum class.
+  Patch by matham.  (Github issue :issue:`3805`)
+
+* The type ``cython.Py_hash_t`` is available in Python mode.
+
+* C-API declarations for ``cpython.fileobject`` were added.
+  Patch by Zackery Spytz.  (Github issue :issue:`3906`)
+
+* C-API declarations for context variables in Python 3.7 were added.
+  Original patch by Zolisa Bleki.  (Github issue :issue:`2281`)
+
+* More C-API declarations for ``cpython.datetime``  were added.
+  Patch by Bluenix2.  (Github issue :issue:`4128`)
+
+* A new module ``cpython.time`` was added with some low-level alternatives to
+  Python's ``time`` module.
+  Patch by Brock Mendel.  (Github issue :issue:`3767`)
+
+* The value ``PyBUF_MAX_NDIM`` was added to the ``cpython.buffer`` module.
+  Patch by John Kirkham.  (Github issue :issue:`3811`)
+
+* "Declaration after use" is now an error for variables.
+  Patch by David Woods.  (Github issue :issue:`3976`)
+
+* More declarations for C++ string methods were added.
+
+* Cython now detects when existing output files were not previously generated
+  by itself and refuses to overwrite them.  It is a common mistake to name
+  the module file of a wrapper after the library (source file) that it wraps,
+  which can lead to surprising errors when the file gets overwritten.
+
+Bugs fixed
+----------
+
+* Annotations were not exposed on annotated (data-)classes.
+  Patch by matsjoyce.  (Github issue :issue:`4151`)
+
+* Inline functions and other code in ``.pxd`` files could accidentally
+  inherit the compiler directives of the ``.pyx`` file that imported them.
+  Patch by David Woods.  (Github issue :issue:`1071`)
+
+* Some issues were resolved that could lead to duplicated C names.
+  Patch by David Woods.  (Github issue :issue:`3716`, :issue:`3741`, :issue:`3734`)
+
+* Modules with unicode names failed to build on Windows.
+  Patch by David Woods.  (Github issue :issue:`4125`)
+
+* ``ndarray.shape`` failed to compile with Pythran and recent NumPy.
+  Patch by Serge Guelton.  (Github issue :issue:`3762`)
+
+* Casting to ctuples is now allowed.
+  Patch by David Woods.  (Github issue :issue:`3808`)
+
+* Structs could not be instantiated with positional arguments in
+  pure Python mode.
+
+* Literal list assignments to pointer variables declared in PEP-526
+  notation failed to compile.
+
+* Nested C++ types were not usable through ctypedefs.
+  Patch by Vadim Pushtaev.  (Github issue :issue:`4039`)
+
+* Overloaded C++ static methods were lost.
+  Patch by Ashwin Srinath.  (Github :issue:`1851`)
+
+* Cython compiled functions always provided a ``__self__`` attribute,
+  regardless of being used as a method or not.
+  Patch by David Woods.  (Github issue :issue:`4036`)
+
+* Calls to ``.__class__()`` of a known extension type failed.
+  Patch by David Woods.  (Github issue :issue:`3954`)
+
+* Generator expressions in pxd-overridden ``cdef`` functions could
+  fail to compile.
+  Patch by Matúš Valo.  (Github issue :issue:`3477`)
+
+* A reference leak on import failures was resolved.
+  Patch by Max Bachmann.  (Github issue :issue:`4056`)
+
+* A C compiler warning about unused code was resolved.
+  (Github issue :issue:`3763`)
+
+* A C compiler warning about enum value casting was resolved in GCC.
+  (Github issue :issue:`2749`)
+
+* Some C compiler warninge were resolved.
+  Patches by Max Bachmann.  (Github issue :issue:`4053`, :issue:`4059`, :issue:`4054`, :issue:`4148`, :issue:`4162`)
+
+* A compile failure for C++ enums in Py3.4 / MSVC was resolved.
+  Patch by Ashwin Srinath.  (Github issue :issue:`3782`)
+
+* Some C++ STL methods did not propagate exceptions.
+  Patch by Max Bachmann.  (Github issue :issue:`4079`)
+
+* An unsupported C-API call in PyPy was fixed.
+  Patch by Max Bachmann.  (Github issue :issue:`4055`)
+
+* The Cython ``CodeWriter`` mishandled no-argument ``return`` statements.
+  Patch by Tao He.  (Github issue :issue:`3795`)
+
+* ``complex`` wasn't supported in PEP-484 type annotations.
+  Patch by David Woods.  (Github issue :issue:`3949`)
+
+* Default arguments of methods were not exposed for introspection.
+  Patch by Vladimir Matveev.  (Github issue :issue:`4061`)
+
+* Extension types inheriting from Python classes could not safely
+  be exposed in ``.pxd``  files.
+  (Github issue :issue:`4106`)
+
+* The profiling/tracing code was adapted to work with Python 3.10b1.
+
+* The internal CPython macro ``Py_ISSPACE()`` is no longer used.
+  Original patch by Andrew Jones.  (Github issue :issue:`4111`)
+
+* Includes all bug-fixes from the :ref:`0.29.23` release.
+
+
+3.0.0 alpha 6 (2020-07-31)
+==========================
+
+Features added
+--------------
+
+* Special methods for binary operators now follow Python semantics.
+  Rather than e.g. a single ``__add__`` method for cdef classes, where
+  "self" can be either the first or second argument, one can now define
+  both ``__add__`` and ``__radd__`` as for standard Python classes.
+  This behavior can be disabled with the ``c_api_binop_methods`` directive
+  to return to the previous semantics in Cython code (available from Cython
+  0.29.20), or the reversed method (``__radd__``) can be implemented in
+  addition to an existing two-sided operator method (``__add__``) to get a
+  backwards compatible implementation.
+  (Github issue :issue:`2056`)
+
+* No/single argument functions now accept keyword arguments by default in order
+  to comply with Python semantics.  The marginally faster calling conventions
+  ``METH_NOARGS`` and ``METH_O`` that reject keyword arguments are still available
+  with the directive ``@cython.always_allow_keywords(False)``.
+  (Github issue :issue:`3090`)
+
+* For-in-loop iteration over ``bytearray`` and memory views is optimised.
+  Patch by David Woods.  (Github issue :issue:`2227`)
+
+* Type inference now works for memory views and slices.
+  Patch by David Woods.  (Github issue :issue:`2227`)
+
+* The ``@returns()`` decorator propagates exceptions by default for suitable C
+  return types when no ``@exceptval()`` is defined.
+  (Github issues :issue:`3625`, :issue:`3664`)
+
+* A low-level inline function ``total_seconds(timedelta)`` was added to
+  ``cpython.datetime`` to bypass the Python method call.  Note that this function
+  is not guaranteed to give exactly the same results for very large time intervals.
+  Patch by Brock Mendel.  (Github issue :issue:`3616`)
+
+* Type inference now understands that ``a, *b = x`` assigns a list to ``b``.
+
+* Limited API support was improved.
+  Patches by Matthias Braun.  (Github issues :issue:`3693`, :issue:`3707`)
+
+* The Cython ``CodeWriter`` can now handle more syntax constructs.
+  Patch by Tao He.  (Github issue :issue:`3514`)
+
+Bugs fixed
+----------
+
+* The construct ``for x in cpp_function_call()`` failed to compile.
+  Patch by David Woods.  (Github issue :issue:`3663`)
+
+* C++ references failed to compile when used as Python object indexes.
+  Patch by David Woods.  (Github issue :issue:`3754`)
+
+* The C++ ``typeid()`` function was allowed in C mode.
+  Patch by Celelibi.  (Github issue :issue:`3637`)
+
+* ``repr()`` was assumed to return ``str`` instead of ``unicode`` with ``language_level=3``.
+  (Github issue :issue:`3736`)
+
+* Includes all bug-fixes from the :ref:`0.29.21` release.
+
+Other changes
+-------------
+
+* The ``numpy`` declarations were updated.
+  Patch by Brock Mendel.  (Github issue :issue:`3630`)
+
+* The names of Cython's internal types (functions, generator, coroutine, etc.)
+  are now qualified with the module name of the internal Cython module that is
+  used for sharing them across Cython implemented modules, for example
+  ``_cython_3_0a5.coroutine``.  This was done to avoid making them look like
+  homeless builtins, to help with debugging, and in order to avoid a CPython
+  warning according to https://bugs.python.org/issue20204
+
+3.0.0 alpha 5 (2020-05-19)
+==========================
+
+Features added
+--------------
+
+* ``.pxd`` files can now be :ref:`versioned <versioning>` by adding an
+  extension like "``.cython-30.pxd``" to prevent older Cython versions (than
+  3.0 in this case) from picking them up.  (Github issue :issue:`3577`)
+
+* Several macros/functions declared in the NumPy API are now usable without
+  holding the GIL.
+
+* `libc.math` was extended to include all C99 function declarations.
+  Patch by Dean Scarff.  (Github issue :issue:`3570`)
+
+Bugs fixed
+----------
+
+* Several issues with arithmetic overflow handling were resolved, including
+  undefined behaviour in C.
+  Patch by Sam Sneddon.  (Github issue :issue:`3588`)
+
+* The improved GIL handling in ``nogil`` functions introduced in 3.0a3
+  could fail to acquire the GIL in some cases on function exit.
+  (Github issue :issue:`3590` etc.)
+
+* A reference leak when processing keyword arguments in Py2 was resolved,
+  that appeared in 3.0a1.
+  (Github issue :issue:`3578`)
+
+* The outdated getbuffer/releasebuffer implementations in the NumPy
+  declarations were removed so that buffers declared as ``ndarray``
+  now use the normal implementation in NumPy.
+
+* Includes all bug-fixes from the :ref:`0.29.18` release.
+
+
+3.0.0 alpha 4 (2020-05-05)
+==========================
+
+Features added
+--------------
+
+* The ``print`` statement (not the ``print()`` function) is allowed in
+  ``nogil`` code without an explicit ``with gil`` section.
+
+* The ``assert`` statement is allowed in ``nogil`` sections.  Here, the GIL is
+  only acquired if the ``AssertionError`` is really raised, which means that the
+  evaluation of the asserted condition only allows C expressions.
+
+* Cython generates C compiler branch hints for unlikely user defined if-clauses
+  in more cases, when they end up raising exceptions unconditionally. This now
+  includes exceptions being raised in ``nogil``/``with gil`` sections.
+
+* Some internal memoryview functions were tuned to reduce object overhead.
+
+Bugs fixed
+----------
+
+* Exception position reporting could run into race conditions on threaded code.
+  It now uses function-local variables again.
+
+* Error handling early in the module init code could lead to a crash.
+
+* Error handling in ``cython.array`` creation was improved to avoid calling
+  C-API functions with an error held.
+
+* Complex buffer item types of structs of arrays could fail to validate.
+  Patch by Leo and smutch.  (Github issue :issue:`1407`)
+
+* When importing the old Cython ``build_ext`` integration with distutils, the
+  additional command line arguments leaked into the regular command.
+  Patch by Kamekameha.  (Github issue :issue:`2209`)
+
+* The improved GIL handling in ``nogil`` functions introduced in 3.0a3
+  could generate invalid C code.
+  (Github issue :issue:`3558`)
+
+* ``PyEval_InitThreads()`` is no longer used in Py3.7+ where it is a no-op.
+
+* Parallel builds of Cython itself (``setup.py build_ext -j N``) failed on Windows.
+
+Other changes
+-------------
+
+* The C property feature has been rewritten and now requires C property methods
+  to be declared ``inline`` (:issue:`3571`).
+
+
+3.0.0 alpha 3 (2020-04-27)
+==========================
+
+Features added
+--------------
+
+* ``nogil`` functions now avoid acquiring the GIL on function exit if possible
+  even if they contain ``with gil`` blocks.
+  (Github issue :issue:`3554`)
+
+* Python private name mangling now falls back to unmangled names for non-Python
+  globals, since double-underscore names are not uncommon in C.  Unmangled Python
+  names are also still found as a legacy fallback but produce a warning.
+  Patch by David Woods.  (Github issue :issue:`3548`)
+
+Bugs fixed
+----------
+
+* Includes all bug-fixes from the :ref:`0.29.17` release.
+
+
+3.0.0 alpha 2 (2020-04-23)
+==========================
+
+Features added
+--------------
+
+* ``std::move()`` is now used in C++ mode for internal temp variables to
+  make them work without copying values.
+  Patch by David Woods.  (Github issues :issue:`3253`, :issue:`1612`)
+
+* ``__class_getitem__`` is supported for types on item access (`PEP-560`_).
+  Patch by msg555.  (Github issue :issue:`2753`)
+
+* The simplified Py3.6 customisation of class creation is implemented (`PEP-487`_).
+  (Github issue :issue:`2781`)
+
+* Conditional blocks in Python code that depend on ``cython.compiled`` are
+  eliminated at an earlier stage, which gives more freedom in writing
+  replacement Python code.
+  Patch by David Woods.  (Github issue :issue:`3507`)
+
+* ``numpy.import_array()`` is automatically called if ``numpy`` has been cimported
+  and it has not been called in the module code.  This is intended as a hidden
+  fail-safe so user code should continue to call ``numpy.import_array``.
+  Patch by David Woods.  (Github issue :issue:`3524`)
+
+* The Cython AST code serialiser class ``CodeWriter`` in ``Cython.CodeWriter``
+  supports more syntax nodes.
+
+* The fastcall/vectorcall protocols are used for several internal Python calls.
+  (Github issue :issue:`3540`)
+
+Bugs fixed
+----------
+
+* With ``language_level=3/3str``, Python classes without explicit base class
+  are now new-style (type) classes also in Py2.  Previously, they were created
+  as old-style (non-type) classes.
+  (Github issue :issue:`3530`)
+
+* C++ ``typeid()`` failed for fused types.
+  Patch by David Woods.  (Github issue :issue:`3203`)
+
+* ``__arg`` argument names in methods were not mangled with the class name.
+  Patch by David Woods.  (Github issue :issue:`1382`)
+
+* Creating an empty unicode slice with large bounds could crash.
+  Patch by Sam Sneddon.  (Github issue :issue:`3531`)
+
+* Decoding an empty bytes/char* slice with large bounds could crash.
+  Patch by Sam Sneddon.  (Github issue :issue:`3534`)
+
+* Temporary buffer indexing variables were not released and could show up in
+  C compiler warnings, e.g. in generators.
+  Patch by David Woods.  (Github issues :issue:`3430`, :issue:`3522`)
+
+* Several C compiler warnings were fixed.
+
+
+3.0.0 alpha 1 (2020-04-12)
+==========================
+
+Features added
+--------------
+
+* Cython functions now use the `PEP-590`_ vectorcall protocol in Py3.7+.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`2263`)
+
+* Unicode identifiers are supported in Cython code (`PEP-3131`_).
+  Patch by David Woods.  (Github issue :issue:`2601`)
+
+* Unicode module names and imports are supported.
+  Patch by David Woods.  (Github issue :issue:`3119`)
+
+* Annotations are no longer parsed, keeping them as strings following `PEP-563`_.
+  Patch by David Woods.  (Github issue :issue:`3285`)
+
+* Preliminary support for the CPython's ``Py_LIMITED_API`` (stable ABI) is
+  available by setting the  ``CYTHON_LIMITED_API`` C macro.  Note that the
+  support is currently in an early stage and many features do not yet work.
+  You currently still have to define ``Py_LIMITED_API`` externally in order
+  to restrict the API usage.  This will change when the feature stabilises.
+  Patches by Eddie Elizondo and David Woods.  (Github issues :issue:`3223`,
+  :issue:`3311`, :issue:`3501`)
+
+* The dispatch to fused functions is now linear in the number of arguments,
+  which makes it much faster, often 2x or more, and several times faster for
+  larger fused types with many specialisations.
+  Patch by will-ca.  (Github issue :issue:`1385`)
+
+* ``with gil/nogil`` statements can be conditional based on compile-time
+  constants, e.g. fused type checks.
+  Patch by Noam Hershtig.  (Github issue :issue:`2579`)
+
+* ``const`` can be used together with fused types.
+  Patch by Thomas Vincent.  (Github issue :issue:`1772`)
+
+* Reimports of already imported modules are substantially faster.
+  (Github issue :issue:`2854`)
+
+* Positional-only arguments are supported in Python functions (`PEP-570`_).
+  Patch by Josh Tobin.  (Github issue :issue:`2915`)
+
+* The ``volatile`` C modifier is supported in Cython code.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`1667`)
+
+* ``@cython.trashcan(True)`` can be used on an extension type to enable the
+  CPython :ref:`trashcan`. This allows deallocating deeply recursive objects
+  without overflowing the stack. Patch by Jeroen Demeyer.  (Github issue :issue:`2842`)
+
+* Inlined properties can be defined for external extension types.
+  Patch by Matti Picus. (Github issue :issue:`2640`, redone later in :issue:`3571`)
+
+* The ``str()`` builtin now calls ``PyObject_Str()`` instead of going
+  through a Python call.
+  Patch by William Ayd.  (Github issue :issue:`3279`)
+
+* String concatenation can now happen in place if possible, by extending the
+  existing string rather than always creating a new one.
+  Patch by David Woods.  (Github issue :issue:`3453`)
+
+* Multiplication of Python numbers with small constant integers is faster.
+  (Github issue :issue:`2808`)
+
+* Some list copying is avoided internally when a new list needs to be created
+  but we already have a fresh one.
+  (Github issue :issue:`3494`)
+
+* Extension types that do not need their own ``tp_new`` implementation (because
+  they have no object attributes etc.) directly inherit the implementation of
+  their parent type if possible.
+  (Github issue :issue:`1555`)
+
+* The attributes ``gen.gi_frame`` and ``coro.cr_frame`` of Cython compiled
+  generators and coroutines now return an actual frame object for introspection.
+  (Github issue :issue:`2306`)
+
+* Several declarations in ``cpython.*``, ``libc.*`` and ``libcpp.*`` were added.
+  Patches by Jeroen Demeyer, Matthew Edwards, Chris Gyurgyik, Jerome Kieffer
+  and Zackery Spytz.
+  (Github issues :issue:`3468`, :issue:`3332`, :issue:`3202`, :issue:`3188`,
+  :issue:`3179`, :issue:`2891`, :issue:`2826`, :issue:`2713`)
+
+* Deprecated NumPy API usages were removed from ``numpy.pxd``.
+  Patch by Matti Picus.  (Github issue :issue:`3365`)
+
+* ``cython.inline()`` now sets the ``NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION``
+  C macro automatically when ``numpy`` is imported in the code, to avoid C compiler
+  warnings about deprecated NumPy C-API usage.
+
+* The builtin ``abs()`` function can now be used on C numbers in nogil code.
+  Patch by Elliott Sales de Andrade.  (Github issue :issue:`2748`)
+
+* `PEP-479`_ (``generator_stop``) is now enabled by default with language level 3.
+  (Github issue :issue:`2580`)
+
+* The ``cython.view.array`` type supports inheritance.
+  Patch by David Woods.  (Github issue :issue:`3413`)
+
+* Code annotation accepts a new debugging argument ``--annotate-fullc`` that
+  will include the complete syntax highlighted C file in the HTML output.
+  (Github issue :issue:`2855`)
+
+* ``--no-capture`` added to ``runtests.py`` to prevent stdout/stderr capturing
+  during srctree tests.
+  Patch by Matti Picus.  (Github issue :issue:`2701`)
+
+* ``--no-docstrings`` option added to ``cythonize`` script.
+  Original patch by mo-han.  (Github issue :issue:`2889`)
+
+* ``cygdb`` gives better error messages when it fails to initialise the
+  Python runtime support in gdb.
+  Patch by Volker Weissmann.  (Github issue :issue:`3489`)
+
+* The Pythran ``shape`` attribute is supported.
+  Patch by Serge Guelton.  (Github issue :issue:`3307`)
+
+Bugs fixed
+----------
+
+* The unicode methods ``.upper()``, ``.lower()`` and ``.title()`` were
+  incorrectly optimised for single character input values and only returned
+  the first character if multiple characters should have been returned.
+  They now use the original Python methods again.
+
+* Fused argument types were not correctly handled in type annotations and
+  ``cython.locals()``.
+  Patch by David Woods.  (Github issues :issue:`3391`, :issue:`3142`)
+
+* Diverging from the usual behaviour, ``len(memoryview)``, ``len(char*)``
+  and ``len(Py_UNICODE*)`` returned an unsigned ``size_t`` value.  They now
+  return a signed ``Py_ssize_t``, like other usages of ``len()``.
+
+* Nested dict literals in function call kwargs could incorrectly raise an
+  error about duplicate keyword arguments, which are allowed when passing
+  them from dict literals.
+  (Github issue :issue:`2963`)
+
+* Item access (subscripting) with integer indices/keys always tried the
+  Sequence protocol before the Mapping protocol, which diverged from Python
+  semantics.  It now passes through the Mapping protocol first when supported.
+  (Github issue :issue:`1807`)
+
+* Name lookups in class bodies no longer go through an attribute lookup.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`3100`)
+
+* Broadcast assignments to a multi-dimensional memory view slice could end
+  up in the wrong places when the underlying memory view is known to be
+  contiguous but the slice is not.
+  (Github issue :issue:`2941`)
+
+* Pickling unbound methods of Python classes failed.
+  Patch by Pierre Glaser.  (Github issue :issue:`2972`)
+
+* The ``Py_hash_t`` type failed to accept arbitrary "index" values.
+  (Github issue :issue:`2752`)
+
+* The first function line number of functions with decorators pointed to the
+  signature line and not the first decorator line, as in Python.
+  Patch by Felix Kohlgrüber.  (Github issue :issue:`2536`)
+
+* Constant integer expressions that used a negative exponent were evaluated
+  as integer 0 instead of the expected float value.
+  Patch by Kryštof Pilnáček.  (Github issue :issue:`2133`)
+
+* The ``cython.declare()`` and ``cython.cast()`` functions could fail in pure mode.
+  Patch by Dmitry Shesterkin.  (Github issue :issue:`3244`)
+
+* ``__doc__`` was not available inside of the class body during class creation.
+  (Github issue :issue:`1635`)
+
+* Setting ``language_level=2`` in a file did not work if ``language_level=3``
+  was enabled globally before.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`2791`)
+
+* ``__init__.pyx`` files were not always considered as package indicators.
+  (Github issue :issue:`2665`)
+
+* Compiling package ``__init__`` files could fail under Windows due to an
+  undefined export symbol.  (Github issue :issue:`2968`)
+
+* A C compiler cast warning was resolved.
+  Patch by Michael Buesch.  (Github issue :issue:`2775`)
+
+* Binding staticmethods of Cython functions were not behaving like Python methods.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`3106`, :issue:`3102`)
+
+* Memoryviews failed to compile when the ``cache_builtins`` feature was disabled.
+  Patch by David Woods.  (Github issue :issue:`3406`)
+
+Other changes
+-------------
+
+* The default language level was changed to ``3str``, i.e. Python 3 semantics,
+  but with ``str`` literals (also in Python 2.7).  This is a backwards incompatible
+  change from the previous default of Python 2 semantics.  The previous behaviour
+  is available through the directive ``language_level=2``.
+  (Github issue :issue:`2565`)
+
+* Cython no longer generates ``__qualname__`` attributes for classes in Python
+  2.x since they are problematic there and not correctly maintained for subclasses.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`2772`)
+
+* Source file fingerprinting now uses SHA-1 instead of MD5 since the latter
+  tends to be slower and less widely supported these days.
+  (Github issue :issue:`2790`)
+
+* The long deprecated include files ``python_*``, ``stdio``, ``stdlib`` and
+  ``stl`` in ``Cython/Includes/Deprecated/`` were removed.  Use the ``libc.*``
+  and ``cpython.*`` pxd modules instead.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`2904`)
+
+* The search order for include files was changed. Previously it was
+  ``include_directories``, ``Cython/Includes``, ``sys.path``. Now it is
+  ``include_directories``, ``sys.path``, ``Cython/Includes``. This was done to
+  allow third-party ``*.pxd`` files to override the ones in Cython.
+  Patch by Matti Picus.  (Github issue :issue:`2905`)
+
+* The command line parser was rewritten and modernised using ``argparse``.
+  Patch by Egor Dranischnikow.  (Github issue :issue:`2952`, :issue:`3001`)
+
+* Dotted filenames for qualified module names (``pkg.mod.pyx``) are deprecated.
+  Use the normal Python package directory layout instead.
+  (Github issue :issue:`2686`)
+
+* Binary Linux wheels now follow the manylinux2010 standard.
+  Patch by Alexey Stepanov.  (Github issue :issue:`3355`)
+
+* Support for Python 2.6 was removed.
+
+.. _`PEP-560`: https://www.python.org/dev/peps/pep-0560
+.. _`PEP-570`: https://www.python.org/dev/peps/pep-0570
+.. _`PEP-487`: https://www.python.org/dev/peps/pep-0487
+.. _`PEP-590`: https://www.python.org/dev/peps/pep-0590
+.. _`PEP-3131`: https://www.python.org/dev/peps/pep-3131
+.. _`PEP-563`: https://www.python.org/dev/peps/pep-0563
+.. _`PEP-479`: https://www.python.org/dev/peps/pep-0479
+
 
 .. _0.29.36:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,7 +250,43 @@ Related fixes
 Compatibility with C
 --------------------
 
-[Various]
+[const/volatile/complex/atomic/etc.]
+
+Related fixes
+^^^^^^^^^^^^^
+
+* The ``volatile`` C modifier is supported in Cython code.
+  Patch by Jeroen Demeyer.  (Github issue :issue:`1667`)
+
+* ``const`` can be used together with fused types.
+  Patch by Thomas Vincent.  (Github issue :issue:`1772`)
+
+* Constant integer expressions that used a negative exponent were evaluated
+  as integer 0 instead of the expected float value.
+  Patch by Kryštof Pilnáček.  (Github issue :issue:`2133`)
+
+* C11 ``complex.h`` is now properly detected.
+  (Github issue :issue:`2513`)
+
+* Standard C/C++ atomic operations are now used for memory views, if available.
+  (Github issue :issue:`4925`)
+
+* ``const`` types could not be returned from functions.
+  Patch by Mike Graham.  (Github issue :issue:`5135`)
+
+* The module state struct was not initialised in correct C (before C23), leading to
+  compile errors on Windows.
+  Patch by yudonglin.  (Github issue :issue:`5169`)
+
+* Structs that contained an array field resulted in incorrect C code.  Their initialisation
+  now uses ``memcpy()``.
+  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5178`)
+
+* With MSVC, Cython no longer enables C-Complex support by accident (which is not supported there).
+  (Github issue :issue:`5512`)
+
+* The ``extern "C"`` and ``extern "C++"`` markers that Cython generates for
+  ``public`` functions can now be controlled by setting the C macro ``CYTHON_EXTERN_C``.
 
 Compatibility with C++
 ----------------------
@@ -442,9 +478,6 @@ Bugs fixed
 * Duplicate values in a ``cpdef`` enum could lead to invalid switch statements.
   (Github issue :issue:`5400`)
 
-* With MSVC, Cython no longer enables C-Complex support by accident (which is not supported there).
-  (Github issue :issue:`5512`)
-
 * The Python implementation of ``cimport cython.cimports…`` could raise an ``ImportError``
   instead of an ``AttributeError`` when looking up package variable names.
   Patch by Matti Picus.  (Github issue :issue:`5411`)
@@ -482,9 +515,6 @@ Other changes
 
 Features added
 --------------
-
-* The ``extern "C"`` and ``extern "C++"`` markers that Cython generates for
-  ``public`` functions can now be controlled by setting the C macro ``CYTHON_EXTERN_C``.
 
 * The normal ``@dataclasses.dataclass`` and ``@functools.total_ordering`` decorators
   can now be used on extension types.  Using the corresponding ``@cython.*`` decorator
@@ -653,12 +683,6 @@ Features added
 * C arrays can be initialised inside of nogil functions.
   Patch by Matúš Valo.  (Github issue :issue:`1662`)
 
-* Standard C/C++ atomic operations are now used for memory views, if available.
-  (Github issue :issue:`4925`)
-
-* C11 ``complex.h`` is now properly detected.
-  (Github issue :issue:`2513`)
-
 * ``cythonize --help`` now also prints information about the supported environment variables.
   Patch by Matúš Valo.  (Github issue :issue:`1711`)
 
@@ -700,19 +724,8 @@ Bugs fixed
   being considered mutable.
   Patch by Max Bachmann.  (Github issue :issue:`5023`)
 
-* ``const`` types could not be returned from functions.
-  Patch by Mike Graham.  (Github issue :issue:`5135`)
-
 * ``cdef public`` functions declared in .pxd files could use an incorrectly mangled C name.
   Patch by EpigeneMax.  (Github issue :issue:`2940`)
-
-* The module state struct was not initialised in correct C (before C23), leading to
-  compile errors on Windows.
-  Patch by yudonglin.  (Github issue :issue:`5169`)
-
-* Structs that contained an array field resulted in incorrect C code.  Their initialisation
-  now uses ``memcpy()``.
-  Patch by Chia-Hsiang Cheng.  (Github issue :issue:`5178`)
 
 * Nesting fused types in other fused types could fail to specialise the inner type.
   (Github issue :issue:`4725`)
@@ -1455,14 +1468,8 @@ Features added
   constants, e.g. fused type checks.
   Patch by Noam Hershtig.  (Github issue :issue:`2579`)
 
-* ``const`` can be used together with fused types.
-  Patch by Thomas Vincent.  (Github issue :issue:`1772`)
-
 * Reimports of already imported modules are substantially faster.
   (Github issue :issue:`2854`)
-
-* The ``volatile`` C modifier is supported in Cython code.
-  Patch by Jeroen Demeyer.  (Github issue :issue:`1667`)
 
 * ``@cython.trashcan(True)`` can be used on an extension type to enable the
   CPython :ref:`trashcan`. This allows deallocating deeply recursive objects
@@ -1568,10 +1575,6 @@ Bugs fixed
 * The first function line number of functions with decorators pointed to the
   signature line and not the first decorator line, as in Python.
   Patch by Felix Kohlgrüber.  (Github issue :issue:`2536`)
-
-* Constant integer expressions that used a negative exponent were evaluated
-  as integer 0 instead of the expected float value.
-  Patch by Kryštof Pilnáček.  (Github issue :issue:`2133`)
 
 * The ``cython.declare()`` and ``cython.cast()`` functions could fail in pure mode.
   Patch by Dmitry Shesterkin.  (Github issue :issue:`3244`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -499,8 +499,6 @@ Bugs fixed
 * Some typedef declarations for libc function types were fixed.
   (Github issue :issue:`5498`)
 
-* Some C compiler warnings and errors in CPython 3.12 were resolved.
-
 * The deprecated ``_PyGC_FINALIZED()`` C-API macro is no longer used.
   Patch by Thomas Caswell and Matúš Valo.  (Github issue :issue:`5481`)
 
@@ -510,9 +508,6 @@ Bugs fixed
 
 * ``cython --version`` now prints the version to stdout instead of stderr.
   (Github issue :issue:`5504`)
-
-* Includes all bug-fixes and features from the 0.29 maintenance branch
-  up to the :ref:`0.29.36` release.
 
 Other changes
 -------------
@@ -545,19 +540,11 @@ Features added
   warns now when a directive is applied needlessly.
   (Github issue :issue:`5399` et al.)
 
-* Unicode identifier names now allow all letters defined in CPython 3.12.
-
 Bugs fixed
 ----------
 
-* Some C compile failures in CPython 3.12.0a6/a7 were resolved.
-
 * Cascaded comparisons between integer constants and Python types could fail to compile.
   (Github issue :issue:`5354`)
-
-* The internal macro ``__PYX_IS_UNSIGNED`` was accidentally duplicated in beta 2
-  which lead to C compile errors.
-  Patch by 0dminnimda.  (Github issue :issue:`5356`)
 
 * Memoryviews with typedef item types could fail to match the non-typedef item types.
   Patch by Yue Yang.  (Github issue :issue:`5373`)
@@ -590,9 +577,6 @@ Bugs fixed
   Patches by Matt Tyson, Lisandro Dalcin, Philipp Wagner, Matti Picus et al.
   (Github issues :issue:`5417`, :issue:`5418`, :issue:`5421`, :issue:`5437`, :issue:`5438`, :issue:`5443`)
 
-* Includes all bug-fixes and features from the 0.29 maintenance branch
-  up to the :ref:`0.29.35` release.
-
 Other changes
 -------------
 
@@ -613,15 +597,6 @@ Features added
 
 Bugs fixed
 ----------
-
-* Unintended internal exception handling lead to a visible performance regression
-  for ``nogil`` memoryview code in 3.0.0b1.
-  (Github issue :issue:`5324`)
-
-* ``None`` default arguments for arguments with fused memoryview types could select a different
-  implementation in 3.0 than in 0.29.x.  The selection behaviour is generally considered
-  suboptimal but was at least reverted to the old behaviour for now.
-  (Github issue :issue:`5297`)
 
 * The new complex vs. floating point behaviour of the ``**`` power operator accidentally
   added a dependency on the GIL, which was really only required on failures.
@@ -704,11 +679,6 @@ Bugs fixed
   on creation, as Python does, and not later on start, as they did previously.
   (Github issue :issue:`1159`)
 
-* Type annotations for Python ``int`` rejected ``long`` under Py2 in the alpha-11 release.
-  They are now ignored again (as always before) when ``language_level=2``, and accept
-  both ``int`` and ``long`` in Py2 (and only ``int`` in Py3) otherwise.
-  (Github issue :issue:`4944`)
-
 * Calling bound classmethods of builtin types could fail trying to call the unbound method.
   (Github issue :issue:`5051`)
 
@@ -777,9 +747,6 @@ Bugs fixed
 
 * Extended glob paths with ``/**/`` and ``\**\`` for finding source files failed on Windows.
 
-* Annotated HTML generation was missing newlines in 3.0.0a11.
-  (Github issue :issue:`4945`)
-
 * Some parser issues were resolved.
   (Github issue :issue:`4992`)
 
@@ -788,9 +755,6 @@ Bugs fixed
 
 * Intel C compilers could complain about unsupported gcc pragmas.
   Patch by Ralf Gommers.  (Github issue :issue:`5052`)
-
-* Includes all bug-fixes and features from the 0.29 maintenance branch
-  up to the :ref:`0.29.33` release.
 
 Other changes
 -------------
@@ -876,10 +840,6 @@ Bugs fixed
 * Several optimised string methods failed to accept ``None`` as arguments to their options.
   Test patch by Kirill Smelkov.  (Github issue :issue:`4737`)
 
-* A regression in 3.0.0a10 was resolved that prevented property setter methods from
-  having the same name as their value argument.
-  Patch by David Woods.  (Github issue :issue:`4836`)
-
 * Typedefs for the ``bint`` type did not always behave like ``bint``.
   Patch by Nathan Manville and 0dminnimda.  (Github issue :issue:`4660`)
 
@@ -905,16 +865,11 @@ Bugs fixed
 * A work-around for StacklessPython < 3.8 was disabled in Py3.8 and later.
   (Github issue :issue:`4329`)
 
-* Improve compatibility with forthcoming CPython 3.12 release.
-
 * Some C compiler warnings were fixed.
   Patch by mwtian.  (Github issue :issue:`4831`)
 
 * The parser allowed some invalid spellings of ``...``.
   Patch by 0dminnimda.  (Github issue :issue:`4868`)
-
-* Includes all bug-fixes and features from the 0.29 maintenance branch
-  up to the :ref:`0.29.32` release.
 
 Other changes
 -------------
@@ -1040,8 +995,6 @@ Bugs fixed
 * A compiler crash when running Cython thread-parallel from distutils was resolved.
   (Github issue :issue:`4503`)
 
-* Includes all bug-fixes from the :ref:`0.29.26` release.
-
 Other changes
 -------------
 
@@ -1064,8 +1017,6 @@ Bugs fixed
 ----------
 
 * A reference counting bug in the new ``@cython.total_ordering`` decorator was fixed.
-
-* Includes all bug-fixes from the :ref:`0.29.24` release.
 
 Other changes
 -------------
@@ -1252,12 +1203,8 @@ Bugs fixed
   be exposed in ``.pxd``  files.
   (Github issue :issue:`4106`)
 
-* The profiling/tracing code was adapted to work with Python 3.10b1.
-
 * The internal CPython macro ``Py_ISSPACE()`` is no longer used.
   Original patch by Andrew Jones.  (Github issue :issue:`4111`)
-
-* Includes all bug-fixes from the :ref:`0.29.23` release.
 
 
 3.0.0 alpha 6 (2020-07-31)
@@ -1309,8 +1256,6 @@ Bugs fixed
 * ``repr()`` was assumed to return ``str`` instead of ``unicode`` with ``language_level=3``.
   (Github issue :issue:`3736`)
 
-* Includes all bug-fixes from the :ref:`0.29.21` release.
-
 Other changes
 -------------
 
@@ -1340,16 +1285,6 @@ Bugs fixed
 * Several issues with arithmetic overflow handling were resolved, including
   undefined behaviour in C.
   Patch by Sam Sneddon.  (Github issue :issue:`3588`)
-
-* The improved GIL handling in ``nogil`` functions introduced in 3.0a3
-  could fail to acquire the GIL in some cases on function exit.
-  (Github issue :issue:`3590` etc.)
-
-* A reference leak when processing keyword arguments in Py2 was resolved,
-  that appeared in 3.0a1.
-  (Github issue :issue:`3578`)
-
-* Includes all bug-fixes from the :ref:`0.29.18` release.
 
 
 3.0.0 alpha 4 (2020-05-05)
@@ -1389,10 +1324,6 @@ Bugs fixed
   additional command line arguments leaked into the regular command.
   Patch by Kamekameha.  (Github issue :issue:`2209`)
 
-* The improved GIL handling in ``nogil`` functions introduced in 3.0a3
-  could generate invalid C code.
-  (Github issue :issue:`3558`)
-
 * Parallel builds of Cython itself (``setup.py build_ext -j N``) failed on Windows.
 
 Other changes
@@ -1416,11 +1347,6 @@ Features added
   globals, since double-underscore names are not uncommon in C.  Unmangled Python
   names are also still found as a legacy fallback but produce a warning.
   Patch by David Woods.  (Github issue :issue:`3548`)
-
-Bugs fixed
-----------
-
-* Includes all bug-fixes from the :ref:`0.29.17` release.
 
 
 3.0.0 alpha 2 (2020-04-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,6 @@ much as possible with Cython 0.29.x. For details, see the `migration guide`_.
 As the development was spread out over several years, a lot of things have
 happened in the meantime. Many crucial bugfixes and some features were
 backported to 0.29.x and are not strictly speaking "new" in Cyton 3.0.0.
-We mark affected lines below with †.
 
 Major themes in 3.0.0
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -177,7 +177,25 @@ Related fixes
 Initial support for Limited API
 -------------------------------
 
-[Text about the status of support for Limited API]
+CPython provides a stable, limited subset of its C-API as the so-called Limited API.
+This C-API comes with the guarantee of a stable ABI, meaning that extensions modules
+that were compiled for one version of CPython can also be imported in later versions
+without recompilation.
+
+There is initial support for this in Cython.  By defining the ``CYTHON_LIMITED_API``
+macro, Cython cuts down its C-API usage and tries to adhere to the Limited C-API.
+By also defining the CPython macro ``Py_LIMITED_API`` to a specific CPython
+compatibility version, you can additionally restrict the C-API during the C compilation,
+thus enforcing the forward compatibility of the extension module, probably at the cost
+of a bit of performance.
+
+Note that "initial support" in Cython really means that setting the ``Py_LIMITED_API``
+macro may not work for your specific code.  There are limitations in the Limited C-API
+that are difficult for Cython to generate C code for, so some advanced Python features
+(like async code) may not lead to C code that cannot adhere to the Limited C-API, or
+where Cython simply does not know yet how to adhere to it.  Basically, if you get your
+code to compile with both macros set, and it passes your test suite, then it should be
+possible to import the extension module also in later CPython versions.
 
 Related fixes
 ^^^^^^^^^^^^^
@@ -218,7 +236,7 @@ Improved fidelity to Python semantics
 -------------------------------------
 
 Cython 3.0.0 also aligns many semantics with Python 3, in particular:
-[TODO: more precise]
+
 * division
 * power operator
 * print
@@ -226,19 +244,24 @@ Cython 3.0.0 also aligns many semantics with Python 3, in particular:
 * types
 * subscripting
 
+
 Improvements in Pure Python mode
 --------------------------------
 
-Pure python mode gained many new features to be able to control
-most things that were usually only available in C. Examples:
-[TODO: improve]
-* with gil / nogil
-* etc.
+Pure python mode gained many new features and was generally overhauled to make
+it as capable as the 
+
 
 Code generation changes
 -----------------------
 
-[cdef dataclasses, total_ordering, numpy ufunc]
+Cython has gained several major new features that speed up both the development
+and the code. Dataclasses have gained an extension type equivalent that implements
+the dataclass features in C code.  Similarly, the ``@functools.total_ordering``
+decorator to an extension type will implement the comparison functions in C.
+
+FInally, NumPy ufuncs can be generated from simple computation functions with the
+new ``@cython.ufunc`` decorator.
 
 Related fixes
 ^^^^^^^^^^^^^
@@ -250,10 +273,16 @@ Related fixes
 * Generated NumPy ufuncs could crash for large arrays due to incorrect GIL handling.
   (Github issue :issue:`5328`)
 
+
 Interaction with numpy
 ----------------------
 
-[Numpy now ships its own declarations, Cython does not use deprecated API anymore, ...]
+The NumPy declarations (``cimport numpy``) were moved over to the NumPy project in order
+to allow version specific changes on their side.
+
+One effect is that Cython does not use deprecated NumPy C-APIs any more.  Thus, you
+can define the respective NumPy C macro to get rid of the compatibility warning at
+C compile time.
 
 Related fixes
 ^^^^^^^^^^^^^
@@ -293,6 +322,7 @@ Related fixes
 * ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
   synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
   since they could mean different things on different platforms.
+
 
 Exception handling
 ------------------
@@ -335,10 +365,11 @@ Related fixes
 * Handling freshly raised exceptions that didn't have a traceback yet could crash.
   (Github issue :issue:`5495`)
 
+
 Compatibility with C
 --------------------
 
-[const/volatile/complex/atomic/etc.]
+The support for C features like ``const`` or ``volatile`` was substantially improved.
 
 Related fixes
 ^^^^^^^^^^^^^
@@ -376,10 +407,12 @@ Related fixes
 * The ``extern "C"`` and ``extern "C++"`` markers that Cython generates for
   ``public`` functions can now be controlled by setting the C macro ``CYTHON_EXTERN_C``.
 
+
 Compatibility with C++
 ----------------------
 
-[Text about forwarding references, ``cpp_locals``, ``std::move``]
+Many C++ features like forwarding references or ``std::move`` are now supported or even used
+internally, if possible.
 
 Related fixes
 ^^^^^^^^^^^^^


### PR DESCRIPTION
With Cython 3.0 in development for a long time, the release notes -- which are split over 15 different sections (11 alphas, 3 betas, at least 1rc, plus GA) and many years -- are IMO very hard to absorb for an average (or even advanced) user. Add on top that various different fixes were backported to 0.29 (or sometimes, just the compatibility, without the functionality), and it becomes pretty much impenetrable to know what's _actually_ in 3.0.

Even though it's probably a bunch of work, I think Cython 3.0 deserves some kind of unified release notes that are an easy reference of what's new, what's already in 0.29, what changed, etc.

I had a moment today to try my hand at this, but quickly realized that I'm a bit in over my head with coming up with categories, writing a prose summary, and accurately categorizing/summarizing the various items. 😅 

Before I pour more time in this, I though I'd open a PR to see if there's even any appetite for this.

My goal would not be to _replace_ the current release notes, they can stay as they are. I see two variants that I'd find worthwhile:
* an additional section with the unified & complete list of changes (ideally relegating the alpha/beta sections to a fold-out)
* an additional section with just a high-level prose summary, leaving the details to the alpha/beta sections.

PS. Only the last commit is currently worth reviewing; the first one is a 1:1 duplication of all the 3.0 release notes, so that it becomes easier to follow later commits that are just moving around lines. This is obviously very much WIP.

