### PR TITLE
Avoid conflict between int-to-py and anonymous-enum-to-py

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -59,7 +59,7 @@ class BaseType(object):
         if self._specialization_name is None:
             # This is not entirely robust.
             common_subs = (self.empty_declaration_code()
-                           # covers both "unsigned " amd "signed "
+                           # covers both "unsigned " and "signed "
                            .replace("signed ", "signed_")
                            .replace("long long", "long_long")
                            .replace(" ", "__"))

--- a/tests/run/c_int_types_T255.pyx
+++ b/tests/run/c_int_types_T255.pyx
@@ -187,7 +187,7 @@ def test_add_short(x, y):
 SSHORT_MAX = <signed short>((<unsigned short>-1)>>1)
 SSHORT_MIN = (-SSHORT_MAX-1)
 
-def test_sshort(short x):
+def test_sshort(signed short x):
    u"""
    >>> test_sshort(SSHORT_MIN-1) #doctest: +ELLIPSIS
    Traceback (most recent call last):
@@ -764,6 +764,20 @@ def test_convert_pylong(x):
    """
    cdef long long r = x
    return r
+
+
+cdef enum:
+   ANONYMOUS_ENUM_MEMBER = 1
+
+def test_anonymous_enum():
+   """
+   The main point here is that the from-py conversion function shouldn't
+   conflict with in
+   >>> test_anonymous_enum()
+   1
+   """
+   return ANONYMOUS_ENUM_MEMBER
+
 
 # -------------------------------------------------------------------
 

--- a/tests/run/c_int_types_T255.pyx
+++ b/tests/run/c_int_types_T255.pyx
@@ -772,7 +772,7 @@ cdef enum:
 def test_anonymous_enum():
    """
    The main point here is that the from-py conversion function shouldn't
-   conflict with in
+   conflict with the function for int
    >>> test_anonymous_enum()
    1
    """


### PR DESCRIPTION
Introduced in dec61cdd222ded6d5f96a635d9c4b0dddcbc4e78 (where `IS_ENUM` was introduced, which meant the implementation diverged but the name stayed the same)

Fixes #5623