### PR TITLE
Change CyFunction to compile with Py_LIMITED_API

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -792,7 +792,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.globalstate["end"].putln("#endif /* Py_PYTHON_H */")
 
         from .. import __version__
-        code.putln('#define CYTHON_ABI "%s"' % __version__.replace('.', '_'))
+        code.putln('#if CYTHON_LIMITED_API')  # CYTHON_COMPILING_IN_LIMITED_API not yet defined
+        # The limited API makes some significant changes to data structures, so we don't
+        # want to shared implementation compiled with and without the limited API.
+        code.putln('#define __PYX_EXTRA_ABI_MODULE_NAME "limited"')
+        code.putln('#else')
+        code.putln('#define __PYX_EXTRA_ABI_MODULE_NAME ""')
+        code.putln('#endif')
+        code.putln('#define CYTHON_ABI "%s" __PYX_EXTRA_ABI_MODULE_NAME' %
+                   __version__.replace('.', '_'))
         code.putln('#define __PYX_ABI_MODULE_NAME "_cython_" CYTHON_ABI')
         code.putln('#define __PYX_TYPE_MODULE_PREFIX __PYX_ABI_MODULE_NAME "."')
         code.putln('#define CYTHON_HEX_VERSION %s' % build_hex_version(__version__))

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -581,8 +581,8 @@ static PyObject *__Pyx_CyFunction_Init(__pyx_CyFunctionObject *op, PyMethodDef *
     if (unlikely(!op->func)) return NULL;
 #endif
     op->flags = flags;
-#if !CYTHON_COMPILING_IN_LIMITED_API
     __Pyx_CyFunction_weakreflist(op) = NULL;
+#if !CYTHON_COMPILING_IN_LIMITED_API
     cf->m_ml = ml;
     cf->m_self = (PyObject *) op;
 #endif

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -32,13 +32,11 @@ typedef struct {
     PyObject_HEAD;
     // We can't "inherit" from func, but we can use it as a data store
     PyObject *func;
-#else
-#if PY_VERSION_HEX < 0x030900B1
+#elif PY_VERSION_HEX < 0x030900B1
     PyCFunctionObject func;
 #else
     // PEP-573: PyCFunctionObject + mm_class
     PyCMethodObject func;
-#endif
 #endif
 #if CYTHON_BACKPORT_VECTORCALL
     __pyx_vectorcallfunc func_vectorcall;
@@ -177,12 +175,10 @@ __Pyx_CyFunction_get_name(__pyx_CyFunctionObject *op, void *context)
     if (unlikely(op->func_name == NULL)) {
 #if CYTHON_COMPILING_IN_LIMITED_API
         op->func_name = PyObject_GetAttrString(op->func, "__name__");
-#else
-#if PY_MAJOR_VERSION >= 3
+#elif PY_MAJOR_VERSION >= 3
         op->func_name = PyUnicode_InternFromString(((PyCFunctionObject*)op)->m_ml->ml_name);
 #else
         op->func_name = PyString_InternFromString(((PyCFunctionObject*)op)->m_ml->ml_name);
-#endif
 #endif  /* CYTHON_COMPILING_IN_LIMITED_API */
         if (unlikely(op->func_name == NULL))
             return NULL;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -752,7 +752,7 @@ __Pyx_CyFunction_repr(__pyx_CyFunctionObject *op)
 
 static PyObject * __Pyx_CyFunction_CallMethod(PyObject *func, PyObject *self, PyObject *arg, PyObject *kw) {
     // originally copied from PyCFunction_Call() in CPython's Objects/methodobject.c
-#if !CYTHON_COMPILING_IN_LIMITED_API
+#if CYTHON_COMPILING_IN_LIMITED_API
     PyObject *f = ((__pyx_CyFunctionObject*)func)->func;
     PyObject *py_name = NULL;
     PyCFunction meth;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -577,6 +577,8 @@ static PyObject *__Pyx_CyFunction_Init(__pyx_CyFunctionObject *op, PyMethodDef *
     if (unlikely(op == NULL))
         return NULL;
 #if CYTHON_COMPILING_IN_LIMITED_API
+    // Note that we end up with a circular reference to op. This isn't
+    // a disaster, but in an ideal world it'd be nice to avoid it.
     op->func = PyCFunction_NewEx(ml, (PyObject*)op, module);
     if (unlikely(!op->func)) return NULL;
 #endif
@@ -854,15 +856,13 @@ static PyObject * __Pyx_CyFunction_CallMethod(PyObject *func, PyObject *self, Py
 static CYTHON_INLINE PyObject *__Pyx_CyFunction_Call(PyObject *func, PyObject *arg, PyObject *kw) {
     PyObject *self, *result;
 #if CYTHON_COMPILING_IN_LIMITED_API
+    // PyCFunction_GetSelf returns a borrowed reference
     self = PyCFunction_GetSelf(((__pyx_CyFunctionObject*)func)->func);
     if (unlikely(!self) && PyErr_Occurred()) return NULL;
 #else
     self = ((PyCFunctionObject*)func)->m_self;
 #endif
     result = __Pyx_CyFunction_CallMethod(func, self, arg, kw);
-#if CYTHON_COMPILING_IN_LIMITED_API
-    Py_DECREF(self);
-#endif
     return result;
 }
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -822,7 +822,7 @@ class __Pyx_FakeReference {
 #endif
 
 // PEP-573: PyCFunction holds reference to defining class (PyCMethodObject)
-#if PY_VERSION_HEX < 0x030900B1
+#if __PYX_LIMITED_VERSION_HEX < 0x030900B1
   #define __Pyx_PyType_FromModuleAndSpec(m, s, b)  ((void)m, PyType_FromSpecWithBases(s, b))
   typedef PyObject *(*__Pyx_PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *, size_t, PyObject *);
 #else
@@ -1165,6 +1165,12 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict,
 #else
   // NOTE: might fail with exception => check for -1
   #define __Pyx_PySequence_SIZE(seq)  PySequence_Size(seq)
+#endif
+
+#if CYTHON_COMPILING_IN_LIMITED_API
+  #define __Pyx_PySequence_ITEM(o, i) PySequence_GetItem(o, i)
+#else
+  #define __Pyx_PySequence_ITEM(o, i) PySequence_ITEM(o, i)
 #endif
 
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
Mostly that we store the PyCFunctionObject as an attribute of it rather than "inheriting" from PyCFunctionObject.

(Actually testing the compilation with `Py_LIMITED_API` defined needs to it be put on top of https://github.com/cython/cython/pull/5550, but I think this PR can stand alone generally)