### PR TITLE
make tests run on numpy1.x and numpy2.x

### DIFF
--- a/tests/memoryview/contig_check.pyx
+++ b/tests/memoryview/contig_check.pyx
@@ -10,15 +10,15 @@ def copy_fortran3(double[:, :, :] mat):
     """
     >>> a = np.ones((1, 1, 1), dtype=np.float64)
     >>> c = copy_fortran3(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     >>> a = np.ones((4, 6, 8), dtype=np.float64, order='F')
     >>> c = copy_fortran3(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     >>> a = np.ones((4, 6, 8), dtype=np.float64, order='C')
     >>> c = copy_fortran3(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     """
     cdef int x, y, z
@@ -41,15 +41,15 @@ def copy_fortran2(double[:, :] mat):
     """
     >>> a = np.ones((1, 1), dtype=np.float64)
     >>> c = copy_fortran2(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     >>> a = np.ones((4, 6), dtype=np.float64, order='F')
     >>> c = copy_fortran2(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     >>> a = np.ones((4, 6), dtype=np.float64, order='C')
     >>> c = copy_fortran2(a)
-    >>> (a == c).all()
+    >>> bool((a == c).all())
     True
     """
     cdef int rows, cols

--- a/tests/memoryview/memoryview_annotation_typing.py
+++ b/tests/memoryview/memoryview_annotation_typing.py
@@ -20,7 +20,7 @@ def one_dim(a: cython.double[:]):
     (2.0, 1)
     """
     a[0] *= 2
-    return a[0], a.ndim
+    return float(a[0]), a.ndim
 
 
 def one_dim_ccontig(a: cython.double[::1]):
@@ -30,7 +30,7 @@ def one_dim_ccontig(a: cython.double[::1]):
     (2.0, 1)
     """
     a[0] *= 2
-    return a[0], a.ndim
+    return float(a[0]), a.ndim
 
 
 def two_dim(a: cython.double[:,:]):
@@ -40,7 +40,7 @@ def two_dim(a: cython.double[:,:]):
     (3.0, 1.0, 2)
     """
     a[0,0] *= 3
-    return a[0,0], a[0,1], a.ndim
+    return float(a[0,0]), float(a[0,1]), a.ndim
 
 
 def variable_annotation(a):
@@ -58,7 +58,7 @@ def variable_annotation(a):
     b = a
     b[1] += 1
     b[2] += 2
-    return b[1]
+    return float(b[1])
 
 
 def slice_none(m: cython.double[:]):
@@ -98,7 +98,7 @@ def slice_optional(m: typing.Optional[cython.double[:]]):
 @cython.cfunc
 def _one_dim_nogil_cfunc(a: cython.double[:]) -> cython.double:
     a[0] *= 2
-    return a[0]
+    return float(a[0])
 
 
 def one_dim_nogil_cfunc(a: cython.double[:]):

--- a/tests/memoryview/numpy_memoryview.pyx
+++ b/tests/memoryview/numpy_memoryview.pyx
@@ -674,9 +674,9 @@ def test_refcount_GH507():
     """
     >>> test_refcount_GH507()
     """
-    a = np.arange(12).reshape([3, 4])
-    cdef np.int_t[:,:] a_view = a
-    cdef np.int_t[:,:] b = a_view[1:2,:].T
+    a = np.arange(12, dtype='int32').reshape([3, 4])
+    cdef np.int32_t[:,:] a_view = a
+    cdef np.int32_t[:,:] b = a_view[1:2,:].T
 
 
 @cython.boundscheck(False)

--- a/tests/memoryview/numpy_memoryview_readonly.pyx
+++ b/tests/memoryview/numpy_memoryview_readonly.pyx
@@ -52,7 +52,7 @@ def test_mmview_ro(x):
 
 def test_update_mmview_rw(x):
     """
-    >>> test_update_mmview_rw(new_array())
+    >>> float(test_update_mmview_rw(new_array()))
     23.0
     """
     update_array(x)

--- a/tests/memoryview/relaxed_strides.pyx
+++ b/tests/memoryview/relaxed_strides.pyx
@@ -40,10 +40,10 @@ NUMPY_HAS_RELAXED_STRIDES = (
 def test_one_sized(array):
     """
     >>> contig = np.ascontiguousarray(np.arange(10, dtype=np.double)[::100])
-    >>> test_one_sized(contig)[0]
+    >>> float(test_one_sized(contig)[0])
     1.0
     >>> a = np.arange(10, dtype=np.double)[::100]
-    >>> if NUMPY_HAS_RELAXED_STRIDES: print(test_one_sized(a)[0])
+    >>> if NUMPY_HAS_RELAXED_STRIDES: print(float(test_one_sized(a)[0]))
     ... else: print(1.0)
     1.0
     """

--- a/tests/run/numpy_parallel.pyx
+++ b/tests/run/numpy_parallel.pyx
@@ -22,7 +22,7 @@ def test_parallel_numpy_arrays():
     4
     """
     cdef Py_ssize_t i, length
