### PR TITLE
pyximport: Use relative paths less, and correctly

### DIFF
--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -185,7 +185,7 @@ def build_module(name, pyxfilename, pyxbuild_dir=None, inplace=False, language_l
     from . import pyxbuild
     olddir = os.getcwd()
     common = ''
-    if pyxbuild_dir:
+    if pyxbuild_dir and sys.platform == 'win32':
         # Windows concatenates the pyxbuild_dir to the pyxfilename when
         # compiling, and then complains that the filename is too long
         common = os.path.commonprefix([pyxbuild_dir, pyxfilename])

--- a/pyximport/pyximport.py
+++ b/pyximport/pyximport.py
@@ -190,8 +190,8 @@ def build_module(name, pyxfilename, pyxbuild_dir=None, inplace=False, language_l
         # compiling, and then complains that the filename is too long
         common = os.path.commonprefix([pyxbuild_dir, pyxfilename])
     if len(common) > 30:
-        pyxfilename = os.path.relpath(pyxfilename)
-        pyxbuild_dir = os.path.relpath(pyxbuild_dir)
+        pyxfilename = os.path.relpath(pyxfilename, common)
+        pyxbuild_dir = os.path.relpath(pyxbuild_dir, common)
         os.chdir(common)
     try:
         so_path = pyxbuild.pyx_to_dll(pyxfilename, extension_mod,


### PR DESCRIPTION
#4630 started to use relative paths in pyximport, when the path got long, to avoid issues on Windows.

This has two issues:
1. A bug, the path calculation assumed that the common path would be the same as the CWD.
2. It loses information, on platforms that don't have this filesystem limitation. In particular, it breaks pretty traceback formatting in `stack_data`, if the source file isn't available at the same relative path.

Discoverd these while investigating [Debian bug #1056872](https://bugs.debian.org/1056872)