### PR TITLE
Fix issues with parallel/exception checked functions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6291,6 +6291,12 @@ class SimpleCallNode(CallNode):
             if needs_cpp_exception_conversion(func_type):
                 env.use_utility_code(UtilityCode.load_cached("CppExceptionConversion", "CppSupport.cpp"))
 
+        if (func_type.exception_value is not None or
+                func_type.exception_check and func_type.exception_check != '+'):
+            if env.nogil:
+                # need to generate refnanny for testing because of exception check
+                env.has_with_gil_block = True
+
         self.overflowcheck = env.directives['overflowcheck']
 
     def calculate_result_code(self):

--- a/Cython/Compiler/ParseTreeTransforms.pxd
+++ b/Cython/Compiler/ParseTreeTransforms.pxd
@@ -76,6 +76,7 @@ cdef class GilCheck(VisitorTransform):
     cdef list env_stack
     cdef bint nogil
     cdef bint nogil_declarator_only
+    cdef bint current_gilstat_node_knows_gil_state
 
 cdef class TransformBuiltinMethods(EnvTransform):
     cdef visit_cython_attribute(self, node)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3514,6 +3514,7 @@ class GilCheck(VisitorTransform):
         # True for 'cdef func() nogil:' functions, as the GIL may be held while
         # calling this function (thus contained 'nogil' blocks may be valid).
         self.nogil_declarator_only = False
+
         self.current_gilstat_node_knows_gil_state = False
         return super(GilCheck, self).__call__(root)
 


### PR DESCRIPTION
Essentially the problem is that a `nogil` function just promises that the function *can* be called without the GIL, not that it actually doesn't have the GIL.

If you call `prange`/`parallel` inside that function while still holding the GIL, if any thread has finished the GIL will be held (... I think it's probably more of a mess than this, but mostly you get away with it...). If a thread is still running and tries to acquire the GIL then it'll deadlock permenantly.

I've solved this by adding an implicit `with nogil` around any `prange`/`parallel` that's in a `nogil` block but isn't certain that it has the GIL.

Fixes #5573 and #5564.