### PR TITLE
Fix -Wundef -Wstrict-prototypes

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -792,7 +792,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.globalstate["end"].putln("#endif /* Py_PYTHON_H */")
 
         from .. import __version__
-        code.putln('#if CYTHON_LIMITED_API')  # CYTHON_COMPILING_IN_LIMITED_API not yet defined
+        code.putln('#if defined(CYTHON_LIMITED_API) && CYTHON_LIMITED_API')  # CYTHON_COMPILING_IN_LIMITED_API not yet defined
         # The limited API makes some significant changes to data structures, so we don't
         # want to shared implementation compiled with and without the limited API.
         code.putln('#define __PYX_EXTRA_ABI_MODULE_NAME "limited"')

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1837,7 +1837,7 @@ static void __pyx_insert_code_object(int code_line, PyCodeObject* code_object) {
 
 /////////////// CheckBinaryVersion.proto ///////////////
 
-static unsigned long __Pyx_get_runtime_version();
+static unsigned long __Pyx_get_runtime_version(void);
 static int __Pyx_check_binary_version(unsigned long ct_version, unsigned long rt_version, int allow_newer);
 
 /////////////// CheckBinaryVersion ///////////////


### PR DESCRIPTION
```
src/petsc4py/PETSc.c:22:5: warning: 'CYTHON_LIMITED_API' is not defined, evaluates to 0 [-Wundef]
#if CYTHON_LIMITED_API
    ^
src/petsc4py/PETSc.c:5283:47: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
static unsigned long __Pyx_get_runtime_version();
                                              ^
                                               void
src/petsc4py/PETSc.c:561483:49: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  static unsigned long __Pyx_get_runtime_version() {
                                                ^
                                                 void
3 warnings generated.
```