### PR TITLE
Minimise the size of the code object table.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10185,10 +10185,6 @@ class CodeObjectNode(ExprNode):
 
         func_name_result = code.get_py_string_const(
             func.name, identifier=True, is_str=False, unicode_value=func.name)
-        # FIXME: better way to get the module file path at module init time? Encoding to use?
-        file_path = StringEncoding.bytes_literal(func.pos[0].get_filenametable_entry().encode('utf8'), 'utf8')
-        file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
-
         varnames_result = self.varnames.result()
 
         # This combination makes CPython create a new dict for "frame.f_locals" (see GH #1836).
@@ -10214,8 +10210,8 @@ class CodeObjectNode(ExprNode):
         flags = '|'.join(flags) or '0'
 
         s = (f"{filename_idx}, {argcount}, {num_posonly_args}, {kwonlyargcount}, "
-             f"{nlocals}, {flags}, {varnames_result}, {file_path_result},"
-             f"{func_name_result}, {self.pos[1]}")
+             f"{nlocals}, {self.pos[1]}, {flags}, "
+             f"{varnames_result}, {func_name_result}")
         code.putln("{%s}, /* %s */" % (s, self.result_code))
 
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2189,50 +2189,32 @@ static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }
 #pragma warning( pop )  /* undo whatever Cython has done to warnings */
 #endif
 
+
 //////////////////// InitCodeObjs.proto ////////////////////////
 
-typedef struct {
-  // To get tracebacks
-  int filename_idx;
-
-  //
-  int argcount;
-  int num_posonly_args; // posonlyargcount (Py3.8+ only)
-  int kwonlyargcount;
-  int nlocals;
-  int flags;
-  // PyObject* names // FIXME?
-  PyObject* varnames;
-  // PyObject* freevars; // FIXME?
-  // PyObject* cellvars; // FIXME
-  PyObject* filename;
-  PyObject* funcname;
-  int firstlineno;
-} __Pyx_CodeObjectTabEntry;
-
-static int __Pyx_InitCodeObjects(__Pyx_CodeObjectTabEntry *table, PyObject **targets, Py_ssize_t N); /* proto */
+static int __Pyx_InitCodeObjects(__Pyx_CodeObjectTabEntry *table, PyObject **filenames, PyObject **targets, Py_ssize_t N); /* proto */
 
 //////////////////// InitCodeObjs ////////////////////////
 //@substitute: naming
 
-static int __Pyx_InitCodeObjects(__Pyx_CodeObjectTabEntry *table, PyObject **targets, Py_ssize_t N) {
+static int __Pyx_InitCodeObjects(__Pyx_CodeObjectTabEntry *table, PyObject **filenames, PyObject **targets, Py_ssize_t N) {
     for (Py_ssize_t i=0; i<N; ++i) {
         PyObject *result = (PyObject*)__Pyx_PyCode_New(
-            table[i].argcount,
-            table[i].num_posonly_args,
-            table[i].kwonlyargcount,
-            table[i].nlocals,
+            (int) table[i].argcount,
+            (int) table[i].num_posonly_args,
+            (int) table[i].kwonlyargcount,
+            (int) table[i].nlocals,
             0,
-            table[i].flags,
+            (int) table[i].flags,
             ${empty_bytes}, // code
             ${empty_tuple}, // consts
             ${empty_tuple}, // names (FIXME)
             table[i].varnames,
             ${empty_tuple}, // freevars (FIXME)
             ${empty_tuple}, // cellvars (FIXME)
-            table[i].filename,
+            filenames[table[i].filename_idx],
             table[i].funcname,
-            table[i].firstlineno,
+            (int) table[i].firstlineno,
             ${empty_bytes} // lnotab
         );
         if (unlikely(!result)) __PYX_ERR(table[i].filename_idx, table[i].firstlineno, bad);


### PR DESCRIPTION
Marking as draft since it currently *increases* the size of the function that builds the code objects. The reason is probably that the table is not static data and the more complex structure might lead to more code overhead in building it.