### PR TITLE
Move Py_UNICODE out of universal utility code

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5500,7 +5500,7 @@ class SliceIndexNode(ExprNode):
                         start_code,
                         code.error_goto_if_null(result, self.pos)))
                 code.globalstate.use_utility_code(
-                          UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
+                    UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
             else:
                 code.putln(
                     "%s = __Pyx_PyUnicode_FromUnicodeAndLength(%s + %s, %s - %s); %s" % (
@@ -5511,7 +5511,7 @@ class SliceIndexNode(ExprNode):
                         start_code,
                         code.error_goto_if_null(result, self.pos)))
                 code.globalstate.use_utility_code(
-                          UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
+                    UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
 
         elif self.base.type is unicode_type:
             code.globalstate.use_utility_code(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5499,6 +5499,8 @@ class SliceIndexNode(ExprNode):
                         base_result,
                         start_code,
                         code.error_goto_if_null(result, self.pos)))
+                code.globalstate.use_utility_code(
+                          UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
             else:
                 code.putln(
                     "%s = __Pyx_PyUnicode_FromUnicodeAndLength(%s + %s, %s - %s); %s" % (
@@ -5508,6 +5510,8 @@ class SliceIndexNode(ExprNode):
                         stop_code,
                         start_code,
                         code.error_goto_if_null(result, self.pos)))
+                code.globalstate.use_utility_code(
+                          UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
 
         elif self.base.type is unicode_type:
             code.globalstate.use_utility_code(

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2685,7 +2685,7 @@ class CPointerBaseType(CType):
 
     def create_to_py_utility_code(self, env):
         if self.to_py_function == "__Pyx_PyUnicode_FromUnicode":
-            # Not included in the standard TypeConversions.c string conversions because Py_UNICODE 
+            # Not included in the standard TypeConversions.c string conversions because Py_UNICODE
             # is deprecated.
             env.use_utility_code(UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
         return super().create_to_py_utility_code(env)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1683,15 +1683,25 @@ class CType(PyrexType):
     #
 
     to_py_function = None
+    to_py_utility_code = None
     from_py_function = None
+    from_py_utility_code = None
     exception_value = None
     exception_check = 1
 
     def create_to_py_utility_code(self, env):
-        return self.to_py_function is not None
+        if self.to_py_function is not None:
+            if self.to_py_utility_code is not None:
+                env.use_utility_code(self.to_py_utility_code)
+            return True
+        return False
 
     def create_from_py_utility_code(self, env):
-        return self.from_py_function is not None
+        if self.from_py_function is not None:
+            if self.from_py_utility_code is not None:
+                env.use_utility_code(self.from_py_utility_code)
+            return True
+        return False
 
     def can_coerce_to_pyobject(self, env):
         return self.create_to_py_utility_code(env)
@@ -2679,16 +2689,11 @@ class CPointerBaseType(CType):
             self.exception_value = "NULL"
         elif self.is_pyunicode_ptr and not base_type.is_error:
             self.to_py_function = "__Pyx_PyUnicode_FromUnicode"
+            self.to_py_utility_code = UtilityCode.load_cached(
+                "pyunicode_from_unicode", "StringTools.c")
             if self.is_ptr:
                 self.from_py_function = "__Pyx_PyUnicode_AsUnicode"
             self.exception_value = "NULL"
-
-    def create_to_py_utility_code(self, env):
-        if self.to_py_function == "__Pyx_PyUnicode_FromUnicode":
-            # Not included in the standard TypeConversions.c string conversions because Py_UNICODE
-            # is deprecated.
-            env.use_utility_code(UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
-        return super().create_to_py_utility_code(env)
 
     def py_type_name(self):
         if self.is_string:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -2683,6 +2683,13 @@ class CPointerBaseType(CType):
                 self.from_py_function = "__Pyx_PyUnicode_AsUnicode"
             self.exception_value = "NULL"
 
+    def create_to_py_utility_code(self, env):
+        if self.to_py_function == "__Pyx_PyUnicode_FromUnicode":
+            # Not included in the standard TypeConversions.c string conversions because Py_UNICODE 
+            # is deprecated.
+            env.use_utility_code(UtilityCode.load_cached("pyunicode_from_unicode", "StringTools.c"))
+        return super().create_to_py_utility_code(env)
+
     def py_type_name(self):
         if self.is_string:
             return "bytes"

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -13,6 +13,7 @@
 static CYTHON_INLINE Py_ssize_t __Pyx_Py_UNICODE_ssize_strlen(const Py_UNICODE *u);/*proto*/
 
 //////////////////// ssize_pyunicode_strlen ////////////////////
+//@requires: pyunicode_strlen
 
 static CYTHON_INLINE Py_ssize_t __Pyx_Py_UNICODE_ssize_strlen(const Py_UNICODE *u) {
     size_t len = __Pyx_Py_UNICODE_strlen(u);
@@ -23,6 +24,27 @@ static CYTHON_INLINE Py_ssize_t __Pyx_Py_UNICODE_ssize_strlen(const Py_UNICODE *
     return (Py_ssize_t) len;
 }
 
+//////////////////// pyunicode_strlen.proto ///////////////
+
+// There used to be a Py_UNICODE_strlen() in CPython 3.x, but it is deprecated since Py3.3.
+static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u); /* proto */
+
+//////////////////// pyunicode_strlen /////////////////////
+
+// Note: will not work in the limited API since Py_UNICODE is not available there.
+// May stop working at some point after Python 3.13 (deprecated)
+static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u)
+{
+    const Py_UNICODE *u_end = u;
+    while (*u_end++) ;
+    return (size_t)(u_end - u - 1);
+}
+
+//////////////////// pyunicode_from_unicode.proto //////////////////////
+//@requires: pyunicode_strlen
+
+#define __Pyx_PyUnicode_FromUnicode(u)       PyUnicode_FromUnicode(u, __Pyx_Py_UNICODE_strlen(u))
+#define __Pyx_PyUnicode_FromUnicodeAndLength PyUnicode_FromUnicode
 
 //////////////////// InitStrings.proto ////////////////////
 
@@ -1161,3 +1183,4 @@ static CYTHON_INLINE PyObject* __Pyx_PyStr_Str(PyObject *obj) {
 
 #define __Pyx_PyObject_Str(obj) \
     (likely(PyString_CheckExact(obj)) ? __Pyx_NewRef(obj) : PyObject_Str(obj))
+

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -1161,7 +1161,7 @@ static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer funcptr,
     } else {
         // on all other platforms (which is the vast majority, since POSIX require a function pointer
         // can be  converted to a void*) we skip the allocation and store directly into the capsule's value.
-        // Use memcpy copy the data from the function pointer to the void*
+        // Use memcpy to copy the data from the function pointer to the void*.
         // (since just casting is prohibited by standard C, and using unions is prohibited by standard c++)
         void *copy_into;
         memcpy((void*)&copy_into, (void*)&funcptr, sizeof(funcptr));

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -85,27 +85,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyUnicode_FromString(const char*);
 #define __Pyx_PyByteArray_FromCString(s)   __Pyx_PyByteArray_FromString((const char*)s)
 #define __Pyx_PyStr_FromCString(s)     __Pyx_PyStr_FromString((const char*)s)
 #define __Pyx_PyUnicode_FromCString(s) __Pyx_PyUnicode_FromString((const char*)s)
-
-// There used to be a Py_UNICODE_strlen() in CPython 3.x, but it is deprecated since Py3.3.
-#if CYTHON_COMPILING_IN_LIMITED_API
-static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const wchar_t *u)
-{
-    const wchar_t *u_end = u;
-    while (*u_end++) ;
-    return (size_t)(u_end - u - 1);
-}
-#else
-static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u)
-{
-    const Py_UNICODE *u_end = u;
-    while (*u_end++) ;
-    return (size_t)(u_end - u - 1);
-}
-#endif
-
 #define __Pyx_PyUnicode_FromOrdinal(o)       PyUnicode_FromOrdinal((int)o)
-#define __Pyx_PyUnicode_FromUnicode(u)       PyUnicode_FromUnicode(u, __Pyx_Py_UNICODE_strlen(u))
-#define __Pyx_PyUnicode_FromUnicodeAndLength PyUnicode_FromUnicode
 #define __Pyx_PyUnicode_AsUnicode            PyUnicode_AsUnicode
 
 #define __Pyx_NewRef(obj) (Py_INCREF(obj), obj)
@@ -1181,7 +1161,7 @@ static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer funcptr,
     } else {
         // on all other platforms (which is the vast majority, since POSIX require a function pointer
         // can be  converted to a void*) we skip the allocation and store directly into the capsule's value.
-        // Use memcpy copy the data from the function pointer to the void* 
+        // Use memcpy copy the data from the function pointer to the void*
         // (since just casting is prohibited by standard C, and using unions is prohibited by standard c++)
         void *copy_into;
         memcpy((void*)&copy_into, (void*)&funcptr, sizeof(funcptr));


### PR DESCRIPTION
It's deprecated in 3.13, so the existence of a function is now generating C warnings. Therefore move it to its own section to be included on demand.

Remove a limited API implementation for it - it isn't in the limited API so just shouldn't be usable there.

Fixes #5982