### PR TITLE
on pypy, skip test that depends on gc behaviour

### DIFF
--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -58,6 +58,8 @@ run.py35_pep492_interop
 # gc issue?
 external_ref_reassignment
 run.exttype_dealloc
+# even if gc.collect is added, order is changed
+memoryview.parallel_refcounting_stress_test
 
 # bugs in cpyext: PyNumber_InPlacePower with non-None modulus is not supported
 run.special_methods_T561


### PR DESCRIPTION
The test added in #5510 does not pass on PyPy. Without adding a `gc.collect, the `release` is never called. But even when adding `gc.collect() between the deletions, the output is different. With this change:
```diff
from cython.parallel cimport prange
 cimport cython
+import gc
 from random import randint, random
 
 include "../buffers/mockbuffers.pxi"
@@ -43,8 +44,11 @@ def refcounting_stress_test(int N):
 
     # make "release" order predictable
     del aview
+    gc.collect()
     del bview
+    gc.collect()
     del cview
+    gc.collect()
 
     return total
```

I get as output (`release c` comes before `release b`)
```
    acquired a
    acquired b
    acquired c
    released a
    released c
    released b
```

I don't think there is a way to get doctest to have alternatives based on implementation, so I suggest skipping the test.