### PR TITLE
Fix indexing of self.args when passing Python object as varargs parameter

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6275,7 +6275,7 @@ class SimpleCallNode(CallNode):
                 else:
                     arg_ctype = arg.type.default_coerced_ctype()
                 if arg_ctype is None:
-                    error(self.args[i].pos,
+                    error(self.args[i-1].pos,
                           "Python object cannot be passed as a varargs parameter")
                 else:
                     args[i] = arg = arg.coerce_to(arg_ctype, env)


### PR DESCRIPTION
This avoids a "Compiler crash in AnalyseExpressionsTransform", although still produces a compile error as intended.

The reason for the issue is that `i` comes from the length of `args`, where there is an additional object first in the list. The `self.args` is therefore offset by 1.

Bonus question: Why is this error here? I found this, as I was monkeypatching this error out. Seemingly, there's no issue passing `PyObject*` as a vararg parameter.