### PR TITLE
Use hex to store large integers

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1439,7 +1439,7 @@ class IntNode(ConstNode):
             # (In hex if sufficiently large to cope with Python's string-to-int limitations.
             #  We use quite a small value of "sufficiently large")
             value = Utils.str_to_number(self.value)
-            formatter = hex if value > sys.maxsize else str
+            formatter = hex if value > (2**64) else str
             plain_integer_string = formatter(value)
             self.result_code = code.get_py_int(plain_integer_string, self.longness)
         else:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1441,6 +1441,9 @@ class IntNode(ConstNode):
             value = Utils.str_to_number(self.value)
             formatter = hex if value > (2**64) else str
             plain_integer_string = formatter(value)
+            if plain_integer_string[-1] in 'lL':
+                # Python 2 fix...
+                plain_integer_string = plain_integer_string[:-1]
             self.result_code = code.get_py_int(plain_integer_string, self.longness)
         else:
             self.result_code = self.get_constant_c_result_code()

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1370,7 +1370,7 @@ class IntNode(ConstNode):
     @property
     def hex_value(self):
         return Utils.strip_l_py2(hex(Utils.str_to_number(self.value)))
-    
+
     @property
     def base_10_value(self):
         return str(Utils.str_to_number(self.value))

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1369,7 +1369,7 @@ class IntNode(ConstNode):
     # writing tests to get a consistent representation of value
     @property
     def hex_value(self):
-        return Utils.strip_l_py2(hex(Utils.str_to_number(self.value)))
+        return Utils.strip_py2_long_suffix(hex(Utils.str_to_number(self.value)))
 
     @property
     def base_10_value(self):
@@ -1452,9 +1452,7 @@ class IntNode(ConstNode):
             value = Utils.str_to_number(self.value)
             formatter = hex if value > (10**13) else str
             plain_integer_string = formatter(value)
-            if plain_integer_string[-1] in 'lL':
-                # Python 2 fix...
-                plain_integer_string = plain_integer_string[:-1]
+            plain_integer_string = Utils.strip_py2_long_suffix(plain_integer_string)
             self.result_code = code.get_py_int(plain_integer_string, self.longness)
         else:
             self.result_code = self.get_constant_c_result_code()

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1436,7 +1436,11 @@ class IntNode(ConstNode):
     def generate_evaluation_code(self, code):
         if self.type.is_pyobject:
             # pre-allocate a Python version of the number
-            plain_integer_string = str(Utils.str_to_number(self.value))
+            # (In hex if sufficiently large to cope with Python's string-to-int limitations.
+            #  We use quite a small value of "sufficiently large")
+            value = Utils.str_to_number(self.value)
+            formatter = hex if value > sys.maxsize else str
+            plain_integer_string = formatter(value)
             self.result_code = code.get_py_int(plain_integer_string, self.longness)
         else:
             self.result_code = self.get_constant_c_result_code()

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1365,6 +1365,16 @@ class IntNode(ConstNode):
     longness = ""
     is_c_literal = None  # unknown
 
+    # hex_value and base_10_value are designed only to simplify
+    # writing tests to get a consistent representation of value
+    @property
+    def hex_value(self):
+        return Utils.strip_l_py2(hex(Utils.str_to_number(self.value)))
+    
+    @property
+    def base_10_value(self):
+        return str(Utils.str_to_number(self.value))
+
     def __init__(self, pos, **kwds):
         ExprNode.__init__(self, pos, **kwds)
         if 'type' not in kwds:
@@ -1437,9 +1447,10 @@ class IntNode(ConstNode):
         if self.type.is_pyobject:
             # pre-allocate a Python version of the number
             # (In hex if sufficiently large to cope with Python's string-to-int limitations.
-            #  We use quite a small value of "sufficiently large")
+            #  We use quite a small value of "sufficiently large" - 10**13 is picked as
+            #  the approximate point where hex strings become shorter)
             value = Utils.str_to_number(self.value)
