### PR TITLE
Modified "pretend_to_initialize" for c++

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -867,23 +867,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.put(Nodes.branch_prediction_macros)
 
-        # For C,  taking an address of a variable is enough to make returning it
-        # defined behaviour. For C++ this isn't true, and we genuinely have to
-        # make sure a variable is initialized.
-        code.putln('#if __cplusplus')
-        code.putln('#include <type_traits>')
-        code.putln('template <typename T> void __Pyx_pretend_to_initialize(T* ptr) {')
-        # In C++11 we have enough introspection to work out which types it's actually
-        # necessary to apply this to (non-trivial types will have been initialized by
-        # the definition). Below that just apply it to eveything.
-        code.putln('#if __cplusplus > 201103L')
-        code.putln('if ((std::is_trivially_default_constructible<T>::value))')
-        code.putln('#endif')
-        code.putln('*ptr = T();')
-        code.putln('}')
-        code.putln('#else')
-        code.putln('static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }')
-        code.putln('#endif')
+        self._put_setup_code(code, "PretendToInitialize")
         code.putln('')
         code.putln('#if !CYTHON_USE_MODULE_STATE')
         code.putln('static PyObject *%s = NULL;' % env.module_cname)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2136,7 +2136,7 @@ static void __Pyx_FastGilFuncInit(void) {
 
 ///////////////////// PretendToInitialize ////////////////////////
 
-#if __cplusplus
+#ifdef __cplusplus
 // In C++ a variable must actually be initialized to make returning
 // it defined behaviour, and there doesn't seem to be a viable compiler trick to
 // avoid that.

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2142,7 +2142,7 @@ static void __Pyx_FastGilFuncInit(void) {
 // avoid that.
 #include <type_traits>
 template <typename T>
-void __Pyx_pretend_to_initialize(T* ptr) {
+static void __Pyx_pretend_to_initialize(T* ptr) {
     // In C++11 we have enough introspection to work out which types it's actually
     // necessary to apply this to (non-trivial types will have been initialized by
     // the definition). Below C++11 just initialize everything.

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2134,6 +2134,30 @@ static void __Pyx_FastGilFuncInit(void) {
 
 #endif
 
+///////////////////// PretendToInitialize ////////////////////////
+
+#if __cplusplus
+// In C++ a variable must actually be initialized to make returning
+// it defined behaviour, and there doesn't seem to be a viable compiler trick to
+// avoid that.
+#include <type_traits>
+template <typename T>
+void __Pyx_pretend_to_initialize(T* ptr) {
+    // In C++11 we have enough introspection to work out which types it's actually
+    // necessary to apply this to (non-trivial types will have been initialized by
+    // the definition). Below C++11 just initialize everything.
+#if __cplusplus > 201103L
+    if ((std::is_trivially_default_constructible<T>::value))
+#endif
+        *ptr = T();
+    (void)ptr;
+}
+#else
+// For C,  taking an address of a variable is enough to make returning it
+// defined behaviour.
+static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }
+#endif
+
 ///////////////////// UtilityCodePragmas /////////////////////////
 
 #ifdef _MSC_VER


### PR DESCRIPTION
In this case we actually have to initialize rather than just do nothing. Fixes #5278.

Supercedes #5296 (I think this is better since it limits the amount of work Cython itself has to do)