### PR TITLE
fix changed code

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -308,7 +308,7 @@ __Pyx_CyFunction_init_defaults(__pyx_CyFunctionObject *op) {
     op->defaults_tuple = __Pyx_PySequence_ITEM(res, 0);
     if (unlikely(!op->defaults_tuple)) result = -1;
     else {
-        op->defaults_tuple = __Pyx_PySequence_ITEM(res, 0);
+        op->defaults_kwdict = __Pyx_PySequence_ITEM(res, 1);
         if (unlikely(!op->defaults_kwdict)) result = -1;
     }
     #endif


### PR DESCRIPTION
PR #5556 changed the code to use `__Pyx_PySequence_ITEM`, but changed a bit too much on this line. This was causing PyPy to fail the `fused_def` test, after the fix the test passes.

[This](https://github.com/cython/cython/commit/9c3268163c#diff-de808597bd4a1085b999963541b05187126914c467a95f52290f810b36660affR311) is the change in the context of the PR