-    cdef np.ndarray[np.int_t] x
+    cdef np.ndarray[np.int64_t] x
 
     try:
         import numpy

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -254,7 +254,7 @@ def inc1_object(np.ndarray[object] arr):
     o += 1
     arr[1] = o # unfortunately, += segfaults for objects
 
-def inc1_int32_t(np.ndarray[np.int32_t] arr):           arr[1] += 1
+def inc1_int64_t(np.ndarray[np.int64_t] arr):           arr[1] += 1
 def inc1_longlong_t(np.ndarray[np.longlong_t] arr):     arr[1] += 1
 def inc1_float_t(np.ndarray[np.float_t] arr):           arr[1] += 1
 def inc1_double_t(np.ndarray[np.double_t] arr):         arr[1] += 1
@@ -263,7 +263,7 @@ def inc1_intp_t(np.ndarray[np.intp_t] arr):             arr[1] += 1
 def inc1_uintp_t(np.ndarray[np.uintp_t] arr):           arr[1] += 1
 
 # The tests below only work on platforms that has the given types
-def inc1_int32_t(np.ndarray[np.int32_t] arr):           arr[1] += 1
+def inc1_int64_t(np.ndarray[np.int64_t] arr):           arr[1] += 1
 def inc1_float64_t(np.ndarray[np.float64_t] arr):       arr[1] += 1
 
 
@@ -290,7 +290,7 @@ def test_dtype(dtype, inc1):
     >>> test_dtype('D', inc1_cdouble_struct)
     >>> test_dtype('G', inc1_clongdouble_struct)
 
-    >>> test_dtype(np.int_, inc1_int_t)
+    >>> test_dtype(np.int_, inc1_int64_t)
     >>> test_dtype(np.longlong, inc1_longlong_t)
     >>> test_dtype(np.float_, inc1_float_t)
     >>> test_dtype(np.double, inc1_double_t)
@@ -299,7 +299,7 @@ def test_dtype(dtype, inc1):
 
     >>> test_dtype(np.longdouble, inc1_longdouble_t)
 
-    >>> test_dtype(np.int32, inc1_int32_t)
+    >>> test_dtype(np.int64, inc1_int64_t)
     >>> test_dtype(np.float64, inc1_float64_t)
 
     Endian tests:

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -254,7 +254,7 @@ def inc1_object(np.ndarray[object] arr):
     o += 1
     arr[1] = o # unfortunately, += segfaults for objects
 
-def inc1_int_t(np.ndarray[np.int_t] arr):               arr[1] += 1
+def inc1_int32_t(np.ndarray[np.int32_t] arr):           arr[1] += 1
 def inc1_longlong_t(np.ndarray[np.longlong_t] arr):     arr[1] += 1
 def inc1_float_t(np.ndarray[np.float_t] arr):           arr[1] += 1
 def inc1_double_t(np.ndarray[np.double_t] arr):         arr[1] += 1

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -290,7 +290,6 @@ def test_dtype(dtype, inc1):
     >>> test_dtype('D', inc1_cdouble_struct)
     >>> test_dtype('G', inc1_clongdouble_struct)
 
-    >>> test_dtype(np.int_, inc1_int64_t)
     >>> test_dtype(np.longlong, inc1_longlong_t)
     >>> test_dtype(np.float_, inc1_float_t)
     >>> test_dtype(np.double, inc1_double_t)

--- a/tests/run/ufunc.pyx
+++ b/tests/run/ufunc.pyx
@@ -111,7 +111,7 @@ def test_plus_one():
     array([[57., 58.],
            [67., 68.],
            [77., 78.]])
-    >>> plus_one(1.j)
+    >>> complex(plus_one(1.j))
     (1+1j)
     """
 
@@ -146,13 +146,13 @@ def test_flow_control():
     """
     >>> np.allclose(return_stops_execution(double_arr_1d), double_arr_1d)
     True
-    >>> return_in_if(-1.)
+    >>> float(return_in_if(-1.))
     1.0
-    >>> return_in_if(2.0)
+    >>> float(return_in_if(2.0))
     2.0
-    >>> nested_loops(5.5)
+    >>> float(nested_loops(5.5))
     6.0
-    >>> nested_loops(105.)
+    >>> float(nested_loops(105.))
     -5.0
     """
 
@@ -166,7 +166,7 @@ def test_nested_function():
     """
     >>> np.allclose(nested_function(double_arr_1d), 2*double_arr_1d)
     True
-    >>> nested_function(-1.)
+    >>> float(nested_function(-1.))
     -2.0
     """
 


### PR DESCRIPTION
Fixes #6072 

Should this also add a numpy2.0b1 test run to CI via the wheels at https://pypi.anaconda.org/scientific-python-nightly-wheels/numpy (i.e. install numpy via this index)?
```
pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
```

Edit: make it a question