### PR TITLE
Partially disable trashcan test in PyPy

### DIFF
--- a/tests/run/trashcan.pyx
+++ b/tests/run/trashcan.pyx
@@ -2,10 +2,18 @@
 
 cimport cython
 
+import sys
+
+# The tests here are to do with a deterministic order of destructors which
+# isn't reliable for PyPy. Therefore, on PyPy we treat the test as
+# "compiles and doesn't crash"
+IS_PYPY = hasattr(sys, 'pypy_version_info')
 
 # Count number of times an object was deallocated twice. This should remain 0.
 cdef int double_deallocations = 0
 def assert_no_double_deallocations():
+    if IS_PYPY:
+        return
     global double_deallocations
     err = double_deallocations
     double_deallocations = 0
@@ -98,6 +106,8 @@ cdef class RecurseList(list):
 cdef int base_deallocated = 0
 cdef int trashcan_used = 0
 def assert_no_trashcan_used():
+    if IS_PYPY:
+        return
     global base_deallocated, trashcan_used
     err = trashcan_used
     trashcan_used = base_deallocated = 0


### PR DESCRIPTION
The test is requiring a derministic order of destruction which PyPy doesn't give reliably and thus we're getting occasional CI failures. Therefore just treat is as compile and don't crash test.