### PR TITLE
Fix dataclasses default field and with no-init

### DIFF
--- a/Cython/Compiler/Dataclass.py
+++ b/Cython/Compiler/Dataclass.py
@@ -419,7 +419,8 @@ def generate_init_code(code, init, node, fields, kw_only):
             annotation = ""
         assignment = ''
         if field.default is not MISSING or field.default_factory is not MISSING:
-            seen_default = True
+            if field.init.value:
+                seen_default = True
             if field.default_factory is not MISSING:
                 ph_name = default_factory_placeholder
             else:

--- a/Tools/make_dataclass_tests.py
+++ b/Tools/make_dataclass_tests.py
@@ -49,12 +49,17 @@ skip_tests = frozenset(
         ("TestKeywordArgs", "test_KW_ONLY_twice"),
         ("TestKeywordArgs", "test_defaults"),
         # uses local variable in class definition
+            # Also: difficulty lining up correct repr string when converting tests
         ("TestCase", "test_default_factory"),
+            # Also: Mock unassignable to list - legitimate for Cython to raise an error
         ("TestCase", "test_default_factory_with_no_init"),
+            # Also: attributes not available on class itself, only instances
         ("TestCase", "test_field_default"),
         ("TestCase", "test_function_annotations"),
         ("TestDescriptors", "test_lookup_on_instance"),
+            # Also: Mock unassignable to int - legitimate for Cython to raise an error
         ("TestCase", "test_default_factory_not_called_if_value_given"),
+            # Also: cdef classes never don't have the attribute
         ("TestCase", "test_class_attrs"),
         ("TestCase", "test_hash_field_rules"),
         ("TestStringAnnotations",),  # almost all the texts here use local variables
@@ -79,6 +84,7 @@ skip_tests = frozenset(
             "test_class_var_frozen",
         ),  # __annotations__ not present on cdef classes https://github.com/cython/cython/issues/4519
         ("TestCase", "test_dont_include_other_annotations"),  # __annotations__
+        ("TestCase", "test_class_marker"),  # __annotations__
         ("TestDocString",),  # don't think cython dataclasses currently set __doc__
         # either cython.dataclasses.field or cython.dataclasses.dataclass called directly as functions
         # (will probably never be supported)
@@ -162,8 +168,6 @@ skip_tests = frozenset(
         ("TestReplace", "test_initvar_with_default_value"),  # needs investigating
         # Maybe bugs?
         # ==========
-        # non-default argument 'z' follows default argument in dataclass __init__ - this message looks right to me!
-        ("TestCase", "test_class_marker"),
         # cython.dataclasses.field parameter 'metadata' must be a literal value - possibly not something we can support?
         ("TestCase", "test_field_metadata_custom_mapping"),
         (

--- a/tests/run/pure_cdef_class_dataclass.py
+++ b/tests/run/pure_cdef_class_dataclass.py
@@ -76,3 +76,14 @@ class NoInitFields:
             # and not initializing it will mess up repr
             assert not hasattr(self, "neither")
             self.neither = None
+
+
+@cython.dataclasses.dataclass
+class NonInitDefaultArgument:
+    """
+    >>> NonInitDefaultArgument(1.0, "hello")
+    NonInitDefaultArgument(x=1.0, y=10, z='hello')
+    """
+    x: float
+    y: int = cython.dataclasses.field(default=10, init=False)
+    z: str  # This is allowed despite following a default argument, because the default argument isn't in init


### PR DESCRIPTION
This should allow a field without a default argument a non-init argument with a default value (because the no-init doesn't appear as an argument in `__init__`).

Also add a few notes on non-working tests from CPython.