### PR TITLE
Improve error diagnostic for exception-spec mismatch

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1077,7 +1077,11 @@ class ExprNode(Node):
         return src
 
     def fail_assignment(self, dst_type):
-        error(self.pos, "Cannot assign type '%s' to '%s'" % (self.type, dst_type))
+        extra_diagnostics = dst_type.assignment_failure_extra_info(self.type)
+        if extra_diagnostics:
+            extra_diagnostics = ". " + extra_diagnostics
+        error(self.pos, "Cannot assign type '%s' to '%s'%s" % (
+            self.type, dst_type, extra_diagnostics))
 
     def check_for_coercion_error(self, dst_type, env, fail=False, default=None):
         if fail and not default:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -318,6 +318,11 @@ class PyrexType(BaseType):
     def assignable_from_resolved_type(self, src_type):
         return self.same_as(src_type)
 
+    def assignment_failure_extra_info(self, src_type):
+        """Override if you can useful provide extra
+        information about why an assignment didn't work."""
+        return ""
+
     def as_argument_type(self):
         return self
 
@@ -2859,6 +2864,22 @@ class CPtrType(CPointerBaseType):
         if other_type.is_array or other_type.is_ptr:
             return self.base_type.is_void or self.base_type.same_as(other_type.base_type)
         return 0
+
+    def assignment_failure_extra_info(self, src_type):
+        if self.base_type.is_cfunction and src_type.is_ptr:
+            src_type = src_type.base_type.resolve()
+        if self.base_type.is_cfunction and src_type.is_cfunction:
+            copied_src_type = copy.copy(src_type)
+            # make the exception values the same as us
+            copied_src_type.exception_check = self.base_type.exception_check
+            copied_src_type.exception_value = self.base_type.exception_value
+            if self.base_type.pointer_assignable_from_resolved_type(copied_src_type):
+                # the only reason we can't assign is because of exception incompatibility
+                msg = "Exception specifications are incompatible."
+                if not self.base_type.exception_check:
+                    msg += " Suggest adding 'noexcept' to type '{}'.".format(src_type)
+                return msg
+        return super(CPtrType, self).assignment_failure_extra_info(src_type)
 
     def specialize(self, values):
         base_type = self.base_type.specialize(values)


### PR DESCRIPTION
It seems like the most common Cython 3 snag is the change in function exception behaviour. This PR adds some extra diagnostics to help people navigate this change, and a general mechanism for adding this kind of diagnostics.

It needs some tests, but I wasn't to see what tests fail to tell me where to put them.