### PR TITLE
Drop PyFPE macros

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1458,8 +1458,6 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, double floatv
             {{return_false}};
         }
     {{else}}
-        // copied from floatobject.c in Py3.5:
-        PyFPE_START_PROTECT("{{op.lower() if not op.endswith('Divide') else 'divide'}}", return NULL)
         {{if c_op == '%'}}
         result = fmod(a, b);
         if (result)
@@ -1469,7 +1467,6 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, double floatv
         {{else}}
         result = a {{c_op}} b;
         {{endif}}
-        PyFPE_END_PROTECT(result)
         return PyFloat_FromDouble(result);
     {{endif}}
 }

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1318,10 +1318,7 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, long intval, 
         {{else}}
             double result;
             {{zerodiv_check('b', 'float')}}
-            // copied from floatobject.c in Py3.5:
-            PyFPE_START_PROTECT("{{op.lower() if not op.endswith('Divide') else 'divide'}}", return NULL)
             result = ((double)a) {{c_op}} (double)b;
-            PyFPE_END_PROTECT(result)
             return PyFloat_FromDouble(result);
         {{endif}}
     }

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -46,6 +46,8 @@ assert limited.cast_float(1) == 1.0
 assert limited.cast_float("2.0") == 2.0
 assert limited.cast_float(bytearray(b"3")) == 3.0
 
+assert limited.add_one(2) == 3
+
 
 ##################### limited.pyx #############################
 
@@ -72,6 +74,9 @@ def lsum(values):
         for value in reversed(<tuple>values):
             result += value
     return result
+    
+def add_one(value):
+    return value + 1
 
 @cython.binding(False)
 def raises():


### PR DESCRIPTION
These macros stopped doing anything in Python 3.7 (and may have been broken before): https://github.com/python/cpython/issues/73323.

This has the side-effect of fixing basic arthmetic in the limited API.