### PR TITLE
cythonize 0.29.x: use force=None as default instead of force=False

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -878,7 +878,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
 
 
 # This is the user-exposed entry point.
-def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, force=False, language=None,
+def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, force=None, language=None,
               exclude_failures=False, **options):
     """
     Compile a set of source modules into C/C++ files and return a list of distutils


### PR DESCRIPTION
I completely overlooked this in https://github.com/cython/cython/pull/5307,
that backport was useless because the signature of `cythonize` is

```python
def cythonize(..., force=False, ...)
```

in 0.29.x instead of

```python
def cytonize(..., force=None, ...)
```

like it is on `3.x`, meaning that setting `CYTHON_FORCE_REGEN=1` had no effect.


