### PR TITLE
Fix cython build rules not accounting for cython-version-platform modifier

### DIFF
--- a/Tools/rules.bzl
+++ b/Tools/rules.bzl
@@ -49,6 +49,38 @@ def pyx_library(
     # TODO(robertwb): It might be better to only generate the C files,
     # letting cc_library (or similar) handle the rest, but there isn't yet
     # support compiling Python C extensions from bazel.
+    python_cmd = """
+import os
+import sys
+
+n = len(sys.argv)
+for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:]):
+    src_file_name = src.split(".")[0]
+    src = src_file_name + ".so"
+    try:
+        os.rename(src, dst)
+    except Exception as e:
+        print("Failed to rename: " + src + " to " + dst)
+        dir = os.path.dirname(src_file_name)
+        renamed_candidate = False
+        for file_name in os.listdir(dir):
+            file, ext = os.path.splitext(file_name)
+            if ext != ".so":
+                continue
+            if not file.startswith(os.path.basename(src_file_name)):
+                continue
+            file_dot_split = file.split(".")
+            if len(file_dot_split) >= 2 and file_dot_split[-1].startswith("cpython-"):
+                potential_src_file_name = os.path.join(dir, file_name)
+                try:
+                    os.rename(potential_src_file_name, dst)
+                    renamed_candidate = True
+                except Exception as e2:
+                    print("Failed to rename: " + potential_src_file_name + " to " + dst)
+                    raise e2
+        if not renamed_candidate:
+            raise e
+"""
     native.genrule(
         name = name + "_cythonize",
         srcs = pyx_srcs,
@@ -56,7 +88,7 @@ def pyx_library(
         cmd = "PYTHONHASHSEED=0 $(location @cython//:cythonize) -k -i %s $(SRCS)" % extra_flags
               # Rename outputs to expected location.
               # TODO(robertwb): Add an option to cythonize itself to do this.
-              + """ && python -c 'import os, sys; n = len(sys.argv); [os.rename(src.split(".")[0] + ".so", dst) for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:])]' $(SRCS) $(OUTS)""",
+              + """ && python -c '%s' $(SRCS) $(OUTS)""" % python_cmd,
         tools = ["@cython//:cythonize"] + pxd_srcs,
     )
 


### PR DESCRIPTION
Running these rules on a RBE on linux produces the following shared object file:

`frontend.cpython-38-x86_64-linux-gnu.so`

The `cpython-38-x86_64-linux-gnu` modifier means that the build rule cannot find this file and fails like so:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
OSError: [Errno 2] No such file or directory
```

This rule is quite hard to decipher so break out the one line script into one that can send explicit errors to the user, and handle cases where the cython version file name modifier was added.

I think a deeper way of solving this might be using arguments in cython to define where the outputs should go, or having cythonize output its outputs and then processing that list, having said that they all require considering deeper issues in cython.