### PR TITLE
update no-compile install from source (closes #5694)

### DIFF
--- a/docs/src/quickstart/install.rst
+++ b/docs/src/quickstart/install.rst
@@ -67,10 +67,6 @@ of Cython with something like
 
 ::
 
-    pip install .  --install-option="--no-cython-compile"
-
-    or
-
     NO_CYTHON_COMPILE=true  pip install .
 
 

--- a/setup.py
+++ b/setup.py
@@ -263,13 +263,18 @@ def run_build():
         This makes Cython the ideal language for writing glue code for external
         C/C++ libraries, and for fast C modules that speed up the execution of
         Python code.
-
+        
+        The newest Cython release can always be downloaded from https://cython.org/. 
+        Unpack the tarball or zip file, enter the directory, and then run::
+        
+            pip install .
+            
         Note that for one-time builds, e.g. for CI/testing, on platforms that are not
         covered by one of the wheel packages provided on PyPI *and* the pure Python wheel
         that we provide is not used, it is substantially faster than a full source build
         to install an uncompiled (slower) version of Cython with::
 
-            pip install Cython --install-option="--no-cython-compile"
+            NO_CYTHON_COMPILE=true pip install .
 
         .. _Pyrex: https://www.cosc.canterbury.ac.nz/greg.ewing/python/Pyrex/
         """),


### PR DESCRIPTION
Removed line using deprecated ``pip --install-options`` (https://github.com/pypa/pip/pull/11858). The second option (setting NO_CYTHON_COMPILE=true) still works. 

closes #5694