### PR TITLE
Fix mistake acquiring GIL while generating closure functions

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2056,7 +2056,7 @@ class FuncDefNode(StatNode, BlockNode):
         # refnanny only
         # Closures are not currently possible for cdef nogil functions,
         # but check them anyway
-        var_decls_definitely_need_gil = self.needs_closure or self.needs_outer_scope
+        var_decls_definitely_need_gil = lenv.nogil and (self.needs_closure or self.needs_outer_scope)
 
         gilstate_decl = None
         var_decls_need_gil = False


### PR DESCRIPTION
It didn't need to acquire the GIL here unless lenv.nogil is set (since while it needs the GIL, it already has it).