### PR TITLE
Refactor stringtab generation

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1606,11 +1606,21 @@ class GlobalState:
             py_strings.sort()
             w = self.parts['pystring_table']
             w.putln("")
-            w.putln("static int __Pyx_CreateStringTabAndInitStrings(void) {")
-            # the stringtab is a function local rather than a global to
-            # ensure that it doesn't conflict with module state
-            w.putln("__Pyx_StringTabEntry %s[] = {" % Naming.stringtab_cname)
-            for py_string_args in py_strings:
+
+            self.parts['module_state'].putln("PyObject *%s[%s];" % (
+                Naming.stringtab_cname, len(py_strings)))
+
+            self.parts['module_state_clear'].putln("for (int n=0; n<%s; ++n) {" % len(py_strings))
+            self.parts['module_state_clear'].putln("Py_CLEAR(clear_module_state->%s[n]);" %
+                Naming.stringtab_cname)
+            self.parts['module_state_clear'].putln("}")
+            self.parts['module_state_traverse'].putln("for (int n=0; n<%s; ++n) {" % len(py_strings))
+            self.parts['module_state_traverse'].putln("Py_VISIT(traverse_module_state->%s[n]);" %
+                Naming.stringtab_cname)
+            self.parts['module_state_traverse'].putln("}")
+
+            w.putln("const __Pyx_StringTabEntry %s[] = {" % Naming.stringtab_cname)
+            for n, py_string_args in enumerate(py_strings):
                 c_cname, _, py_string = py_string_args
                 if not py_string.is_str or not py_string.encoding or \
                         py_string.encoding in ('ASCII', 'USASCII', 'US-ASCII',
@@ -1619,27 +1629,21 @@ class GlobalState:
                 else:
                     encoding = '"%s"' % py_string.encoding.lower()
 
-                self.parts['module_state'].putln("PyObject *%s;" % py_string.cname)
-                self.parts['module_state_defines'].putln("#define %s %s->%s" % (
+                self.parts['module_state_defines'].putln("#define %s %s->%s[%s]" % (
                     py_string.cname,
                     Naming.modulestateglobal_cname,
-                    py_string.cname))
-                self.parts['module_state_clear'].putln("Py_CLEAR(clear_module_state->%s);" %
-                    py_string.cname)
-                self.parts['module_state_traverse'].putln("Py_VISIT(traverse_module_state->%s);" %
-                    py_string.cname)
+                    Naming.stringtab_cname,
+                    n))
                 if py_string.py3str_cstring:
                     w.putln("#if PY_MAJOR_VERSION >= 3")
-                    w.putln("{&%s, %s, sizeof(%s), %s, %d, %d, %d}," % (
-                        py_string.cname,
+                    w.putln("{%s, sizeof(%s), %s, %d, %d, %d}," % (
                         py_string.py3str_cstring.cname,
                         py_string.py3str_cstring.cname,
                         '0', 1, 0,
                         py_string.intern
                         ))
                     w.putln("#else")
-                w.putln("{&%s, %s, sizeof(%s), %s, %d, %d, %d}," % (
-                    py_string.cname,
+                w.putln("{%s, sizeof(%s), %s, %d, %d, %d}," % (
                     c_cname,
                     c_cname,
                     encoding,
@@ -1649,14 +1653,15 @@ class GlobalState:
                     ))
                 if py_string.py3str_cstring:
                     w.putln("#endif")
-            w.putln("{0, 0, 0, 0, 0, 0, 0}")
+            w.putln("{0, 0, 0, 0, 0, 0}")
             w.putln("};")
-            w.putln("return __Pyx_InitStrings(%s);" % Naming.stringtab_cname)
-            w.putln("}")
 
             init_constants.putln(
-                "if (__Pyx_CreateStringTabAndInitStrings() < 0) %s;" %
-                    init_constants.error_goto(self.module_pos))
+                "if (__Pyx_InitStrings(%s, %s->%s) < 0) %s;" % (
+                    Naming.stringtab_cname,
+                    Naming.modulestateglobal_cname,
+                    Naming.stringtab_cname,
+                    init_constants.error_goto(self.module_pos)))
 
     def generate_num_constants(self):
         consts = [(c.py_type, c.value[0] == '-', len(c.value), c.value, c.value_code, c)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1485,7 +1485,7 @@ static CYTHON_INLINE float __PYX_NAN() {
 
 /////////////// UtilityFunctionPredeclarations.proto ///////////////
 
-typedef struct {PyObject **p; const char *s; const Py_ssize_t n; const char* encoding;
+typedef struct {const char *s; const Py_ssize_t n; const char* encoding;
                 const char is_unicode; const char is_str; const char intern; } __Pyx_StringTabEntry; /*proto*/
 
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -26,12 +26,12 @@ static CYTHON_INLINE Py_ssize_t __Pyx_Py_UNICODE_ssize_strlen(const Py_UNICODE *
 
 //////////////////// InitStrings.proto ////////////////////
 
-static int __Pyx_InitStrings(__Pyx_StringTabEntry *t); /*proto*/
+static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target); /*proto*/
 
 //////////////////// InitStrings ////////////////////
 
-static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
-    while (t->p) {
+static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target) {
+    while (t->s) {
         PyObject *str;
         if (t->is_unicode | t->is_str) {
             if (t->intern) {
@@ -46,11 +46,12 @@ static int __Pyx_InitStrings(__Pyx_StringTabEntry *t) {
         }
         if (!str)
             return -1;
-        *t->p = str;
+        *target = str;
         // initialise cached hash value
         if (PyObject_Hash(str) == -1)
             return -1;
         ++t;
+        ++target;
     }
     return 0;
 }


### PR DESCRIPTION
The stringtab can be a global constant rather than a function local variable that's largely initialized at runtime. Storage of cached strings in the module state is converted to a big array of PyObjects (which means some code can be replaced with loops).

Hopefully helps a bit with https://github.com/cython/cython/issues/4425

A few quick tests on Cython's own modules suggest <1% decrease in binary size, so probably worthwhile.