### PR TITLE
Make performance hints a directive rather than an Option

### DIFF
--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -191,8 +191,8 @@ def _write_file_encode(file, line):
         file.write(line.encode('ascii', 'replace'))
 
 
-def performance_hint(position, message):
-    if not Options.show_performance_hints:
+def performance_hint(position, message, env):
+    if not env.directives['show_performance_hints']:
         return
     warn = CompileWarning(position, message)
     line = "performance hint: %s\n" % warn

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6485,7 +6485,8 @@ class SimpleCallNode(CallNode):
                     if nogil:
                         if not exc_checks:
                             PyrexTypes.write_noexcept_performance_hint(
-                                self.pos, function_name=None, void_return=self.type.is_void)
+                                self.pos, code.funcstate.scope,
+                                function_name=None, void_return=self.type.is_void)
                         code.globalstate.use_utility_code(
                             UtilityCode.load_cached("ErrOccurredWithGIL", "Exceptions.c"))
                         exc_checks.append("__Pyx_ErrOccurredWithGIL()")

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -148,10 +148,6 @@ buffer_max_dims = 8
 #: Number of function closure instances to keep in a freelist (0: no freelists)
 closure_freelist_size = 8
 
-#: Show performance hints -- these aren't warning but some people may not want
-# to see them
-show_performance_hints = True
-
 
 def get_directive_defaults():
     # To add an item to this list, all accesses should be changed to use the new
@@ -240,6 +236,7 @@ _directive_defaults = {
     'warn.unused_arg': False,
     'warn.unused_result': False,
     'warn.multiple_declarators': True,
+    'show_performance_hints': True,
 
 # optimizations
     'optimize.inline_defnode_calls': True,

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -5438,16 +5438,22 @@ def cap_length(s, max_prefix=63, max_len=1024):
     hash_prefix = hashlib.sha256(s.encode('ascii')).hexdigest()[:6]
     return '%s__%s__etc' % (hash_prefix, s[:max_len-17])
 
-def write_noexcept_performance_hint(pos, function_name=None, void_return=False):
+def write_noexcept_performance_hint(pos, env, function_name=None, void_return=False):
     on_what = "on '%s' " % function_name if function_name else ""
     msg = (
-        "Exception check %swill always require the GIL to be acquired. Possible solutions:\n"
-        "\t1. Declare the function as 'noexcept' if you control the definition and "
-                                "you're sure you don't want the function to raise exceptions.\n"
+        "Exception check %swill always require the GIL to be acquired."
     ) % on_what
+    solutions = ["Declare the function as 'noexcept' if you control the definition and "
+                                "you're sure you don't want the function to raise exceptions."]
     if void_return:
-        msg += "\t2. Use an 'int' return type on the function to allow an error code to be returned."
-    performance_hint(pos, msg)
+        solutions.append(
+            "Use an 'int' return type on the function to allow an error code to be returned.")
+    if len(solutions) == 1:
+        msg = "%s %s" % (msg, solutions[0])
+    else:
+        solutions = ["\t%s. %s" % (i+1, s) for i, s in enumerate(solutions)]
+        msg = "%s\nPossible solutions:\n%s" % (msg, "\n".join(solutions))
+    performance_hint(pos, msg, env)
 
 def remove_cv_ref(tp, remove_fakeref=False):
     # named by analogy with c++ std::remove_cv_ref

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -942,7 +942,7 @@ class Scope(object):
                 # don't warn about external functions here - the user likely can't do anything
                 defining and not in_pxd and not inline_in_pxd):
             PyrexTypes.write_noexcept_performance_hint(
-                pos, function_name=name, void_return=type.return_type.is_void)
+                pos, self, function_name=name, void_return=type.return_type.is_void)
         return entry
 
     def declare_cgetter(self, name, return_type, pos=None, cname=None,

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1051,6 +1051,11 @@ to turn the warning on / off.
    Warns about multiple variables declared on the same line with at least one pointer type.
    For example ``cdef double* a, b`` - which, as in C, declares ``a`` as a pointer, ``b`` as
    a value type, but could be mininterpreted as declaring two pointers.
+   
+``show_performance_hints`` (default True)
+  Show performance hints during compilation pointing to places in the code which can yield performance degradation.
+  Note that performance hints are not warnings and hence the directives starting with ``warn.`` above do not affect them
+  and they will not trigger a failure when "error on warnings" is enabled.
 
 
 .. _how_to_set_directives:

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -200,19 +200,19 @@ def test_performance_hint_nogil():
 
 # Note that we're only able to check the first line of the performance hint
 _PERFORMANCE_HINTS = """
-20:9: Exception check will always require the GIL to be acquired. Possible solutions:
-24:5: Exception check on 'f' will always require the GIL to be acquired. Possible solutions:
-34:5: Exception check on 'release_gil_in_nogil' will always require the GIL to be acquired. Possible solutions:
-39:6: Exception check on 'release_gil_in_nogil2' will always require the GIL to be acquired. Possible solutions:
-49:28: Exception check will always require the GIL to be acquired. Possible solutions:
-51:29: Exception check will always require the GIL to be acquired. Possible solutions:
-55:5: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired. Possible solutions:
-59:6: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired. Possible solutions:
-68:24: Exception check will always require the GIL to be acquired. Possible solutions:
-70:25: Exception check will always require the GIL to be acquired. Possible solutions:
-133:5: Exception check on 'copy_array_exception' will always require the GIL to be acquired. Possible solutions:
-184:28: Exception check will always require the GIL to be acquired. Possible solutions:
-187:5: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired. Possible solutions:
-195:30: Exception check will always require the GIL to be acquired. Possible solutions:
-198:36: Exception check will always require the GIL to be acquired. Possible solutions:
+20:9: Exception check will always require the GIL to be acquired.
+24:5: Exception check on 'f' will always require the GIL to be acquired.
+34:5: Exception check on 'release_gil_in_nogil' will always require the GIL to be acquired.
+39:6: Exception check on 'release_gil_in_nogil2' will always require the GIL to be acquired.
+49:28: Exception check will always require the GIL to be acquired.
+51:29: Exception check will always require the GIL to be acquired.
+55:5: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired.
+59:6: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired.
+68:24: Exception check will always require the GIL to be acquired.
+70:25: Exception check will always require the GIL to be acquired.
+133:5: Exception check on 'copy_array_exception' will always require the GIL to be acquired.
+184:28: Exception check will always require the GIL to be acquired.
+187:5: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
+195:30: Exception check will always require the GIL to be acquired.
+198:36: Exception check will always require the GIL to be acquired.
 """


### PR DESCRIPTION
Note I've removed the former option because I doubt it's been around long enough for people to use it. However, I could do both if needed.

Fixes https://github.com/cython/cython/issues/5757 (Note I haven't skipped them on explicit `except *` as I suggested there, just because that's a harder change so I'll look at it separately when I have more time)

Supersedes https://github.com/cython/cython/pull/5759/