### PR TITLE
codespell: add config, workflow (so no new typos sneak in) and get some typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,8 @@
 [codespell]
-skip = .git,*.pdf,*.svg,msvc_strings.pyx,cython.st
+skip = .git,*.pdf,*.svg,msvc_strings.pyx,cython.st,test_genericclass_exttype.pyx,e_invalid_special_cython_modules.py
 # case sensitive etc
 # Tripple -- relates to kate. Not sure if could be fixed
-ignore-regex= Tripple|/Fo|ist das|TOi
+ignore-regex= Tripple|/Fo|ist das|TOi|respect to the includee
 # forin - ? tag used in 3 files. may be could be renamed?
-ignore-words-list = asend,forin,nd,mis,te,nin,ue,ccompiler,ket
+# delimeters - typo, but used in API so kept as is
+ignore-words-list = asend,forin,nd,mis,te,nin,ue,ccompiler,ket,defin,delimeters,filetests,crasher

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,7 @@
 [codespell]
-skip = .git,*.pdf,*.svg
-#
-# ignore-words-list =
+skip = .git,*.pdf,*.svg,msvc_strings.pyx,cython.st
+# case sensitive etc
+# Tripple -- relates to kate. Not sure if could be fixed
+ignore-regex= Tripple|/Fo|ist das|TOi
+# forin - ? tag used in 3 files. may be could be renamed?
+ignore-words-list = asend,forin,nd,mis,te,nin,ue,ccompiler,ket

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -727,7 +727,7 @@ Related changes
   Patch by David Woods.  (Github issue :issue:`4935`)
 
 * ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
-  synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
+  syncing Cython with upstream NumPy v1.25.0.  The aliases were confusing
   since they could mean different things on different platforms.
 
 
@@ -1553,7 +1553,7 @@ Other changes
   to make it more visible.
 
 * ``np.long_t`` and ``np.ulong_t`` were removed from the NumPy declarations,
-  synching Cython with upstream NumPy v1.25.0.  The aliases were confusing
+  syncing Cython with upstream NumPy v1.25.0.  The aliases were confusing
   since they could mean different things on different platforms.
 
 
@@ -3094,7 +3094,7 @@ Bugs fixed
 Bugs fixed
 ----------
 
-* A refence leak of the for-loop list/tuple iterable was resolved if the for-loop's
+* A reference leak of the for-loop list/tuple iterable was resolved if the for-loop's
   ``else:`` branch executes a ``break`` for an outer loop.
   (Github issue :issue:`5347`)
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1230,7 +1230,7 @@ class PyObjectType(PyrexType):
     #
     #  Base class for all Python object types (reference-counted).
     #
-    #  buffer_defaults  dict or None     Default options for bu
+    #  buffer_defaults  dict or None     Default options for buffer
 
     name = "object"
     is_pyobject = 1

--- a/Cython/Tempita/_tempita.py
+++ b/Cython/Tempita/_tempita.py
@@ -103,8 +103,8 @@ class Template(object):
             delimeters = (self.default_namespace['start_braces'],
                           self.default_namespace['end_braces'])
         else:
-            #assert len(delimeters) == 2 and all([isinstance(delimeter, basestring)
-            #                                     for delimeter in delimeters])
+            #assert len(delimeters) == 2 and all([isinstance(delimiter, basestring)
+            #                                     for delimiter in delimeters])
             self.default_namespace = self.__class__.default_namespace.copy()
             self.default_namespace['start_braces'] = delimeters[0]
             self.default_namespace['end_braces'] = delimeters[1]

--- a/Tools/cython-numpy-mode-kate.xml
+++ b/Tools/cython-numpy-mode-kate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language>
-<!-- Python syntax highlightning v0.9 by Per Wigren -->
+<!-- Python syntax highlighting v0.9 by Per Wigren -->
 <!-- Python syntax highlighting v1.9 by Michael Bueker (improved keyword differentiation) -->
 <!-- Python syntax highlighting v1.97 by Paul Giannaros -->
 <!-- Pyrex syntax highlighting v0.1 by Matthew Marshall -->

