### PR TITLE
Update description of how to set flags for OpenMP with MSVC

### DIFF
--- a/docs/src/userguide/parallelism.rst
+++ b/docs/src/userguide/parallelism.rst
@@ -187,7 +187,7 @@ enable OpenMP.  For gcc this can be done as follows in a ``setup.py``:
 
         .. literalinclude:: ../../examples/userguide/parallelism/setup_pyx.py
 
-For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`` option, nor should you pass the argument ``'/openmp'`` or ``'-fopenmp'`` to the ``'extra_link_args'`` option to prevent an unnecessary warning.
+For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`` option, and you should not pass either of the arguments ``'/openmp'`` or ``'-fopenmp'`` to the ``'extra_link_args'`` option to prevent an unnecessary warning.
 
 
 Breaking out of loops

--- a/docs/src/userguide/parallelism.rst
+++ b/docs/src/userguide/parallelism.rst
@@ -187,7 +187,7 @@ enable OpenMP.  For gcc this can be done as follows in a ``setup.py``:
 
         .. literalinclude:: ../../examples/userguide/parallelism/setup_pyx.py
 
-For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'``, and to prevent uncesseary warnings don't pass any arguments to ``'extra_link_args'``.
+For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`` option, nor should you pass the argument ``'/openmp'`` or ``'-fopenmp'`` to the ``'extra_link_args'`` option to prevent an unnecessary warning.
 
 
 Breaking out of loops

--- a/docs/src/userguide/parallelism.rst
+++ b/docs/src/userguide/parallelism.rst
@@ -187,7 +187,7 @@ enable OpenMP.  For gcc this can be done as follows in a ``setup.py``:
 
         .. literalinclude:: ../../examples/userguide/parallelism/setup_pyx.py
 
-For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`` option, and you should not pass either of the arguments ``'/openmp'`` or ``'-fopenmp'`` to the ``'extra_link_args'`` option to prevent an unnecessary warning.
+For the Microsoft Visual C++ compiler, use ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`` option. Don't add any OpenMP flags to the ``'extra_link_args'`` option.
 
 
 Breaking out of loops

--- a/docs/src/userguide/parallelism.rst
+++ b/docs/src/userguide/parallelism.rst
@@ -187,7 +187,7 @@ enable OpenMP.  For gcc this can be done as follows in a ``setup.py``:
 
         .. literalinclude:: ../../examples/userguide/parallelism/setup_pyx.py
 
-For Microsoft Visual C++ compiler, use ``'/openmp'`` instead of ``'-fopenmp'``.
+For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`, and to prevent uncesseary warnings don't pass any arguments to ``'extra_link_args'``.
 
 
 Breaking out of loops

--- a/docs/src/userguide/parallelism.rst
+++ b/docs/src/userguide/parallelism.rst
@@ -187,7 +187,7 @@ enable OpenMP.  For gcc this can be done as follows in a ``setup.py``:
 
         .. literalinclude:: ../../examples/userguide/parallelism/setup_pyx.py
 
-For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'`, and to prevent uncesseary warnings don't pass any arguments to ``'extra_link_args'``.
+For the Microsoft Visual C++ compiler, the correct flag is ``'/openmp'`` instead of ``'-fopenmp'`` for the ``'extra_compile_args'``, and to prevent uncesseary warnings don't pass any arguments to ``'extra_link_args'``.
 
 
 Breaking out of loops


### PR DESCRIPTION
If one is using MSVC on Windows and inserting "/openmp" in the extra_link_args option, then one will receive an unnecessary warning. It's only necessary to include "-fopenmp" when using gcc.