### PR TITLE
Make classmethod work in limited-api

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1753,7 +1753,9 @@ static int __pyx_FusedFunction_init(PyObject *module) {
 
 //////////////////// ClassMethod.proto ////////////////////
 
+#if !CYTHON_COMPILING_IN_LIMITED_API
 #include "descrobject.h"
+#endif
 CYTHON_UNUSED static PyObject* __Pyx_Method_ClassMethod(PyObject *method); /*proto*/
 
 //////////////////// ClassMethod ////////////////////
@@ -1784,6 +1786,7 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
     if (__Pyx_TypeCheck(method, methoddescr_type))
 #endif
     {
+#if !CYTHON_COMPILING_IN_LIMITED_API
         // cdef classes
         PyMethodDescrObject *descr = (PyMethodDescrObject *)method;
         #if PY_VERSION_HEX < 0x03020000
@@ -1792,8 +1795,17 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
         PyTypeObject *d_type = descr->d_common.d_type;
         #endif
         return PyDescr_NewClassMethod(d_type, descr->d_method);
+#else
+        return PyErr_Format(
+            PyExc_SystemError,
+            "Cython cannot yet handle classmethod on a MethodDescriptorType (%S) in limited API mode. "
+            "This is most likely a classmethod in a cdef class method with binding=False. "
+            "Try setting 'binding' to True.",
+            method);
+#endif
     }
 #endif
+#if !CYTHON_COMPILING_IN_LIMITED_API
     else if (PyMethod_Check(method)) {
         // python classes
         return PyClassMethod_New(PyMethod_GET_FUNCTION(method));
@@ -1801,4 +1813,36 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
     else {
         return PyClassMethod_New(method);
     }
+#else
+    {
+        PyObject *types_module, *method_type=NULL, *func=NULL;
+        PyObject *builtins, *classmethod, *result=NULL;
+        types_module = PyImport_ImportModule("types");
+        if (!types_module) {
+            return NULL;
+        }
+        method_type = PyObject_GetAttrString(types_module, "MethodType");
+        if (!method_type) goto bad;
+        if (__Pyx_TypeCheck(method, method_type)) {
+            func = PyObject_GetAttrString(method, "__func__");
+            if (!func) goto bad;
+        } else {
+            func = method;
+            Py_INCREF(func);
+        }
+        builtins = PyEval_GetBuiltins(); // borrowed
+        if (!builtins) goto bad;
+        classmethod = PyDict_GetItemString(builtins, "classmethod");
+        // classmethod is borrowed
+        if (!classmethod) goto bad;
+        result = PyObject_CallFunctionObjArgs(classmethod, func, NULL);
+
+        bad:
+        Py_XDECREF(func);
+        Py_XDECREF(method_type);
+        Py_DECREF(types_module);
+        return result;
+    }
+#endif
+
 }

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -38,6 +38,9 @@ limited.C()
 limited.D()
 limited.E()
 
+assert limited.C.cm() == limited.C().cm() == limited.C
+assert limited.D.cm() == limited.D().cm() == limited.D
+
 assert limited.decode(b'a', bytearray(b'b')) == "ab"
 
 assert limited.cast_float(1) == 1.0
@@ -82,10 +85,14 @@ def cast_float(object o):
     return float(o)
 
 class C:
-    pass
+    @classmethod
+    def cm(cls):
+        return cls
 
 cdef class D:
-    pass
+    @classmethod
+    def cm(cls):
+        return cls
 
 cdef class E(D):
     pass


### PR DESCRIPTION
Except for the case where binding=False, which I don't think we can easily do. I don't care that much given that binding=True works correctly.

Fixes #5797