### PR TITLE
Tighten the constness on some string arrays

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1670,7 +1670,7 @@ class GlobalState:
         encodings.sort(key=len)  # stable sort to make sure '0' comes first, index 0
         assert not encodings or '0' not in encodings or encodings[0] == '0', encodings
         encodings_map = {encoding: i for i, encoding in enumerate(encodings)}
-        w.putln("static const char* %s[] = { %s };" % (
+        w.putln("static const char * const %s[] = { %s };" % (
             Naming.stringtab_encodings_cname,
             ', '.join(encodings),
         ))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -933,7 +933,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
     def generate_filename_table(self, code):
         from os.path import isabs, basename
         code.putln("")
-        code.putln("static const char *%s[] = {" % Naming.filetable_cname)
+        code.putln("static const char* const %s[] = {" % Naming.filetable_cname)
         if code.globalstate.filename_list:
             for source_desc in code.globalstate.filename_list:
                 file_path = source_desc.get_filenametable_entry()

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -884,7 +884,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.putln('static int %s;' % Naming.lineno_cname)
         code.putln('static int %s = 0;' % Naming.clineno_cname)
-        code.putln('static const char * %s = %s;' % (Naming.cfilenm_cname, Naming.file_c_macro))
+        code.putln('static const char * const %s = %s;' % (Naming.cfilenm_cname, Naming.file_c_macro))
         code.putln('static const char *%s;' % Naming.filename_cname)
 
         env.use_utility_code(UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c"))

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -49,11 +49,11 @@ static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u)
 
 //////////////////// InitStrings.proto ////////////////////
 
-static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target, const char** encoding_names); /*proto*/
+static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target, const char* const* encoding_names); /*proto*/
 
 //////////////////// InitStrings ////////////////////
 
-static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target, const char** encoding_names) {
+static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target, const char* const* encoding_names) {
     while (t->s) {
         PyObject *str;
         if (t->is_unicode | t->is_str) {


### PR DESCRIPTION
This seems to take about 1.5% off the size of
compiled "ParseTreeTransforms".

Essentially the original version is "an array of pointers to unmodifiable strings". The new version is
"an unmodifiable array pointers to unmodifiable strings". Presumably the advantage is that the compiler can know the result at compile-time in a lot of cases.