### PR TITLE
Skip acquiring  GIL for __PYX_XCLEAR_MEMVIEW

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2363,8 +2363,7 @@ class FuncDefNode(StatNode, BlockNode):
             if entry.type.needs_refcounting:
                 if entry.is_arg and not entry.cf_is_reassigned:
                     continue
-                if not entry.type.is_memoryviewslice:
-                    # __PYX_XCLEAR_MEMVIEW acquires GIL internally.
+                if entry.type.refcounting_needs_gil:
                     assure_gil('success')
             # FIXME ideally use entry.xdecref_cleanup but this currently isn't reliable
             code.put_var_xdecref(entry, have_gil=gil_owned['success'])

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2363,7 +2363,9 @@ class FuncDefNode(StatNode, BlockNode):
             if entry.type.needs_refcounting:
                 if entry.is_arg and not entry.cf_is_reassigned:
                     continue
-                assure_gil('success')
+                if not entry.type.is_memoryviewslice:
+                    # __PYX_XCLEAR_MEMVIEW acquires GIL internally.
+                    assure_gil('success')
             # FIXME ideally use entry.xdecref_cleanup but this currently isn't reliable
             code.put_var_xdecref(entry, have_gil=gil_owned['success'])
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -207,6 +207,7 @@ class PyrexType(BaseType):
     #  needs_cpp_construction  boolean     Needs C++ constructor and destructor when used in a cdef class
     #  needs_refcounting     boolean     Needs code to be generated similar to incref/gotref/decref.
     #                                    Largely used internally.
+    #  refcounting_needs_gil boolean     Reference counting needs GIL to be acquired.
     #  equivalent_type       type        A C or Python type that is equivalent to this Python or C type.
     #  default_value         string      Initial value that can be assigned before first user assignment.
     #  declaration_value     string      The value statically assigned on declaration (if any).
@@ -280,6 +281,7 @@ class PyrexType(BaseType):
     has_attributes = 0
     needs_cpp_construction = 0
     needs_refcounting = 0
+    refcounting_needs_gil = True
     equivalent_type = None
     default_value = ""
     declaration_value = ""
@@ -638,6 +640,7 @@ class MemoryViewSliceType(PyrexType):
         # memoryview and pyobject code could be generated in the same way.
         # However, memoryviews are sufficiently specialized that this doesn't
         # seem practical. Implement a limited version of it for now
+    refcounting_needs_gil = False  # __PYX_XCLEAR_MEMVIEW acquires GIL internally.
     scope = None
 
     # These are special cased in Defnode


### PR DESCRIPTION
This PR Generate following code:

![image](https://github.com/cython/cython/assets/827060/b7614d7d-bc49-4e17-ac13-0c9b20944233)

Comparing to master generated code:
![image](https://github.com/cython/cython/assets/827060/34c0c66c-3d07-491e-b8f0-3aff979e5579)

Note: Code example is taken from bug report.

Closes #5670