### PR TITLE
Remove unused Entry.pep563_annotation

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -167,7 +167,6 @@ class Entry:
     borrowed = 0
     init = ""
     annotation = None
-    pep563_annotation = None
     visibility = 'private'
     is_builtin = 0
     is_cglobal = 0


### PR DESCRIPTION
I don't think it was ever used.

(No need to review... just checking I haven't missed anything. I'll merge it if it passes)