-            formatter = hex if value > (2**64) else str
+            formatter = hex if value > (10**13) else str
             plain_integer_string = formatter(value)
             if plain_integer_string[-1] in 'lL':
                 # Python 2 fix...

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -32,6 +32,7 @@ from .Code import UtilityCode, TempitaUtilityCode
 from .StringEncoding import EncodedString, bytes_literal, encoded_string
 from .Errors import error, warning
 from .ParseTreeTransforms import SkipDeclarations
+from .. import Utils
 
 try:
     from __builtin__ import reduce
@@ -4474,9 +4475,7 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
             longness = "LL"[:max(len(getattr(operand1, 'longness', '')),
                                  len(getattr(operand2, 'longness', '')))]
             value = hex(int(node.constant_result))
-            if value[-1] in 'lL':
-                # Python 2 fix
-                value = value[:-1]
+            value = Utils.strip_l_py2(value)
             new_node = ExprNodes.IntNode(pos=node.pos,
                                          unsigned=unsigned, longness=longness,
                                          value=value,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4473,9 +4473,13 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                        getattr(operand2, 'unsigned', '')
             longness = "LL"[:max(len(getattr(operand1, 'longness', '')),
                                  len(getattr(operand2, 'longness', '')))]
+            value = hex(int(node.constant_result))
+            if value[-1] in 'lL':
+                # Python 2 fix
+                value = value[:-1]
             new_node = ExprNodes.IntNode(pos=node.pos,
                                          unsigned=unsigned, longness=longness,
-                                         value=hex(int(node.constant_result)),
+                                         value=value,
                                          constant_result=int(node.constant_result))
             # IntNode is smart about the type it chooses, so we just
             # make sure we were not smarter this time

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4475,7 +4475,7 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
                                  len(getattr(operand2, 'longness', '')))]
             new_node = ExprNodes.IntNode(pos=node.pos,
                                          unsigned=unsigned, longness=longness,
-                                         value=str(int(node.constant_result)),
+                                         value=hex(int(node.constant_result)),
                                          constant_result=int(node.constant_result))
             # IntNode is smart about the type it chooses, so we just
             # make sure we were not smarter this time

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -4475,7 +4475,7 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
             longness = "LL"[:max(len(getattr(operand1, 'longness', '')),
                                  len(getattr(operand2, 'longness', '')))]
             value = hex(int(node.constant_result))
