### PR TITLE
add tag for numpy in error test, update actions versions (#5985)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,12 +225,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         if: startsWith(matrix.python-version, '3.') || startsWith(matrix.python-version, 'pypy')
         with:
           python-version: ${{ matrix.python-version }}
@@ -247,7 +247,7 @@ jobs:
             which pip
 
       - name: Compilation Cache
-        uses: hendrikmuhs/ccache-action@v1.2.9
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           variant: ${{ startsWith(runner.os, 'windows') && 'sccache' || 'ccache' }}  # fake ternary
           key: ${{ runner.os }}-hendrikmuhs-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ matrix.backend == 'c' || matrix.backend == 'c,cpp' }}-${{ contains(matrix.backend, 'cpp') }}-${{ hashFiles('test-requirements*.txt', '.github/**/ci.yml', 'Tools/**/ci-run.sh') }}
@@ -259,16 +259,16 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload HTML docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: htmldocs
           path: docs/build/html
           if-no-files-found: ignore
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
-          name: wheels-${{ runner.os }}${{ matrix.extra_hash }}
+          name: wheels-${{ runner.os }}-${{ matrix.python-version }}${{ matrix.extra_hash }}
           path: dist/*.whl
           if-no-files-found: ignore
 
@@ -283,10 +283,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -295,7 +295,7 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: pycoverage_html
           path: coverage-report-html
@@ -310,12 +310,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
 
@@ -324,7 +324,7 @@ jobs:
         run: bash ./Tools/ci-run.sh
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: cycoverage_html
           path: coverage-report-html
@@ -335,6 +335,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
         python: ["cp36", "cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]  # Note: Wheels not needed for PyPy
     steps:
       - name: Checkout Cython
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         
       - name: Set up QEMU
         if: contains(matrix.buildplat[1], '_aarch64')
@@ -94,7 +94,7 @@ jobs:
             ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b')
               || contains(github.ref_name, 'rc') || contains(github.ref_name, 'dev') }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
@@ -110,10 +110,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Cython
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       # Used to push the built wheels
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5.0.0
         with:
           # Build sdist on lowest supported Python
           python-version: '3.8'
@@ -124,12 +124,12 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel --no-cython-compile --universal
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: sdist
           path: ./dist/*.tar.gz
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.0
         with:
           name: pure-wheel
           path: ./dist/*.whl

--- a/tests/errors/nogil_buffer_acquisition.pyx
+++ b/tests/errors/nogil_buffer_acquisition.pyx
@@ -1,4 +1,5 @@
 # mode: error
+#tag: numpy
 
 cimport numpy as np
 
@@ -6,5 +7,5 @@ cdef void func(np.ndarray[np.double_t, ndim=1] myarray) nogil:
     pass
 
 _ERRORS = u"""
-5:15: Buffer may not be acquired without the GIL. Consider using memoryview slices instead.
+6:15: Buffer may not be acquired without the GIL. Consider using memoryview slices instead.
 """


### PR DESCRIPTION
* add tag for numpy in error test

* fix the test for the extra line

* upgrade github actions to versions using node20

* update ccache action, add python version to wheel upload name

Barkport of #5985 to 3.0.x - just confirming that it runs correctly there