### PR TITLE
Adapt 0.29.x _PyLong_AsByteArray to 3.13 changes

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -988,7 +988,11 @@ static CYTHON_INLINE {{TYPE}} {{FROM_PY_FUNCTION}}(PyObject *x) {
                 unsigned char *bytes = (unsigned char *)&val;
                 int ret = _PyLong_AsByteArray((PyLongObject *)v,
                                               bytes, sizeof(val),
-                                              is_little, !is_unsigned);
+                                              is_little, !is_unsigned
+#if PY_VERSION_HEX >= 0x030d00a4
+                                              , 1 // with_exceptions
+#endif              
+                                              );
                 Py_DECREF(v);
                 if (likely(!ret))
                     return val;


### PR DESCRIPTION
It's added an extra `with_exceptions` parameter in https://github.com/python/cpython/commit/7861dfd26a41e40c2b4361eb0bb1356b9b4a064b

The changes doesn't seem needed in 3.0.x+