### PR TITLE
Limited api generators

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -29,7 +29,7 @@ from .Code import UtilityCode, TempitaUtilityCode
 from . import StringEncoding
 from . import Naming
 from . import Nodes
-from .Nodes import Node, utility_code_for_imports, SingleAssignmentNode
+from .Nodes import Node, SingleAssignmentNode
 from . import PyrexTypes
 from .PyrexTypes import py_object_type, typecast, error_type, \
     unspecified_type
@@ -2819,11 +2819,6 @@ class ImportNode(ExprNode):
                 self.module_name.py_result(),
                 self.name_list.py_result() if self.name_list else '0',
                 self.level)
-
-        if self.level <= 0 and module_name in utility_code_for_imports:
-            helper_func, code_name, code_file = utility_code_for_imports[module_name]
-            code.globalstate.use_utility_code(UtilityCode.load_cached(code_name, code_file))
-            import_code = '%s(%s)' % (helper_func, import_code)
 
         code.putln("%s = %s; %s" % (
             self.result(),

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3088,7 +3088,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("%s = PyUnicode_FromStringAndSize(\"\", 0); %s" % (
             Naming.empty_unicode, code.error_goto_if_null(Naming.empty_unicode, self.pos)))
 
-        for ext_type in ('CyFunction', 'FusedFunction', 'Coroutine', 'Generator', 'AsyncGen', 'StopAsyncIteration'):
+        for ext_type in ('CyFunction', 'FusedFunction',
+                         'Coroutine', 'Generator', 'AsyncGen', 'StopAsyncIteration', 'CoroutineInternalCallable'):
             code.putln("#ifdef __Pyx_%s_USED" % ext_type)
             code.put_error_if_neg(self.pos, "__pyx_%s_init(%s)" % (ext_type, env.module_cname))
             code.putln("#endif")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3155,10 +3155,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("/*--- Execution code ---*/")
         code.mark_pos(None)
 
-        code.putln("#if defined(__Pyx_Generator_USED) || defined(__Pyx_Coroutine_USED)")
-        code.put_error_if_neg(self.pos, "__Pyx_patch_abc()")
-        code.putln("#endif")
-
         if profile or linetrace:
             code.put_trace_call(header3, self.pos, nogil=not code.funcstate.gil_owned)
             code.funcstate.can_trace = True

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -194,4 +194,5 @@ used_types_and_macros = [
     ('__pyx_IterableCoroutineType', '__Pyx_IterableCoroutine_USED'),
     ('__pyx_CoroutineAwaitType', '__Pyx_Coroutine_USED'),
     ('__pyx_CoroutineType', '__Pyx_Coroutine_USED'),
+    ('__pyx_CoroutineInternalCallableType', '__Pyx_CoroutineInternalCallable_USED'),
 ]

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8787,9 +8787,6 @@ utility_code_for_cimports = {
     'cython.view'           : cython_view_utility_code,
 }
 
-utility_code_for_imports = {
-}
-
 def cimport_numpy_check(node, code):
     # shared code between CImportStatNode and FromCImportStatNode
     # check to ensure that import_array is called

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8788,10 +8788,6 @@ utility_code_for_cimports = {
 }
 
 utility_code_for_imports = {
-    # utility code used when special modules are imported.
-    # TODO: Consider a generic user-level mechanism for importing
-    'asyncio': ("__Pyx_patch_asyncio", "PatchAsyncIO", "Coroutine.c"),
-    'inspect': ("__Pyx_patch_inspect", "PatchInspect", "Coroutine.c"),
 }
 
 def cimport_numpy_check(node, code):

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -683,7 +683,7 @@ static int __Pyx_PyGen__FetchStopIterationValue(PyThreadState *$local_tstate_cna
     *pvalue = value;
     return 0;
 
-#if CYTHON_COMPILING_IN_LIMITED_API
+#if !CYTHON_ASSUME_SAFE_MACROS
   limited_api_failure:
     Py_XDECREF(et);
     Py_XDECREF(tb);

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -529,7 +529,7 @@ static PyObject *__Pyx_CoroutineInternalCallable_call(
     // It should be called with 0 args.
     // We just assert this because it shouldn't be possible for a user to get here
     assert(!kwargs);
-    assert(!PyTuple_GetSize(args) == 0);
+    assert(!PyTuple_Size(args) == 0);
     gen->is_running = 1;
     result = gen->body(gen, self_->tstate, self_->value);
     gen->is_running = 0;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1597,16 +1597,17 @@ static PyObject *__pyx_Fetch_GeneratorWrapper(void) {
         PyObject *globals=NULL;
         PyObject *compiled, *eval_result, *builtins;
 
-#if __PYX_LIMITED_VERSION_HEX >= 0x030A0000
+        globals = PyDict_New();
+        if (unlikely(!globals)) return NULL;
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
         // On Python >= 3.10 the builtins are always available
-        // when evaluating, so we can save the effort of copying them.
-        builtins = PyDict_New();
-#else
+        // when evaluating, so we can save a bit of effort setting them up.
         builtins = PyEval_GetBuiltins(); // borrowed
         if (unlikely(!builtins)) return NULL;
-        globals = PyDict_Copy(builtins);
+        if (unlikely(PyDict_SetItemString(globals, "__builtins__", builtins)<0))
+            goto bad;
 #endif
-        if (unlikely(!globals)) return NULL;
+        
 
         compiled = Py_CompileString(
             CSTRING("""\

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1421,7 +1421,6 @@ static __pyx_CoroutineObject *__Pyx__Coroutine_NewInit(
 
 //////////////////// Coroutine ////////////////////
 //@requires: CoroutineBase
-//@requires: PatchGeneratorABC
 //@requires: ObjectHandling.c::PyObject_GenericGetAttrNoDict
 
 static void __Pyx_CoroutineAwait_dealloc(PyObject *self) {
@@ -1916,7 +1915,6 @@ static int __pyx_IterableCoroutine_init(PyObject *module) {
 
 //////////////////// Generator ////////////////////
 //@requires: CoroutineBase
-//@requires: PatchGeneratorABC
 //@requires: ObjectHandling.c::PyObject_GenericGetAttrNoDict
 
 static PyMethodDef __pyx_Generator_methods[] = {
@@ -2123,172 +2121,6 @@ static void __Pyx__ReturnWithStopIteration(PyObject* value) {
 #endif
     PyErr_SetObject(PyExc_StopIteration, exc);
     Py_DECREF(exc);
-}
-
-
-//////////////////// PatchModuleWithCoroutine.proto ////////////////////
-
-static PyObject* __Pyx_Coroutine_patch_module(PyObject* module, const char* py_code); /*proto*/
-
-//////////////////// PatchModuleWithCoroutine ////////////////////
-//@substitute: naming
-
-static PyObject* __Pyx_Coroutine_patch_module(PyObject* module, const char* py_code) {
-#if defined(__Pyx_Generator_USED) || defined(__Pyx_Coroutine_USED)
-    int result;
-    PyObject *globals, *result_obj;
-    globals = PyDict_New();  if (unlikely(!globals)) goto ignore;
-    result = PyDict_SetItemString(globals, "_cython_coroutine_type",
-    #ifdef __Pyx_Coroutine_USED
-        (PyObject*)__pyx_CoroutineType);
-    #else
-        Py_None);
-    #endif
-    if (unlikely(result < 0)) goto ignore;
-    result = PyDict_SetItemString(globals, "_cython_generator_type",
-    #ifdef __Pyx_Generator_USED
-        (PyObject*)__pyx_GeneratorType);
-    #else
-        Py_None);
-    #endif
-    if (unlikely(result < 0)) goto ignore;
-    if (unlikely(PyDict_SetItemString(globals, "_module", module) < 0)) goto ignore;
-    if (unlikely(PyDict_SetItemString(globals, "__builtins__", $builtins_cname) < 0)) goto ignore;
-    result_obj = PyRun_String(py_code, Py_file_input, globals, globals);
-    if (unlikely(!result_obj)) goto ignore;
-    Py_DECREF(result_obj);
-    Py_DECREF(globals);
-    return module;
-
-ignore:
-    Py_XDECREF(globals);
-    PyErr_WriteUnraisable(module);
-    if (unlikely(PyErr_WarnEx(PyExc_RuntimeWarning, "Cython module failed to patch module with custom type", 1) < 0)) {
-        Py_DECREF(module);
-        module = NULL;
-    }
-#else
-    // avoid "unused" warning
-    py_code++;
-#endif
-    return module;
-}
-
-
-//////////////////// PatchGeneratorABC.proto ////////////////////
-
-// register with Generator/Coroutine ABCs in 'collections.abc'
-// see https://bugs.python.org/issue24018
-static int __Pyx_patch_abc(void); /*proto*/
-
-//////////////////// PatchGeneratorABC ////////////////////
-//@requires: PatchModuleWithCoroutine
-
-#ifndef CYTHON_REGISTER_ABCS
-#define CYTHON_REGISTER_ABCS 1
-#endif
-
-#if defined(__Pyx_Generator_USED) || defined(__Pyx_Coroutine_USED)
-static PyObject* __Pyx_patch_abc_module(PyObject *module); /*proto*/
-static PyObject* __Pyx_patch_abc_module(PyObject *module) {
-    module = __Pyx_Coroutine_patch_module(
-        module, CSTRING("""\
-if _cython_generator_type is not None:
-    try: Generator = _module.Generator
-    except AttributeError: pass
-    else: Generator.register(_cython_generator_type)
-if _cython_coroutine_type is not None:
-    try: Coroutine = _module.Coroutine
-    except AttributeError: pass
-    else: Coroutine.register(_cython_coroutine_type)
-""")
-    );
-    return module;
-}
-#endif
-
-static int __Pyx_patch_abc(void) {
-#if defined(__Pyx_Generator_USED) || defined(__Pyx_Coroutine_USED)
-    static int abc_patched = 0;
-    if (CYTHON_REGISTER_ABCS && !abc_patched) {
-        PyObject *module;
-        module = PyImport_ImportModule("collections.abc");
-        if (unlikely(!module)) {
-            PyErr_WriteUnraisable(NULL);
-            if (unlikely(PyErr_WarnEx(PyExc_RuntimeWarning,
-                        "Cython module failed to register with collections.abc module", 1) < 0)) {
-                return -1;
-            }
-        } else {
-            module = __Pyx_patch_abc_module(module);
-            abc_patched = 1;
-            if (unlikely(!module))
-                return -1;
-            Py_DECREF(module);
-        }
-        // also register with "backports_abc" module if available, just in case
-        module = PyImport_ImportModule("backports_abc");
-        if (module) {
-            module = __Pyx_patch_abc_module(module);
-            Py_XDECREF(module);
-        }
-        if (!module) {
-            PyErr_Clear();
-        }
-    }
-#else
-    // avoid "unused" warning for __Pyx_Coroutine_patch_module()
-    if ((0)) __Pyx_Coroutine_patch_module(NULL, NULL);
-#endif
-    return 0;
-}
-
-
-//////////////////// PatchAsyncIO.proto ////////////////////
-
-// run after importing "asyncio" to patch Cython generator support into it
-static PyObject* __Pyx_patch_asyncio(PyObject* module); /*proto*/
-
-//////////////////// PatchAsyncIO ////////////////////
-
-// TODO: remove
-static PyObject* __Pyx_patch_asyncio(PyObject* module) {
-    return module;
-}
-
-
-//////////////////// PatchInspect.proto ////////////////////
-
-// run after importing "inspect" to patch Cython generator support into it
-static PyObject* __Pyx_patch_inspect(PyObject* module); /*proto*/
-
-//////////////////// PatchInspect ////////////////////
-//@requires: PatchModuleWithCoroutine
-
-static PyObject* __Pyx_patch_inspect(PyObject* module) {
-#if defined(__Pyx_Generator_USED) && (!defined(CYTHON_PATCH_INSPECT) || CYTHON_PATCH_INSPECT)
-    static int inspect_patched = 0;
-    if (unlikely((!inspect_patched) && module)) {
-        module = __Pyx_Coroutine_patch_module(
-            module, CSTRING("""\
-old_types = getattr(_module.isgenerator, '_cython_generator_types', None)
-if old_types is None or not isinstance(old_types, set):
-    old_types = set()
-    def cy_wrap(orig_func, type=type, cython_generator_types=old_types):
-        def cy_isgenerator(obj): return type(obj) in cython_generator_types or orig_func(obj)
-        cy_isgenerator._cython_generator_types = cython_generator_types
-        return cy_isgenerator
-    _module.isgenerator = cy_wrap(_module.isgenerator)
-old_types.add(_cython_generator_type)
-""")
-        );
-        inspect_patched = 1;
-    }
-#else
-    // avoid "unused" warning for __Pyx_Coroutine_patch_module()
-    if ((0)) return __Pyx_Coroutine_patch_module(module, NULL);
-#endif
-    return module;
 }
 
 

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -529,7 +529,7 @@ static PyObject *__Pyx_CoroutineInternalCallable_call(
     // It should be called with 0 args.
     // We just assert this because it shouldn't be possible for a user to get here
     assert(!kwargs);
-    assert(!PyTuple_Size(args) == 0);
+    assert(PyTuple_Size(args) == 0);
     gen->is_running = 1;
     result = gen->body(gen, self_->tstate, self_->value);
     gen->is_running = 0;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -554,7 +554,7 @@ static PyType_Spec __pyx_CoroutineInternalCallableType_spec = {
     sizeof(__pyx_CoroutineInternalCallable),
     0,
     Py_TPFLAGS_DEFAULT
-    #if __Pyx_LIMITED_API_VERSION_HEX >= 0x030A0000
+    #if __PYX_LIMITED_VERSION_HEX >= 0x030A0000
         // We make it uncreatable where convenient. It doesn't really matter though
         // because there isn't much a user can do with it.
         | Py_TPFLAGS_DISALLOW_INSTANTIATION
@@ -1595,8 +1595,17 @@ static PyObject *__pyx_Cached_GeneratorWrapper = NULL;
 static PyObject *__pyx_Fetch_GeneratorWrapper(void) {
     if (!__pyx_Cached_GeneratorWrapper) {
         PyObject *globals=NULL;
-        PyObject *compiled, *eval_result;
-        globals = PyDict_New();
+        PyObject *compiled, *eval_result, *builtins;
+
+#if __PYX_LIMITED_VERSION_HEX >= 0x030A0000
+        // On Python >= 3.10 the builtins are always available
+        // when evaluating, so we can save the effort of copying them.
+        builtins = PyDict_New();
+#else
+        builtins = PyEval_GetBuiltins(); // borrowed
+        if (unlikely(!builtins)) return NULL;
+        globals = PyDict_Copy(builtins);
+#endif
         if (unlikely(!globals)) return NULL;
 
         compiled = Py_CompileString(

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -46,6 +46,24 @@ assert limited.cast_float(1) == 1.0
 assert limited.cast_float("2.0") == 2.0
 assert limited.cast_float(bytearray(b"3")) == 3.0
 
+gen = limited.my_generator(1)
+assert next(gen) == 1
+assert next(gen) == 1
+try:
+    next(gen)
+except StopIteration:
+    pass
+else:
+    assert False  # should have finished
+
+gen = limited.my_generator("raise")
+try:
+    next(gen)
+except RuntimeError:
+    pass
+else:
+    assert False  # should have raised
+
 
 ##################### limited.pyx #############################
 
@@ -97,3 +115,9 @@ cdef class D:
 
 cdef class E(D):
     pass
+
+def my_generator(x):
+    if x == "raise":
+        raise RuntimeError
+    yield x
+    yield x


### PR DESCRIPTION
Like most limited API stuff, this isn't pretty. I couldn't
work out a way of doing the necessary work on frame objects in
__pyx_Coroutine_SendEx so instead I deferred that to a
hidden Python generator object. This generator object just
yields the result of a callable that calls our generator body.
    
This hopefully ends up with everything set as Python expects
(since it did the work itself), and not too much overhead.

Draft for now because it depends on https://github.com/cython/cython/pull/5835
(I didn't want to rewrite a bunch of code that was going to immediately be removed)