### PR TITLE
Add setuptools as dependency for python > 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options]
+install_requires =
+    setuptools;python_version>'3.11'
+
 [flake8]
 max-complexity = 10
 


### PR DESCRIPTION
distutils is removed from python >= 3.12. Setuptools contains backward compatible distutils interface.

Fixes #5751
