### PR TITLE
Fix as_cfunction analysing args in wrong scope

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -872,6 +872,7 @@ class CArgDeclNode(Node):
     # is_dynamic     boolean            Non-literal arg stored inside CyFunction
     # pos_only       boolean            Is a positional-only argument
     # type_from_annotation boolean      Was the type deduced from an annotation
+    # type_according_to_pyx  PyrexType or None  The type assigned by the pxd file
     #
     # name_cstring                         property that converts the name to a cstring taking care of unicode
     #                                      and quoting it
@@ -893,6 +894,7 @@ class CArgDeclNode(Node):
     annotation = None
     is_dynamic = 0
     type_from_annotation = False
+    type_according_to_pxd = None
 
     def declared_name(self):
         return self.declarator.declared_name()
@@ -959,7 +961,15 @@ class CArgDeclNode(Node):
             arg_type = self.inject_type_from_annotations(env)
             if arg_type is not None:
                 base_type = arg_type
-        return self.declarator.analyse(base_type, env, nonempty=nonempty)
+        name, type_ = self.declarator.analyse(base_type, env, nonempty=nonempty)
+        if (type_ is None or type_ is PyrexTypes.py_object_type and
+                self.type_according_to_pxd is not None):
+            # Use an overridden type from the pxd if available.
+            # If the type is resolved to something else, and contradicts
+            # the type from the pxd this is likely an error (but generated elsewhere)
+            type_ = self.type_according_to_pxd
+        return name, type_
+
 
     def inject_type_from_annotations(self, env):
         annotation = self.annotation
@@ -3083,23 +3093,8 @@ class DefNode(FuncDefNode):
         nogil = nogil or with_gil
 
         if cfunc is None:
-            cfunc_args = []
-            for formal_arg in self.args:
-                name_declarator, type = formal_arg.analyse(scope, nonempty=1)
-                cfunc_args.append(PyrexTypes.CFuncTypeArg(name=name_declarator.name,
-                                                          cname=None,
-                                                          annotation=formal_arg.annotation,
-                                                          type=py_object_type,
-                                                          pos=formal_arg.pos))
-            cfunc_type = PyrexTypes.CFuncType(return_type=py_object_type,
-                                              args=cfunc_args,
-                                              has_varargs=False,
-                                              exception_value=None,
-                                              exception_check=exception_check,
-                                              nogil=nogil,
-                                              with_gil=with_gil,
-                                              is_overridable=overridable)
-            cfunc = CVarDefNode(self.pos, type=cfunc_type)
+            cfunc_type = None
+            cfunc = CVarDefNode(self.pos)
         else:
             if scope is None:
                 scope = cfunc.scope
@@ -3108,38 +3103,57 @@ class DefNode(FuncDefNode):
                 error(self.pos, "wrong number of arguments")
                 error(cfunc.pos, "previous declaration here")
             for i, (formal_arg, type_arg) in enumerate(zip(self.args, cfunc_type.args)):
-                name_declarator, type = formal_arg.analyse(scope, nonempty=1,
-                                                           is_self_arg=(i == 0 and scope.is_c_class_scope))
-                if type is None or type is PyrexTypes.py_object_type:
-                    formal_arg.type = type_arg.type
-                    formal_arg.name_declarator = name_declarator
+                formal_arg.type_according_to_pxd = type_arg.type
 
-        if exception_value is None and cfunc_type.exception_value is not None:
+        if exception_value is None and cfunc_type and cfunc_type.exception_value is not None:
             from .ExprNodes import ConstNode
             exception_value = ConstNode(
                 self.pos, value=cfunc_type.exception_value, type=cfunc_type.return_type)
+
+        if cfunc_type is not None:
+            # If we have cfunc_type (i.e. it's come from a pxdfile)
+            # we can fill in a lot more information than if we don't
+            declarator_kwds = dict(
+                exception_check = cfunc_type.exception_check,
+                with_gil = cfunc_type.with_gil,
+                nogil = cfunc_type.nogil
+            )
+            def_node_kwds = dict(
+                overridable = cfunc_type.is_overridable,
+                type = cfunc_type,
+                with_gil = cfunc_type.with_gil,
+                nogil = cfunc_type.nogil,
+            )
+            base_type = CAnalysedBaseTypeNode(self.pos, type=cfunc_type.return_type)
+        else:
+            declarator_kwds = dict(
+                exception_check = exception_check,
+                nogil = nogil,
+                with_gil = with_gil,
+            )
+            def_node_kwds = dict(
+                overridable = overridable,
+                nogil = nogil,
+                with_gil = with_gil,
+            )
+            base_type = CAnalysedBaseTypeNode(self.pos, type=py_object_type)
         declarator = CFuncDeclaratorNode(self.pos,
                                          base=CNameDeclaratorNode(self.pos, name=self.name, cname=None),
                                          args=self.args,
                                          has_varargs=False,
-                                         exception_check=cfunc_type.exception_check,
                                          exception_value=exception_value,
-                                         with_gil=cfunc_type.with_gil,
-                                         nogil=cfunc_type.nogil)
+                                         **declarator_kwds)
         return CFuncDefNode(self.pos,
                             modifiers=modifiers or [],
-                            base_type=CAnalysedBaseTypeNode(self.pos, type=cfunc_type.return_type),
+                            base_type = base_type,
                             declarator=declarator,
                             body=self.body,
                             doc=self.doc,
-                            overridable=cfunc_type.is_overridable,
-                            type=cfunc_type,
-                            with_gil=cfunc_type.with_gil,
-                            nogil=cfunc_type.nogil,
                             visibility='private',
                             api=False,
                             directive_locals=getattr(cfunc, 'directive_locals', {}),
-                            directive_returns=returns)
+                            directive_returns=returns,
+                            **def_node_kwds)
 
     def is_cdef_func_compatible(self):
         """Determines if the function's signature is compatible with a

--- a/tests/run/pure_pxd.srctree
+++ b/tests/run/pure_pxd.srctree
@@ -8,7 +8,7 @@ from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 
 setup(
-    ext_modules=cythonize("a.py"),
+    ext_modules=cythonize("*.py"),
 )
 
 
@@ -109,3 +109,17 @@ cpdef int func(x, int y, z) except? -1  # argument names should not matter, type
 
 
 cdef int sum_generator_expression(int a)
+
+############## b.pxd #######
+
+# no cimport cython should appear in this file
+# "b" tests https://github.com/cython/cython/issues/5970 alone
+
+cdef void get_a_c_string(Py_ssize_t *length)
+
+############## b.py ########
+
+import cython
+
+def get_a_c_string(length: cython.pointer(cython.Py_ssize_t)) -> cython.void:
+    pass


### PR DESCRIPTION
Fixes #5970.

The basic cause of the issue was: if the argument in the .py file has an annotation, then that annotation was analysed in the scope of the .pxd file. Because the cimports were different in the two files then it failed.

My view is that as_cfunction is called much too early to be reliably analysing types in the .py file. Therefore, I've removed this. Instead the arg type from the pxd file is stashed somewhere so that it can be used later when the types from the .py file are properly analysed. I think this is a worthwhile simplification.