### PR TITLE
Stop fallback indexing code using PySequence_*Item first

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -467,7 +467,7 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
 #else
     // PySequence_GetItem behaves differently to PyObject_GetItem for i<0
     // and possibly some other cases so can't generally be substituted
-    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o)) {
+    if (is_list || !PyMapping_Check(o)) {
         return PySequence_GetItem(o, i);
     }
 #endif
@@ -538,7 +538,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
 #else
     // PySequence_SetItem behaves differently that PyObject_SetItem for i<0
     // and possibly some other cases so can't generally be substituted
-    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o))
+    if (is_list || !PyMapping_Check(o))
     {
         return PySequence_SetItem(o, i, v);
     }
@@ -574,7 +574,7 @@ static CYTHON_INLINE int __Pyx_DelItemInt_Fast(PyObject *o, Py_ssize_t i,
 #if !CYTHON_USE_TYPE_SLOTS
     // PySequence_DelItem behaves differently than PyObject_DelItem for i<0
     // and possibly some other cases so can't generally be substituted
-    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o)) {
+    if (is_list || !PyMapping_Check(o)) {
         return PySequence_DelItem(o, i);
     }
 #else

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -536,7 +536,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
         }
     }
 #else
-    // PySequence_SetItem behaves differently that PyObject_SetItem for i<0
+    // PySequence_SetItem behaves differently to PyObject_SetItem for i<0
     // and possibly some other cases so can't generally be substituted
     if (is_list || !PyMapping_Check(o))
     {
@@ -572,7 +572,7 @@ static int __Pyx_DelItem_Generic(PyObject *o, PyObject *j) {
 static CYTHON_INLINE int __Pyx_DelItemInt_Fast(PyObject *o, Py_ssize_t i,
                                                int is_list, CYTHON_NCP_UNUSED int wraparound) {
 #if !CYTHON_USE_TYPE_SLOTS
-    // PySequence_DelItem behaves differently than PyObject_DelItem for i<0
+    // PySequence_DelItem behaves differently to PyObject_DelItem for i<0
     // and possibly some other cases so can't generally be substituted
     if (is_list || !PyMapping_Check(o)) {
         return PySequence_DelItem(o, i);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -465,7 +465,9 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
         }
     }
 #else
-    if (is_list || PySequence_Check(o)) {
+    // PySequence_GetItem behaves differently to PyObject_GetItem for i<0
+    // and possibly some other cases so can't generally be substituted
+    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o)) {
         return PySequence_GetItem(o, i);
     }
 #endif
@@ -534,11 +536,9 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
         }
     }
 #else
-#if CYTHON_COMPILING_IN_PYPY
-    if (is_list || (PySequence_Check(o) && !PyDict_Check(o)))
-#else
-    if (is_list || PySequence_Check(o))
-#endif
+    // PySequence_SetItem behaves differently that PyObject_SetItem for i<0
+    // and possibly some other cases so can't generally be substituted
+    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o))
     {
         return PySequence_SetItem(o, i, v);
     }
