### PR TITLE
limited API: avoid checking binary version

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3076,7 +3076,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.put_setup_refcount_context(header3)
 
         env.use_utility_code(UtilityCode.load("CheckBinaryVersion", "ModuleSetupCode.c"))
-        code.putln('#if !CYTHON_LIMITED_API')
+        code.putln('#if !CYTHON_COMPILING_IN_LIMITED_API')
         code.put_error_if_neg(self.pos, "__Pyx_check_binary_version()")
         code.putln('#endif')
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3076,7 +3076,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.put_setup_refcount_context(header3)
 
         env.use_utility_code(UtilityCode.load("CheckBinaryVersion", "ModuleSetupCode.c"))
+        code.putln('#if !CYTHON_LIMITED_API')
         code.put_error_if_neg(self.pos, "__Pyx_check_binary_version()")
+        code.putln('#endif')
 
         code.putln("#ifdef __Pxy_PyFrame_Initialize_Offsets")
         code.putln("__Pxy_PyFrame_Initialize_Offsets();")


### PR DESCRIPTION
With the limited API, the binary version should not be checked.

Currently, the following warning is raised:
```
RuntimeWarning: compile time version 3.7 of module 'xx' does not match runtime version 3.10
```