### PR TITLE
cygdb step reliability

### DIFF
--- a/Cython/Debugger/Tests/test_libcython_in_gdb.py
+++ b/Cython/Debugger/Tests/test_libcython_in_gdb.py
@@ -388,7 +388,7 @@ class TestUpDown(DebugTestCase):
 
         result = gdb.execute('cy up', to_string=True)
         assert 'spam()' in result
-        assert 'os.path.join("foo", "bar")' in result
+        assert 'some_c_function()' not in result
 
 
 class TestExec(DebugTestCase):

--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -3,6 +3,7 @@ GDB extension that adds Cython support.
 """
 
 
+import os
 import sys
 import textwrap
 import functools
@@ -232,9 +233,12 @@ class CythonBase:
 
     @default_selected_gdb_frame()
     def get_c_lineno(self, frame):
-        sal, fun = frame.find_sal(), frame.function()
-        ccall = sal.symtab.fullname() != fun.symtab.fullname()
-        return fun.line if ccall else sal.line
+        sal = frame.find_sal()
+        fn = self.get_cython_function(frame)
+        cycall = os.path.realpath(sal.symtab.fullname()) == \
+            os.path.realpath(fn.module.c_filename)
+        return sal.line if cycall and sal.line in fn.module.lineno_c2cy else \
+            frame.function().line
 
     @default_selected_gdb_frame()
     def get_cython_function(self, frame):


### PR DESCRIPTION
Cygdb's step function is specified as stepping into any Cython call or any C function called directly from Cython. This means it's possible for the existing `get_c_lineno` to return a line number in an included C file that was called directly by Cython. This patch fixes, for example, this [minimal repo](https://github.com/pearcemc/cython-example/tree/8a468acba5aabdd41a432efb86e9e24172942004).

I've left in the `repr` implementations I used to debug the problem.