### PR TITLE
Cygdb completion bug fix: handle_brkchars support

### DIFF
--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -838,6 +838,9 @@ class CyBreak(CythonCommand):
         else:
             all_names = qnames
 
+        if word is None:
+            return all_names
+
         words = text.strip().split()
         if not words or '.' not in words[-1]:
             # complete unqualified


### PR DESCRIPTION
In most cases, gdb calls the [completion method twice](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/python/py-cmd.c;h=7143c1c5f7fdce9316a8c41fc2246bc6a07630d4;hb=HEAD#l140), meaning that it's possible for [`word`](https://github.com/kentslaney/cython/blob/6ea8ca4e9701a2ced71b9abdf201563c6a9bc507/Cython/Debugger/libcython.py#L828) to be [`None`](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/python/py-cmd.c;h=7143c1c5f7fdce9316a8c41fc2246bc6a07630d4;hb=HEAD#l195) (in this case, [`text` is also empty](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=gdb/completer.c;h=d69ddcceca9ce5940e5fce136f10529228d7917d;hb=HEAD#l1269)). This means that, in some cases, `CyBreak.complete` will throw
```
Traceback (most recent call last):
  File ".../Cython/Debugger/libpython.py", line 1953, in wrapper
    return function(*args, **kwargs)
  File ".../Cython/Debugger/libcython.py", line 844, in complete
    seen = set(text[:-len(word)].split())
TypeError: object of type 'NoneType' has no len()
```

My fix is to special case `word is None` to return `all_names`. Another possible solution would be to replace `word` with `word or ""` in lines [844](https://github.com/cython/cython/blob/15675a5e2ff2685b9aa1af7695fe306548361a92/Cython/Debugger/libcython.py#L844) and [846](https://github.com/cython/cython/blob/15675a5e2ff2685b9aa1af7695fe306548361a92/Cython/Debugger/libcython.py#L846).