### PR TITLE
Add missing unicode C API functions and Py_UNICODE warning

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14144,6 +14144,14 @@ class CoerceFromPyTypeNode(CoercionNode):
                 warning(arg.pos,
                         "Obtaining '%s' from externally modifiable global Python value" % result_type,
                         level=1)
+            if self.type.is_pyunicode_ptr:
+                warning(arg.pos,
+                        "Py_UNICODE* has been removed in Python 3.12. This conversion to a "
+                        "Py_UNICODE* will no longer compile in those Python versions. "
+                        "Use Python C API functions like PyUnicode_AsWideCharString if you "
+                        "need to obtain a wchar_t* on Windows - "
+                        "you will need to free this string manually after use.",
+                        level=1)
 
     def analyse_types(self, env):
         # The arg is always already analysed

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14147,10 +14147,9 @@ class CoerceFromPyTypeNode(CoercionNode):
             if self.type.is_pyunicode_ptr:
                 warning(arg.pos,
                         "Py_UNICODE* has been removed in Python 3.12. This conversion to a "
-                        "Py_UNICODE* will no longer compile in those Python versions. "
+                        "Py_UNICODE* will no longer compile in the latest Python versions. "
                         "Use Python C API functions like PyUnicode_AsWideCharString if you "
-                        "need to obtain a wchar_t* on Windows - "
-                        "you will need to free this string manually after use.",
+                        "need to obtain a wchar_t* on Windows (and free the string manually after use).",
                         level=1)
 
     def analyse_types(self, env):

--- a/Cython/Includes/cpython/unicode.pxd
+++ b/Cython/Includes/cpython/unicode.pxd
@@ -1,3 +1,4 @@
+from libc.stddef cimport wchar_t
 
 cdef extern from *:
     ctypedef unsigned char Py_UCS1  # uint8_t
@@ -180,14 +181,33 @@ cdef extern from *:
     # following functions. Support is optimized if Python's own
     # Py_UNICODE type is identical to the system's wchar_t.
 
-    #ctypedef int wchar_t
-
     # Create a Unicode object from the wchar_t buffer w of the given
     # size. Return NULL on failure.
-    #PyObject* PyUnicode_FromWideChar(wchar_t *w, Py_ssize_t size)
+    object PyUnicode_FromWideChar(wchar_t *w, Py_ssize_t size)
 
-    #Py_ssize_t PyUnicode_AsWideChar(object o, wchar_t *w, Py_ssize_t size)
+    # Copy the Unicode object contents into the wchar_t buffer w.
+    # At most size wchar_t characters are copied (excluding a possibly
+    # trailing null termination character). Return the number of wchar_t
+    # characters copied or -1 in case of an error. Note that the
+    # esulting wchar_t* string may or may not be null-terminated.
+    # It is the responsibility of the caller to make sure that the wchar_t*
+    # string is null-terminated in case this is required by the application.
+    # Also, note that the wchar_t* string might contain null characters,
+    # which would cause the string to be truncated when used with most C functions.
+    Py_ssize_t PyUnicode_AsWideChar(object o, wchar_t *w, Py_ssize_t size)
 
+    # Convert the Unicode object to a wide character string. The output
+    # string always ends with a null character. If size is not NULL,
+    # write the number of wide characters (excluding the trailing null
+    # termination character) into *size. Note that the resulting wchar_t
+    # string might contain null characters, which would cause the string
+    # to be truncated when used with most C functions. If size is NULL and
+    # the wchar_t* string contains null characters a ValueError is raised.
+
+    # Returns a buffer allocated by PyMem_New (use PyMem_Free() to free it)
+    # on success. On error, returns NULL and *size is undefined. Raises a
+    # MemoryError if memory allocation is failed.
+    wchar_t *PyUnicode_AsWideCharString(object o, Py_ssize_t *size)
 
 # Unicode Methods
 

--- a/tests/errors/charptr_from_temp.pyx
+++ b/tests/errors/charptr_from_temp.pyx
@@ -59,8 +59,11 @@ _ERRORS = """
 #23:5: Storing unsafe C derivative of temporary Python reference
 #23:15: Casting temporary Python object to non-numeric non-Python type
 26:8: Storing unsafe C derivative of temporary Python reference
+38:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
 41:8: Obtaining 'Py_UNICODE *' from externally modifiable global Python value
+41:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
 44:10: Storing unsafe C derivative of temporary Python reference
+44:10: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
 52:7: Storing unsafe C derivative of temporary Python reference
 52:7: Unsafe C derivative of temporary Python reference used in conditional expression
 """

--- a/tests/errors/charptr_from_temp.pyx
+++ b/tests/errors/charptr_from_temp.pyx
@@ -59,11 +59,11 @@ _ERRORS = """
 #23:5: Storing unsafe C derivative of temporary Python reference
 #23:15: Casting temporary Python object to non-numeric non-Python type
 26:8: Storing unsafe C derivative of temporary Python reference
-38:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
+38:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in the latest Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows (and free the string manually after use).
 41:8: Obtaining 'Py_UNICODE *' from externally modifiable global Python value
-41:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
+41:8: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in the latest Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows (and free the string manually after use).
 44:10: Storing unsafe C derivative of temporary Python reference
-44:10: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in those Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows - you will need to free this string manually after use.
+44:10: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in the latest Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows (and free the string manually after use).
 52:7: Storing unsafe C derivative of temporary Python reference
 52:7: Unsafe C derivative of temporary Python reference used in conditional expression
 """


### PR DESCRIPTION
1. Add missing C API functions for unicode to wchar_t (since these are what should be used to replace Py_UNICODE*).
2. Add an explicit warning for users converting to Py_UNICODE*.