### PR TITLE
Add setuptools as optional dependency

### DIFF
--- a/Cython/Build/__init__.py
+++ b/Cython/Build/__init__.py
@@ -3,8 +3,17 @@ from .Dependencies import cythonize
 import sys
 if sys.version_info < (3, 7):
     from .Distutils import build_ext
-del sys
 
+if sys.version_info > (3, 11):
+    try:
+        import setuptools
+    except ImportError:
+        raise ImportError(
+            "Missing optional dependency 'setuptools'. "
+            "Use pip or conda to install setuptools."
+        )
+
+del sys
 
 def __getattr__(name):
     if name == 'build_ext':

--- a/Cython/Distutils/__init__.py
+++ b/Cython/Distutils/__init__.py
@@ -1,2 +1,14 @@
+import sys
+if sys.version_info > (3, 11):
+    try:
+        import setuptools
+    except ImportError:
+        raise ImportError(
+            "Missing optional dependency 'setuptools'. "
+            "Use pip or conda to install setuptools."
+        )
+
+del sys
+
 from Cython.Distutils.build_ext import build_ext
 from Cython.Distutils.extension import Extension

--- a/docs/src/quickstart/install.rst
+++ b/docs/src/quickstart/install.rst
@@ -44,7 +44,11 @@ according to the system used:
 
 The simplest way of installing Cython is by using ``pip``::
 
-  pip install Cython
+  pip install Cython[setuptools]
+
+.. Note::
+   When cython is used only to generate .c files, setuptools optional dependency can be omited.
+   This is useful mainly when alternative build system like meson is used.
 
 On platforms that are covered by one of the binary wheel packages provided on PyPI,
 this will install an accelerated wheel which contains some Cython compiled modules.
@@ -58,7 +62,7 @@ The newest Cython release can always be downloaded from
 https://cython.org/.  Unpack the tarball or zip file, enter the
 directory, and then run::
 
-  pip install .
+  pip install .[setuptools]
 
 
 For one-time installations from a Cython source checkout, it is substantially
@@ -67,11 +71,11 @@ of Cython with something like
 
 ::
 
-    pip install .  --install-option="--no-cython-compile"
+    pip install .[setuptools] --install-option="--no-cython-compile"
 
     or
 
-    NO_CYTHON_COMPILE=true  pip install .
+    NO_CYTHON_COMPILE=true  pip install .[setuptools]
 
 
 .. [Anaconda] https://docs.anaconda.com/anaconda/

--- a/pyximport/pyxbuild.py
+++ b/pyximport/pyxbuild.py
@@ -6,6 +6,17 @@ out_fname = pyx_to_dll("foo.pyx")
 import os
 import sys
 
+if sys.version_info > (3, 11):
+    try:
+        import setuptools
+    except ImportError:
+        raise ImportError(
+            "Missing optional dependency 'setuptools'. "
+            "Use pip or conda to install setuptools."
+        )
+
+del sys
+
 from distutils.errors import DistutilsArgError, DistutilsError, CCompilerError
 from distutils.extension import Extension
 from distutils.util import grok_environment_error

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options.extras_require]
+setuptools =
+    setuptools
+
 [flake8]
 max-complexity = 10
 


### PR DESCRIPTION
This PR is alternative to #5753. I think this is superior because:
1. projects which uses not-setuptools build system will not have unneeded dependency
2. this is standard way how to manage dependencies which are optional - setuptools is needed only for building .c files.

Fixes https://github.com/cython/cython/issues/5751