### PR TITLE
Fix memoryview type checking issue

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1495,7 +1495,7 @@ class BuiltinObjectType(PyObjectType):
             type_check = "PyMemoryView_Check"
         else:
             type_check = 'Py%s_Check' % type_name.capitalize()
-        if exact and type_name not in ('bool', 'slice', 'Exception'):
+        if exact and type_name not in ('bool', 'slice', 'Exception', 'memoryview'):
             type_check += 'Exact'
         return type_check
 

--- a/tests/run/builtin_memory_view.pyx
+++ b/tests/run/builtin_memory_view.pyx
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 
-import sys
+import io
 
 cimport cython
 #from cpython.memoryview cimport PyMemoryView_GET_BUFFER
@@ -59,3 +59,16 @@ def test_in_with(x):
     """
     with memoryview(x) as xv:
         print(xv[1])
+
+
+def test_returned_type():
+    """
+    This is really just a compile test. An optimization was being
+    applied in a way that generated invalid code
+    >>> test_returned_type()
+    98
+    """
+    def foo() -> memoryview:
+        return io.BytesIO(b"abc").getbuffer()
+
+    print(foo()[1])

--- a/tests/run/builtin_memory_view.pyx
+++ b/tests/run/builtin_memory_view.pyx
@@ -67,6 +67,7 @@ def test_returned_type():
     98
     """
     def foo() -> memoryview:
-        return bytearray(b"abc")
+        rv = memoryview(b"abc")[:]
+        return rv
 
     print(foo()[1])

--- a/tests/run/builtin_memory_view.pyx
+++ b/tests/run/builtin_memory_view.pyx
@@ -4,8 +4,6 @@
 
 from __future__ import print_function
 
-import io
-
 cimport cython
 #from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 
@@ -69,6 +67,6 @@ def test_returned_type():
     98
     """
     def foo() -> memoryview:
-        return io.BytesIO(b"abc").getbuffer()
+        return bytearray(b"abc")
 
     print(foo()[1])


### PR DESCRIPTION
Fix the compilation error:

```
error: call to undeclared function 'PyMemoryView_CheckExact'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  if (!(likely(PyMemoryView_CheckExact(__pyx_v_rv))||((__pyx_v_rv) == Py_None) || __Pyx_RaiseUnexpectedTypeError("memoryview", __pyx_v_rv))) __PYX_ERR(0, 172, __pyx_L1_error)
```
