### PR TITLE
Add NPY_FR_GENERIC enumeration

### DIFF
--- a/Cython/Includes/numpy/__init__.pxd
+++ b/Cython/Includes/numpy/__init__.pxd
@@ -858,6 +858,7 @@ cdef extern from "numpy/arrayscalars.h":
         NPY_FR_ps
         NPY_FR_fs
         NPY_FR_as
+        NPY_FR_GENERIC
 
 
 #


### PR DESCRIPTION
This exists in numpy/ndarraytypes.h

https://github.com/numpy/numpy/blob/67539a40cb13bad56a650809bf10a49e905a250d/numpy/core/include/numpy/ndarraytypes.h#L258