### PR TITLE
[Docs] Reorganize and improve documenation of `include_dirs` and `include_path`

### DIFF
--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -1510,6 +1510,7 @@ if the corresponding definition file also defines that type.
     and classes from each other without the Python overhead. To read more about
     what how to do that, you can see :ref:`pxd_files`.
 
+.. _definition_file:
 
 The definition file
 -------------------

--- a/docs/src/userguide/language_basics.rst
+++ b/docs/src/userguide/language_basics.rst
@@ -1538,6 +1538,7 @@ wants to  access :keyword:`cdef` attributes and methods, or to inherit from
     presence in a definition file does that. You only need a public
     declaration if you want to make something available to external C code.
 
+.. _include_statement:
 
 The include statement and include files
 ---------------------------------------

--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -108,6 +108,8 @@ then execute :
 
 This will install the newest Cython into SAGE.
 
+.. _numpy_compilation:
+
 Compilation
 ===========
 

--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -158,14 +158,14 @@ Setuptools allows us to create setup.py file to automate compilation of both Cyt
 
     extensions = [
         Extension("*", ["*.pyx"],
-            library_dirs=[numpy.get_include()]),
+            include_dirs=[numpy.get_include()]),
     ]
     setup(
         name="My hello app",
         ext_modules=cythonize(extensions),
     )
 
-The path to the NumPy headers is passed to the C compiler via the ``library_dirs=[numpy.get_include()])`` parameter.
+The path to the NumPy headers is passed to the C compiler via the ``include_dirs=[numpy.get_include()]`` parameter.
 
 .. note::
 

--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -150,7 +150,7 @@ Python by using a normal ``import yourmod`` statement.
 Compilation using setuptools
 ----------------------------
 
-Setuptools allows us to create setup.py file to automate both compilation of Cython files and generated C files.::
+Setuptools allows us to create setup.py file to automate compilation of both Cython files and generated C files.::
 
     from setuptools import Extension, setup
     from Cython.Build import cythonize
@@ -165,7 +165,7 @@ Setuptools allows us to create setup.py file to automate both compilation of Cyt
         ext_modules=cythonize(extensions),
     )
 
-Path to NumPy headers is passed to C compiler via ``library_dirs=[numpy.get_include()])`` parameter.
+The path to the NumPy headers is passed to the C compiler via the ``library_dirs=[numpy.get_include()])`` parameter.
 
 .. note::
 
@@ -193,7 +193,7 @@ or (see below)::
 
 With older Cython releases, setting this macro will fail the C compilation,
 because Cython generates code that uses this deprecated C-API.  However, the
-warning has no negative effects even in recent NumPy versions including 1.18.x.
+warning has no negative effects even in recent NumPy versions.
 You can ignore it until you (or your library's users) switch to a newer NumPy
 version that removes this long deprecated API, in which case you also need to
 use Cython 3.0 or later.  Thus, the earlier you switch to Cython 3.0, the

--- a/docs/src/userguide/numpy_tutorial.rst
+++ b/docs/src/userguide/numpy_tutorial.rst
@@ -202,8 +202,6 @@ use Cython 3.0 or later.  Thus, the earlier you switch to Cython 3.0, the
 better for your users.
 
 
-
-
 The first Cython program
 ==========================
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -150,7 +150,7 @@ documentation`_. To compile the extension for use in the current directory use:
 Configuring the C-Build
 ------------------------
 
-If you have :ref:`Cython include files <include_statement>` in non-standard places you can pass an
+If you have :ref:`Cython include files <include_statement>` or :ref:`Cython definition files <definition_file>` in non-standard places you can pass an
 ``include_path`` parameter to ``cythonize``::
 
     from setuptools import setup

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -150,7 +150,7 @@ documentation`_. To compile the extension for use in the current directory use:
 Configuring the C-Build
 ------------------------
 
-If you have include files in non-standard places you can pass an
+If you have Cython include files in non-standard places you can pass an
 ``include_path`` parameter to ``cythonize``::
 
     from setuptools import setup
@@ -160,43 +160,6 @@ If you have include files in non-standard places you can pass an
         name="My hello app",
         ext_modules=cythonize("src/*.pyx", include_path=[...]),
     )
