### PR TITLE
Rationalize the different cline traceback options

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -819,7 +819,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             f" {Naming.lineno_cname} = lineno;"
             f" (void) {Naming.lineno_cname};"
             "%s"  # for C line info
-            f" (void) {Naming.clineno_cname}; "  # always surpress warnings
+            f" (void) {Naming.clineno_cname}; "  # always suppress warnings
             "}"
         )
         cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -819,15 +819,16 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             f" {Naming.lineno_cname} = lineno;"
             f" (void) {Naming.lineno_cname};"
             "%s"  # for C line info
-            f" (void) {Naming.clineno_cname}; "  # always suppress warnings
+            f" (void) {Naming.clineno_cname}; "  # always surpress warnings
             "}"
         )
         cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"
 
-        code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
-        code.putln(f"#define CYTHON_CLINE_IN_TRACEBACK  {2 if options.c_line_in_traceback else 0}")
-        code.putln("#endif")
-        code.putln("#if CYTHON_CLINE_IN_TRACEBACK")
+        if not options.c_line_in_traceback:
+            code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
+            code.putln("#define CYTHON_CLINE_IN_TRACEBACK  0")
+            code.putln("#endif")
+        code.putln("#if !defined(CYTHON_CLINE_IN_TRACEBACK) || CYTHON_CLINE_IN_TRACEBACK")
         code.putln(mark_errpos_code % cline_info)
         code.putln("#else")
         code.putln(mark_errpos_code % "")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -810,34 +810,30 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         self._put_setup_code(code, "PythonCompatibility")
         self._put_setup_code(code, "MathInitCode")
 
-        if options.c_line_in_traceback:
-<<<<<<< HEAD
-            # Actually the storing cline can be surprisingly costly in terms of code size.
-            # So skip it if we know that we're going to ignore it later.
-            code.putln("#if defined(CYTHON_CLINE_IN_TRACEBACK) && !CYTHON_CLINE_IN_TRACEBACK")
-            code.putln("#define __PYX_ASSIGN_CLINE")
-            code.putln("#else")
-            code.putln(f"#define __PYX_ASSIGN_CLINE {Naming.clineno_cname} = {Naming.line_c_macro}")
-            code.putln("#endif")
-            cinfo = f"__PYX_ASSIGN_CLINE;"
-=======
-            cinfo = "%s = %s; " % (Naming.clineno_cname, Naming.line_c_macro)
->>>>>>> real_origin/master
-        else:
-            cinfo = ""
-            # We may as well eliminate a bunch of code elsewhere that handles
-            # printing the cline, since we aren't recording the cline.
-            code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
-            code.putln("#define CYTHON_CLINE_IN_TRACEBACK 0")
-            code.putln("#endif")
-        code.putln("#define __PYX_MARK_ERR_POS(f_index, lineno) \\")
+        # Error handling and position macros.
         # Using "(void)cname" to prevent "unused" warnings.
-        code.putln("    { %s = %s[f_index]; (void)%s; %s = lineno; (void)%s; %s (void)%s; }" % (
-            Naming.filename_cname, Naming.filetable_cname, Naming.filename_cname,
-            Naming.lineno_cname, Naming.lineno_cname,
-            cinfo,
-            Naming.clineno_cname,
-        ))
+        mark_errpos_code = (
+            "#define __PYX_MARK_ERR_POS(f_index, lineno)  {"
+            f" {Naming.filename_cname} = {Naming.filetable_cname}[f_index];"
+            f" (void) {Naming.filename_cname};"
+            f" {Naming.lineno_cname} = lineno;"
+            f" (void) {Naming.lineno_cname};"
+            "%s"  # for C line info
+            f" (void) {Naming.clineno_cname}; "  # always surpress warnings
+            "}"
+        )
+        cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"
+
+        if not options.c_line_in_traceback:
+            code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
+            code.putln("#define CYTHON_CLINE_IN_TRACEBACK  0")
+            code.putln("#endif")
+        code.putln("#if !defined(CYTHON_CLINE_IN_TRACEBACK) || CYTHON_CLINE_IN_TRACEBACK")
+        code.putln(mark_errpos_code % cline_info)
+        code.putln("#else")
+        code.putln(mark_errpos_code % "")
+        code.putln("#endif")
+
         code.putln("#define __PYX_ERR(f_index, lineno, Ln_error) \\")
         code.putln("    { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }")
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -833,7 +833,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         # 5)  if nothing is set, the default is to disable the feature
 
         default_cline_runtime = 0
-        print("XXXXXXX", options.c_line_in_traceback)
         if options.c_line_in_traceback is not None:
             # explicitly set by user
             default_cline_runtime = int(options.c_line_in_traceback)
@@ -842,7 +841,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln(f"#define CYTHON_CLINE_IN_TRACEBACK_RUNTIME {default_cline_runtime}")
         code.putln("#endif")
 
-        code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
+        code.putln("#if !defined(CYTHON_CLINE_IN_TRACEBACK) || CYTHON_CLINE_IN_TRACEBACK_RUNTIME")
+        code.putln("#undef CYTHON_CLINE_IN_TRACEBACK")
         code.putln("#define CYTHON_CLINE_IN_TRACEBACK CYTHON_CLINE_IN_TRACEBACK_RUNTIME")
         code.putln("#endif")
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -819,16 +819,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             f" {Naming.lineno_cname} = lineno;"
             f" (void) {Naming.lineno_cname};"
             "%s"  # for C line info
-            f" (void) {Naming.clineno_cname}; "  # always surpress warnings
+            f" (void) {Naming.clineno_cname}; "  # always suppress warnings
             "}"
         )
         cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"
 
