### PR TITLE
Fix a null comparison compiler warning visible with gcc 12

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -216,8 +216,7 @@ static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
     {
         #if PY_MAJOR_VERSION >= 3
         if (level == -1) {
-            // Avoid C compiler warning if strchr() evaluates to false at compile time.
-            if ((1) && (strchr(__Pyx_MODULE_NAME, '.'))) {
+            if (strchr(__Pyx_MODULE_NAME, '.') != NULL) {
                 /* try package relative import first */
                 module = PyImport_ImportModuleLevelObject(
                     name, $moddict_cname, empty_dict, from_list, 1);


### PR DESCRIPTION
Closes gh-5663

The older workaround was added in commit 12bbe5f3d2. Since `strchr` may return `NULL`, I don't see a reason here not to check for that the regular way. This fixes the warnings I'm seeing in the SciPy build.