### PR TITLE
Declare tuple/slice/other constants in arrays

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1568,7 +1568,7 @@ class GlobalState:
                 part_writer = self.parts[f'module_state_{part}']
                 part_writer.putln(f"for (Py_ssize_t i=0; i<{count}; ++i) {{")
                 op = "Py_CLEAR" if part == 'clear' else "Py_VISIT"
-                part_writer.putln(f"{op}({part}_module_state->{full_prefix});")
+                part_writer.putln(f"{op}({part}_module_state->{full_prefix}[i]);")
                 part_writer.putln("}")
 
     def generate_cached_methods_decls(self):

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1360,7 +1360,7 @@ class GlobalState:
             c = self.new_num_const(str_value, 'float', value_code)
         return c
 
-    def get_py_const(self, prefix='', dedup_key=None):
+    def get_py_const(self, prefix, dedup_key=None):
         if dedup_key is not None:
             const = self.dedup_const_index.get(dedup_key)
             if const is not None:
@@ -2103,7 +2103,7 @@ class CCodeWriter:
     def get_py_float(self, str_value, value_code):
         return self.globalstate.get_float_const(str_value, value_code).cname
 
-    def get_py_const(self, prefix='', dedup_key=None):
+    def get_py_const(self, prefix, dedup_key=None):
         return self.globalstate.get_py_const(prefix, dedup_key)
 
     def get_string_const(self, text):

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1559,7 +1559,7 @@ class GlobalState:
             self.parts['module_state_traverse'].putln(
                 "Py_VISIT(traverse_module_state->%s);" % cname)
 
-        for prefix, count in self.array_consts.items():
+        for prefix, count in sorted(self.array_consts.items()):
             full_prefix = f"{Naming.pyrex_prefix}{prefix}"
             self.parts['module_state'].putln(f"PyObject *{full_prefix}[{count}];")
             self.parts['module_state_defines'].putln(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1770,7 +1770,7 @@ class UnicodeNode(ConstNode):
             if StringEncoding.string_contains_lone_surrogates(self.value):
                 # lone (unpaired) surrogates are not really portable and cannot be
                 # decoded by the UTF-8 codec in Py3.3+
-                self.result_code = code.get_py_const(py_object_type, 'ustring')
+                self.result_code = code.get_py_const('ustring')
                 data_cname = code.get_string_const(
                     StringEncoding.BytesLiteral(self.value.encode('unicode_escape')))
                 const_code = code.get_cached_constants_writer(self.result_code)
@@ -5780,7 +5780,7 @@ class SliceNode(ExprNode):
     def generate_result_code(self, code):
         if self.is_literal:
             dedup_key = make_dedup_key(self.type, (self,))
-            self.result_code = code.get_py_const(py_object_type, 'slice', cleanup_level=2, dedup_key=dedup_key)
+            self.result_code = code.get_py_const('slice', dedup_key=dedup_key)
             code = code.get_cached_constants_writer(self.result_code)
             if code is None:
                 return  # already initialised
@@ -8715,7 +8715,7 @@ class TupleNode(SequenceNode):
             # The "mult_factor" is part of the deduplication if it is also constant, i.e. when
             # we deduplicate the multiplied result.  Otherwise, only deduplicate the constant part.
             dedup_key = make_dedup_key(self.type, [self.mult_factor if self.is_literal else None] + self.args)
-            tuple_target = code.get_py_const(py_object_type, 'tuple', cleanup_level=2, dedup_key=dedup_key)
+            tuple_target = code.get_py_const('tuple', dedup_key=dedup_key)
             const_code = code.get_cached_constants_writer(tuple_target)
             if const_code is not None:
                 # constant is not yet initialised


### PR DESCRIPTION
As opposed to declaring them individually.

Unlikely to make a huge different in compiled size (except to module-state builds, where it simplifies the cleanup). However, does mean that things like tuples can be indexed, which may help with optimizing codeobjecttab