### PR TITLE
Add __Pyx_PyList_pack function

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8052,7 +8052,7 @@ class SequenceNode(ExprNode):
     unpacked_items = None
     mult_factor = None
     slow = False  # trade speed for code size (e.g. use PyTuple_Pack())
-    needs_subexpr_cleanup = False  # set to True in code-generation if we
+    needs_subexpr_disposal = False  # set to True in code-generation if we
             # didn't steal references to our temps and thus need to dispose
             # of them normally.
 
@@ -8206,7 +8206,7 @@ class SequenceNode(ExprNode):
                 ', '.join(arg.py_result() for arg in self.args),
                 code.error_goto_if_null(target, self.pos)))
             code.put_gotref(target, py_object_type)
-            self.needs_subexpr_cleanup = True
+            self.needs_subexpr_disposal = True
         elif self.type.is_ctuple:
             for i, arg in enumerate(self.args):
                 code.putln("%s.f%s = %s;" % (
@@ -8240,7 +8240,7 @@ class SequenceNode(ExprNode):
                 code.putln('for (%s=0; %s < %s; %s++) {' % (
                     counter, counter, c_mult, counter
                     ))
-                self.needs_subexpr_cleanup = True
+                self.needs_subexpr_disposal = True
             else:
                 offset = ''
 
@@ -8272,7 +8272,7 @@ class SequenceNode(ExprNode):
             code.putln('}')
 
     def generate_subexpr_disposal_code(self, code):
-        if self.needs_subexpr_cleanup:
+        if self.needs_subexpr_disposal:
             super().generate_subexpr_disposal_code(code)
         else:
             # We call generate_post_assignment_code here instead

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8086,7 +8086,8 @@ class SequenceNode(ExprNode):
                 mult_factor = mult_factor.coerce_to_pyobject(env)
             self.mult_factor = mult_factor.coerce_to_simple(env)
         self.is_temp = 1
-        if env.is_module_scope:
+        if (env.is_module_scope or env.is_c_class_scope or
+                (env.is_py_class_scope and env.outer_scope.is_module_scope)):
             # TODO - potentially behave differently in loops?
             self.slow = True
         # not setting self.type here, subtypes do this
@@ -8267,7 +8268,9 @@ class SequenceNode(ExprNode):
     def generate_subexpr_disposal_code(self, code):
         if self.mult_factor and self.mult_factor.type.is_int:
             super().generate_subexpr_disposal_code(code)
-        elif self.type is tuple_type and (self.is_literal or self.slow):
+        elif ((self.type is tuple_type or self.type is list_type) and
+                (self.is_literal or self.slow) and
+                len(self.args) > 0):
             super().generate_subexpr_disposal_code(code)
         else:
             # We call generate_post_assignment_code here instead

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8182,8 +8182,8 @@ class SequenceNode(ExprNode):
                 else:
                     size_factor = ' * (%s)' % (c_mult,)
 
-        if ((self.type is tuple_type or self.type is list_type) and 
-                (self.is_literal or self.slow) and 
+        if ((self.type is tuple_type or self.type is list_type) and
+                (self.is_literal or self.slow) and
                 not c_mult and
                 len(self.args) > 0):
             # use PyTuple_Pack() to avoid generating huge amounts of one-time code

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2902,3 +2902,30 @@ static CYTHON_INLINE void __Pyx_RaiseCppAttributeError(const char *varname); /*p
 static CYTHON_INLINE void __Pyx_RaiseCppAttributeError(const char *varname) {
     PyErr_Format(PyExc_AttributeError, "C++ attribute '%s' is not initialized", varname);
 }
+
+/////////////// ListPack.proto //////////////////////////////////////
+
+// Equivalent to PyTuple_Pack for sections where we want to reduce the code size
+static PyObject *__Pyx_PyList_Pack(Py_ssize_t n, ...); /* proto */
+
+/////////////// ListPack //////////////////////////////////////
+
+static PyObject *__Pyx_PyList_Pack(Py_ssize_t n, ...) {
+    va_list va;
+    PyObject *l = PyList_New(n);
+    va_start(va, n);
+    if (!l) goto end;
+
+    for (Py_ssize_t i=0; i<n; ++i) {
+        PyObject *arg = va_arg(va, PyObject*);
+        Py_INCREF(arg);
+        if (__Pyx_PyList_SET_ITEM(l, i, arg)) {
+            Py_CLEAR(l);
+            goto end;
+        }
+    }
+
+    end:
+    va_end(va);
+    return l;
+}

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2914,12 +2914,12 @@ static PyObject *__Pyx_PyList_Pack(Py_ssize_t n, ...) {
     va_list va;
     PyObject *l = PyList_New(n);
     va_start(va, n);
-    if (!l) goto end;
+    if (unlikely(!l)) goto end;
 
     for (Py_ssize_t i=0; i<n; ++i) {
         PyObject *arg = va_arg(va, PyObject*);
         Py_INCREF(arg);
-        if (__Pyx_PyList_SET_ITEM(l, i, arg)) {
+        if (unlikely(__Pyx_PyList_SET_ITEM(l, i, arg))) {
             Py_CLEAR(l);
             goto end;
         }


### PR DESCRIPTION
Analagous to "PyTuple_Pack" designed to be used in "slow" (i.e. module-level) code. The main thing this catches are lists used in "from something import name".

Also use `PyTuple_Pack` more thoroughly in module-level code. The slow attribute of SequenceNode was never being set. This probably affects tuples used in class construction like the bases tuple, which isn't a literal.

(Part of "looking at small marginal module-size gains" https://github.com/cython/cython/issues/4425)