### PR TITLE
Implement a better check for the import time Python version

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3076,8 +3076,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.put_setup_refcount_context(header3)
 
         env.use_utility_code(UtilityCode.load("CheckBinaryVersion", "ModuleSetupCode.c"))
-        code.put_error_if_neg(
-            self.pos, "__Pyx_check_binary_version(PY_VERSION_HEX, __Pyx_get_runtime_version(), CYTHON_COMPILING_IN_LIMITED_API)")
+        code.put_error_if_neg(self.pos, "__Pyx_check_binary_version("
+                                        "__PYX_LIMITED_VERSION_HEX, "
+                                        "__Pyx_get_runtime_version(), "
+                                        "CYTHON_COMPILING_IN_LIMITED_API)"
+        )
 
         code.putln("#ifdef __Pxy_PyFrame_Initialize_Offsets")
         code.putln("__Pxy_PyFrame_Initialize_Offsets();")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3076,7 +3076,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.put_setup_refcount_context(header3)
 
         env.use_utility_code(UtilityCode.load("CheckBinaryVersion", "ModuleSetupCode.c"))
-        code.put_error_if_neg(self.pos, "__Pyx_check_binary_version()")
+        code.put_error_if_neg(
+            self.pos, "__Pyx_check_binary_version(PY_VERSION_HEX, __Pyx_get_runtime_version(), CYTHON_COMPILING_IN_LIMITED_API)")
 
         code.putln("#ifdef __Pxy_PyFrame_Initialize_Offsets")
         code.putln("__Pxy_PyFrame_Initialize_Offsets();")

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1809,7 +1809,7 @@ static int __Pyx_check_binary_version(unsigned long ct_version, unsigned long rt
 
 static unsigned long __Pyx_get_runtime_version() {
     // We will probably never need the alpha/beta status, so avoid the complexity to parse it.
-#if PY_VERSION_HEX >= 0x030B00A4
+#if __PYX_LIMITED_VERSION_HEX >= 0x030B00A4
     return Py_Version & ~0xFFUL;
 #else
     const char* rt_version = Py_GetVersion();

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1819,7 +1819,7 @@ static unsigned long __Pyx_get_runtime_version() {
     int i = 0;
     while (factor) {
         while ('0' <= rt_version[i] && rt_version[i] <= '9') {
-            digit = digit * 10 + (unsigned long) (rt_version[i] - '0');
+            digit = digit * 10 + (unsigned int) (rt_version[i] - '0');
             ++i;
         }
         version += factor * digit;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -689,7 +689,7 @@ class __Pyx_FakeReference {
 
         #if __PYX_LIMITED_VERSION_HEX >= 0x030B0000
         minor_version = 11; // we don't yet need to distinguish between versions > 11
-        // Note that from 3.13, when we do we can use Py_Version 
+        // Note that from 3.13, when we do we can use Py_Version
         #else
         if (!(version_info = PySys_GetObject("version_info"))) goto end;
         if (!(py_minor_version = PySequence_GetItem(version_info, 1))) goto end;
@@ -716,10 +716,10 @@ class __Pyx_FakeReference {
             // 3.10 switches lnotab for linetable, but is otherwise the same
             result = PyObject_CallFunction(code_type, "iiiiiiOOOOOOiOO", a,p, k, l, s, f, code,
                           c, n, v, fn, name, fline, lnos, fv, cell);
-        } else {    
+        } else {
             // 3.11, 3.12
             // code(argcount, posonlyargcount, kwonlyargcount, nlocals, stacksize,
-            //    flags, codestring, constants, names, varnames, filename, name, 
+            //    flags, codestring, constants, names, varnames, filename, name,
             //    qualname, firstlineno, linetable, exceptiontable, freevars=(), cellvars=(), /)
             // We use name and qualname for simplicity
             if (!(exception_table = PyBytes_FromStringAndSize(NULL, 0))) goto end;
@@ -1802,49 +1802,60 @@ static void __pyx_insert_code_object(int code_line, PyCodeObject* code_object) {
 
 /////////////// CheckBinaryVersion.proto ///////////////
 
-static int __Pyx_check_binary_version(void);
+static unsigned long __Pyx_get_runtime_version();
+static int __Pyx_check_binary_version(unsigned long ct_version, unsigned long rt_version, int allow_newer);
 
 /////////////// CheckBinaryVersion ///////////////
 
-static int __Pyx_check_binary_version(void) {
-    char ctversion[5];
-    int same=1, i, found_dot;
-    const char* rt_from_call = Py_GetVersion();
-    PyOS_snprintf(ctversion, 5, "%d.%d", PY_MAJOR_VERSION, PY_MINOR_VERSION);
-    // slightly convoluted, but now that we're into double digit version numbers we can no longer just rely on the length.
-    found_dot = 0;
-    for (i = 0; i < 4; i++) {
-        if (!ctversion[i]) {
-            // if they are the same, just check that the runtime version doesn't continue with further numbers
-            same = (rt_from_call[i] < '0' || rt_from_call[i] > '9');
-            break;
+static unsigned long __Pyx_get_runtime_version() {
+    // We will probably never need the alpha/beta status, so avoid the complexity to parse it.
+#if PY_VERSION_HEX >= 0x030B00A4
+    return Py_Version & ~0xFFUL;
+#else
+    const char* rt_version = Py_GetVersion();
+    unsigned long version = 0;
+    unsigned long factor = 0x01000000UL;
+    unsigned int digit = 0;
+    int i = 0;
+    while (factor) {
+        while ('0' <= rt_version[i] && rt_version[i] <= '9') {
+            digit = digit * 10 + (unsigned long) (rt_version[i] - '0');
+            ++i;
         }
-        if (rt_from_call[i] != ctversion[i]) {
-            same = 0;
+        version += factor * digit;
+        if (rt_version[i] != '.')
             break;
-        }
+        digit = 0;
+        factor >>= 8;
+        ++i;
     }
+    return version;
+#endif
+}
 
-    if (!same) {
-        char rtversion[5] = {'\0'};
-        // copy the runtime-version for the error message
+static int __Pyx_check_binary_version(unsigned long ct_version, unsigned long rt_version, int allow_newer) {
+    // runtime version is: -1 => older, 0 => equal, 1 => newer
+    const unsigned long MAJOR_MINOR = 0xFFFF0000UL;
+    if ((rt_version & MAJOR_MINOR) == (ct_version & MAJOR_MINOR))
+        return 0;
+    if (likely(allow_newer && (rt_version & MAJOR_MINOR) > (ct_version & MAJOR_MINOR)))
+        return 1;
+
+    {
         char message[200];
-        for (i=0; i<4; ++i) {
-            if (rt_from_call[i] == '.') {
-                if (found_dot) break;
-                found_dot = 1;
-            } else if (rt_from_call[i] < '0' || rt_from_call[i] > '9') {
-                break;
-            }
-            rtversion[i] = rt_from_call[i];
-        }
         PyOS_snprintf(message, sizeof(message),
-                      "compile time version %s of module '%.100s' "
-                      "does not match runtime version %s",
-                      ctversion, __Pyx_MODULE_NAME, rtversion);
+                      "compile time Python version %d.%d "
+                      "of module '%.100s' "
+                      "%s "
+                      "runtime version %d.%d",
+                       (int) (ct_version >> 24), (int) ((ct_version >> 16) & 0xFF),
+                       __Pyx_MODULE_NAME,
+                       (allow_newer) ? "was newer than" : "does not match",
+                       (int) (rt_version >> 24), (int) ((rt_version >> 16) & 0xFF)
+       );
+        // returns 0 or -1
         return PyErr_WarnEx(NULL, message, 1);
     }
-    return 0;
 }
 
 /////////////// IsLittleEndian.proto ///////////////

--- a/tests/run/compare_binary_pyversions.pyx
+++ b/tests/run/compare_binary_pyversions.pyx
@@ -42,7 +42,7 @@ def test_compare_binary_versions_exact():
             else:
                 try:
                     check_binary_version(ct_version, rt_version, 0)
-                except RuntimeWarning as exc:
+                except Warning as exc:
                     assert "does not match runtime version" in str(exc), exc
                 else:
                     assert not "raised", (hex(rt_version), hex(ct_version))
@@ -70,7 +70,7 @@ def test_compare_binary_versions_minimum():
             else:
                 try:
                     check_binary_version(ct_version, rt_version, 1)
-                except RuntimeWarning as exc:
+                except Warning as exc:
                     if rt_version & major_and_minor < ct_version & major_and_minor:
                         assert "was newer than runtime version" in str(exc), exc
                     else:

--- a/tests/run/compare_binary_pyversions.pyx
+++ b/tests/run/compare_binary_pyversions.pyx
@@ -1,0 +1,79 @@
+# mode: run
+# tag: internal
+
+cdef extern from *:
+    int check_binary_version "__Pyx_check_binary_version" (unsigned long ct_version, unsigned long rt_version, int allow_newer) except -1
+    unsigned long get_runtime_version "__Pyx_get_runtime_version" ()
+    unsigned long PY_VERSION_HEX
+
+
+def test_get_runtime_version():
+    """
+    >>> test_get_runtime_version()
+    True
+    """
+    cdef unsigned long rt_version = get_runtime_version()
+    return PY_VERSION_HEX & ~0xFF == rt_version or  (hex(PY_VERSION_HEX), hex(rt_version))
+
+
+def iter_hex_versions():
+    cdef long major, minor, dot
+    for major in range(0, 20):
+        for minor in range(0, 20, 3):
+            for dot in range(0, 20, 3):
+                yield ((major * 16 + minor) * 16 + dot) * 16
+
+
+def test_compare_binary_versions_exact():
+    """
+    >>> import warnings
+    >>> warnings.simplefilter("error")
+    >>> test_compare_binary_versions_exact()
+    >>> warnings.resetwarnings()
+    """
+    cdef long major_and_minor = 0xFFFF0000
+    cdef long rt_version, ct_version
+
+    versions = list(iter_hex_versions())
+    for ct_version in versions:
+        for rt_version in versions:
+            if rt_version & major_and_minor == ct_version & major_and_minor:
+                assert check_binary_version(ct_version, rt_version, 0) == 0, (hex(rt_version), hex(ct_version))
+            else:
+                try:
+                    check_binary_version(ct_version, rt_version, 0)
+                except RuntimeWarning as exc:
+                    assert "does not match runtime version" in str(exc), exc
+                else:
+                    assert not "raised", (hex(rt_version), hex(ct_version))
+
+
+def test_compare_binary_versions_minimum():
+    """
+    >>> import warnings
+    >>> warnings.simplefilter("error")
+    >>> test_compare_binary_versions_minimum()
+    >>> warnings.resetwarnings()
+    """
+    cdef long major_and_minor = 0xFFFF0000
+    cdef long rt_version, ct_version
+
+    versions = list(iter_hex_versions())
+    for ct_version in versions:
+        for rt_version in versions:
+            if rt_version & major_and_minor >= ct_version & major_and_minor:
+                result = check_binary_version(ct_version, rt_version, 1)
+                if rt_version & major_and_minor > ct_version & major_and_minor:
+                    assert result == 1, (hex(rt_version), hex(ct_version))
+                else:
+                    assert result == 0, (hex(rt_version), hex(ct_version))
+            else:
+                try:
+                    check_binary_version(ct_version, rt_version, 1)
+                except RuntimeWarning as exc:
+                    if rt_version & major_and_minor < ct_version & major_and_minor:
+                        assert "was newer than runtime version" in str(exc), exc
+                    else:
+                        assert "does not match runtime version" in str(exc), exc
+                else:
+                    assert not "raised", (hex(rt_version), hex(ct_version))


### PR DESCRIPTION
The compile time Python version is allowed to be older when using the Limited API / stable ABI.

Closes https://github.com/cython/cython/pull/5689