-
-Often, Python packages that offer a C-level API provide a way to find
-the necessary include files, e.g. for NumPy::
-
-    include_path = [numpy.get_include()]
-
-.. note::
-
-    Using memoryviews or importing NumPy with ``import numpy`` does not mean that
-    you have to add the path to NumPy include files. You need to add this path only
-    if you use ``cimport numpy``.
-
-Despite this, you may still get warnings like the following from the compiler,
-because Cython is not disabling the usage of the old deprecated Numpy API::
-
-   .../include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
-
-In Cython 3.0, you can get rid of this warning by defining the C macro
-``NPY_NO_DEPRECATED_API`` as ``NPY_1_7_API_VERSION``
-in your build, e.g.::
-
-    # distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
-
-or (see below)::
-
-    Extension(
-        ...,
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-    )
-
-With older Cython releases, setting this macro will fail the C compilation,
-because Cython generates code that uses this deprecated C-API.  However, the
-warning has no negative effects even in recent NumPy versions including 1.18.x.
-You can ignore it until you (or your library's users) switch to a newer NumPy
-version that removes this long deprecated API, in which case you also need to
-use Cython 3.0 or later.  Thus, the earlier you switch to Cython 3.0, the
-better for your users.
 
 If you need to specify compiler options, libraries to link with or other
 linker options you will need to create ``Extension`` instances manually
@@ -222,8 +185,29 @@ in one line)::
         ext_modules=cythonize(extensions),
     )
 
+Some useful options to know about are
+
+* ``include_dirs``- list of directories to search for C/C++ header files (in Unix form for portability)
+* ``libraries`` - list of library names (not filenames or paths) to link against,
+* ``library_dirs`` - list of directories to search for C/C++ libraries at link time.
+
 Note that when using setuptools, you should import it before Cython, otherwise,
 both might disagree about the class to use here.
+
+Often, Python packages that offer a C-level API provide a way to find
+the necessary C header files::
+
+    from setuptools import Extension, setup
+    from Cython.Build import cythonize
+
+    extensions = [
+        Extension("*", ["*.pyx"],
+            include_dirs=["/usr/local/include"]),
+    ]
+    setup(
+        name="My hello app",
+        ext_modules=cythonize(extensions),
+    )
 
 If your options are static (for example you do not need to call a tool like
 ``pkg-config`` to determine them) you can also provide them directly in your
@@ -258,9 +242,7 @@ as follows::
     )
 
 The :class:`Extension` class takes many options, and a fuller explanation can
-be found in the `setuptools documentation`_. Some useful options to know about
-are ``include_dirs``, ``libraries``, and ``library_dirs`` which specify where
-to find the ``.h`` and library files when linking to external libraries.
+be found in the `setuptools documentation`_.
 
 .. _setuptools documentation: https://setuptools.readthedocs.io/
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -191,7 +191,7 @@ in one line)::
 
 Some useful options to know about are
 
-* ``include_dirs``- list of directories to search for C/C++ header files (in Unix form for portability)
+* ``include_dirs``- list of directories to search for C/C++ header files (in Unix form for portability),
 * ``libraries`` - list of library names (not filenames or paths) to link against,
 * ``library_dirs`` - list of directories to search for C/C++ libraries at link time.
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -150,7 +150,7 @@ documentation`_. To compile the extension for use in the current directory use:
 Configuring the C-Build
 ------------------------
 
-If you have Cython include files in non-standard places you can pass an
+If you have :ref:`Cython include files <include_statement>` in non-standard places you can pass an
 ``include_path`` parameter to ``cythonize``::
 
     from setuptools import setup

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -150,6 +150,10 @@ documentation`_. To compile the extension for use in the current directory use:
 Configuring the C-Build
 ------------------------
 
+.. note::
+
+   More details on building Cython modules that use cimport numpy can be found in the :ref:`Numpy section <numpy_compilation>` of the user guide.
+
 If you have :ref:`Cython include files <include_statement>` or :ref:`Cython definition files <definition_file>` in non-standard places you can pass an
 ``include_path`` parameter to ``cythonize``::
 


### PR DESCRIPTION
This PR:

* Fixes wrong documentation of `include_path` which does not control search path of C/C++ headers - fixes #1480
* Improves documentation of `Extention` parameters used in example to have it self contained and reader does not need to visit setuptools documentation for details.
* Adds *Compilation using setuptools* chapter to *Cython for NumPy users* and include numpy related documentation from *Source files and compilation*.