-            value = Utils.strip_l_py2(value)
+            value = Utils.strip_py2_long_suffix(value)
             new_node = ExprNodes.IntNode(pos=node.pos,
                                          unsigned=unsigned, longness=longness,
                                          value=value,

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -439,7 +439,11 @@ def str_to_number(value):
         literal_type = value[1]  # 0'o' - 0'b' - 0'x'
         if literal_type in 'xX':
             # hex notation ('0x1AF')
-            value = int(value[2:], 16)
+            if value[-1] in 'lL':
+                # Python-2 complication
+                value = int(value[2:-1], 16)
+            else:
+                value = int(value[2:], 16)
         elif literal_type in 'oO':
             # Py3 octal notation ('0o136')
             value = int(value[2:], 8)

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -439,11 +439,8 @@ def str_to_number(value):
         literal_type = value[1]  # 0'o' - 0'b' - 0'x'
         if literal_type in 'xX':
             # hex notation ('0x1AF')
-            if value[-1] in 'lL':
-                # Python-2 complication
-                value = int(value[2:-1], 16)
-            else:
-                value = int(value[2:], 16)
+            value = strip_l_py2(value)
+            value = int(value[2:], 16)
         elif literal_type in 'oO':
             # Py3 octal notation ('0o136')
             value = int(value[2:], 8)
@@ -456,6 +453,16 @@ def str_to_number(value):
     else:
         value = int(value, 0)
     return -value if is_neg else value
+
+
+def strip_l_py2(value_str):
+    """
+    Python 2 likes to append 'L' to stringified numbers
+    which in then can't process when converting them to numbers.
+    """
+    if value_str[-1] in 'lL':
+        return value_str[:-1]
+    return value_str
 
 
 def long_literal(value):

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -439,7 +439,7 @@ def str_to_number(value):
         literal_type = value[1]  # 0'o' - 0'b' - 0'x'
         if literal_type in 'xX':
             # hex notation ('0x1AF')
-            value = strip_l_py2(value)
+            value = strip_py2_long_suffix(value)
             value = int(value[2:], 16)
         elif literal_type in 'oO':
             # Py3 octal notation ('0o136')
@@ -455,7 +455,7 @@ def str_to_number(value):
     return -value if is_neg else value
 
 
-def strip_l_py2(value_str):
+def strip_py2_long_suffix(value_str):
     """
     Python 2 likes to append 'L' to stringified numbers
     which in then can't process when converting them to numbers.

--- a/runtests.py
+++ b/runtests.py
@@ -473,7 +473,10 @@ VER_DEP_MODULES = {
                                            'run.unicode_imports',  # encoding problems on appveyor in Py2
                                            'run.reimport_failure',  # reimports don't do anything in Py2
                                            'run.cpp_stl_cmath_cpp17',
-                                           'run.cpp_stl_cmath_cpp20'
+                                           'run.cpp_stl_cmath_cpp20',
+                                           'run.large_integer_T5290',  # Py2 adds an L at the end of
+                                                                # names with 'hex' so there's a slight
+                                                                # mismatch in variable names.
                                            ]),
     (3,): (operator.ge, lambda x: x in ['run.non_future_division',
                                         'compile.extsetslice',

--- a/runtests.py
+++ b/runtests.py
@@ -473,10 +473,7 @@ VER_DEP_MODULES = {
                                            'run.unicode_imports',  # encoding problems on appveyor in Py2
                                            'run.reimport_failure',  # reimports don't do anything in Py2
                                            'run.cpp_stl_cmath_cpp17',
-                                           'run.cpp_stl_cmath_cpp20',
-                                           'run.large_integer_T5290',  # Py2 adds an L at the end of
-                                                                # names with 'hex' so there's a slight
-                                                                # mismatch in variable names.
+                                           'run.cpp_stl_cmath_cpp20'
                                            ]),
     (3,): (operator.ge, lambda x: x in ['run.non_future_division',
                                         'compile.extsetslice',

--- a/tests/run/constant_folding.py
+++ b/tests/run/constant_folding.py
@@ -494,12 +494,14 @@ def cascaded_cmp_with_partial_constants_and_false_end(a, b, c):
     '//PrimaryCmpNode',
     '//PrimaryCmpNode//IntNode',
     '//PrimaryCmpNode//IntNode[@value = "0"]',
-    '//PrimaryCmpNode//IntNode[@value = "4294967296"]',
+    '//PrimaryCmpNode//IntNode[@value = "0x100000000"]',
 )
 @cython.test_fail_if_path_exists(
     '//PrimaryCmpNode//IntBinopNode',
     '//PrimaryCmpNode//IntNode[@value = "1"]',
+    '//PrimaryCmpNode//IntNode[@value = "0x1"]',
     '//PrimaryCmpNode//IntNode[@value = "32"]',
+    '//PrimaryCmpNode//IntNode[@value = "0x20"]',
 )
 def const_in_binop(v):
     """

--- a/tests/run/constant_folding.py
+++ b/tests/run/constant_folding.py
@@ -424,20 +424,20 @@ def combined():
 
 
 @cython.test_assert_path_exists(
-    '//IntNode[@value = "2"]',
-    '//IntNode[@value = "4"]',
-    '//IntNode[@value = "5"]',
-    '//IntNode[@value = "7"]',
+    '//IntNode[@base_10_value = "2"]',
+    '//IntNode[@base_10_value = "4"]',
+    '//IntNode[@base_10_value = "5"]',
+    '//IntNode[@base_10_value = "7"]',
     '//BoolBinopNode//PrimaryCmpNode',
-    '//BoolBinopNode[.//PrimaryCmpNode//IntNode[@value = "4"] and .//PrimaryCmpNode//IntNode[@value = "5"]]',
-    '//PrimaryCmpNode[.//IntNode[@value = "2"] and .//IntNode[@value = "4"]]',
-    '//PrimaryCmpNode[.//IntNode[@value = "5"] and .//IntNode[@value = "7"]]',
+    '//BoolBinopNode[.//PrimaryCmpNode//IntNode[@base_10_value = "4"] and .//PrimaryCmpNode//IntNode[@base_10_value = "5"]]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "2"] and .//IntNode[@base_10_value = "4"]]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "5"] and .//IntNode[@base_10_value = "7"]]',
 )
 @cython.test_fail_if_path_exists(
-    '//IntNode[@value = "1"]',
-    '//IntNode[@value = "8"]',
-    '//PrimaryCmpNode[.//IntNode[@value = "4"] and .//IntNode[@value = "5"]]',
-    '//PrimaryCmpNode[.//IntNode[@value = "2"] and .//IntNode[@value = "7"]]',
+    '//IntNode[@base_10_value = "1"]',
+    '//IntNode[@base_10_value = "8"]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "4"] and .//IntNode[@base_10_value = "5"]]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "2"] and .//IntNode[@base_10_value = "7"]]',
     '//BoolNode',
 )
 def cascaded_cmp_with_partial_constants(a, b):
@@ -457,22 +457,22 @@ def cascaded_cmp_with_partial_constants(a, b):
 
 
 @cython.test_assert_path_exists(
-    '//IntNode[@value = "2"]',
-    '//IntNode[@value = "4"]',
-    '//IntNode[@value = "5"]',
-    '//IntNode[@value = "7"]',
+    '//IntNode[@base_10_value = "2"]',
+    '//IntNode[@base_10_value = "4"]',
+    '//IntNode[@base_10_value = "5"]',
+    '//IntNode[@base_10_value = "7"]',
     '//BoolBinopNode',
     '//SingleAssignmentNode//BoolBinopNode',
     '//SingleAssignmentNode//BoolBinopNode//NameNode[@name = "a"]',
     '//SingleAssignmentNode//BoolBinopNode//NameNode[@name = "b"]',
-    '//BoolBinopNode[.//PrimaryCmpNode//IntNode[@value = "4"] and .//PrimaryCmpNode//IntNode[@value = "5"]]',
+    '//BoolBinopNode[.//PrimaryCmpNode//IntNode[@base_10_value = "4"] and .//PrimaryCmpNode//IntNode[@base_10_value = "5"]]',
     '//BoolNode[@value = False]',
 )
 @cython.test_fail_if_path_exists(
     '//SingleAssignmentNode//NameNode[@name = "c"]',
-    '//IntNode[@value = "1"]',
-    '//PrimaryCmpNode[.//IntNode[@value = "4"] and .//IntNode[@value = "5"]]',
-    '//PrimaryCmpNode[.//IntNode[@value = "2"] and .//IntNode[@value = "7"]]',
+    '//IntNode[@base_10_value = "1"]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "4"] and .//IntNode[@base_10_value = "5"]]',
+    '//PrimaryCmpNode[.//IntNode[@base_10_value = "2"] and .//IntNode[@base_10_value = "7"]]',
     '//BoolNode[@value = True]',
 )
 def cascaded_cmp_with_partial_constants_and_false_end(a, b, c):
@@ -493,15 +493,13 @@ def cascaded_cmp_with_partial_constants_and_false_end(a, b, c):
 @cython.test_assert_path_exists(
     '//PrimaryCmpNode',
     '//PrimaryCmpNode//IntNode',
-    '//PrimaryCmpNode//IntNode[@value = "0"]',
-    '//PrimaryCmpNode//IntNode[@value = "0x100000000"]',
+    '//PrimaryCmpNode//IntNode[@base_10_value = "0"]',
+    '//PrimaryCmpNode//IntNode[@base_10_value = "4294967296"]',
 )
 @cython.test_fail_if_path_exists(
     '//PrimaryCmpNode//IntBinopNode',
-    '//PrimaryCmpNode//IntNode[@value = "1"]',
-    '//PrimaryCmpNode//IntNode[@value = "0x1"]',
-    '//PrimaryCmpNode//IntNode[@value = "32"]',
-    '//PrimaryCmpNode//IntNode[@value = "0x20"]',
+    '//PrimaryCmpNode//IntNode[@base_10_value = "1"]',
+    '//PrimaryCmpNode//IntNode[@base_10_value = "32"]',
 )
 def const_in_binop(v):
     """

--- a/tests/run/int_literals.pyx
+++ b/tests/run/int_literals.pyx
@@ -193,3 +193,12 @@ def py_bin():
     (1, -2, 15)
     """
     return 0b01, -0b10, 0b1111
+
+def big_value():
+    """
+    >>> _ = big_value()
+    """
+    # Not quite a literal, but Cython expands the binop and inserts the literal
+    # into the C source. Which means it must be converted to a hex string to avoid
+    # hitting Python's integer conversion limits
+    return 10**10000

--- a/tests/run/int_literals.pyx
+++ b/tests/run/int_literals.pyx
@@ -196,7 +196,8 @@ def py_bin():
 
 def big_value():
     """
-    >>> _ = big_value()
+    >>> big_value() == (10**10000)
+    True
     """
     # Not quite a literal, but Cython expands the binop and inserts the literal
     # into the C source. Which means it must be converted to a hex string to avoid

--- a/tests/run/large_integer_T5290.py
+++ b/tests/run/large_integer_T5290.py
@@ -1,5 +1,5 @@
-# cython: test_assert_c_code_has = __pyx_int_large_498767777577077770_xxx_709777877895072797
-# cython: test_assert_c_code_has = __pyx_int_large2_498767777577077770_xxx_709777877895072797
+# cython: test_assert_c_code_has = __pyx_int_large_0x16a76f60ab5d456a_xxx_1cd89e1a3713adcc1d
+# cython: test_assert_c_code_has = __pyx_int_large2_0x16a76f60ab5d456a_xxx_1cd89e1a3713adcc1d
 
 """
 >>> print(large_int1)

--- a/tests/run/pure_py.py
+++ b/tests/run/pure_py.py
@@ -357,7 +357,7 @@ def count_digits_in_carray(digits):
     return counts
 
 
-@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@value = '-1']")
+@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@base_10_value = '-1']")
 @cython.ccall
 @cython.returns(cython.long)
 @cython.exceptval(-1)
@@ -374,7 +374,7 @@ def ccall_except(x):
     return x+1
 
 
-@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@value = '-1']")
+@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@base_10_value = '-1']")
 @cython.cfunc
 @cython.returns(cython.long)
 @cython.exceptval(-1)
@@ -395,7 +395,7 @@ def call_cdef_except(x):
     return cdef_except(x)
 
 
-@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@value = '-1']")
+@cython.test_assert_path_exists("//CFuncDeclaratorNode//IntNode[@base_10_value = '-1']")
 @cython.ccall
 @cython.returns(cython.long)
 @cython.exceptval(-1, check=True)
@@ -414,7 +414,7 @@ def ccall_except_check(x):
     return x+1
 
 
-@cython.test_fail_if_path_exists("//CFuncDeclaratorNode//IntNode[@value = '-1']")
+@cython.test_fail_if_path_exists("//CFuncDeclaratorNode//IntNode[@base_10_value = '-1']")
 @cython.test_assert_path_exists("//CFuncDeclaratorNode")
 @cython.ccall
 @cython.returns(cython.long)
@@ -432,7 +432,7 @@ def ccall_except_check_always(x):
     return x+1
 
 
-@cython.test_fail_if_path_exists("//CFuncDeclaratorNode//IntNode[@value = '-1']")
+@cython.test_fail_if_path_exists("//CFuncDeclaratorNode//IntNode[@base_10_value = '-1']")
 @cython.test_assert_path_exists("//CFuncDeclaratorNode")
 @cython.ccall
 @cython.returns(cython.long)


### PR DESCRIPTION
This avoids running into Python's limits about the maximum number of digits to use in string conversion.

Fixes #5596

I suspect this isn't *everywhere* that could generate long number strings but it's sufficient to solve the reported bug.