@@ -572,7 +572,9 @@ static int __Pyx_DelItem_Generic(PyObject *o, PyObject *j) {
 static CYTHON_INLINE int __Pyx_DelItemInt_Fast(PyObject *o, Py_ssize_t i,
                                                int is_list, CYTHON_NCP_UNUSED int wraparound) {
 #if !CYTHON_USE_TYPE_SLOTS
-    if (is_list || PySequence_Check(o)) {
+    // PySequence_DelItem behaves differently than PyObject_DelItem for i<0
+    // and possibly some other cases so can't generally be substituted
+    if (is_list || PyList_CheckExact(o) || PyTuple_CheckExact(o)) {
         return PySequence_DelItem(o, i);
     }
 #else

--- a/tests/pypy_bugs.txt
+++ b/tests/pypy_bugs.txt
@@ -30,7 +30,6 @@ run.cdef_multiple_inheritance_errors
 run.cdivision_CEP_516
 run.cyfunction
 run.final_cdef_class
-run.index
 run.pyclass_special_methods
 run.reimport_from_package
 run.reimport_from_subinterpreter

--- a/tests/run/index.pyx
+++ b/tests/run/index.pyx
@@ -20,18 +20,20 @@ import cython
 
 def index_tuple(tuple t, int i):
     """
+    (minor PyPy error formatting bug here, hence ELLIPSIS)
+
     >>> index_tuple((1,1,2,3,5), 0)
     1
     >>> index_tuple((1,1,2,3,5), 3)
     3
     >>> index_tuple((1,1,2,3,5), -1)
     5
-    >>> index_tuple((1,1,2,3,5), 100)
+    >>> index_tuple((1,1,2,3,5), 100)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    IndexError: tuple index out of range
-    >>> index_tuple((1,1,2,3,5), -7)
+    IndexError: ... index out of range
+    >>> index_tuple((1,1,2,3,5), -7)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    IndexError: tuple index out of range
+    IndexError: ... index out of range
     >>> index_tuple(None, 0)
     Traceback (most recent call last):
     TypeError: 'NoneType' object is not subscriptable
@@ -46,12 +48,12 @@ def index_list(list L, int i):
     13
     >>> index_list([2,3,5,7,11,13,17,19], -1)
     19
-    >>> index_list([2,3,5,7,11,13,17,19], 100)
+    >>> index_list([2,3,5,7,11,13,17,19], 100)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    IndexError: list index out of range
-    >>> index_list([2,3,5,7,11,13,17,19], -10)
+    IndexError: ... index out of range
+    >>> index_list([2,3,5,7,11,13,17,19], -10)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    IndexError: list index out of range
+    IndexError: ... index out of range
     >>> index_list(None, 0)
     Traceback (most recent call last):
     TypeError: 'NoneType' object is not subscriptable
@@ -60,6 +62,8 @@ def index_list(list L, int i):
 
 def index_object(object o, int i):
     """
+    (minor PyPy error formatting bug here, hence ELLIPSIS)
+
     >>> index_object([2,3,5,7,11,13,17,19], 1)
     3
     >>> index_object([2,3,5,7,11,13,17,19], -1)
@@ -335,3 +339,33 @@ def set_large_index(obj, Py_ssize_t index):
     obj.expected = index
     obj[index] = index
     assert obj.expected is None
+
+
+class DoesntLikePositiveIndices(object):
+    def __getitem__(self, idx):
+        if idx >= 0:
+            raise RuntimeError("Positive index")
+        return "Good"
+
+    def __setitem__(self, idx, value):
+        if idx >= 0:
+            raise RuntimeError("Positive index")
+
+    def __delitem__(self, idx):
+        if idx >= 0:
+            raise RuntimeError("Positive index")
+
+    def __len__(self):
+        return 500
+
+def test_call_with_negative_numbers():
+    """
+    The key point is that Cython shouldn't default to PySequence_*Item
+    since that invisibly adjusts negative numbers to be len(o)-idx.
+    >>>
+    """
+    cdef int idx = -5
+    indexme = DoesntLikePositiveIndices()
+    del indexme[idx]
+    indexme[idx] = "something"
+    return indexme[idx]

--- a/tests/run/index.pyx
+++ b/tests/run/index.pyx
@@ -362,7 +362,8 @@ def test_call_with_negative_numbers():
     """
     The key point is that Cython shouldn't default to PySequence_*Item
     since that invisibly adjusts negative numbers to be len(o)-idx.
-    >>>
+    >>> test_call_with_negative_numbers()
+    'Good'
     """
     cdef int idx = -5
     indexme = DoesntLikePositiveIndices()


### PR DESCRIPTION
since this behaves differently to the PyObject functions.

Fixes #5776 and some indexing bugs on PyPy and the Limited API