-        if not options.c_line_in_traceback:
-            code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
-            code.putln("#define CYTHON_CLINE_IN_TRACEBACK  0")
-            code.putln("#endif")
-        code.putln("#if !defined(CYTHON_CLINE_IN_TRACEBACK) || CYTHON_CLINE_IN_TRACEBACK")
+        code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
+        code.putln(f"#define CYTHON_CLINE_IN_TRACEBACK  {2 if options.c_line_in_traceback else 0}")
+        code.putln("#endif")
+        code.putln("#if CYTHON_CLINE_IN_TRACEBACK")
         code.putln(mark_errpos_code % cline_info)
         code.putln("#else")
         code.putln(mark_errpos_code % "")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -824,14 +824,13 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         )
         cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"
 
-        # 0)  C macros take precedence over options
+        # Show the C code line in tracebacks or not? C macros take precedence over (deprecated) options.
         # 1)  "CYTHON_CLINE_IN_TRACEBACK=0"  always disables C lines in tracebacks
-        # 3) "CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1"  enables the feature + runtime configuration
-        # 2a) "options.c_line_in_traceback=True"   changes the default to 
-        #     CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
-        # 2b) "options.c_line_in_traceback=False"  changes the default to disable the feature        
-        # 4)  "CYTHON_CLINE_IN_TRACEBACK=1"  enables the feature without runtime configuration
-        # 5)  default if nothing is set is to disable the feature
+        # 2) "CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1"  enables the feature + runtime configuration
+        # 2a) "options.c_line_in_traceback=True"   changes the default to CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
+        # 2b) "options.c_line_in_traceback=False"  changes the default to disable C lines
+        # 4)  "CYTHON_CLINE_IN_TRACEBACK=1"  enables C lines without runtime configuration
+        # 5)  if nothing is set, the default is to disable the feature
 
         default_cline_runtime = 0
         print("XXXXXXX", options.c_line_in_traceback)

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -825,12 +825,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         cline_info = f" {Naming.clineno_cname} = {Naming.line_c_macro};"
 
         # Show the C code line in tracebacks or not? C macros take precedence over (deprecated) options.
-        # 1)  "CYTHON_CLINE_IN_TRACEBACK=0"  always disables C lines in tracebacks
-        # 2) "CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1"  enables the feature + runtime configuration
+        # 1) "CYTHON_CLINE_IN_TRACEBACK=0"  always disables C lines in tracebacks
+        # 2) "CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1" enables the feature + runtime configuration
         # 2a) "options.c_line_in_traceback=True"   changes the default to CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
         # 2b) "options.c_line_in_traceback=False"  changes the default to disable C lines
-        # 4)  "CYTHON_CLINE_IN_TRACEBACK=1"  enables C lines without runtime configuration
-        # 5)  if nothing is set, the default is to disable the feature
+        # 4) "CYTHON_CLINE_IN_TRACEBACK=1"         enables C lines without runtime configuration
+        # 5) if nothing is set, the default is to disable the feature
 
         default_cline_runtime = 0
         if options.c_line_in_traceback is not None:
@@ -841,8 +841,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln(f"#define CYTHON_CLINE_IN_TRACEBACK_RUNTIME {default_cline_runtime}")
         code.putln("#endif")
 
-        code.putln("#if !defined(CYTHON_CLINE_IN_TRACEBACK) || CYTHON_CLINE_IN_TRACEBACK_RUNTIME")
-        code.putln("#undef CYTHON_CLINE_IN_TRACEBACK")
+        code.putln("#ifndef CYTHON_CLINE_IN_TRACEBACK")
         code.putln("#define CYTHON_CLINE_IN_TRACEBACK CYTHON_CLINE_IN_TRACEBACK_RUNTIME")
         code.putln("#endif")
 

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -810,12 +810,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         self._put_setup_code(code, "PythonCompatibility")
         self._put_setup_code(code, "MathInitCode")
 
-        # Using "(void)cname" to prevent "unused" warnings.
         if options.c_line_in_traceback:
             cinfo = "%s = %s; " % (Naming.clineno_cname, Naming.line_c_macro)
         else:
             cinfo = ""
         code.putln("#define __PYX_MARK_ERR_POS(f_index, lineno) \\")
