### PR TITLE
Remove allowed_failure from Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,6 @@ jobs:
         env: [{}]
 
         include:
-          # Temporary - Allow failure on Python 3.12+ jobs (https://github.com/cython/cython/issues/5470)
-          - python-version: "3.12"
-            allowed_failure: true
           - python-version: "3.13-dev"
             allowed_failure: true
 

--- a/runtests.py
+++ b/runtests.py
@@ -458,7 +458,6 @@ EXT_EXTRAS = {
     'tag:cppexecpolicies': require_gcc("9.1"),
 }
 
-
 # TODO: use tags
 VER_DEP_MODULES = {
     # tests are excluded if 'CurrentPythonVersion OP VersionTuple', i.e.
@@ -477,6 +476,8 @@ VER_DEP_MODULES = {
     ]),
     # See https://github.com/python/cpython/issues/104614 - fixed in Py3.12.0b2, remove eventually.
     (3,12,0,'beta',1): (operator.eq, lambda x: 'cdef_multiple_inheritance' in x or 'pep442' in x),
+    # Profiling is broken on Python 3.12
+    (3,12): ((lambda actual, v3_12: actual[:2]==v3_12), (lambda x: x.find("pstats") != -1)),
 
 }
 


### PR DESCRIPTION
and disable profiling tests there, since it doesn't look like we'll be able to fix them.

Knowing about other regressions is probably more important than testing profiling...