### PR TITLE
Modified CondExprNode generate_evaluation_code to resolve gh-5555

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12861,7 +12861,10 @@ class CondExprNode(ExprNode):
         code.mark_pos(self.pos)
         self.allocate_temp_result(code)
         self.test.generate_evaluation_code(code)
-        code.putln("if (%s) {" % self.test.result())
+        cond_val = self.test.result()
+        if not cond_val.startswith("(") or not cond_val.endswith(")"):
+            cond_val = "(" + cond_val + ")"
+        code.putln("if %s {" % cond_val)
         self.eval_and_get(code, self.true_val)
         code.putln("} else {")
         self.eval_and_get(code, self.false_val)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12863,7 +12863,7 @@ class CondExprNode(ExprNode):
         self.test.generate_evaluation_code(code)
         cond_val = self.test.result()
         if not cond_val.startswith("(") or not cond_val.endswith(")"):
-            cond_val = "(" + cond_val + ")"
+            cond_val = "(%s)" % cond_val
         code.putln("if %s {" % cond_val)
         self.eval_and_get(code, self.true_val)
         code.putln("} else {")


### PR DESCRIPTION
Only wrap conditional statement in parenthesis if it does not start with ( or does not end with ) already.

This change resolves gh-5555 and its duplicate gh-5584 which I filed.

@da-woods Please let me know if you'd like tests to be added.