### PR TITLE
Only write the version to stderr, if it's a separate file descriptor from stdout

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -776,7 +776,7 @@ def main(command_line = 0):
         print("Cython version %s" % __version__)
         # For legacy reasons, we also write the version to stderr.
         # New tools should expect it in stdout, but existing ones still pipe from stderr.
-        if not sys.stderr.isatty():
+        if not sys.stderr.isatty() and os.fstat(1) != os.fstat(2):
             sys.stderr.write("Cython version %s\n" % __version__)
     if options.working_path!="":
         os.chdir(options.working_path)


### PR DESCRIPTION
At least one project tries to detect the Cython version by redirecting stderr to stdout and capturing it. This is done in pure POSIX shell, so it probably seemed like the simple and obvious solution for a less capable programming language given that no output at all was expected on stdout.

But the result is that the version number appears twice, and then gets misparsed and ends up triggering bad assumptions in the code running cython.

It turns out that it's pretty easy to just print once, though. Detect when stdout and stderr are redirected to the same location, and only print once.

See #5504
Fixes https://bugs.gentoo.org/911333