### PR TITLE
line break after backtrace frame source

### DIFF
--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -324,7 +324,7 @@ class CythonBase:
         sys.stdout.write('\n')
 
         try:
-            sys.stdout.write('    ' + source_desc.get_source(lineno))
+            sys.stdout.write('    ' + source_desc.get_source(lineno) + '\n')
         except gdb.GdbError:
             pass
 


### PR DESCRIPTION
In order for the back trace to look like [this](https://gist.github.com/msabramo/6904372#file-cygdb-out-L65-L71), there needs to be a line break after printing a line of source code, since [`get_source` doesn't add one](https://github.com/cython/cython/blob/0e1026cb7c767450a88ab822e8eda2b451dee3c6/Cython/Debugger/libcython.py#L443)