### PR TITLE
refactor out use of numpy.distutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,6 @@ jobs:
         env: [{}]
 
         include:
-          # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
-          - python-version: 3.12-dev
-            allowed_failure: true
-
           # Ubuntu sub-jobs:
           # ================
           # GCC 11 (with latest language standards)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
         env: [{}]
 
         include:
+          # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
+          - python-version: 3.12-dev
+            allowed_failure: true
+
           # Ubuntu sub-jobs:
           # ================
           # GCC 11 (with latest language standards)

--- a/Demos/setup.py
+++ b/Demos/setup.py
@@ -12,13 +12,14 @@ ext_modules = cythonize("**/*.pyx", exclude="numpy_*.pyx")
 
 # Only compile the following if numpy is installed.
 try:
-    from numpy.distutils.misc_util import get_numpy_include_dirs
-    numpy_demo = [Extension("*",
-                            ["numpy_*.pyx"],
-                            include_dirs=get_numpy_include_dirs())]
-    ext_modules.extend(cythonize(numpy_demo))
+    from numpy import get_include
 except ImportError:
     pass
+else:
+    numpy_demo = [Extension("*",
+                            ["numpy_*.pyx"],
+                            include_dirs=get_include())]
+    ext_modules.extend(cythonize(numpy_demo))
 
 setup(
   name = 'Demos',

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -96,12 +96,15 @@ if [[ $PYTHON_VERSION == "2.7"* ]]; then
 elif [[ $PYTHON_VERSION == "3."[45]* ]]; then
   python -m pip install wheel || exit 1
   python -m pip install -r test-requirements-34.txt || exit 1
+elif [[ $PYTHON_VERSION == "3.6"* ]]; then
+  python -m pip install wheel || exit 1
+  python -m pip install -r test-requirements-36.txt || exit 1
 elif [[ $PYTHON_VERSION == "pypy-2.7" ]]; then
   pip install wheel || exit 1
   pip install -r test-requirements-pypy27.txt || exit 1
 elif [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
   python -m pip install wheel || exit 1
-  python -m pip install -r test-requirements-312.txt || exit 1
+  python -m pip install --pre -r test-requirements-312.txt || exit 1
 else
   python -m pip install -U pip "setuptools<60" wheel || exit 1
 

--- a/runtests.py
+++ b/runtests.py
@@ -253,7 +253,10 @@ def update_numpy_extension(ext, set_api17_macro=True):
         os.path.abspath(os.path.join(np.get_include(), '..', 'lib'))
     ]
     ext.library_dirs += lib_path
-    ext.libraries += ["npymath", "m"]
+    if sys.platform == "win32":
+        ext.libraries += ["npymath"]
+    else:
+        ext.libraries += ["npymath", "m"]
     ext.include_dirs.append(np.get_include())
 
     if set_api17_macro and getattr(np, '__version__', '') not in ('1.19.0', '1.19.1'):

--- a/runtests.py
+++ b/runtests.py
@@ -246,19 +246,19 @@ def update_linetrace_extension(ext):
 
 
 def update_numpy_extension(ext, set_api17_macro=True):
-    import numpy
-    from numpy.distutils.misc_util import get_info
+    import numpy as np
+    # Add paths for npyrandom and npymath libraries:
+    lib_path = [
+        os.path.abspath(os.path.join(np.get_include(), '..', '..', 'random', 'lib')),
+        os.path.abspath(os.path.join(np.get_include(), '..', 'lib'))
+    ]
+    ext.library_dirs += lib_path
 
-    ext.include_dirs.append(numpy.get_include())
+    ext.include_dirs.append(np.get_include())
 
-    if set_api17_macro and getattr(numpy, '__version__', '') not in ('1.19.0', '1.19.1'):
+    if set_api17_macro and getattr(np, '__version__', '') not in ('1.19.0', '1.19.1'):
         ext.define_macros.append(('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'))
-
-    # We need the npymath library for numpy.math.
-    # This is typically a static-only library.
-    for attr, value in get_info('npymath').items():
-        getattr(ext, attr).extend(value)
-
+    del np
 
 def update_gdb_extension(ext, _has_gdb=[None]):
     # We should probably also check for Python support.

--- a/runtests.py
+++ b/runtests.py
@@ -253,7 +253,7 @@ def update_numpy_extension(ext, set_api17_macro=True):
         os.path.abspath(os.path.join(np.get_include(), '..', 'lib'))
     ]
     ext.library_dirs += lib_path
-
+    ext.libraries += ["npymath", "m"]
     ext.include_dirs.append(np.get_include())
 
     if set_api17_macro and getattr(np, '__version__', '') not in ('1.19.0', '1.19.1'):

--- a/test-requirements-312.txt
+++ b/test-requirements-312.txt
@@ -1,4 +1,4 @@
-#numpy
+numpy
 coverage
 pycodestyle
 setuptools

--- a/test-requirements-36.txt
+++ b/test-requirements-36.txt
@@ -1,0 +1,5 @@
+jupyter
+pytest  # needed by IPython/Jupyter integration tests
+line_profiler<4  # currently 4 appears to collect no profiling info
+setuptools<60
+pywinpty<2.0.0 ; os_name == "nt"  # jupyter dependency, no wheels after 2.0


### PR DESCRIPTION
Fixes #5607 by refactoring places that import `numpy.distutils`, which is deprecated. `numpy.get_include` has existed forever (well, since 2006), there is no fear it is missing from an older NumPy.