### PR TITLE
Add extra info on annotation inexact type

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -871,6 +871,7 @@ class CArgDeclNode(Node):
     # kw_only        boolean            Is a keyword-only argument
     # is_dynamic     boolean            Non-literal arg stored inside CyFunction
     # pos_only       boolean            Is a positional-only argument
+    # type_from_annotation boolean      Was the type deduced from an annotation
     #
     # name_cstring                         property that converts the name to a cstring taking care of unicode
     #                                      and quoting it
@@ -891,6 +892,7 @@ class CArgDeclNode(Node):
     default_value = None
     annotation = None
     is_dynamic = 0
+    type_from_annotation = False
 
     def declared_name(self):
         return self.declarator.declared_name()
@@ -992,6 +994,8 @@ class CArgDeclNode(Node):
             elif not self.or_none and arg_type.can_be_optional():
                 self.not_none = True
 
+        if arg_type:
+            self.type_from_annotation = True
         return arg_type
 
     def calculate_default_value_code(self, code):
@@ -2441,13 +2445,18 @@ class FuncDefNode(StatNode, BlockNode):
                 UtilityCode.load_cached("ArgTypeTest", "FunctionArguments.c"))
             typeptr_cname = arg.type.typeptr_cname
             arg_code = "((PyObject *)%s)" % arg.entry.cname
+            exact = 0
+            if arg.type.is_builtin_type and arg.type.require_exact:
+                # 2 is used to indicate that the type is from the annotation
+                # and provide a little extra info on failure.
+                exact = 2 if arg.type_from_annotation else 1
             code.putln(
                 'if (unlikely(!__Pyx_ArgTypeTest(%s, %s, %d, %s, %s))) %s' % (
                     arg_code,
                     typeptr_cname,
                     arg.accept_none,
                     arg.name_cstring,
-                    arg.type.is_builtin_type and arg.type.require_exact,
+                    exact,
                     code.error_goto(arg.pos)))
         else:
             error(arg.pos, "Cannot test type of extern C class without type object name specification")

--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -1,6 +1,8 @@
 //////////////////// ArgTypeTest.proto ////////////////////
 
 
+// Exact is 0 (False), 1 (True) or 2 (True and from annotation)
+// The latter gives a small amount of extra error diagnostics
 #define __Pyx_ArgTypeTest(obj, type, none_allowed, name, exact) \
     ((likely(__Pyx_IS_TYPE(obj, type) | (none_allowed && (obj == Py_None)))) ? 1 : \
         __Pyx__ArgTypeTest(obj, type, name, exact))
@@ -8,23 +10,54 @@
 static int __Pyx__ArgTypeTest(PyObject *obj, PyTypeObject *type, const char *name, int exact); /*proto*/
 
 //////////////////// ArgTypeTest ////////////////////
+//@substitute: naming
 
 static int __Pyx__ArgTypeTest(PyObject *obj, PyTypeObject *type, const char *name, int exact)
 {
     __Pyx_TypeName type_name;
     __Pyx_TypeName obj_type_name;
+    PyObject *extra_info = $empty_unicode;
+    int from_annotation_subclass = 0;
     if (unlikely(!type)) {
         PyErr_SetString(PyExc_SystemError, "Missing type object");
         return 0;
     }
     else if (!exact) {
         if (likely(__Pyx_TypeCheck(obj, type))) return 1;
+    } else if (exact == 2) {
+        // type from annotation
+        if (__Pyx_TypeCheck(obj, type)) {
+            from_annotation_subclass = 1;
+            extra_info = PYUNICODE("Note that Cython is deliberately stricter than PEP-484 and rejects subclasses of builtin types. If you need to pass subclasses then set the 'annotation_typing' directive to False.");
+        }
     }
     type_name = __Pyx_PyType_GetName(type);
     obj_type_name = __Pyx_PyType_GetName(Py_TYPE(obj));
     PyErr_Format(PyExc_TypeError,
         "Argument '%.200s' has incorrect type (expected " __Pyx_FMT_TYPENAME
-        ", got " __Pyx_FMT_TYPENAME ")", name, type_name, obj_type_name);
+        ", got " __Pyx_FMT_TYPENAME ")"
+#if __PYX_LIMITED_VERSION_HEX < 0x030C0000
+        "%s%U"
+#endif
+        , name, type_name, obj_type_name
+#if __PYX_LIMITED_VERSION_HEX < 0x030C0000
+        , (from_annotation_subclass ? ". " : ""), extra_info
+#endif
+        );
+#if __PYX_LIMITED_VERSION_HEX >= 0x030C0000
+    // Set the extra_info as a note instead. In principle it'd be possible to do this
+    // from Python 3.11 up, but PyErr_GetRaisedException makes it much easier so do it
+    // from Python 3.12 instead.
+    if (exact == 2 && from_annotation_subclass) {
+        PyObject *res;
+        PyObject *vargs[2];
+        vargs[0] = PyErr_GetRaisedException();
+        vargs[1] = extra_info;
+        res = PyObject_VectorcallMethod(PYUNICODE("add_note"), vargs, 2, NULL);
+        Py_XDECREF(res);
+        PyErr_SetRaisedException(vargs[0]);
+    }
+#endif
     __Pyx_DECREF_TypeName(type_name);
     __Pyx_DECREF_TypeName(obj_type_name);
     return 0;

