### PR TITLE
Fix types in cpdef_extern_func

### DIFF
--- a/tests/run/cpdef_extern_func.pyx
+++ b/tests/run/cpdef_extern_func.pyx
@@ -1,6 +1,5 @@
 # cython: c_string_type=str
 # cython: c_string_encoding=ascii
-# distutils: extra_compile_args=-fpermissive
 
 __doc__ = """
 >>> sqrt(1)
@@ -12,9 +11,9 @@ __doc__ = """
 >>> log(10)  # doctest: +ELLIPSIS
 Traceback (most recent call last):
 NameError: ...name 'log' is not defined
->>> strchr('abcabc', ord('c'))
+>>> my_strchr('abcabc', ord('c'))
 'cabc'
->>> strchr(needle=ord('c'), haystack='abcabc')
+>>> my_strchr(needle=ord('c'), haystack='abcabc')
 'cabc'
 """
 
@@ -24,5 +23,12 @@ cdef extern from "math.h":
     cdef double log(double) # not wrapped
 
 cdef extern from "string.h":
-    # signature must be exact in C++, disagrees with C
-    cpdef const char* strchr(const char *haystack, int needle);
+    """
+    /* the return type of strchr differs between C and C++. This
+    test is not interested in that, so create a wrapper function with
+    a known return type */
+    const char* my_strchr(const char *haystack, int needle) {
+        return strchr(haystack, needle);
+    }
+    """
+    cpdef const char* my_strchr(const char *haystack, int needle);


### PR DESCRIPTION
I don't think the test is really interested in the exact type of strchr, so instead wrap a function with a known function type.

Fixes #5939