### PR TITLE
Update signature of make_unique

### DIFF
--- a/Cython/Includes/libcpp/memory.pxd
+++ b/Cython/Includes/libcpp/memory.pxd
@@ -106,8 +106,7 @@ cdef extern from "<memory>" namespace "std" nogil:
     # Smart pointer non-member operations
     shared_ptr[T] make_shared[T](...) except +
 
-    # Temporaries used for exception handling break generated code
-    unique_ptr[T] make_unique[T](...) # except +
+    unique_ptr[T] make_unique[T](...) except +
 
     # No checking on the compatibility of T and U.
     cdef shared_ptr[T] static_pointer_cast[T, U](const shared_ptr[U]&)

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -61,8 +61,7 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 
 ////////////// MoveIfSupported.proto //////////////////
 
-#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
-  // move should be defined for these versions of MSVC, but __cplusplus isn't set usefully
+#if CYTHON_USE_CPP11_FEATURES
   #include <utility>
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
 #else

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -61,7 +61,7 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 
 ////////////// MoveIfSupported.proto //////////////////
 
-#if CYTHON_USE_CPP11_FEATURES
+#if CYTHON_USE_CPP_STD_MOVE
   #include <utility>
   #define __PYX_STD_MOVE_IF_SUPPORTED(x) std::move(x)
 #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -479,6 +479,16 @@
 # endif
 #endif
 
+#ifndef CYTHON_USE_CPP11_FEATURES
+  // msvc doesn't set __cplusplus to a useful value
+  #if defined(__cplusplus) && ( \
+    __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600))
+    #define CYTHON_USE_CPP11_FEATURES 1
+  #else
+    #define CYTHON_USE_CPP11_FEATURES 0
+  #endif
+#endif
+
 #define __Pyx_void_to_None(void_result) ((void)(void_result), Py_INCREF(Py_None), Py_None)
 
 #ifdef _MSC_VER

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -479,13 +479,13 @@
 # endif
 #endif
 
-#ifndef CYTHON_USE_CPP11_FEATURES
+#ifndef CYTHON_USE_CPP_STD_MOVE
   // msvc doesn't set __cplusplus to a useful value
   #if defined(__cplusplus) && ( \
     __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600))
-    #define CYTHON_USE_CPP11_FEATURES 1
+    #define CYTHON_USE_CPP_STD_MOVE 1
   #else
-    #define CYTHON_USE_CPP11_FEATURES 0
+    #define CYTHON_USE_CPP_STD_MOVE 0
   #endif
 #endif
 

--- a/tests/run/cpp_smart_ptr.pyx
+++ b/tests/run/cpp_smart_ptr.pyx
@@ -1,7 +1,7 @@
 # mode: run
-# tag: cpp, werror, cpp11, no-cpp-locals
+# tag: cpp, werror, cpp14, no-cpp-locals
 
-from libcpp.memory cimport unique_ptr, shared_ptr, default_delete, dynamic_pointer_cast
+from libcpp.memory cimport unique_ptr, shared_ptr, default_delete, dynamic_pointer_cast, make_unique
 from libcpp cimport nullptr
 
 cdef extern from "cpp_smart_ptr_helper.h":
@@ -9,6 +9,9 @@ cdef extern from "cpp_smart_ptr_helper.h":
         CountAllocDealloc(int*, int*)
 
     cdef cppclass FreePtr[T]:
+        pass
+
+    cdef cppclass RaiseOnConstruct:
         pass
 
 
@@ -44,6 +47,16 @@ def test_unique_ptr():
     assert x_ptr3.get() != nullptr;
     x_ptr3.reset()
     assert x_ptr3.get() == nullptr;
+
+    # Test that make_unique works
+    cdef unique_ptr[int] x_ptr4
+    x_ptr4 = make_unique[int](5)
+    assert(x_ptr4) != nullptr
+    cdef unique_ptr[RaiseOnConstruct] x_ptr5
+    try:
+        x_ptr5 = make_unique[RaiseOnConstruct]()
+    except RuntimeError:
+        pass  # good - this is what we expect
 
 
 def test_const_shared_ptr():

--- a/tests/run/cpp_smart_ptr_helper.h
+++ b/tests/run/cpp_smart_ptr_helper.h
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 class CountAllocDealloc {
   public:
       CountAllocDealloc(int* alloc_count, int* dealloc_count)
@@ -21,4 +23,11 @@ struct FreePtr {
       t=nullptr;
     }
   }
+};
+
+class RaiseOnConstruct {
+  public:
+    RaiseOnConstruct() {
+      throw std::runtime_error("Oh no!");
+    }
 };


### PR DESCRIPTION
Also tweak the selection for move-if-supported. This now lets the user enable it by a define even if the compiler support isn't detected. This is useful because the new signature for make_unique kind of relies on move-if-supported to work.

Fixes #5560