### PR TITLE
Fix fused function default argument coercion

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9718,6 +9718,8 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
                 if not must_use_constants:
                     if arg.default.is_literal:
                         arg.default = DefaultLiteralArgNode(arg.pos, arg.default)
+                        if arg.default.type:
+                            arg.default = arg.default.coerce_to(arg.type, env)
                     else:
                         arg.is_dynamic = True
                         if arg.type.is_pyobject:

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -135,6 +135,17 @@ def opt_func(fused_t obj, cython.floating myf = 1.2, cython.integral myi = 7,
     print cython.typeof(obj), cython.typeof(myf), cython.typeof(myi)
     print obj, "%.2f" % myf, myi, "%.2f" % f, i
 
+def non_fused_opt(fused_t obj, value=5):
+    """
+    PyObject constants as parts of fused functions weren't being created correctly
+    which would lead this to crash
+    >>> non_fused_opt(0)
+    5
+    >>> non_fused_opt("str", 10)
+    10
+    """
+    print value
+
 def run_cyfunction_check():
     """
     tp_base of the fused function was being set incorrectly meaning


### PR DESCRIPTION
Python object fused function arguments weren't being correctly coerced, which meant that sometimes an int was being cast directly to a PyObject*, causing a crash if you actually tried to use it.