### PR TITLE
Run CI with PyPy3, update caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,6 @@ jobs:
             extra_hash: "-stackless"
           # Pypy
           - os: ubuntu-20.04
-            python-version: pypy-2.7
-            backend: c
-            env: { NO_CYTHON_COMPILE: 1 }
-          - os: ubuntu-20.04
             python-version: pypy-3.9-v7.3.12
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
             extra_hash: "-stackless"
           # Pypy
           - os: ubuntu-20.04
+            python-version: pypy-2.7
+            backend: c
+            env: { NO_CYTHON_COMPILE: 1 }
+          - os: ubuntu-20.04
             python-version: pypy-3.9-v7.3.12
             backend: c
             env: { NO_CYTHON_COMPILE: 1 }
@@ -221,7 +225,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Python2 (Linux)
-        if: matrix.python-version == '2.7' && startsWith(matrix.os, 'ubuntu')
+        if: (matrix.python-version == '2.7' && startsWith(matrix.os, 'ubuntu')) || startsWith(matrix.python-version, 'pypy-2')
         run: |
             sudo ln -fs python2 /usr/bin/python
             sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
         id: compilation-cache
         with:
           key: ${{ runner.os }}-hendrikmuhs-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('test-requirements*.txt', '.github/**/ci.yml', 'Tools/**/ci-run.sh') }}
+          path: ./
 
       
       - name: Cache used?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,12 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v3
-        if: startsWith(matrix.python-version, '3.') || startsWith(matrix.python-version, 'pypy-3')
+        if: startsWith(matrix.python-version, '3.') || startsWith(matrix.python-version, 'pypy')
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Python2 (Linux)
-        if: (matrix.python-version == '2.7' && startsWith(matrix.os, 'ubuntu')) || startsWith(matrix.python-version, 'pypy-2')
+        if: matrix.python-version == '2.7' && startsWith(matrix.os, 'ubuntu')
         run: |
             sudo ln -fs python2 /usr/bin/python
             sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v3
-        if: startsWith(matrix.python-version, '3.')
+        if: startsWith(matrix.python-version, '3.') || startsWith(matrix.python-version, 'pypy-3')
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -236,11 +236,14 @@ jobs:
             which pip
 
       - name: Compilation Cache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: actions/cache@v3
+        id: compilation-cache
         with:
-          variant: ${{ startsWith(runner.os, 'windows') && 'sccache' || 'ccache' }}  # fake ternary
           key: ${{ runner.os }}-hendrikmuhs-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('test-requirements*.txt', '.github/**/ci.yml', 'Tools/**/ci-run.sh') }}
-          max-size: ${{ env.CCACHE_MAXSIZE }}
+
+      
+      - name: Cache used?
+        run: echo ${{ steps.compilation-cache.outputs.cache-hit }}
 
       - name: Run CI
         continue-on-error: ${{ matrix.allowed_failure || false }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,15 +232,11 @@ jobs:
             which pip
 
       - name: Compilation Cache
-        uses: actions/cache@v3
-        id: compilation-cache
+        uses: hendrikmuhs/ccache-action@v1.2.9
         with:
+          variant: ${{ startsWith(runner.os, 'windows') && 'sccache' || 'ccache' }}  # fake ternary
           key: ${{ runner.os }}-hendrikmuhs-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('test-requirements*.txt', '.github/**/ci.yml', 'Tools/**/ci-run.sh') }}
-          path: ./
-
-      
-      - name: Cache used?
-        run: echo ${{ steps.compilation-cache.outputs.cache-hit }}
+          max-size: ${{ env.CCACHE_MAXSIZE }}
 
       - name: Run CI
         continue-on-error: ${{ matrix.allowed_failure || false }}


### PR DESCRIPTION
Three tweaks:
- The pypy3 CI run was using CPython since the condition to set up python was wrong
- Remove the pypy2 CI run, it is not popular enough to justify the resources
- Update the CI caching action to a newer version ~code and add a check if it is used~. The older action was [emitting warnings](https://github.com/cython/cython/actions/runs/5708344400) (scroll down a bit in the central window)~, revert to using the official action instead of a fork of a fork. I added a check if the cache is used, which should help debugging caching issues.~