### PR TITLE
Create code object tab as module global with indices

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1755,9 +1755,6 @@ class GlobalState:
                 init_constants.error_goto(self.module_pos)))
 
     def generate_codeobject_constants(self):
-        if not self.codeobject_constants:
-            return
-
         w = self.parts['pycodeobj_table']
 
         self.use_utility_code(UtilityCode.load_cached("InitCodeObjs", "ModuleSetupCode.c"))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3135,8 +3135,18 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.putln("/*--- Constants init code ---*/")
         code.put_error_if_neg(self.pos, "__Pyx_InitCachedConstants()")
-        # code objects come after the other globals (since they use strings and tuples)
-        code.put_error_if_neg(self.pos, "__Pyx_CreateCodeObjectTabAndInitCode()")
+        # Code objects come after the other globals (since they use strings and tuples).
+        # Pass None for pos to not lose the position set inside __Pyx_InitCodeObjects.
+        code.put_error_if_neg(
+            None,
+            "__Pyx_InitCodeObjects(%s, (void*)%s, sizeof(%s)/sizeof(__Pyx_CodeObjectTabEntry)-1, &%s, &%s, &%s)" % (
+                Naming.codeobjtab_cname+"_",
+                Naming.modulestateglobal_cname,
+                Naming.codeobjtab_cname+"_",
+                Naming.filename_cname,
+                Naming.lineno_cname,
+                Naming.clineno_cname
+        ))
 
         code.putln("/*--- Global type/function init code ---*/")
 

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -75,6 +75,7 @@ interned_prefixes = {
     'umethod': pyrex_prefix + "umethod_",
 }
 
+const_table_index_prefix = pyrex_prefix + "i_"
 ctuple_type_prefix = pyrex_prefix + "ctuple_"
 args_cname       = pyrex_prefix + "args"
 nargs_cname      = pyrex_prefix + "nargs"

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2227,7 +2227,9 @@ static int __Pyx_InitCodeObjects(const __Pyx_CodeObjectTabEntry *table,
     int $clineno_cname = 0;
     $modulestate_cname *modstate = ($modulestate_cname*)modstate_v;
     for (Py_ssize_t i=0; i<N; ++i) {
-        PyObject *varnames = modstate->__pyx__tuple[table[i].varnames];
+        PyObject *varnames = table[i].varnames >= 0 ?
+          modstate->__pyx__tuple[table[i].varnames] :
+          $empty_tuple;
         PyObject *filename = modstate->$stringtab_cname[table[i].filename];
         PyObject *funcname = modstate->$stringtab_cname[table[i].funcname];
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2222,7 +2222,9 @@ static int __Pyx_InitCodeObjects(const __Pyx_CodeObjectTabEntry *table,
         void *modstate_v,
         Py_ssize_t N,
         const char **filename, int *lineno, int *clineno) {
-
+    const char *$filename_cname = NULL;
+    int $lineno_cname = 0;
+    int $clineno_cname = 0;
     $modulestate_cname *modstate = ($modulestate_cname*)modstate_v;
     for (Py_ssize_t i=0; i<N; ++i) {
         PyObject *varnames = modstate->__pyx__tuple[table[i].varnames];


### PR DESCRIPTION
This currently looks to only save a tiny amount of space so may not actually be worth it. Therefore I'm marking it as draft.

The one useful thing it does do is to restore some error origin information that was lost from the code object generation. However we could cherry-pick it anyway.

It also might make it easier to pack the structure better and so save some actual space.