### PR TITLE
Allow 'cython -M' to work without distutils installed

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -13,14 +13,25 @@ import re, sys, time
 from glob import iglob
 from io import open as io_open
 from os.path import relpath as _relpath
-from distutils.extension import Extension
-from distutils.util import strtobool
 import zipfile
 
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+
+try:
+    from distutils.util import strtobool
+except ImportError:
+    def strtobool(val):
+        """Convert a string representation of truth to true (1) or false (0)."""
+        val = val.lower()
+        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+            return 1
+        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+            return 0
+        else:
+            raise ValueError("invalid truth value {!r}".format(val))
 
 try:
     import gzip
@@ -755,6 +766,8 @@ def default_create_extension(template, kwds):
 # This may be useful for advanced users?
 def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=False, language=None,
                           exclude_failures=False):
+    from distutils.extension import Extension
+
     if language is not None:
         print('Warning: passing language={0!r} to cythonize() is deprecated. '
               'Instead, put "# distutils: language={0}" in your .pyx or .pxd file(s)'.format(language))

--- a/Cython/Build/__init__.py
+++ b/Cython/Build/__init__.py
@@ -1,2 +1,5 @@
 from .Dependencies import cythonize
-from .Distutils import build_ext
+try:
+    from .Distutils import build_ext
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
When 'cython' is run specifying the -M command line option, the Cython.Build.Dependencies module is imported. This modules also contains support code to build Cython extensions via distutils or setuptools. Importing it fails when running with Python 3.12, where the distutils module has been removed.

Move one distutils import into the function that requires it. Handle one import error and re-implement the simple utility function that is required.

The Cython.Build module also re-exports the Cython.Distutils module. To preserve the exported API, the only sensible thing is to allow the corresponding import to fail when distutils is not present.

Fixes #5692.