### PR TITLE
Improve optimisation of "dict.pop()"

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1780,7 +1780,9 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
 /////////////// CallUnboundCMethod0.proto ///////////////
 //@substitute: naming
 
+CYTHON_UNUSED
 static PyObject* __Pyx__CallUnboundCMethod0(__Pyx_CachedCFunction* cfunc, PyObject* self); /*proto*/
+
 #if CYTHON_COMPILING_IN_CPYTHON
 // FASTCALL methods receive "&empty_tuple" as simple "PyObject[0]*"
 #define __Pyx_CallUnboundCMethod0(cfunc, self)  \
@@ -1823,6 +1825,7 @@ bad:
 
 /////////////// CallUnboundCMethod1.proto ///////////////
 
+CYTHON_UNUSED
 static PyObject* __Pyx__CallUnboundCMethod1(__Pyx_CachedCFunction* cfunc, PyObject* self, PyObject* arg);/*proto*/
 
 #if CYTHON_COMPILING_IN_CPYTHON
@@ -1886,6 +1889,7 @@ bad:
 
 /////////////// CallUnboundCMethod2.proto ///////////////
 
+CYTHON_UNUSED
 static PyObject* __Pyx__CallUnboundCMethod2(__Pyx_CachedCFunction* cfunc, PyObject* self, PyObject* arg1, PyObject* arg2); /*proto*/
 
 #if CYTHON_COMPILING_IN_CPYTHON

--- a/tests/run/dict_pop.pyx
+++ b/tests/run/dict_pop.pyx
@@ -3,6 +3,11 @@
 
 cimport cython
 
+class FailHash:
+    def __hash__(self):
+        raise TypeError()
+
+
 @cython.test_assert_path_exists("//PythonCapiCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def dict_pop(dict d, key):
@@ -10,6 +15,11 @@ def dict_pop(dict d, key):
     >>> d = { 1: 10, 2: 20 }
     >>> dict_pop(d, 1)
     (10, {2: 20})
+    >>> dict_pop(d, FailHash())
+    Traceback (most recent call last):
+    TypeError
+    >>> d
+    {2: 20}
     >>> dict_pop(d, 3)
     Traceback (most recent call last):
     KeyError: 3
@@ -26,6 +36,11 @@ def dict_pop_default(dict d, key, default):
     >>> d = { 1: 10, 2: 20 }
     >>> dict_pop_default(d, 1, "default")
     (10, {2: 20})
+    >>> dict_pop_default(d, FailHash(), 30)
+    Traceback (most recent call last):
+    TypeError
+    >>> d
+    {2: 20}
     >>> dict_pop_default(d, 3, None)
     (None, {2: 20})
     >>> dict_pop_default(d, 3, "default")
@@ -34,6 +49,26 @@ def dict_pop_default(dict d, key, default):
     (20, {})
     """
     return d.pop(key, default), d
+
+
+@cython.test_assert_path_exists("//PythonCapiCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def dict_pop_ignored(dict d, key):
+    """
+    >>> d = {1: 2, 'a': 'b'}
+    >>> dict_pop_ignored(d, 'a')
+    >>> d
+    {1: 2}
+    >>> dict_pop(d, FailHash())
+    Traceback (most recent call last):
+    TypeError
+    >>> d
+    {1: 2}
+    >>> dict_pop_ignored(d, 123)
+    >>> d
+    {1: 2}
+    """
+    d.pop(key, None)
 
 
 cdef class MyType:

--- a/tests/run/dict_pop.pyx
+++ b/tests/run/dict_pop.pyx
@@ -59,7 +59,7 @@ def dict_pop_ignored(dict d, key):
     >>> dict_pop_ignored(d, 'a')
     >>> d
     {1: 2}
-    >>> dict_pop(d, FailHash())
+    >>> dict_pop_ignored(d, FailHash())
     Traceback (most recent call last):
     TypeError
     >>> d


### PR DESCRIPTION
Use the new `PyDict_Pop()` function in Py3.13 and special-case the common "discard and ignore" use case.