### PR TITLE
Fix minor regression related to print_version()

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -773,7 +773,7 @@ def main(command_line = 0):
         sources = args
 
     if options.show_version:
-        print_version()
+        Utils.print_version()
 
     if options.working_path!="":
         os.chdir(options.working_path)


### PR DESCRIPTION
Looks like this was inadvertently introduced in https://github.com/cython/cython/commit/2a625fbd8793a83e16c524b7804710591dfe363e.

Fixes `cython --version`, which is used by `FindCython.cmake`