### PR TITLE
Add enum class decl to before types block

### DIFF
--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -69,6 +69,7 @@ auto __Pyx_pythran_to_python(T &&value) -> decltype(to_python(
 #endif
 
 ////////////// EnumClassDecl.proto //////////////////
+//@proto_block: utility_code_proto_before_types
 
 #if defined (_MSC_VER)
   #if _MSC_VER >= 1910

--- a/tests/compile/cppenum.pyx
+++ b/tests/compile/cppenum.pyx
@@ -40,3 +40,9 @@ cdef enum class Color(int):
 cdef enum class Color2(int):
     RED = (<int> Color.RED)
     GREEN = (<int> Color.GREEN)
+
+
+# enum class as cdef class function parameter
+cdef class A:
+    cdef Spam f(self, Spam s):
+        return s


### PR DESCRIPTION
When a scoped enumeration appears in the declaration of a method of a cdef class, the C++ declaration of the method currently appears before the necessary macro is defined. This PR moves that declaration to a different section that is always before type declarations.

Resolves #5637 