### PR TITLE
add tag for numpy in error test, update actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -198,14 +198,14 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload HTML docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: htmldocs
           path: docs/build/html
           if-no-files-found: ignore
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: wheels-${{ runner.os }}${{ matrix.extra_hash }}
           path: dist/*.whl
@@ -222,10 +222,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11"
 
@@ -234,7 +234,7 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: pycoverage_html
           path: coverage-report-html
@@ -249,12 +249,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11"
 
@@ -263,7 +263,7 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: cycoverage_html
           path: coverage-report-html
@@ -274,6 +274,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Compilation Cache
-        uses: hendrikmuhs/ccache-action@v1.2.9
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           variant: ${{ startsWith(runner.os, 'windows') && 'sccache' || 'ccache' }}  # fake ternary
           key: ${{ runner.os }}-hendrikmuhs-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('test-requirements*.txt', '.github/**/ci.yml', 'Tools/**/ci-run.sh') }}
@@ -207,7 +207,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4.3.0
         with:
-          name: wheels-${{ runner.os }}${{ matrix.extra_hash }}
+          name: wheels-${{ runner.os }}-${{ matrix.python-version }}${{ matrix.extra_hash }}
           path: dist/*.whl
           if-no-files-found: ignore
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout Cython
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         
       - name: Set up QEMU
         if: runner.os == 'Linux' && !contains(matrix.only, 'x86') && !contains(matrix.only, 'i686')
@@ -127,7 +127,7 @@ jobs:
             ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b')
               || contains(github.ref_name, 'rc') || contains(github.ref_name, 'dev') }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: ${{ matrix.only }}
           path: ./wheelhouse/*.whl
@@ -144,10 +144,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Cython
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       # Used to push the built wheels
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5.0.0
         with:
           # Build sdist on lowest supported Python
           python-version: '3.8'
@@ -158,12 +158,12 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel --no-cython-compile
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: sdist
           path: ./dist/*.tar.gz
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: pure-wheel
           path: ./dist/*.whl

--- a/tests/errors/nogil_buffer_acquisition.pyx
+++ b/tests/errors/nogil_buffer_acquisition.pyx
@@ -1,4 +1,5 @@
 # mode: error
+#tag: numpy
 
 cimport numpy as np
 

--- a/tests/errors/nogil_buffer_acquisition.pyx
+++ b/tests/errors/nogil_buffer_acquisition.pyx
@@ -7,5 +7,5 @@ cdef void func(np.ndarray[np.double_t, ndim=1] myarray) nogil:
     pass
 
 _ERRORS = u"""
-5:15: Buffer may not be acquired without the GIL. Consider using memoryview slices instead.
+6:15: Buffer may not be acquired without the GIL. Consider using memoryview slices instead.
 """


### PR DESCRIPTION
Fixes #5979

Before (without numpy installed):
```
$ python runtests.py nogil_buffer_acquisition -vv
Python 3.11.7 (main, Dec  8 2023, 18:56:58) [GCC 11.4.0]

Running tests against Cython 3.1.0a0 55c24376c6173f255f8b063625b466e1c7c169e8
Using Cython language level 2.
Test dependency not found: 'numpy'
...
Backends: c,cpp

runTest (__main__.CythonCompileTestCase.runTest)
[-1] compiling (c/cy2) nogil_buffer_acquisition ... 
=== Expected: ===
5:15: Buffer may not be acquired without the GIL. Consider using memoryview slices instead.

=== Got: ===
3:8: 'numpy.pxd' not found
5:15: 'ndarray' is not a type identifier

FAIL
```

After (without numpy installed)
```
$ python runtests.py nogil_buffer_acquisition -vv
Python 3.11.7 (main, Dec  8 2023, 18:56:58) [GCC 11.4.0]

Running tests against Cython 3.1.0a0 55c24376c6173f255f8b063625b466e1c7c169e8 + uncommitted changes
Using Cython language level 2.
Test dependency not found: 'numpy'
...

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Following tests excluded because of missing dependencies on your system:
   errors.nogil_buffer_acquisition
Most expensive pipeline stages: 
ALL DONE

```