### PR TITLE
Update ci.yml for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12-dev"
+          - "3.12"
         env: [{}]
 
-        include:
-          # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
-          - python-version: 3.12-dev
-            allowed_failure: true
+        #include:
+        #  # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
+        #  - python-version: 3.12-dev
+        #    allowed_failure: true
 
           # Ubuntu sub-jobs:
           # ================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           - "3.12"
         env: [{}]
 
-        #include:
+        include:
         #  # Temporary - Allow failure on Python 3.12-dev jobs until they are in beta (feature frozen)
         #  - python-version: 3.12-dev
         #    allowed_failure: true


### PR DESCRIPTION
Which has now been released so we should be able to use the live version