--- a/docs/src/userguide/migrating_to_cy30.rst
+++ b/docs/src/userguide/migrating_to_cy30.rst
@@ -247,6 +247,11 @@ any Python object for ``x``), unless the language level is explicitly
 set to 2.  To mitigate the effect, Cython 3.0 still accepts both Python
 ``int`` and ``long`` values under Python 2.x.
 
+One potential issue you may encounter is that types like ``typing.List``
+are now understood in annotations (where previously they were ignored)
+and are interpreted to mean *exact* ``list``. This is stricter than
+the interpretation specified in PEP-484, which also allows subclasses.
+
 To make it easier to handle cases where your interpretation of type
 annotations differs from Cython's, Cython 3 now supports setting the
 ``annotation_typing`` :ref:`directive <compiler-directives>` on a

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -402,7 +402,7 @@ def test_inexact_types(d: dict):
     ...    test_inexact_types(OrderedDict())
     ... except TypeError as e:
     ...    assert ("Cython is deliberately stricter than PEP-484" in e.args[0] or
-    ...               any("Cython is deliberately stricter than PEP-484" in getattr(e, "__notes__", []))), e
+    ...            any("Cython is deliberately stricter than PEP-484" in note for note in getattr(e, "__notes__", []))), e
     ... else:
     ...    assert False
     """

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -391,6 +391,24 @@ def int_alias(a: cython.int, b: cy_i):
     print(cython.typeof(b))
 
 
+def test_inexact_types(d: dict):
+    """
+    >>> test_inexact_types({})  # good
+
+    Check that our custom pep484 warning is in either the error message
+    or the exception notes
+    >>> from collections import OrderedDict
+    >>> try:
+    ...    test_inexact_types(OrderedDict())
+    ... except TypeError as e:
+    ...    assert ("Cython is deliberately stricter than PEP-484" in e.args[0] or
+    ...               any("Cython is deliberately stricter than PEP-484" in getattr(e.__notes__, []))), e
+    ... else:
+    ...    assert False
+    """
+    pass
+
+
 _WARNINGS = """
 15:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 15:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -402,7 +402,7 @@ def test_inexact_types(d: dict):
     ...    test_inexact_types(OrderedDict())
     ... except TypeError as e:
     ...    assert ("Cython is deliberately stricter than PEP-484" in e.args[0] or
-    ...               any("Cython is deliberately stricter than PEP-484" in getattr(e.__notes__, []))), e
+    ...               any("Cython is deliberately stricter than PEP-484" in getattr(e, "__notes__", []))), e
     ... else:
     ...    assert False
     """


### PR DESCRIPTION
For most builtin types, Cython interprets an annotation to mean that an exact type is required. This is stricter than PEP-484 and occassionally causes confusion.

1. Adds a bit more detail to the exception message in these cases (or to `__notes__` in Python 3.12+) to explain.
2. Add a note in the migration guide.

I've only applied this to function arguments. Applying it to general assignments would be possible but looks significantly more complicated so I thought it better to cover the main case.

Related issue: https://github.com/cython/cython/issues/5908