### PR TITLE
Disable all freelist code outside cpython

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1541,10 +1541,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     slot_func)
         code.putln("")
         if freelist_size:
+            code.putln("#if PYTHON_COMPILING_IN_CPYTHON")
             code.putln("static %s[%d];" % (
                 scope.parent_type.declaration_code(freelist_name),
                 freelist_size))
             code.putln("static int %s = 0;" % freecount_name)
+            code.putln("#endif")
             code.putln("")
         code.putln(
             "static PyObject *%s(PyTypeObject *t, %sPyObject *a, %sPyObject *k) {" % (
@@ -3407,6 +3409,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 scope = cclass_type.scope
                 freelist_name = scope.mangle_internal(Naming.freelist_name)
                 freecount_name = scope.mangle_internal(Naming.freecount_name)
+                code.putln('#if CYTHON_COMPILING_IN_CPYTHON')  # freelists are only used here
                 code.putln("while (%s > 0) {" % freecount_name)
                 code.putln("PyObject* o = (PyObject*)%s[--%s];" % (
                     freelist_name, freecount_name))
@@ -3418,6 +3421,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("if (tp_free) tp_free(o);")
                 code.putln("#endif")
                 code.putln("}")
+                code.putln('#endif')  # CYTHON_COMPILING_IN_CPYTHON
 #        for entry in env.pynum_entries:
 #            code.put_decref_clear(entry.cname,
 #                                  PyrexTypes.py_object_type,

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1541,7 +1541,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     slot_func)
         code.putln("")
         if freelist_size:
-            code.putln("#if CYTHON_COMPILING_IN_CPYTHON")
+            code.putln("#if CYTHON_USE_FREELISTS")
             code.putln("static %s[%d];" % (
                 scope.parent_type.declaration_code(freelist_name),
                 freelist_size))
@@ -1576,7 +1576,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 else:
                     type_safety_check = ' & (int)(!__Pyx_PyType_HasFeature(t, (Py_TPFLAGS_IS_ABSTRACT | Py_TPFLAGS_HEAPTYPE)))'
                 obj_struct = type.declaration_code("", deref=True)
-                code.putln("#if CYTHON_COMPILING_IN_CPYTHON")
+                code.putln("#if CYTHON_USE_FREELISTS")
                 code.putln(
                     "if (likely((int)(%s > 0) & (int)(t->tp_basicsize == sizeof(%s))%s)) {" % (
                         freecount_name, obj_struct, type_safety_check))
@@ -1815,7 +1815,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                         ' & (int)(!__Pyx_PyType_HasFeature(Py_TYPE(o), (Py_TPFLAGS_IS_ABSTRACT | Py_TPFLAGS_HEAPTYPE)))')
 
                 type = scope.parent_type
