### PR TITLE
skip tests with limited-api tag on non-cpython

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -807,6 +807,8 @@ class TestBuilder(object):
                 if self.cython_only:
                     # EndToEnd tests always execute arbitrary build and test code
                     continue
+                if skip_limited(tags):
+                    continue
                 if 'cpp' not in tags['tag'] or 'cpp' in self.languages:
                     suite.addTest(EndToEndTest(filepath, workdir,
                              self.cleanup_workdir, stats=self.stats,
@@ -869,6 +871,8 @@ class TestBuilder(object):
                 'cpp' in tags['tag'] and not 'no-cpp-locals' in tags['tag']):
             extra_directives_list.append({'cpp_locals': True})
         if not languages:
+            return []
+        if skip_limited(tags):
             return []
 
         language_levels = [2, 3] if 'all_language_levels' in tags['tag'] else [None]
@@ -949,6 +953,12 @@ def skip_c(tags):
                     return True
     return False
 
+def skip_limited(tags):
+    if sys.implementation.name == 'cpython':
+        return False
+    # on all non-cpython, skip limited-api tests
+    if 'limited-api' in tags['tag']:
+        return True
 
 def filter_stderr(stderr_bytes):
     """

--- a/runtests.py
+++ b/runtests.py
@@ -961,7 +961,7 @@ def skip_limited(tags):
     # on all non-cpython, skip limited-api tests
     if 'limited-api' in tags['tag']:
         return True
-
+    return False
 def filter_stderr(stderr_bytes):
     """
     Filter annoying warnings from output.

--- a/runtests.py
+++ b/runtests.py
@@ -954,6 +954,8 @@ def skip_c(tags):
     return False
 
 def skip_limited(tags):
+    if sys.version_info[0] < 3:
+        return True
     if sys.implementation.name == 'cpython':
         return False
     # on all non-cpython, skip limited-api tests

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -1,4 +1,5 @@
 # mode: run
+# tag: limited-api
 
 # This is a bare minimum test to test compilation of the limited
 # API with the Py_LIMITED_API macro defined, with an example that's


### PR DESCRIPTION
Add handling for a new `limited-api` tag that skips such tests when run under a non-cpython interpreter

Closes #5659 

Tested locally with `pypy runtests.py isolated_limited_api_tests` and `python3.9 runtests.py isolated_limited_api_tests`