### PR TITLE
Added missing `replace` functions to C++ `std::string` definition

### DIFF
--- a/Cython/Includes/libcpp/string.pxd
+++ b/Cython/Includes/libcpp/string.pxd
@@ -196,6 +196,16 @@ cdef extern from "<string>" namespace "std" nogil:
         void insert(iterator p, size_t n, char c) except +
         iterator insert(iterator p, char c) except +
 
+        string& replace(size_t pos, size_t len, const string& str) except +
+        string& replace(iterator i1, iterator i2, const string& str) except +
+        string& replace(size_t pos, size_t len, const string& str, size_t subpos, size_t sublen) except +
+        string& replace(size_t pos, size_t len, const char* s) except +
+        string& replace(iterator i1, iterator i2, const char* s) except +
+        string& replace(size_t pos, size_t len, const char* s, size_t n) except +
+        string& replace(iterator i1, iterator i2, const char* s, size_t n) except +
+        string& replace(size_t pos, size_t len, size_t n, char c) except +
+        string& replace(iterator i1, iterator i2, size_t n, char c) except +
+
         size_t copy(char* s, size_t len, size_t pos) except +
         size_t copy(char* s, size_t len) except +
 

--- a/tests/run/cpp_stl_string.pyx
+++ b/tests/run/cpp_stl_string.pyx
@@ -196,6 +196,19 @@ def test_substr(char *a):
     z = s.substr()
     return x.c_str(), y.c_str(), z.c_str()
 
+def test_replace(char *a, char *b, char* fill):
+    """
+    >>> test_replace(b_asdf, b_asdg, b_s)  == (b_asdg+b_asdf[2:], b_asdf[:-2]+b_asdg[-2:], (b_s*4)+b_asdg[2:])
+    True
+    """
+    cdef string s1 = string(a)
+    cdef string s2 = string(a)
+    cdef string s3 = string(b)
+    s1.replace(0, 2, s3)
+    s2.replace(s2.size()-2, 2, s3, s3.size()-2, 2)
+    s3.replace(0, 2, 4, fill[0])
+    return s1.c_str(), s2.c_str(), s3.c_str()
+
 def test_append(char *a, char *b):
     """
     >>> test_append(b_asdf, '1234'.encode('ASCII')) == b_asdf + '1234'.encode('ASCII')


### PR DESCRIPTION
Hi, I noticed the other day that the `string.replace(...)` functions were missing in libcpp.string. Assuming there was no reason they are missing, I've added them to the pxd file.