-                code.putln("#if CYTHON_COMPILING_IN_CPYTHON")
+                code.putln("#if CYTHON_USE_FREELISTS")
                 code.putln(
                     "if (((int)(%s < %d) & (int)(Py_TYPE(o)->tp_basicsize == sizeof(%s))%s)) {" % (
                         freecount_name,
@@ -3409,7 +3409,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 scope = cclass_type.scope
                 freelist_name = scope.mangle_internal(Naming.freelist_name)
                 freecount_name = scope.mangle_internal(Naming.freecount_name)
-                code.putln('#if CYTHON_COMPILING_IN_CPYTHON')  # freelists are only used here
+                code.putln('#if CYTHON_USE_FREELISTS')
                 code.putln("while (%s > 0) {" % freecount_name)
                 code.putln("PyObject* o = (PyObject*)%s[--%s];" % (
                     freelist_name, freecount_name))
@@ -3421,7 +3421,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 code.putln("if (tp_free) tp_free(o);")
                 code.putln("#endif")
                 code.putln("}")
-                code.putln('#endif')  # CYTHON_COMPILING_IN_CPYTHON
+                code.putln('#endif')  # CYTHON_USE_FREELISTS
 #        for entry in env.pynum_entries:
 #            code.put_decref_clear(entry.cname,
 #                                  PyrexTypes.py_object_type,

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1541,7 +1541,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     slot_func)
         code.putln("")
         if freelist_size:
-            code.putln("#if PYTHON_COMPILING_IN_CPYTHON")
+            code.putln("#if CYTHON_COMPILING_IN_CPYTHON")
             code.putln("static %s[%d];" % (
                 scope.parent_type.declaration_code(freelist_name),
                 freelist_size))

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -247,7 +247,7 @@
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 0
   #endif
   #undef CYTHON_USE_FREELISTS
-  #define CYTHON_USE_FREELISTS
+  #define CYTHON_USE_FREELISTS 0
 
 #elif defined(Py_GIL_DISABLED) || defined(Py_NOGIL)
   #define CYTHON_COMPILING_IN_PYPY 0

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -114,6 +114,8 @@
   #ifndef CYTHON_UPDATE_DESCRIPTOR_DOC
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 0
   #endif
+  #undef CYTHON_USE_FREELISTS
+  #define CYTHON_USE_FREELISTS 0
 
 #elif defined(PYPY_VERSION)
   #define CYTHON_COMPILING_IN_PYPY 1
@@ -175,6 +177,8 @@
   #ifndef CYTHON_UPDATE_DESCRIPTOR_DOC
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 0
   #endif
+  #undef CYTHON_USE_FREELISTS
+  #define CYTHON_USE_FREELISTS 0
 
 #elif defined(CYTHON_LIMITED_API)
   // EXPERIMENTAL !!
@@ -242,6 +246,8 @@
   #ifndef CYTHON_UPDATE_DESCRIPTOR_DOC
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 0
   #endif
+  #undef CYTHON_USE_FREELISTS
+  #define CYTHON_USE_FREELISTS
 
 #elif defined(Py_GIL_DISABLED) || defined(Py_NOGIL)
   #define CYTHON_COMPILING_IN_PYPY 0
@@ -290,6 +296,12 @@
   #define CYTHON_USE_DICT_VERSIONS 0
   #undef CYTHON_USE_EXC_INFO_STACK
   #define CYTHON_USE_EXC_INFO_STACK 0
+  #ifndef CYTHON_USE_FREELISTS
+  // TODO - we could probably enable CYTHON_USE_FREELISTS by default in future since
+  // this is just a variant of cpython now, but we'd need to be very careful to make
+  // them thread safe. Since it will probably work, let the user decide.
+  #define CYTHON_USE_FREELISTS 0
+  #endif
 
 #else
   #define CYTHON_COMPILING_IN_PYPY 0
@@ -377,6 +389,9 @@
   #endif
   #ifndef CYTHON_UPDATE_DESCRIPTOR_DOC
     #define CYTHON_UPDATE_DESCRIPTOR_DOC 1
+  #endif
+  #ifndef CYTHON_USE_FREELISTS
+    #define CYTHON_USE_FREELISTS 1
   #endif
 #endif
 

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -658,6 +658,8 @@ definition, for example,::
         # attributes and methods
 
 
+.. _freelist:
+        
 Fast instantiation
 ===================
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1242,3 +1242,8 @@ hidden by default since most users will be uninterested in changing them.
             
         ``CYTHON_UPDATE_DESCRIPTOR_DOC``
             Attempt to provide docstrings also for special (double underscore) methods.
+            
+        ``CYTHON_USE_FREELISTS``
+            Enable the use of freelists on extension types with
+            :ref:`the cython.freelist decorator<freelist>`.
+            

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1245,5 +1245,5 @@ hidden by default since most users will be uninterested in changing them.
             
         ``CYTHON_USE_FREELISTS``
             Enable the use of freelists on extension types with
-            :ref:`the cython.freelist decorator<freelist>`.
+            :ref:`the @cython.freelist decorator<freelist>`.
             

--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -223,7 +223,7 @@ Depending on the application, one way or the other may be better:
 
   These constants can be cimported from the ``cpython.object`` module.
 
-* If you use the `functools.total_ordering<https://docs.python.org/3/library/functools.html#functools.total_ordering>`_
+* If you use the `functools.total_ordering <https://docs.python.org/3/library/functools.html#functools.total_ordering>`_
   decorator on an extension type/``cdef`` class, Cython replaces it with a low-level reimplementation
   designed specifically for extension types.  (On a normal Python classes, the ``functools`` 
   decorator continues to work as before.)  As a shortcut you can also use ``cython.total_ordering``, which


### PR DESCRIPTION
Avoids a few unused variable warnings. (It's unused anyway so this just gets rid of the definitions and a bit of pointless cleanup)