### PR TITLE
PEP 703: Rename `PY_NOGIL` to `Py_GIL_DISABLED`

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -243,7 +243,7 @@
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 0
   #endif
 
-#elif defined(Py_GIL_DISABLED)
+#elif defined(Py_GIL_DISABLED) || defined(Py_NOGIL)
   #define CYTHON_COMPILING_IN_PYPY 0
   #define CYTHON_COMPILING_IN_CPYTHON 0
   #define CYTHON_COMPILING_IN_LIMITED_API 0


### PR DESCRIPTION
Follow on from https://github.com/cython/cython/pull/4914.

The Python Steering Council has chosen `Py_GIL_DISABLED` instead of `Py_NOGIL`:

* https://github.com/python/steering-council/issues/214#issuecomment-1817942256

Updated in CPython:

* https://github.com/python/cpython/pull/111864
* https://github.com/python/cpython/issues/111863

Let's update to match.

cc @colesbury 