+        # Using "(void)cname" to prevent "unused" warnings.
         code.putln("    { %s = %s[f_index]; (void)%s; %s = lineno; (void)%s; %s (void)%s; }" % (
             Naming.filename_cname, Naming.filetable_cname, Naming.filename_cname,
             Naming.lineno_cname, Naming.lineno_cname,

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -812,14 +812,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         # Using "(void)cname" to prevent "unused" warnings.
         if options.c_line_in_traceback:
-            cinfo = "%s = %s; (void)%s; " % (Naming.clineno_cname, Naming.line_c_macro, Naming.clineno_cname)
+            cinfo = "%s = %s; " % (Naming.clineno_cname, Naming.line_c_macro)
         else:
             cinfo = ""
         code.putln("#define __PYX_MARK_ERR_POS(f_index, lineno) \\")
-        code.putln("    { %s = %s[f_index]; (void)%s; %s = lineno; (void)%s; %s}" % (
+        code.putln("    { %s = %s[f_index]; (void)%s; %s = lineno; (void)%s; %s (void)%s; }" % (
             Naming.filename_cname, Naming.filetable_cname, Naming.filename_cname,
             Naming.lineno_cname, Naming.lineno_cname,
-            cinfo
+            cinfo,
+            Naming.clineno_cname,
         ))
         code.putln("#define __PYX_ERR(f_index, lineno, Ln_error) \\")
         code.putln("    { __PYX_MARK_ERR_POS(f_index, lineno) goto Ln_error; }")

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -147,7 +147,6 @@ buffer_max_dims = 8
 #: Number of function closure instances to keep in a freelist (0: no freelists)
 closure_freelist_size = 8
 
-
 def get_directive_defaults():
     # To add an item to this list, all accesses should be changed to use the new
     # directive, and the global option itself should be set to an instance of
@@ -643,6 +642,7 @@ class CompilationOptions:
         # ignore valid options that are not in the defaults
         unknown_options.difference_update(['include_path'])
         if unknown_options:
+            import pdb; pdb.set_trace()
             message = "got unknown compilation option%s, please remove: %s" % (
                 's' if len(unknown_options) > 1 else '',
                 ', '.join(unknown_options))
@@ -787,7 +787,7 @@ default_options = dict(
     evaluate_tree_assertions=False,
     emit_linenums=False,
     relative_path_in_code_position_comments=True,
-    c_line_in_traceback=True,
+    c_line_in_traceback=None,
     language_level=None,  # warn but default to 2
     formal_grammar=False,
     gdb_debug=False,

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -642,7 +642,6 @@ class CompilationOptions:
         # ignore valid options that are not in the defaults
         unknown_options.difference_update(['include_path'])
         if unknown_options:
-            import pdb; pdb.set_trace()
             message = "got unknown compilation option%s, please remove: %s" % (
                 's' if len(unknown_options) > 1 else '',
                 ', '.join(unknown_options))

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -147,6 +147,7 @@ buffer_max_dims = 8
 #: Number of function closure instances to keep in a freelist (0: no freelists)
 closure_freelist_size = 8
 
+
 def get_directive_defaults():
     # To add an item to this list, all accesses should be changed to use the new
     # directive, and the global option itself should be set to an instance of

--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -110,6 +110,10 @@ class build_ext(_build_ext):
         if self.get_extension_attr(ext, 'cython_cplus'):
             ext.language = 'c++'
 
+        if hasattr(ext, 'no_c_in_traceback'):
+            c_line_in_traceback = not ext.no_c_in_traceback
+        else:
+            c_line_in_traceback = None
         options = {
             'use_listing_file': self.get_extension_attr(ext, 'cython_create_listing'),
             'emit_linenums': self.get_extension_attr(ext, 'cython_line_directives'),
@@ -118,7 +122,7 @@ class build_ext(_build_ext):
             'build_dir': self.build_temp if self.get_extension_attr(ext, 'cython_c_in_temp') else None,
             'generate_pxi': self.get_extension_attr(ext, 'cython_gen_pxi'),
             'gdb_debug': self.get_extension_attr(ext, 'cython_gdb'),
-            'c_line_in_traceback': not getattr(ext, 'no_c_in_traceback', 0),
+            'c_line_in_traceback': c_line_in_traceback,
             'compile_time_env': self.get_extension_attr(ext, 'cython_compile_time_env', default=None),
         }
 

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -773,7 +773,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: PyErrFetchRestore
 //@substitute: naming
 
-#if CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1
+#if !(CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1)
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     PyObject *use_cline;
     PyObject *ptype, *pvalue, *ptraceback;

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -761,7 +761,7 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
 
 /////////////// CLineInTraceback.proto ///////////////
 
-#if CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1 /* 0 or 1 to disable/enable C line display in tracebacks at C compile time */
+#ifdef CYTHON_CLINE_IN_TRACEBACK  /* 0 or 1 to disable/enable C line display in tracebacks at C compile time */
 #define __Pyx_CLineForTraceback(tstate, c_line)  (((CYTHON_CLINE_IN_TRACEBACK)) ? c_line : 0)
 #else
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
@@ -773,7 +773,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: PyErrFetchRestore
 //@substitute: naming
 
-#if !(CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1)
+#ifndef CYTHON_CLINE_IN_TRACEBACK
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     PyObject *use_cline;
     PyObject *ptype, *pvalue, *ptraceback;

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -761,10 +761,10 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
 
 /////////////// CLineInTraceback.proto ///////////////
 
-#ifdef CYTHON_CLINE_IN_TRACEBACK  /* 0 or 1 to disable/enable C line display in tracebacks at C compile time */
-#define __Pyx_CLineForTraceback(tstate, c_line)  (((CYTHON_CLINE_IN_TRACEBACK)) ? c_line : 0)
-#else
+#if CYTHON_CLINE_IN_TRACEBACK_RUNTIME
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
+#else
+#define __Pyx_CLineForTraceback(tstate, c_line)  (((CYTHON_CLINE_IN_TRACEBACK)) ? c_line : 0)
 #endif
 
 /////////////// CLineInTraceback ///////////////
@@ -773,7 +773,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: PyErrFetchRestore
 //@substitute: naming
 
-#ifndef CYTHON_CLINE_IN_TRACEBACK
+#if CYTHON_CLINE_IN_TRACEBACK_RUNTIME
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     PyObject *use_cline;
     PyObject *ptype, *pvalue, *ptraceback;

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -761,7 +761,7 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
 
 /////////////// CLineInTraceback.proto ///////////////
 
-#if CYTHON_CLINE_IN_TRACEBACK_RUNTIME
+#if CYTHON_CLINE_IN_TRACEBACK && CYTHON_CLINE_IN_TRACEBACK_RUNTIME
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 #else
 #define __Pyx_CLineForTraceback(tstate, c_line)  (((CYTHON_CLINE_IN_TRACEBACK)) ? c_line : 0)
@@ -773,7 +773,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: PyErrFetchRestore
 //@substitute: naming
 
-#if CYTHON_CLINE_IN_TRACEBACK_RUNTIME
+#if CYTHON_CLINE_IN_TRACEBACK && CYTHON_CLINE_IN_TRACEBACK_RUNTIME
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     PyObject *use_cline;
     PyObject *ptype, *pvalue, *ptraceback;

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -761,7 +761,7 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
 
 /////////////// CLineInTraceback.proto ///////////////
 
-#ifdef CYTHON_CLINE_IN_TRACEBACK  /* 0 or 1 to disable/enable C line display in tracebacks at C compile time */
+#if CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1 /* 0 or 1 to disable/enable C line display in tracebacks at C compile time */
 #define __Pyx_CLineForTraceback(tstate, c_line)  (((CYTHON_CLINE_IN_TRACEBACK)) ? c_line : 0)
 #else
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
@@ -773,7 +773,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: PyErrFetchRestore
 //@substitute: naming
 
-#ifndef CYTHON_CLINE_IN_TRACEBACK
+#if CYTHON_CLINE_IN_TRACEBACK == 0 || CYTHON_CLINE_IN_TRACEBACK == 1
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     PyObject *use_cline;
     PyObject *ptype, *pvalue, *ptraceback;

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -741,9 +741,6 @@ Here are the options that are available:
 .. autodata:: Cython.Compiler.Options.cimport_from_pyx
 .. autodata:: Cython.Compiler.Options.buffer_max_dims
 .. autodata:: Cython.Compiler.Options.closure_freelist_size
-Cython.Compiler.Options. **c_line_in_traceback** = True
-    See :ref:`cline_in_traceback`
-
 
 .. _compiler-directives:
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1116,33 +1116,25 @@ values passed to ``cythonize``.
 C line numbers in tracebacks
 ============================
 
-Control of whether to show the C line number in the traceback is complicated so is
-detailed here separately.  The main reason to want to disable it is that it can give
-a notable reduction in binary file size (0-5%, depending on the module).
+To provide more detailed debug information, Python tracebacks of Cython modules
+show the C line where the exception originated (or was propagated). This feature is not
+entirely for free and can visibly increase the C compile time as well as adding 0-5% to the
+size of the binary extension module. It can therefore be disabled using a C macro.
 
-At the top level it is controlled by the Cython option ``Options.cline_in_c_line_in_traceback``
-which defaults to ``True``.  You can also turn this off by passing ``--no-c-in-traceback``
-to Cython on the command line.
+* ``CYTHON_CLINE_IN_TRACEBACK=1`` always shows the C line number in tracebacks,
+* ``CYTHON_CLINE_IN_TRACEBACK=0`` never shows the C line number in tracebacks,
 
-Provided ``Options.cline_in_c_line_in_traceback`` is on, then you can use the C macro
-``CYTHON_CLINE_IN_TRACEBACK`` to control the exact behaviour:
-
-* ``CYTHON_CLINE_IN_TRACEBACK==1`` always shows the C line number in tracebacks,
-* ``CYTHON_CLINE_IN_TRACEBACK==0`` never shows the C line number in tracebacks,
-* the default is to pick at runtime (you can explicitly set this with
-  ``CYTHON_CLINE_IN_TRACEBACK==2`` from Cython 3.1 upwards, but is still the default
-  in earlier versions).
+If the macro is *not* defined by the build setup or ``CFLAGS``, the feature is included and
+can be enabled and disabled at runtime, at the before mentioned cost of longer C compile
+times and larger extension modules.
   
-For the default behaviour of picking at runtime, you can import the
-module ``cython_runtime`` and set the variable ``cline_in_traceback`` in that
-module to either ``True`` or ``False`` to control the behaviour as your Cython
-code is being run.
+For changing the value at runtime, you can import the special module ``cython_runtime``
+after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
+to either true or false to control the behaviour as your Cython code is being run.
 
-From Cython 3.1 we will be allowing users to pick the full range of behaviours with
-the ``CYTHON_CLINE_IN_TRACEBACK`` macro define so it should no longer be necessary to
-use ``Options.cline_in_c_line_in_traceback``.
-However, in earlier versions it is necessary to turn this option off if you want to
-get the benefit of the reduced binary file size.
+Previously, the Cython option ``c_line_in_traceback`` or the command
+line argument ``--no-c-in-traceback`` could be used to disable this feature. This is still
+possible, but should be migrated to using the C macro instead.
 
 C macro defines
 ===============

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1135,7 +1135,9 @@ to either true or false to control the behaviour as your Cython code is being ru
 In Cython 3.0 and earlier, the Cython option ``c_line_in_traceback`` or the command
 line argument ``--no-c-in-traceback`` could be used to disable this feature.
 From Cython 3.1, this is still
-possible, but should be migrated to using the C macro instead.
+possible, but should be migrated to using the C macro instead.  Below Cython 3.1
+the macros still work as described but the Cython option is needed to remove
+the compile-time cost.
 
 C macro defines
 ===============

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1128,12 +1128,13 @@ If the macro is *not* defined by the build setup or ``CFLAGS``, the feature is i
 can be enabled and disabled at runtime, at the before mentioned cost of longer C compile
 times and larger extension modules.
   
-For changing the value at runtime, you can import the special module ``cython_runtime``
+To change the value at runtime, you can import the special module ``cython_runtime``
 after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
 to either true or false to control the behaviour as your Cython code is being run.
 
-Previously, the Cython option ``c_line_in_traceback`` or the command
-line argument ``--no-c-in-traceback`` could be used to disable this feature. This is still
+In Cython 3.0 and earlier, the Cython option ``c_line_in_traceback`` or the command
+line argument ``--no-c-in-traceback`` could be used to disable this feature.
+From Cython 3.1, this is still
 possible, but should be migrated to using the C macro instead.
 
 C macro defines

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1116,25 +1116,33 @@ C line numbers in tracebacks
 To provide more detailed debug information, Python tracebacks of Cython modules
 show the C line where the exception originated (or was propagated). This feature is not
 entirely for free and can visibly increase the C compile time as well as adding 0-5% to the
-size of the binary extension module. It can therefore be disabled using a C macro.
+size of the binary extension module. It is therefore disabled in Cython 3.1 and can be controlled using C macros.
 
 * ``CYTHON_CLINE_IN_TRACEBACK=1`` always shows the C line number in tracebacks,
 * ``CYTHON_CLINE_IN_TRACEBACK=0`` never shows the C line number in tracebacks,
 
-If the macro is *not* defined by the build setup or ``CFLAGS``, the feature is included and
-can be enabled and disabled at runtime, at the before mentioned cost of longer C compile
-times and larger extension modules. This is the default behaviour.
-  
-To change the value at runtime, you can import the special module ``cython_runtime``
-after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
-to either true or false to control the behaviour as your Cython code is being run.
+Unless the feature is disabled completely with this macro, there is also support for enabling and disabling
+the feature at runtime, at the before mentioned cost of longer C compile times and larger extension modules.
+This can be configured with the C macro
 
-In Cython 3.0 and earlier, the Cython option ``c_line_in_traceback`` or the command
-line argument ``--no-c-in-traceback`` could be used to disable this feature.
-From Cython 3.1, this is still
-possible, but should be migrated to using the C macro instead.  Below Cython 3.1
-the macros still work as described but the Cython option is needed to remove
-the compile-time cost.
+``CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1``
+  
+To then change the behaviour at runtime, you can import the special module ``cython_runtime``
+after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
+to either true or false to control the behaviour as your Cython code is being run::
+
+    import cython_runtime
+    cython_runtime.cline_in_traceback = True
+    
+    raise ValueError(5)
+
+If both macros are *not* defined by the build setup or ``CFLAGS``, the feature is disabled.
+
+In Cython 3.0 and earlier, the Cython compiler option ``c_line_in_traceback`` or the command
+line argument ``--no-c-in-traceback`` could also be used to disable this feature.
+From Cython 3.1, this is still possible, but should be migrated to using the C macros instead.
+Before Cython 3.1, the ``CYTHON_CLINE_IN_TRACABACK`` macro still works as described
+but the Cython option is needed to remove the compile-time cost.
 
 C macro defines
 ===============

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1138,7 +1138,8 @@ to either true or false to control the behaviour as your Cython code is being ru
 
 If both macros are *not* defined by the build setup or ``CFLAGS``, the feature is disabled.
 
-In Cython 3.0 and earlier, the Cython compiler option ``c_line_in_traceback`` or the command
+In Cython 3.0 and earlier, the Cython compiler option ``c_line_in_traceback`` (passed as
+an argument to ``cythonize`` in ``setup.py``) or the command
 line argument ``--no-c-in-traceback`` could also be used to disable this feature.
 From Cython 3.1, this is still possible, but should be migrated to using the C macros instead.
 Before Cython 3.1, the ``CYTHON_CLINE_IN_TRACABACK`` macro still works as described

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1142,7 +1142,7 @@ In Cython 3.0 and earlier, the Cython compiler option ``c_line_in_traceback`` (p
 an argument to ``cythonize`` in ``setup.py``) or the command
 line argument ``--no-c-in-traceback`` could also be used to disable this feature.
 From Cython 3.1, this is still possible, but should be migrated to using the C macros instead.
-Before Cython 3.1, the ``CYTHON_CLINE_IN_TRACABACK`` macro still works as described
+Before Cython 3.1, the ``CYTHON_CLINE_IN_TRACEBACK`` macro already works as described
 but the Cython option is needed to remove the compile-time cost.
 
 C macro defines

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -699,7 +699,6 @@ You can see them also by typing ```%%cython?`` in IPython or a Jupyter notebook.
 
 ============================================  =======================================================================================================================================
 
-
 .. _compiler_options:
 
 Compiler options
@@ -742,6 +741,8 @@ Here are the options that are available:
 .. autodata:: Cython.Compiler.Options.cimport_from_pyx
 .. autodata:: Cython.Compiler.Options.buffer_max_dims
 .. autodata:: Cython.Compiler.Options.closure_freelist_size
+Cython.Compiler.Options. **c_line_in_traceback** = True
+    See :ref:`cline_in_traceback`
 
 
 .. _compiler-directives:
@@ -1110,6 +1111,39 @@ This will override the default directives as specified in the ``compiler_directi
 Note that explicit per-file or local directives as explained above take precedence over the
 values passed to ``cythonize``.
 
+.. _cline_in_traceback:
+
+C line numbers in tracebacks
+============================
+
+Control of whether to show the C line number in the traceback is complicated so is
+detailed here separately.  The main reason to want to disable it is that it can give
+a notable reduction in binary file size (0-5%, depending on the module).
+
+At the top level it is controlled by the Cython option ``Options.cline_in_c_line_in_traceback``
+which defaults to ``True``.  You can also turn this off by passing ``--no-c-in-traceback``
+to Cython on the command line.
+
+Provided ``Options.cline_in_c_line_in_traceback`` is on, then you can use the C macro
+``CYTHON_CLINE_IN_TRACEBACK`` to control the exact behaviour:
+
+* ``CYTHON_CLINE_IN_TRACEBACK==1`` always shows the C line number in tracebacks,
+* ``CYTHON_CLINE_IN_TRACEBACK==0`` never shows the C line number in tracebacks,
+* the default is to pick at runtime (you can explicitly set this with
+  ``CYTHON_CLINE_IN_TRACEBACK==2`` from Cython 3.1 upwards, but is still the default
+  in earlier versions).
+  
+For the default behaviour of picking at runtime, you can import the
+module ``cython_runtime`` and set the variable ``cline_in_traceback`` in that
+module to either ``True`` or ``False`` to control the behaviour as your Cython
+code is being run.
+
+From Cython 3.1 we will be allowing users to pick the full range of behaviours with
+the ``CYTHON_CLINE_IN_TRACEBACK`` macro define so it should no longer be necessary to
+use ``Options.cline_in_c_line_in_traceback``.
+However, in earlier versions it is necessary to turn this option off if you want to
+get the benefit of the reduced binary file size.
+
 C macro defines
 ===============
 
@@ -1154,6 +1188,10 @@ most important to least important:
 ``CYTHON_EXTERN_C``
     Slightly different to the other macros, this controls how ``cdef public``
     functions appear to C++ code. See :ref:`CYTHON_EXTERN_C` for full details.
+
+``CYTHON_CLINE_IN_TRACEBACK``
+    Controls whether C lines numbers appear in tracebacks.
+    See :ref:`cline_in_traceback` for a complete description.
     
 There is a further list of macros which turn off various optimizations or language
 features.  Under normal circumstance Cython enables these automatically based on the

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -699,6 +699,7 @@ You can see them also by typing ```%%cython?`` in IPython or a Jupyter notebook.
 
 ============================================  =======================================================================================================================================
 
+
 .. _compiler_options:
 
 Compiler options
@@ -741,6 +742,7 @@ Here are the options that are available:
 .. autodata:: Cython.Compiler.Options.cimport_from_pyx
 .. autodata:: Cython.Compiler.Options.buffer_max_dims
 .. autodata:: Cython.Compiler.Options.closure_freelist_size
+
 
 .. _compiler-directives:
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1126,7 +1126,7 @@ size of the binary extension module. It can therefore be disabled using a C macr
 
 If the macro is *not* defined by the build setup or ``CFLAGS``, the feature is included and
 can be enabled and disabled at runtime, at the before mentioned cost of longer C compile
-times and larger extension modules.
+times and larger extension modules. This is the default behaviour.
   
 To change the value at runtime, you can import the special module ``cython_runtime``
 after loading a Cython module and set the attribute ``cline_in_traceback`` in that module

--- a/runtests.py
+++ b/runtests.py
@@ -1227,6 +1227,7 @@ class CythonCompileTestCase(unittest.TestCase):
             generate_pxi = False,
             evaluate_tree_assertions = True,
             common_utility_include_dir = common_utility_include_dir,
+            c_line_in_traceback = True,
             **extra_compile_options
             )
         cython_compile(module_path, options=options, full_module_name=module)

--- a/tests/run/cline_in_traceback.srctree
+++ b/tests/run/cline_in_traceback.srctree
@@ -7,24 +7,27 @@ PYTHON run_all_tests.py
 from Cython.Build.Dependencies import cythonize
 from setuptools import setup, Extension
 
-setup(ext_modules = cythonize(
-    Extension("test_on", ["test_on.pyx"]),
-    Extension("test_off", ["test_off.pyx"]),
-    Extension("test_runtime", ["test_runtime.pyx"]),
-    Extension("test_default", ["test_default.pyx"]),
-    Extension("test_contradicting_macros", ["test_contradicting_macros.pyx"]),
+setup(ext_modules = cythonize([
+        Extension("test_on", ["test_on.pyx"]),
+        Extension("test_off", ["test_off.pyx"]),
+        Extension("test_runtime", ["test_runtime.pyx"]),
+        Extension("test_default", ["test_default.pyx"]),
+        Extension("test_contradicting_macros", ["test_contradicting_macros.pyx"]),
+    ],
 ))
 
-setup(ext_modules = cythonize(
-    Extension("test_options_on", ["test_options_on.pyx"]),
-    Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"]),
+setup(ext_modules = cythonize([
+        Extension("test_options_on", ["test_options_on.pyx"]),
+        Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"]),
+    ],
     c_line_in_traceback = True,
 ))
 
-setup(ext_modules = cythonize(
-    Extension("test_options_off", ["test_options_off.pyx"]),
-    Extension("test_options_off_overridden1", ["test_options_off_overridden1.pyx"]),
-    Extension("test_options_off_overridden2", ["test_options_off_overridden2.pyx"]),
+setup(ext_modules = cythonize([
+        Extension("test_options_off", ["test_options_off.pyx"]),
+        Extension("test_options_off_overridden1", ["test_options_off_overridden1.pyx"]),
+        Extension("test_options_off_overridden2", ["test_options_off_overridden2.pyx"]),
+    ],
     c_line_in_traceback = False,
 ))
 

--- a/tests/run/cline_in_traceback.srctree
+++ b/tests/run/cline_in_traceback.srctree
@@ -1,124 +1,41 @@
-PYTHON setup_on.py build_ext --inplace
-PYTHON setup_off.py build_ext --inplace
-PYTHON setup_runtime.py build_ext --inplace
-PYTHON setup_default.py build_ext --inplace
-PYTHON setup_options_on.py build_ext --inplace
-PYTHON setup_options_off.py build_ext --inplace
-PYTHON setup_options_off_overridden1.py build_ext --inplace
-PYTHON setup_options_off_overridden2.py build_ext --inplace
-PYTHON setup_options_on_overridden.py build_ext --inplace
-
+PYTHON setup.py build_ext --inplace
 PYTHON run_all_tests.py
 
 
-######## setup_on.py ########
+######## setup.py ########
 
 from Cython.Build.Dependencies import cythonize
 from setuptools import setup, Extension
 
-setup(
-    ext_modules = cythonize(
-        Extension("test_on", ["test_on.pyx"],
-            define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 1)],
-    )))
-    
-######## setup_off.py ########
+setup(ext_modules = cythonize(
+    Extension("test_on", ["test_on.pyx"]),
+    Extension("test_off", ["test_off.pyx"]),
+    Extension("test_runtime", ["test_runtime.pyx"]),
+    Extension("test_default", ["test_default.pyx"]),
+    Extension("test_contradicting_macros", ["test_contradicting_macros.pyx"]),
+))
 
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
+setup(ext_modules = cythonize(
+    Extension("test_options_on", ["test_options_on.pyx"]),
+    Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"]),
+    c_line_in_traceback = True,
+))
 
-setup(
-    ext_modules = cythonize(
-        Extension("test_off", ["test_off.pyx"],
-            define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 0)],
-    )))
-
-######## setup_runtime.py ########
-
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_runtime", ["test_runtime.pyx"],
-            define_macros=[("CYTHON_CLINE_IN_TRACEBACK_RUNTIME", 1)],
-    )))
-    
-######## setup_default.py ########
-
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_default", ["test_default.pyx"]
-    )))
-    
-######## setup_options_on.py ########
-
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_options_on", ["test_options_on.pyx"]),
-        c_line_in_traceback = True
-    ))
-    
-####### setup_options_off.py #########
-
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_options_off", ["test_options_off.pyx"]),
-        c_line_in_traceback = False
-    ))
-    
-####### setup_options_off_overridden1.py #########
-
-# less important test, but macros should be the ultimate decider
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_options_off_overridden1", ["test_options_off_overridden1.pyx"],
-        define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 1)],
-    ), c_line_in_traceback=False))
-    
-####### setup_options_off_overridden2.py #########
-
-# less important test, but macros should be the ultimate decider
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_options_off_overridden2", ["test_options_off_overridden2.pyx"],
-        define_macros=[("CYTHON_CLINE_IN_TRACEBACK_RUNTIME", 1)],
-    ), c_line_in_traceback = False))
- 
-####### setup_options_on_overridden.py #########
-
-# less important test, but macros should be the ultimate decider
-from Cython.Build.Dependencies import cythonize
-from setuptools import setup, Extension
-
-setup(
-    ext_modules = cythonize(
-        Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"],
-        define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 0)],
-    ), c_line_in_traceback = True))
+setup(ext_modules = cythonize(
+    Extension("test_options_off", ["test_options_off.pyx"]),
+    Extension("test_options_off_overridden1", ["test_options_off_overridden1.pyx"]),
+    Extension("test_options_off_overridden2", ["test_options_off_overridden2.pyx"]),
+    c_line_in_traceback = False,
+))
 
 
 ####### test_on.pyx ###############
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK=1
 
 include "should_be_on.pxi"
 
 ####### test_off.pyx ###############
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK=0
 
 include "should_be_off.pxi"
 
