### PR TITLE
Restore except +ddd exception specifications

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2653,8 +2653,16 @@ class CFuncDefNode(FuncDefNode):
                 # it really is impossible to reason about what the user wants to happens
                 # if they've specified a C++ exception translation function. Therefore,
                 # raise an error.
-                error(self.pos,
-                    "Only extern functions can throw C++ exceptions.")
+                warning(self.pos,
+                    "Only extern functions can throw C++ exceptions.\n"
+                    "Using exception translation functions for user-defined functions "
+                    "was never intended to work since Cython is not designed to allow C++ "
+                    "exceptions to propagate through its code. Specifically, if the function uses "
+                    "reference counted types (like Python objects) then these will likely "
+                    "be leaked on a C++ exception. Similarly 'try ... finally' and "
+                    "'with' statements will not be correctly executed. Use at your own risk "
+                    "be aware that any issues with this function will not be treated as a bug "
+                    "in Cython.", 3)
             else:
                 warning(self.pos,
                     "Only extern functions can throw C++ exceptions.", 2)

--- a/tests/errors/cppexc_non_extern.pyx
+++ b/tests/errors/cppexc_non_extern.pyx
@@ -1,5 +1,5 @@
 # mode: error
-# tag: warnings
+# tag: warnings, cpp
 
 cdef inline void handle_exception():
     pass
@@ -13,10 +13,7 @@ cdef test_func1(self) except +handle_exception:
 cdef test_func2(self) except +:
     pass
 
-_ERRORS = """
-9:5: Only extern functions can throw C++ exceptions.
-"""
-
 _WARNINGS = """
+9:5: Only extern functions can throw C++ exceptions.
 13:5: Only extern functions can throw C++ exceptions.
 """


### PR DESCRIPTION
This fixes #5981, by re-enabling something that we thought was unused. I've made the warning much more aggressive.

I'm unconvinced that it's a good idea though - it definitely has the potential to generate dodgy code (that leaks resources, and straight invalid code e.g #3064)