### PR TITLE
Avoid undefined behavior in overflow checks

### DIFF
--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -233,7 +233,7 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
       if ((b > 0) && (a > LONG_MAX - b)
           || (b < 0) && (a < LONG_MIN - b)) {
         *overflow |= 1;
-        return -1;
+        return 0;
       }
       return a + b;
 #ifdef HAVE_LONG_LONG
@@ -241,7 +241,7 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
       if ((b > 0) && (a > LLONG_MAX - b)
           || (b < 0) && (a < LLONG_MIN - b)) {
         *overflow |= 1;
-        return -1;
+        return 0;
       }
       return a + b;
 #endif
@@ -274,19 +274,19 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
         return __Pyx_mul_const_{{NAME}}_checking_overflow(b, a, overflow);
     } else if ((sizeof({{INT}}) < sizeof(long))) {
         if ((b == 0)
-            || (b > 0) && (a > LONG_MAX / b)
+            ||(b > 0) && (a > LONG_MAX / b)
             || (b < 0) && (a < LONG_MIN / b)) {
           *overflow |= 1;
-          return -1;
+          return 0;
         }
         return ({{INT}}) a * b;
 #ifdef HAVE_LONG_LONG
     } else if ((sizeof({{INT}}) < sizeof(PY_LONG_LONG))) {
         if ((b == 0)
-            || (b > 0) && (a > LLONG_MAX / b)
+            ||(b > 0) && (a > LLONG_MAX / b)
             || (b < 0) && (a < LLONG_MIN / b)) {
           *overflow |= 1;
-          return -1;
+          return 0;
         }
         return ({{INT}}) a * b;
 #endif

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -233,7 +233,7 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
       if ((b > 0) && (a > LONG_MAX - b)
           || (b < 0) && (a < LONG_MIN - b)) {
         *overflow |= 1;
-        return 0;
+        return -1;
       }
       return a + b;
 #ifdef HAVE_LONG_LONG
@@ -241,7 +241,7 @@ static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{I
       if ((b > 0) && (a > LLONG_MAX - b)
           || (b < 0) && (a < LLONG_MIN - b)) {
         *overflow |= 1;
-        return 0;
+        return -1;
       }
       return a + b;
 #endif
@@ -274,19 +274,19 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
         return __Pyx_mul_const_{{NAME}}_checking_overflow(b, a, overflow);
     } else if ((sizeof({{INT}}) < sizeof(long))) {
         if ((b == 0)
-            ||(b > 0) && (a > LONG_MAX / b)
+            || (b > 0) && (a > LONG_MAX / b)
             || (b < 0) && (a < LONG_MIN / b)) {
           *overflow |= 1;
-          return 0;
+          return -1;
         }
         return ({{INT}}) a * b;
 #ifdef HAVE_LONG_LONG
     } else if ((sizeof({{INT}}) < sizeof(PY_LONG_LONG))) {
         if ((b == 0)
-            ||(b > 0) && (a > LLONG_MAX / b)
+            || (b > 0) && (a > LLONG_MAX / b)
             || (b < 0) && (a < LLONG_MIN / b)) {
           *overflow |= 1;
-          return 0;
+          return -1;
         }
         return ({{INT}}) a * b;
 #endif

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -230,20 +230,16 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
 
 static CYTHON_INLINE {{INT}} __Pyx_add_{{NAME}}_checking_overflow({{INT}} a, {{INT}} b, int *overflow) {
     if ((sizeof({{INT}}) < sizeof(long))) {
-      if ((b > 0) && (a > LONG_MAX - b)
-          || (b < 0) && (a < LONG_MIN - b)) {
-        *overflow |= 1;
-        return 0;
-      }
-      return a + b;
+        long big_r = ((long) a) + ((long) b);
+        {{INT}} r = ({{INT}}) big_r;
+        *overflow |= big_r != r;
+        return r;
 #ifdef HAVE_LONG_LONG
     } else if ((sizeof({{INT}}) < sizeof(PY_LONG_LONG))) {
-      if ((b > 0) && (a > LLONG_MAX - b)
-          || (b < 0) && (a < LLONG_MIN - b)) {
-        *overflow |= 1;
-        return 0;
-      }
-      return a + b;
+        PY_LONG_LONG big_r = ((PY_LONG_LONG) a) + ((PY_LONG_LONG) b);
+        {{INT}} r = ({{INT}}) big_r;
+        *overflow |= big_r != r;
+        return r;
 #endif
     } else {
         // Signed overflow undefined, but unsigned overflow is well defined. Casting is
@@ -273,22 +269,16 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_{{NAME}}_checking_overflow({{INT}} a, {{I
     } else if (__Pyx_is_constant(a)) {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(b, a, overflow);
     } else if ((sizeof({{INT}}) < sizeof(long))) {
-        if ((b == 0)
-            ||(b > 0) && (a > LONG_MAX / b)
-            || (b < 0) && (a < LONG_MIN / b)) {
-          *overflow |= 1;
-          return 0;
-        }
-        return ({{INT}}) a * b;
+        long big_r = ((long) a) * ((long) b);
+        {{INT}} r = ({{INT}}) big_r;
+        *overflow |= big_r != r;
+        return ({{INT}}) r;
 #ifdef HAVE_LONG_LONG
     } else if ((sizeof({{INT}}) < sizeof(PY_LONG_LONG))) {
-        if ((b == 0)
-            ||(b > 0) && (a > LLONG_MAX / b)
-            || (b < 0) && (a < LLONG_MIN / b)) {
-          *overflow |= 1;
-          return 0;
-        }
-        return ({{INT}}) a * b;
+        PY_LONG_LONG big_r = ((PY_LONG_LONG) a) * ((PY_LONG_LONG) b);
+        {{INT}} r = ({{INT}}) big_r;
+        *overflow |= big_r != r;
+        return ({{INT}}) r;
 #endif
     } else {
         return __Pyx_mul_const_{{NAME}}_checking_overflow(a, b, overflow);
@@ -314,10 +304,6 @@ static CYTHON_INLINE {{INT}} __Pyx_mul_const_{{NAME}}_checking_overflow({{INT}} 
         *overflow |= a > __PYX_MIN({{INT}}) / b;
         *overflow |= a < __PYX_MAX({{INT}}) / b;
     }
-
-    if (*overflow) {
-      return -1;
-    }
     return ({{INT}}) (((unsigned {{INT}})a) * ((unsigned {{INT}}) b));
 }
 #endif  // defined(__PYX_HAVE_BUILTIN_OVERFLOW)
@@ -327,10 +313,7 @@ static CYTHON_INLINE {{INT}} __Pyx_div_{{NAME}}_checking_overflow({{INT}} a, {{I
         *overflow |= 1;
         return 0;
     }
-    if (*overflow |= a == __PYX_MIN({{INT}}) && b == -1) {
-      return -1;
-    }
-
+    *overflow |= a == __PYX_MIN({{INT}}) && b == -1;
     return ({{INT}}) ((unsigned {{INT}}) a / (unsigned {{INT}}) b);
 }
 


### PR DESCRIPTION
ref https://github.com/cython/cython/issues/5705#issuecomment-1721865551

These were detected downstream when trying to use UBSAN with Cython. Not sure if there is a way to test that in current CI