### PR TITLE
pyupgrade: Update codebase to Python 3 syntax and features

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -236,7 +236,7 @@ class DistutilsInfo:
                 line = line[1:].lstrip()
                 kind = next((k for k in ("distutils:","cython:") if line.startswith(k)), None)
                 if kind is not None:
-                    key, _, value = [s.strip() for s in line[len(kind):].partition('=')]
+                    key, _, value = (s.strip() for s in line[len(kind):].partition('='))
                     type = distutils_settings.get(key, None)
                     if line.startswith("cython:") and type is None: continue
                     if type in (list, transitive_list):

--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -88,7 +88,7 @@ class IntroduceBufferAuxiliaryVars(CythonTransform):
 
             auxvars = ((PyrexTypes.c_pyx_buffer_nd_type, Naming.pybuffernd_prefix),
                        (PyrexTypes.c_pyx_buffer_type, Naming.pybufferstruct_prefix))
-            pybuffernd, rcbuffer = [decvar(type, prefix) for (type, prefix) in auxvars]
+            pybuffernd, rcbuffer = (decvar(type, prefix) for (type, prefix) in auxvars)
 
             entry.buffer_aux = Symtab.BufferAux(pybuffernd, rcbuffer)
 

--- a/Cython/Compiler/MatchCaseNodes.py
+++ b/Cython/Compiler/MatchCaseNodes.py
@@ -76,7 +76,7 @@ class PatternNode(Node):
     def __init__(self, pos, **kwds):
         if "as_targets" not in kwds:
             kwds["as_targets"] = []
-        super(PatternNode, self).__init__(pos, **kwds)
+        super().__init__(pos, **kwds)
 
     def is_irrefutable(self):
         return False
@@ -177,7 +177,7 @@ class OrPatternNode(PatternNode):
         return child_targets
 
     def validate_irrefutable(self):
-        super(OrPatternNode, self).validate_irrefutable()
+        super().validate_irrefutable()
         found_irrefutable_case = None
         for alternative in self.alternatives:
             if found_irrefutable_case:

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -523,7 +523,7 @@ def parse_directive_list(s, relaxed_bool=False, ignore_unknown=False,
             continue
         if '=' not in item:
             raise ValueError('Expected "=" in option "%s"' % item)
-        name, value = [s.strip() for s in item.strip().split('=', 1)]
+        name, value = (s.strip() for s in item.strip().split('=', 1))
         if name not in _directive_defaults:
             found = False
             if name.endswith('.all'):
@@ -611,7 +611,7 @@ def parse_compile_time_env(s, current_settings=None):
             continue
         if '=' not in item:
             raise ValueError('Expected "=" in option "%s"' % item)
-        name, value = [s.strip() for s in item.split('=', 1)]
+        name, value = (s.strip() for s in item.split('=', 1))
         result[name] = parse_variable_value(value)
     return result
 

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1051,7 +1051,7 @@ def _append_escape_sequence(kind, builder, escape_sequence, s):
         builder.append(escape_sequence)
 
 
-_parse_escape_sequences_raw, _parse_escape_sequences = [re.compile((
+_parse_escape_sequences_raw, _parse_escape_sequences = (re.compile((
     # escape sequences:
     br'(\\(?:' +
     (br'\\?' if is_raw else (
@@ -1070,7 +1070,7 @@ _parse_escape_sequences_raw, _parse_escape_sequences = [re.compile((
     br'[^\\{}]+)'
     ).decode('us-ascii')).match
     for is_raw in (True, False)
-]
+)
 
 
 def _f_string_error_pos(pos, string, i):

--- a/Cython/Compiler/Tests/TestParseTreeTransforms.py
+++ b/Cython/Compiler/Tests/TestParseTreeTransforms.py
@@ -243,7 +243,7 @@ class TestDebugTransform(DebuggerTestCase):
                          'codefile.closure', 'codefile.inner')
             required_xml_attrs = 'name', 'cname', 'qualified_name'
             assert all(f in xml_funcs for f in funcnames)
-            spam, ham, eggs = [xml_funcs[funcname] for funcname in funcnames]
+            spam, ham, eggs = (xml_funcs[funcname] for funcname in funcnames)
 
             self.assertEqual(spam.attrib['name'], 'spam')
             self.assertNotEqual('spam', spam.attrib['cname'])

--- a/Cython/Compiler/TreeFragment.py
+++ b/Cython/Compiler/TreeFragment.py
@@ -230,7 +230,7 @@ class TreeFragment:
             name = "(tree fragment)"
 
         if isinstance(code, str):
-            def fmt(x): return u"\n".join(strip_common_indent(x.split(u"\n")))
+            def fmt(x): return "\n".join(strip_common_indent(x.split("\n")))
 
             fmt_code = fmt(code)
             fmt_pxds = {}


### PR DESCRIPTION
This small PR updates the Python code to Python 3 syntax and features, removing old, depreciated and redundant code. [pyupgrade](https://github.com/asottile/pyupgrade) 3.15.1 with `--keep-percent-format --py3-plus` was used.

Also a few list comprehensions are replaced by Generator Expressions ([PEP 289](https://peps.python.org/pep-0289/), Python 2.4+).

Only changes in the Cython directory are included in this commit. The tests, docs and other files stay identical.