### PR TITLE
Disable flakey line_trace test on Py3.12 windows 3.12

### DIFF
--- a/tests/run/line_trace.pyx
+++ b/tests/run/line_trace.pyx
@@ -401,7 +401,7 @@ def skip_on_win_py3_12_0(func):
     if sys.version_info == (3, 12, 0) and sys.platform == "win32":
         # This test is mysteriously failing on the CI only. Disable
         # it for now and hope that the next minor release fixes it.
-        return
+        return None
     return func
 
 


### PR DESCRIPTION
I've been unable to reproduce it locally, so don't really have an idea how to fix it. Therefore, disable it.

I've done so for one minor version only for now in the hope in magically improves with an update.