### PR TITLE
Tolerate literal globs (GH-5942 backport to 3.0.x)

### DIFF
--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -316,7 +316,7 @@ def find_versioned_file(directory, filename, suffix,
     assert not suffix or suffix[:1] == '.'
     path_prefix = os.path.join(directory, filename)
 
-    matching_files = glob.glob(path_prefix + ".cython-*" + suffix)
+    matching_files = glob.glob(''.join([ '['+c+']' if c in '[]*?' else c for c in path_prefix]) + ".cython-*" + suffix)
     path = path_prefix + suffix
     if not os.path.exists(path):
         path = None

--- a/tests/run/sys_path_globbed.srctree
+++ b/tests/run/sys_path_globbed.srctree
@@ -1,0 +1,27 @@
+# tag: gh5942
+
+PYTHON setup.py build_ext --inplace
+PYTHON -c "from tglob import mytest; mytest()"
+
+######## tglob.pyx ########
+def mytest():
+    assert True
+
+######## setup.py ########
+import sys
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup, Extension
+
+sys.path.append("[Hello-World]*?")
+
+try:
+    from __builtin__ import reload
+except ImportError:
+    from importlib import reload
+reload(sys)  # Magic
+
+setup(
+    ext_modules=cythonize(["tglob.pyx"], language_level="3"),
+)
+


### PR DESCRIPTION
If your build environment uses literal globbing characters in its file paths, Cython 3.0 might fail, because `find_versioned_file` in `Utils.py` was slapping a `*` in the path and expecting it to properly glob. This fails in certain large build environments that use, for example, brackets in system paths. Escape paths from `sys.path` and other sources before looking for different versions of collateral files. This is a backport that works with Python 2.7.

Addresses GitHub issue [#5942](https://github.com/cython/cython/issues/5942); see [pull request for `master`](https://github.com/cython/cython/pull/5956).