### PR TITLE
CYTHON_LIMITED_API: Fix import utility code

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -219,13 +219,8 @@ static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
             // Avoid C compiler warning if strchr() evaluates to false at compile time.
             if ((1) && (strchr(__Pyx_MODULE_NAME, '.'))) {
                 /* try package relative import first */
-                #if CYTHON_COMPILING_IN_LIMITED_API
-                module = PyImport_ImportModuleLevelObject(
-                    name, empty_dict, empty_dict, from_list, 1);
-                #else
                 module = PyImport_ImportModuleLevelObject(
                     name, $moddict_cname, empty_dict, from_list, 1);
-                #endif
                 if (unlikely(!module)) {
                     if (unlikely(!PyErr_ExceptionMatches(PyExc_ImportError)))
                         goto bad;
@@ -244,13 +239,8 @@ static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
                 name, $moddict_cname, empty_dict, from_list, py_level, (PyObject *)NULL);
             Py_DECREF(py_level);
             #else
-            #if CYTHON_COMPILING_IN_LIMITED_API
-            module = PyImport_ImportModuleLevelObject(
-                name, empty_dict, empty_dict, from_list, level);
-            #else
             module = PyImport_ImportModuleLevelObject(
                 name, $moddict_cname, empty_dict, from_list, level);
-            #endif
             #endif
         }
     }


### PR DESCRIPTION
If enabling CYTHON_LIMITED_API, relative imports are failing the following way:

```
$ python3 -c 'from mpi4py import MPI'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "src/mpi4py/MPI/MPI.pyx", line 12, in init mpi4py.MPI
    bootstrap()
  File "src/mpi4py/MPI/atimport.pxi", line 291, in mpi4py.MPI.bootstrap
    getOptions(&options)
  File "src/mpi4py/MPI/atimport.pxi", line 139, in mpi4py.MPI.getOptions
    from . import rc
KeyError: "'__name__' not in globals"
```

After looking elsewhere in utility codes, looks like using `$moddict_cname` with `CYTHON_COMPILING_IN_LIMITED_API` enabled should work by now after all the changes to support per-module state.