### PR TITLE
Do no-type-slots dictoffset check as python lookup

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -180,10 +180,10 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
                 }
 #if !(CYTHON_USE_TYPE_SLOTS || CYTHON_COMPILING_IN_PYPY)
               dictoffset_return:
-    #endif
-    #if CYTHON_AVOID_BORROWED_REFS
+#endif
+#if CYTHON_AVOID_BORROWED_REFS
                 Py_DECREF(b0);
-    #endif
+#endif
                 return -1;
             }
         }

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -158,7 +158,7 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
         if (dictoffset == 0)
         {
             Py_ssize_t b_dictoffset = 0;
-#if CYTHON_USE_TYPE_SLOTS
+#if CYTHON_USE_TYPE_SLOTS || CYTHON_COMPILING_IN_PYPY
             b = b->tp_dictoffset;
 #else
             PyObject *py_b_dictoffset = PyObject_GetAttrString((PyObject*)b, "__dictoffset__");

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -155,38 +155,36 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
 #endif
             return -1;
         }
-#if !CYTHON_USE_TYPE_SLOTS
-        if (dictoffset == 0) {
-            PyErr_Format(PyExc_TypeError,
-                "extension type '%s.200s': "
-                "unable to validate whether bases have a __dict__ "
-                "when CYTHON_USE_TYPE_SLOTS is off "
-                "(likely because you are building in the limited API). "
-                "Therefore, all extension types with multiple bases "
-                "must add 'cdef dict __dict__' in this compilation mode",
-                type_name);
-#if CYTHON_AVOID_BORROWED_REFS
-            Py_DECREF(b0);
-#endif
-            return -1;
-        }
-#else
-        if (dictoffset == 0 && b->tp_dictoffset)
+        if (dictoffset == 0)
         {
-            __Pyx_TypeName b_name = __Pyx_PyType_GetName(b);
-            PyErr_Format(PyExc_TypeError,
-                "extension type '%.200s' has no __dict__ slot, "
-                "but base type '" __Pyx_FMT_TYPENAME "' has: "
-                "either add 'cdef dict __dict__' to the extension type "
-                "or add '__slots__ = [...]' to the base type",
-                type_name, b_name);
-            __Pyx_DECREF_TypeName(b_name);
-#if CYTHON_AVOID_BORROWED_REFS
-            Py_DECREF(b0);
+            Py_ssize_t b_dictoffset = 0;
+#if CYTHON_USE_TYPE_SLOTS
+            b =  = b->tp_dictoffset;
+#else
+            PyObject *py_b_dictoffset = PyObject_GetAttrString((PyObject*)b, "__dictoffset__");
+            if (!py_b_dictoffset) goto dictoffset_return;
+            b_dictoffset = PyLong_AsSsize_t(py_b_dictoffset);
+            Py_DECREF(py_b_dictoffset);
+            if (b_dictoffset == -1 && PyErr_Occurred()) goto dictoffset_return;
 #endif
-            return -1;
+            if (b_dictoffset) {
+                __Pyx_TypeName b_name = __Pyx_PyType_GetName(b);
+                PyErr_Format(PyExc_TypeError,
+                    "extension type '%.200s' has no __dict__ slot, "
+                    "but base type '" __Pyx_FMT_TYPENAME "' has: "
+                    "either add 'cdef dict __dict__' to the extension type "
+                    "or add '__slots__ = [...]' to the base type",
+                    type_name, b_name);
+                __Pyx_DECREF_TypeName(b_name);
+                {
+                  dictoffset_return:
+    #if CYTHON_AVOID_BORROWED_REFS
+                    Py_DECREF(b0);
+    #endif
+                    return -1;
+                }
+            }
         }
-#endif
 #if CYTHON_AVOID_BORROWED_REFS
         Py_DECREF(b0);
 #endif

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -178,7 +178,7 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
                         type_name, b_name);
                     __Pyx_DECREF_TypeName(b_name);
                 }
-    #if !CYTHON_USE_TYPE_SLOTS
+#if !(CYTHON_USE_TYPE_SLOTS || CYTHON_COMPILING_IN_PYPY)
               dictoffset_return:
     #endif
     #if CYTHON_AVOID_BORROWED_REFS

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -159,7 +159,7 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
         {
             Py_ssize_t b_dictoffset = 0;
 #if CYTHON_USE_TYPE_SLOTS
-            b =  = b->tp_dictoffset;
+            b = b->tp_dictoffset;
 #else
             PyObject *py_b_dictoffset = PyObject_GetAttrString((PyObject*)b, "__dictoffset__");
             if (!py_b_dictoffset) goto dictoffset_return;
@@ -168,21 +168,23 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
             if (b_dictoffset == -1 && PyErr_Occurred()) goto dictoffset_return;
 #endif
             if (b_dictoffset) {
-                __Pyx_TypeName b_name = __Pyx_PyType_GetName(b);
-                PyErr_Format(PyExc_TypeError,
-                    "extension type '%.200s' has no __dict__ slot, "
-                    "but base type '" __Pyx_FMT_TYPENAME "' has: "
-                    "either add 'cdef dict __dict__' to the extension type "
-                    "or add '__slots__ = [...]' to the base type",
-                    type_name, b_name);
-                __Pyx_DECREF_TypeName(b_name);
                 {
-                  dictoffset_return:
-    #if CYTHON_AVOID_BORROWED_REFS
-                    Py_DECREF(b0);
-    #endif
-                    return -1;
+                    __Pyx_TypeName b_name = __Pyx_PyType_GetName(b);
+                    PyErr_Format(PyExc_TypeError,
+                        "extension type '%.200s' has no __dict__ slot, "
+                        "but base type '" __Pyx_FMT_TYPENAME "' has: "
+                        "either add 'cdef dict __dict__' to the extension type "
+                        "or add '__slots__ = [...]' to the base type",
+                        type_name, b_name);
+                    __Pyx_DECREF_TypeName(b_name);
                 }
+    #if CYTHON_USE_TYPE_SLOTS
+              dictoffset_return:
+    #endif
+    #if CYTHON_AVOID_BORROWED_REFS
+                Py_DECREF(b0);
+    #endif
+                return -1;
             }
         }
 #if CYTHON_AVOID_BORROWED_REFS

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -178,7 +178,7 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
                         type_name, b_name);
                     __Pyx_DECREF_TypeName(b_name);
                 }
-    #if CYTHON_USE_TYPE_SLOTS
+    #if !CYTHON_USE_TYPE_SLOTS
               dictoffset_return:
     #endif
     #if CYTHON_AVOID_BORROWED_REFS

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -159,7 +159,7 @@ static int __Pyx_validate_bases_tuple(const char *type_name, Py_ssize_t dictoffs
         {
             Py_ssize_t b_dictoffset = 0;
 #if CYTHON_USE_TYPE_SLOTS || CYTHON_COMPILING_IN_PYPY
-            b = b->tp_dictoffset;
+            b_dictoffset = b->tp_dictoffset;
 #else
             PyObject *py_b_dictoffset = PyObject_GetAttrString((PyObject*)b, "__dictoffset__");
             if (!py_b_dictoffset) goto dictoffset_return;


### PR DESCRIPTION
Rather than just declaring it impossible.

Fixes #5696

(Note that this isn't sufficient to declare multiply-inherited cdef classes in the limited api - the calling code generates a few `PyTuple_GET_ITEM`s. However, I have tested the dictoffset code itself)