### PR TITLE
Simplify the handling of immediate (and highly unlikely) failures when entering a Python function wrapper

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3890,9 +3890,14 @@ class DefNodeWrapper(FuncDefNode):
             code.putln("%s = PyTuple_GET_SIZE(%s);" % (
                 Naming.nargs_cname, Naming.args_cname))
             code.putln("#else")
-            code.putln("%s = PyTuple_Size(%s);" % (
-                Naming.nargs_cname, Naming.args_cname))
-            code.putln(code.error_goto_if_neg(Naming.nargs_cname, self.pos))
+            # An error here is very unlikely, but we risk a (conditionally) unused error label,
+            # so we just skip the traceback and return immediately.
+            code.putln("%s = PyTuple_Size(%s); if (%s) return %s;" % (
+                Naming.nargs_cname,
+                Naming.args_cname,
+                code.unlikely("%s < 0" % Naming.nargs_cname),
+                self.error_value(),
+             ))
             code.putln("#endif")
             if self.signature.use_fastcall:
                 code.putln("#endif")
@@ -3913,17 +3918,13 @@ class DefNodeWrapper(FuncDefNode):
             self.generate_stararg_copy_code(code)
 
         else:
-            self.generate_tuple_and_keyword_parsing_code(self.args, end_label, code, decl_code)
+            self.generate_tuple_and_keyword_parsing_code(self.args, code, decl_code)
             self.needs_values_cleanup = True
 
         code.error_label = old_error_label
         if code.label_used(our_error_label):
             if not code.label_used(end_label):
                 code.put_goto(end_label)
-            # This goto is just to suppress a warning that our_error_label is unused
-            # since it's quite likely that the only use is guarded by
-            # CYTHON_AVOID_BORROWED_REFERENCES
-            code.put_goto(our_error_label)
             code.put_label(our_error_label)
             self.generate_argument_values_cleanup_code(code)
 
@@ -3958,6 +3959,7 @@ class DefNodeWrapper(FuncDefNode):
             code.globalstate.use_utility_code(
                 UtilityCode.load_cached("RaiseArgTupleInvalid", "FunctionArguments.c"))
             code.putln("if (unlikely(%s > 0)) {" % Naming.nargs_cname)
+            # Direct return simplifies **kwargs cleanup, but we give no traceback.
             code.put('__Pyx_RaiseArgtupleInvalid(%s, 1, 0, 0, %s); return %s;' % (
                 self.name.as_c_string_literal(), Naming.nargs_cname, self.error_value()))
             code.putln("}")
@@ -3995,20 +3997,16 @@ class DefNodeWrapper(FuncDefNode):
             self.starstar_arg.entry.xdecref_cleanup = False
             code.putln("}")
 
+        # Normal (traceback) error handling from this point on to clean up the kwargs dict.
+
         if self.self_in_stararg and not self.target.is_staticmethod:
             assert not self.signature.use_fastcall
             # need to create a new tuple with 'self' inserted as first item
-            code.put("%s = PyTuple_New(%s + 1); if (unlikely(!%s)) " % (
+            code.putln("%s = PyTuple_New(%s + 1); %s" % (
                 self.star_arg.entry.cname,
                 Naming.nargs_cname,
-                self.star_arg.entry.cname))
-            if self.starstar_arg and self.starstar_arg.entry.cf_used:
-                code.putln("{")
-                code.put_var_xdecref_clear(self.starstar_arg.entry)
-                code.putln("return %s;" % self.error_value())
-                code.putln("}")
-            else:
-                code.putln("return %s;" % self.error_value())
+                code.error_goto_if_null(self.star_arg.entry.cname, self.pos)
+            ))
             code.put_var_gotref(self.star_arg.entry)
             code.put_incref(Naming.self_cname, py_object_type)
             code.put_giveref(Naming.self_cname, py_object_type)
@@ -4034,7 +4032,7 @@ class DefNodeWrapper(FuncDefNode):
                 Naming.args_cname))
             self.star_arg.entry.xdecref_cleanup = 0
 
-    def generate_tuple_and_keyword_parsing_code(self, args, success_label, code, decl_code):
+    def generate_tuple_and_keyword_parsing_code(self, args, code, decl_code):
         code.globalstate.use_utility_code(
             UtilityCode.load_cached("fastcall", "FunctionArguments.c"))
 
@@ -4212,15 +4210,19 @@ class DefNodeWrapper(FuncDefNode):
         code.putln('}')  # end of the whole argument unpacking block
 
         if code.label_used(argtuple_error_label):
-            code.put_goto(success_label)
+            skip_error_handling = code.new_label("skip")
+            code.put_goto(skip_error_handling)
+
             code.put_label(argtuple_error_label)
             code.globalstate.use_utility_code(
                 UtilityCode.load_cached("RaiseArgTupleInvalid", "FunctionArguments.c"))
