### PR TITLE
Declare PY_SSIZE_T_MAX/PY_SSIZE_T_MIN as const 

### DIFF
--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -60,7 +60,7 @@ cdef extern from "Python.h":
     void Py_INCREF(object)
     list PyList_New(Py_ssize_t size)
     void PyList_SET_ITEM(object list, Py_ssize_t i, object o)
-    cdef Py_ssize_t PY_SSIZE_T_MAX
+    const Py_ssize_t PY_SSIZE_T_MAX
 
 @cname("{{cname}}")
 cdef object {{cname}}(const vector[X]& v):

--- a/tests/compile/vector_include.pyx
+++ b/tests/compile/vector_include.pyx
@@ -1,0 +1,24 @@
+# mode: compile
+# tag: cpp
+
+# Test that using functionality from libcpp.vector does not lead to compile
+# errors when wildcard imports are used as well.
+
+# Import libcpp.vector, which declares PY_SSIZE_T_MAX.
+from libcpp.vector cimport vector
+
+# Import any other module using a wildcard import.
+from spam import *
+
+# Use the imports (details don't matter).
+cdef extern from *:
+    """
+    #include <vector>
+    std::vector<int> get_vector()
+    {
+      return std::vector<int>(17);
+    }
+    """
+    vector[int] get_vector()
+
+my_vector = get_vector()

--- a/tests/run/bytesmethods.pyx
+++ b/tests/run/bytesmethods.pyx
@@ -1,8 +1,8 @@
 cimport cython
 
 cdef extern from *:
-    cdef Py_ssize_t PY_SSIZE_T_MIN
-    cdef Py_ssize_t PY_SSIZE_T_MAX
+    const Py_ssize_t PY_SSIZE_T_MIN
+    const Py_ssize_t PY_SSIZE_T_MAX
 
 SSIZE_T_MAX = PY_SSIZE_T_MAX
 SSIZE_T_MIN = PY_SSIZE_T_MIN

--- a/tests/run/charptr_decode.pyx
+++ b/tests/run/charptr_decode.pyx
@@ -2,8 +2,8 @@
 cimport cython
 
 cdef extern from *:
-    cdef Py_ssize_t PY_SSIZE_T_MIN
-    cdef Py_ssize_t PY_SSIZE_T_MAX
+    const Py_ssize_t PY_SSIZE_T_MIN
+    const Py_ssize_t PY_SSIZE_T_MAX
 
 
 ############################################################

--- a/tests/run/unicode_slicing.pyx
+++ b/tests/run/unicode_slicing.pyx
@@ -169,8 +169,8 @@ __doc__ = u"""
 """
 
 cdef extern from *:
-    cdef Py_ssize_t PY_SSIZE_T_MIN
-    cdef Py_ssize_t PY_SSIZE_T_MAX
+    const Py_ssize_t PY_SSIZE_T_MIN
+    const Py_ssize_t PY_SSIZE_T_MAX
 
 SSIZE_T_MAX = PY_SSIZE_T_MAX
 SSIZE_T_MIN = PY_SSIZE_T_MIN


### PR DESCRIPTION
Follow the lead of `Cython/Includes/cpython/pyport.pxd` to declare
`PY_SSIZE_T_MIN` and `PY_SSIZE_T_MAX` as `const`. This prevents Cython
from trying to override or assign to this "variable" when doing wildcard
imports.

Add a test that shows this behavior in one example.

Fixes https://github.com/cython/cython/issues/5562

---

Note: This PR morphed from just the test case to a patch that includes a modified version of the test as well.