### PR TITLE
Fix distutils sources syntax

### DIFF
--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -228,7 +228,7 @@ If you have some C files that have been wrapped with Cython and you want to
 compile them into your extension, you can define the setuptools ``sources``
 parameter::
 
-    # distutils: sources = helper.c, another_helper.c
+    # distutils: sources = [helper.c, another_helper.c]
 
 Note that these sources are added to the list of sources of the current
 extension module.  Spelling this out in the :file:`setup.py` file looks


### PR DESCRIPTION
The example raised the following error while cythonising.
`error: unknown file type '.c,'`
It looks like the correct syntax is either without the comma or with brackets around.

The function that parses this is here
https://github.com/cython/cython/blob/master/Cython/Build/Dependencies.py#L139