### PR TITLE
Skip building trees for nodes with invalid tag name

### DIFF
--- a/Cython/Debugger/DebugWriter.py
+++ b/Cython/Debugger/DebugWriter.py
@@ -18,10 +18,18 @@ except ImportError:
             etree = None
 
 from ..Compiler import Errors
+from ..Compiler.StringEncoding import EncodedString
 
 
 def is_valid_tag(name):
-    if hasattr(name, "startswith"):
+    """
+    Names like '.0' are used internally for arguments
+    to functions creating generator expressions,
+    however they are not identifiers. 
+
+    See gh-5552
+    """
+    if isinstance(name, EncodedString):
         if name.startswith(".") and name[1:].isnumeric():
             return False
     return True

--- a/Cython/Debugger/DebugWriter.py
+++ b/Cython/Debugger/DebugWriter.py
@@ -27,10 +27,10 @@ def is_valid_tag(name):
     to functions creating generator expressions,
     however they are not identifiers. 
 
-    See gh-5552
+    See https://github.com/cython/cython/issues/5552
     """
     if isinstance(name, EncodedString):
-        if name.startswith(".") and name[1:].isnumeric():
+        if name.startswith(".") and name[1:].isdecimal():
             return False
     return True
 

--- a/Cython/Debugger/DebugWriter.py
+++ b/Cython/Debugger/DebugWriter.py
@@ -20,6 +20,13 @@ except ImportError:
 from ..Compiler import Errors
 
 
+def is_valid_tag(name):
+    if hasattr(name, "startswith"):
+        if name.startswith(".") and name[1:].isnumeric():
+            return False
+    return True
+
+
 class CythonDebugWriter(object):
     """
     Class to output debugging information for cygdb
@@ -39,14 +46,17 @@ class CythonDebugWriter(object):
         self.start('cython_debug', attrs=dict(version='1.0'))
 
     def start(self, name, attrs=None):
-        self.tb.start(name, attrs or {})
+        if is_valid_tag(name):
+            self.tb.start(name, attrs or {})
 
     def end(self, name):
-        self.tb.end(name)
+        if is_valid_tag(name):
+            self.tb.end(name)
 
     def add_entry(self, name, **attrs):
-        self.tb.start(name, attrs)
-        self.tb.end(name)
+        if is_valid_tag(name):
+            self.tb.start(name, attrs)
+            self.tb.end(name)
 
     def serialize(self):
         self.tb.end('Module')

--- a/Cython/Debugger/DebugWriter.py
+++ b/Cython/Debugger/DebugWriter.py
@@ -25,7 +25,7 @@ def is_valid_tag(name):
     """
     Names like '.0' are used internally for arguments
     to functions creating generator expressions,
-    however they are not identifiers. 
+    however they are not identifiers.
 
     See https://github.com/cython/cython/issues/5552
     """


### PR DESCRIPTION
This change attempts to exclude arguments with invalid tag names from being inserted into the `TreeBuilder` as per comment from gh-5552.

It does resolve the exception reported  in gh-5552 and in gh-5686, but I am not sure whether this is the best way to implement the idea to skip nodes with invalid names. 

Please feel free to suggest improvements. 