--- a/Tools/gen_tests_for_posix_pxds.py
+++ b/Tools/gen_tests_for_posix_pxds.py
@@ -7,7 +7,7 @@ POSIX_PXDS_DIR = PROJECT_ROOT / "Cython/Includes/posix"
 TEST_PATH = PROJECT_ROOT / "tests/compile/posix_pxds.pyx"
 
 def main():
-    datas = [
+    data = [
         "# tag: posix\n"
         "# mode: compile\n"
         "\n"
@@ -32,10 +32,10 @@ def main():
             "from posix.{name} cimport *\n"
         ).format(name=name)
 
-        datas.append(s)
+        data.append(s)
 
     with open(TEST_PATH, "w", encoding="utf-8", newline="\n") as f:
-        f.write("\n".join(datas))
+        f.write("\n".join(data))
 
 if __name__ == "__main__":
     main()

--- a/Tools/kate.diff
+++ b/Tools/kate.diff
@@ -11,7 +11,7 @@ diff -r db4133d43a7e -r 0a6ce52272f6 Tools/cython-numpy-mode-kate.xml
 @@ -0,0 +1,1133 @@
 +<?xml version="1.0" encoding="UTF-8"?>
 +<!DOCTYPE language>
-+<!-- Python syntax highlightning v0.9 by Per Wigren -->
++<!-- Python syntax highlighting v0.9 by Per Wigren -->
 +<!-- Python syntax highlighting v1.9 by Michael Bueker (improved keyword differentiation) -->
 +<!-- Python syntax highlighting v1.97 by Paul Giannaros -->
 +<!-- Pyrex syntax highlighting v0.1 by Matthew Marshall -->

--- a/runtests.py
+++ b/runtests.py
@@ -2096,8 +2096,7 @@ class EmbedTest(unittest.TestCase):
 
 def load_listfile(filename):
     # just re-use the FileListExclude implementation
-    fle = FileListExcluder(filename)
-    return list(fle.excludes)
+    return list(FileListExcluder(filename))
 
 class MissingDependencyExcluder(object):
     def __init__(self, deps):

--- a/runtests.py
+++ b/runtests.py
@@ -938,9 +938,9 @@ def skip_c(tags):
     # dictionary so we check before looping.
     if 'distutils' in tags:
         for option in tags['distutils']:
-            splitted = option.split('=')
-            if len(splitted) == 2:
-                argument, value = splitted
+            split = option.split('=')
+            if len(split) == 2:
+                argument, value = split
                 if argument.strip() == 'language' and value.strip() == 'c++':
                     return True
     return False

--- a/tests/run/cpp_classes_def.pyx
+++ b/tests/run/cpp_classes_def.pyx
@@ -27,7 +27,7 @@ cdef cppclass RegularPolygon(Shape):
     void do_with() except *:
         # only a compile test - the file doesn't actually have to exist
         # "with" was broken by https://github.com/cython/cython/issues/4212
-        with open("doesnt matter") as f:
+        with open("does not matter") as f:
             return
 
 def test_Poly(int n, float radius=1):

--- a/tests/run/pep448_test_extcall.pyx
+++ b/tests/run/pep448_test_extcall.pyx
@@ -451,7 +451,7 @@ def call_method(Foo):
 
 # A PyCFunction that takes only positional parameters should allow an
 # empty keyword dictionary to pass without a complaint, but raise a
-# TypeError if te dictionary is not empty
+# TypeError if the dictionary is not empty
 
 def call_builtin_empty_dict():
     """


### PR DESCRIPTION
Config does exclude quite a bit of ideosyncratic constructs and even a typo (`delimeters`) which is now part of the API, so I decided to leave it alone for this round. 