@@ -127,6 +44,7 @@ include "should_be_off.pxi"
 include "should_be_runtime.pxi"
 
 ####### test_runtime.pyx ##############
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
 
 include "should_be_runtime.pxi"
 
@@ -143,14 +61,23 @@ include "should_be_runtime.pxi"
 include "should_be_off.pxi"
 
 ####### test_options_off_overridden1.pyx #######
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK=1
 
 include "should_be_on.pxi"
 
 ####### test_options_off_overridden2.pyx #######
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
 
 include "should_be_runtime.pxi"
 
 ####### test_options_on_overridden.pyx #######
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK=0
+
+include "should_be_off.pxi"
+
+####### test_contradicting_macros.pyx #######
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1
+# distutils: define_macros=CYTHON_CLINE_IN_TRACEBACK=0
 
 include "should_be_off.pxi"
 
@@ -198,6 +125,7 @@ def run():
     except Exception as e:
         helpers.validate_no_cline_in_traceback(e.__traceback__)
 
+
 ####### helpers.py ##############
 
 import traceback
@@ -213,6 +141,7 @@ def validate_no_cline_in_traceback(tb):
     formatted = traceback.format_tb(tb)
     assert not cline_re.search(formatted[0]), formatted
 
+
 ####### run_all_tests.py #########
 
 import test_on; test_on.run()
