### PR TITLE
Ensure analyse_types marks SimpleCallNode as analysed

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5959,7 +5959,6 @@ class CallNode(ExprNode):
             self.function.set_cname(type.empty_declaration_code())
             self.analyse_c_function_call(env)
             self.type = type
-            self.analysed = True
             return True
 
     def is_lvalue(self):
@@ -6037,11 +6036,11 @@ class SimpleCallNode(CallNode):
         return self.args, None
 
     def analyse_types(self, env):
-        if self.analyse_as_type_constructor(env):
-            return self
         if self.analysed:
             return self
         self.analysed = True
+        if self.analyse_as_type_constructor(env):
+            return self
         self.function.is_called = 1
         self.function = self.function.analyse_types(env)
         function = self.function

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5959,6 +5959,7 @@ class CallNode(ExprNode):
             self.function.set_cname(type.empty_declaration_code())
             self.analyse_c_function_call(env)
             self.type = type
+            self.analysed = True
             return True
 
     def is_lvalue(self):

--- a/tests/run/cyfunction_defaults.pyx
+++ b/tests/run/cyfunction_defaults.pyx
@@ -2,8 +2,6 @@
 # mode: run
 # tag: cyfunction, closures
 
-from libcpp.vector cimport vector
-
 cimport cython
 import sys
 
@@ -314,8 +312,6 @@ cdef class C:
         pass
     def f10(self, a, /, b=1, *, int[:] c=None):
         pass
-    def f11(self, vector[double] a = vector[double](2, 1.0)):
-        pass
 
 
 def check_defaults_on_methods_for_introspection():
@@ -351,8 +347,5 @@ def check_defaults_on_methods_for_introspection():
     (1,)
     >>> C.f10.__kwdefaults__
     {'c': None}
-    >>> C.f11.__defaults__
-    ([1.0, 1.0],)
-    >>> C.f11.__kwdefaults__
     """
     pass

--- a/tests/run/cyfunction_defaults.pyx
+++ b/tests/run/cyfunction_defaults.pyx
@@ -2,6 +2,8 @@
 # mode: run
 # tag: cyfunction, closures
 
+from libcpp.vector cimport vector
+
 cimport cython
 import sys
 
@@ -312,6 +314,8 @@ cdef class C:
         pass
     def f10(self, a, /, b=1, *, int[:] c=None):
         pass
+    def f11(self, vector[double] a = vector[double](2, 1.0)):
+        pass
 
 
 def check_defaults_on_methods_for_introspection():
@@ -347,5 +351,8 @@ def check_defaults_on_methods_for_introspection():
     (1,)
     >>> C.f10.__kwdefaults__
     {'c': None}
+    >>> C.f11.__defaults__
+    ([1.0, 1.0],)
+    >>> C.f11.__kwdefaults__
     """
     pass

--- a/tests/run/cyfunction_defaults_cpp.pyx
+++ b/tests/run/cyfunction_defaults_cpp.pyx
@@ -1,0 +1,29 @@
+# cython: binding=True
+# mode: run
+# tag: cyfunction, cpp
+
+from libcpp.vector cimport vector
+
+cdef class A:
+    def f1(self, a, b=1, vector[double] c = vector[double]()):
+        pass
+    def f2(self, a, b=1,/, vector[double] c = vector[double](1, 2.0)):
+        pass
+    def f3(self, a, /, b=1, *, c = vector[double](2, 3.0)):
+        pass
+
+
+def check_defaults_on_methods():
+    """
+    >>> A.f1.__defaults__
+    (1, [])
+    >>> A.f1.__kwdefaults__
+    >>> A.f2.__defaults__
+    (1, [2.0])
+    >>> A.f2.__kwdefaults__
+    >>> A.f3.__defaults__
+    (1,)
+    >>> A.f3.__kwdefaults__
+    {'c': [3.0, 3.0]}
+    """
+    pass


### PR DESCRIPTION
Related to #5553
The `analyse_types` function does not mark SimpleCallNode as analysed after successfully analysing the node as a type constructor. In #5553, this results in `vector[double]()` being analysed twice, as a constructor and as an initialisation function, and therefore the type is misinterpreted as void eventually.