-            code.put('__Pyx_RaiseArgtupleInvalid(%s, %d, %d, %d, %s); ' % (
+            code.putln('__Pyx_RaiseArgtupleInvalid(%s, %d, %d, %d, %s); %s' % (
                 self_name_csafe, has_fixed_positional_count,
                 min_positional_args, max_positional_args,
-                Naming.nargs_cname))
-            code.putln(code.error_goto(self.pos))
+                Naming.nargs_cname,
+                code.error_goto(self.pos)
+            ))
+            code.put_label(skip_error_handling)
 
     def generate_arg_assignment(self, arg, item, code):
         if arg.type.is_pyobject:

--- a/tests/run/always_allow_keywords_T295.pyx
+++ b/tests/run/always_allow_keywords_T295.pyx
@@ -31,6 +31,14 @@ def func1(arg):
     >>> func1(*[None])
     >>> func1(arg=None)
     """
+    return arg
+
+def func1_unused(arg):
+    """
+    >>> func1_unused(None)
+    >>> func1_unused(*[None])
+    >>> func1_unused(arg=None)
+    """
 
 @cython.always_allow_keywords(False)
 def func2(arg):
@@ -38,6 +46,15 @@ def func2(arg):
     >>> func2(None)
     >>> func2(*[None])
     >>> assert_typeerror_no_keywords(func2, arg=None)
+    """
+    return arg
+
+@cython.always_allow_keywords(False)
+def func2_unused(arg):
+    """
+    >>> func2_unused(None)
+    >>> func2_unused(*[None])
+    >>> assert_typeerror_no_keywords(func2_unused, arg=None)
     """
 
 @cython.always_allow_keywords(True)
@@ -47,8 +64,15 @@ def func3(arg):
     >>> func3(*[None])
     >>> func3(arg=None)
     """
-    pass
+    return arg
 
+@cython.always_allow_keywords(True)
+def func3_unused(arg):
+    """
+    >>> func3_unused(None)
+    >>> func3_unused(*[None])
+    >>> func3_unused(arg=None)
+    """
 
 cdef class A:
     """

--- a/tests/run/callargs.pyx
+++ b/tests/run/callargs.pyx
@@ -1,3 +1,27 @@
+# mode: run
+# tag: call
+
+
+def func0():
+    """
+    >>> func0()
+    """
+
+
+def onearg(arg):
+    """
+    >>> onearg(None)
+    None
+    """
+    print(arg)
+
+
+def onearg_unused(arg):
+    """
+    >>> onearg_unused(None)
+    """
+
+
 def c(a=10, b=20, **kwds):
     """
     >>> c()
@@ -38,8 +62,65 @@ def d(a, b=1, *args, **kwds):
     """
     print a, b, len(args), len(kwds)
 
+
 def e(*args, **kwargs):
+    """
+    >>> e()
+    0 0
+    >>> e(1)
+    1 0
+    >>> e(1,2)
+    2 0
+    >>> e(1,2)
+    2 0
+    >>> e(a=4)
+    0 1
+    >>> e(a=4, b=5)
+    0 2
+    >>> e(1,2, x=5)
+    2 1
+    """
     print len(args), len(kwargs)
+
+
+def args_kwargs_unused(*args, **kwargs):
+    """
+    >>> args_kwargs_unused()
+    >>> args_kwargs_unused(1, 2, 3)
+    >>> args_kwargs_unused(x=5)
+    >>> args_kwargs_unused(1, 2, 3, x=5)
+    """
+
+
+def args_kwargs_unused_args(*args, **kwargs):
+    """
+    >>> args_kwargs_unused_args()
+    0
+    >>> args_kwargs_unused_args(1, 2, 3)
+    0
+    >>> args_kwargs_unused_args(x=5)
+    1
+    >>> args_kwargs_unused_args(1, 2, 3, x=5)
+    1
+    >>> args_kwargs_unused_args(1, 2, 3, x=5, y=4)
+    2
+    """
+    return len(kwargs)
+
+
+def args_kwargs_unused_kwargs(*args, **kwargs):
+    """
+    >>> args_kwargs_unused_kwargs()
+    0
+    >>> args_kwargs_unused_kwargs(1, 2, 3)
+    3
+    >>> args_kwargs_unused_kwargs(x=5)
+    0
+    >>> args_kwargs_unused_kwargs(1, 2, 3, x=5)
+    3
+    """
+    return len(args)
+
 
 def f(*args):
     """


### PR DESCRIPTION
Returning immediately instead of going through the error label (and creating a traceback) avoids a potentially unused label (due to preprocessor guards).

Closes https://github.com/cython/cython/issues/5681