@@ -224,3 +153,4 @@ import test_options_off; test_options_off.run()
 import test_options_off_overridden1; test_options_off_overridden1.run()
 import test_options_off_overridden2; test_options_off_overridden2.run()
 import test_options_on_overridden; test_options_on_overridden.run()
+import test_contradicting_macros; test_contradicting_macros.run()

--- a/tests/run/cline_in_traceback.srctree
+++ b/tests/run/cline_in_traceback.srctree
@@ -1,0 +1,225 @@
+PYTHON setup_on.py build_ext --inplace
+PYTHON setup_off.py build_ext --inplace
+PYTHON setup_runtime.py build_ext --inplace
+PYTHON setup_default.py build_ext --inplace
+PYTHON setup_options_on.py build_ext --inplace
+PYTHON setup_options_off.py build_ext --inplace
+PYTHON setup_options_off_overridden1.py build_ext --inplace
+PYTHON setup_options_off_overridden2.py build_ext --inplace
+PYTHON setup_options_on_overridden.py build_ext --inplace
+
+PYTHON run_all_tests.py
+
+
+
+######## setup_on.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_on", ["test_on.pyx"],
+            define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 1)],
+    )))
+    
+######## setup_off.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_off", ["test_off.pyx"],
+            define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 0)],
+    )))
+
+######## setup_runtime.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_runtime", ["test_runtime.pyx"],
+            define_macros=[("CYTHON_CLINE_IN_TRACEBACK_RUNTIME", 1)],
+    )))
+    
+######## setup_default.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_default", ["test_default.pyx"]
+    )))
+    
+######## setup_options_on.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_options_on", ["test_options_on.pyx"]),
+        c_line_in_traceback = True
+    ))
+    
+####### setup_options_off.py #########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_options_off", ["test_options_off.pyx"]),
+        c_line_in_traceback = False
+    ))
+    
+####### setup_options_off_overridden1.py #########
+
+# less important test, but macros should be the ultimate decider
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_options_off_overridden1", ["test_options_off_overridden1.pyx"],
+        define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 1)],
+    ), c_line_in_traceback=False))
+    
+####### setup_options_off_overridden2.py #########
+
+# less important test, but macros should be the ultimate decider
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_options_off_overridden2", ["test_options_off_overridden2.pyx"],
+        define_macros=[("CYTHON_CLINE_IN_TRACEBACK_RUNTIME", 1)],
+    ), c_line_in_traceback = False))
+ 
+####### setup_options_on_overridden.py #########
+
+# less important test, but macros should be the ultimate decider
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup, Extension
+
+setup(
+    ext_modules = cythonize(
+        Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"],
+        define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 0)],
+    ), c_line_in_traceback = True))
+    
+####### test_on.pyx ###############
+
+include "should_be_on.pxi"
+
+####### test_off.pyx ###############
+
+include "should_be_off.pxi"
+
+####### test_runtime.pyx ###############
+
+include "should_be_runtime.pxi"
+
+####### test_runtime.pyx ##############
+
+include "should_be_runtime.pxi"
+
+####### test_default.pyx ##############
+
+include "should_be_off.pxi"
+
+####### test_options_on.pyx ########
+
+include "should_be_runtime.pxi"
+
+####### test_options_off.pyx ########
+
+include "should_be_off.pxi"
+
+####### test_options_off_overridden1.pyx #######
+
+include "should_be_on.pxi"
+
+####### test_options_off_overridden2.pyx #######
+
+include "should_be_runtime.pxi"
+
+####### test_options_on_overridden.pyx #######
+
+include "should_be_off.pxi"
+
+####### should_be_on.pxi #########
+
+import helpers
+
+def run():
+    try:
+        raise RuntimeError
+    except Exception as e:
+        helpers.validate_cline_in_traceback(e.__traceback__)
+        
+####### should_be_off.pxi #########
+
+import helpers
+
+def run():
+    try:
+        raise RuntimeError
+    except Exception as e:
+        helpers.validate_no_cline_in_traceback(e.__traceback__)
+        
+####### should_be_runtime.pxi #########
+
+import helpers
+import cython_runtime
+
+def run():
+    try:
+        raise RuntimeError
+    except Exception as e:
+        helpers.validate_no_cline_in_traceback(e.__traceback__)
+
+    cython_runtime.cline_in_traceback = True
+    try:
+        raise RuntimeError
+    except Exception as e:
+        helpers.validate_cline_in_traceback(e.__traceback__)
+
+    cython_runtime.cline_in_traceback = False
+    try:
+        raise RuntimeError
+    except Exception as e:
+        helpers.validate_no_cline_in_traceback(e.__traceback__)
+
+####### helpers.py ##############
+
+import traceback
+import re
+
+cline_re = re.compile(r"[(]\w*[.]c:\d*[)]")
+
+def validate_cline_in_traceback(tb):
+    formatted = traceback.format_tb(tb)
+    assert cline_re.search(formatted[0]), formatted
+    
+def validate_no_cline_in_traceback(tb):
+    formatted = traceback.format_tb(tb)
+    assert not cline_re.search(formatted[0]), formatted
+
+####### run_all_tests.py #########
+
+import test_on; test_on.run()
+import test_off; test_off.run()
+import test_runtime; test_runtime.run()
+import test_default; test_default.run()
+import test_options_on; test_options_on.run()
+import test_options_off; test_options_off.run()
+import test_options_off_overridden1; test_options_off_overridden1.run()
+import test_options_off_overridden2; test_options_off_overridden2.run()
+import test_options_on_overridden; test_options_on_overridden.run()

