### PR TITLE
Reserve vector memory upfront

### DIFF
--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -42,7 +42,7 @@ cdef extern from *:
         void push_back(T&) except +
         void reserve(size_t) except +
 
-    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval)
+    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
 
 @cname("{{cname}}")
 cdef vector[X] {{cname}}(object o) except *:

--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -40,12 +40,22 @@ cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const string& s):
 cdef extern from *:
     cdef cppclass vector "std::vector" [T]:
         void push_back(T&) except +
+        void reserve(size_t)
+
+    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval)
 
 @cname("{{cname}}")
 cdef vector[X] {{cname}}(object o) except *:
+
     cdef vector[X] v
+    cdef Py_ssize_t s = PyObject_LengthHint(o, -1)
+
+    if s > 0:
+        v.reserve(s)
+
     for item in o:
         v.push_back(<X>item)
+
     return v
 
 

--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -42,7 +42,7 @@ cdef extern from *:
         void push_back(T&) except +
         void reserve(size_t) except +
 
-    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
+    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval)
 
 @cname("{{cname}}")
 cdef vector[X] {{cname}}(object o) except *:

--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -40,7 +40,7 @@ cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const string& s):
 cdef extern from *:
     cdef cppclass vector "std::vector" [T]:
         void push_back(T&) except +
-        void reserve(size_t)
+        void reserve(size_t) except +
 
     cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval)
 

--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -42,16 +42,16 @@ cdef extern from *:
         void push_back(T&) except +
         void reserve(size_t) except +
 
-    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval)
+    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
 
 @cname("{{cname}}")
 cdef vector[X] {{cname}}(object o) except *:
 
     cdef vector[X] v
-    cdef Py_ssize_t s = PyObject_LengthHint(o, -1)
+    cdef Py_ssize_t s = PyObject_LengthHint(o, 0)
 
     if s > 0:
-        v.reserve(s)
+        v.reserve(<size_t> s)
 
     for item in o:
         v.push_back(<X>item)

--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -143,16 +143,16 @@ def test_generator_to_vector():
 class LengthlessIterable(object):
     def __getitem__(self, pos):
         if pos == 3:
-            raise StopIteration()
+            raise StopIteration
         return pos+1
 
 class LengthlessIterableRaises(LengthlessIterable):
-    def __length_hint__():
+    def __length_hint__(self):
         raise Exception('__length_hint__ called')
 
 def test_iterable_to_vector():
     """
-    >>> test_generator_to_vector()
+    >>> test_iterable_to_vector()
     [1, 2, 3]
     """
     i = LengthlessIterable()
@@ -160,8 +160,10 @@ def test_iterable_to_vector():
 
 def test_iterable_raises_to_vector():
     """
-    >>> test_generator_to_vector()
-    [1, 2, 3]
+    >>> test_iterable_raises_to_vector()
+    Traceback (most recent call last):
+    ...
+    Exception: __length_hint__ called
     """
     i = LengthlessIterableRaises()
     return takes_vector(i)

--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -137,7 +137,7 @@ def test_generator_to_vector():
     >>> test_generator_to_vector()
     [1, 2, 3]
     """
-    g = (x for x in [1,2,3])
+    g = (x for x in [1, 2, 3])
     return takes_vector(g)
 
 def test_string_vector(s):

--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -140,6 +140,32 @@ def test_generator_to_vector():
     g = (x for x in [1, 2, 3])
     return takes_vector(g)
 
+class LengthlessIterable(object):
+    def __getitem__(self, pos):
+        if pos == 3:
+            raise StopIteration()
+        return pos+1
+
+class LengthlessIterableRaises(LengthlessIterable):
+    def __length_hint__():
+        raise Exception('__length_hint__ called')
+
+def test_iterable_to_vector():
+    """
+    >>> test_generator_to_vector()
+    [1, 2, 3]
+    """
+    i = LengthlessIterable()
+    return takes_vector(i)
+
+def test_iterable_raises_to_vector():
+    """
+    >>> test_generator_to_vector()
+    [1, 2, 3]
+    """
+    i = LengthlessIterableRaises()
+    return takes_vector(i)
+
 def test_string_vector(s):
     """
     >>> list(map(decode, test_string_vector('ab cd ef gh'.encode('ascii'))))

--- a/tests/run/cpp_stl_conversion.pyx
+++ b/tests/run/cpp_stl_conversion.pyx
@@ -115,6 +115,7 @@ def test_int_vector(o):
     return v
 
 cdef vector[int] takes_vector(vector[int] x):
+    assert x[2] == 3
     return x
 
 def test_list_literal_to_vector():
@@ -130,6 +131,14 @@ def test_tuple_literal_to_vector():
     [1, 2, 3]
     """
     return takes_vector((1, 2, 3))
+
+def test_generator_to_vector():
+    """
+    >>> test_generator_to_vector()
+    [1, 2, 3]
+    """
+    g = (x for x in [1,2,3])
+    return takes_vector(g)
 
 def test_string_vector(s):
     """


### PR DESCRIPTION
Calling push_back in a loop to grow the vector caused it to perform repeated unnecessary memory allocations.

In this change, the necessary memory is reserved once ahead of the loop. This has a significant performance improvement for large data sets.

For objects which do not have a length, the original behaviour is preserved.