--- a/tests/run/cline_in_traceback.srctree
+++ b/tests/run/cline_in_traceback.srctree
@@ -11,7 +11,6 @@ PYTHON setup_options_on_overridden.py build_ext --inplace
 PYTHON run_all_tests.py
 
 
-
 ######## setup_on.py ########
 
 from Cython.Build.Dependencies import cythonize
@@ -113,7 +112,8 @@ setup(
         Extension("test_options_on_overridden", ["test_options_on_overridden.pyx"],
         define_macros=[("CYTHON_CLINE_IN_TRACEBACK", 0)],
     ), c_line_in_traceback = True))
-    
+
+
 ####### test_on.pyx ###############
 
 include "should_be_on.pxi"
@@ -153,6 +153,7 @@ include "should_be_runtime.pxi"
 ####### test_options_on_overridden.pyx #######
 
 include "should_be_off.pxi"
+
 
 ####### should_be_on.pxi #########
 


### PR DESCRIPTION
 * If the user has specified the c_line_in_traceback=False option
      to the Cython compiler, then set CYTHON_CLINE_IN_TRACEBACK=0 to
      avoid generating all the code to print clines out.
* If the user has defined the C flag CYTHON_CLINE_IN_TRACEBACK=0 then
  skip recording the C line on an exception (since we know this
  is expensive in terms of code size, and we'll never actually
  use what we've recorded)

PR also includes commits from #6035 so merge that first.

This should probably be 3.1 only.