### PR TITLE
Fix warnings for "implicit noexcept" when using `legacy_implicit_noexcept=True`

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -704,6 +704,19 @@ class CFuncDeclaratorNode(CDeclaratorNode):
 
         exc_val = None
         exc_check = 0
+
+        if (env.directives["legacy_implicit_noexcept"]
+                and not return_type.is_pyobject
+                and not self.has_explicit_exc_clause
+                and self.exception_check
+                and visibility != 'extern'):
+            # implicit noexcept, with a warning
+            self.exception_check = False
+            warning(self.pos,
+                    "Implicit noexcept declaration is deprecated."
+                    " Function declaration should contain 'noexcept' keyword.",
+                    level=2)
+
         if self.exception_check == '+':
             env.add_include_file('ios')         # for std::ios_base::failure
             env.add_include_file('new')         # for std::bad_alloc

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3141,9 +3141,7 @@ def p_exception_value_clause(s, is_extern):
                 exc_check = False
             # exc_val can be non-None even if exc_check is False, c.f. "except -1"
             exc_val = p_test(s)
-    if not is_extern and not exc_clause and s.context.legacy_implicit_noexcept:
-        exc_check = False
-        warning(s.position(), "Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.", level=2)
+
     return exc_val, exc_check, exc_clause
 
 c_arg_list_terminators = cython.declare(frozenset, frozenset((

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -169,6 +169,6 @@ cdef inline int extend(array self, array other) except -1:
         PyErr_BadArgument()
     return extend_buffer(self, other.data.as_chars, Py_SIZE(other))
 
-cdef inline void zero(array self):
+cdef inline void zero(array self) noexcept:
     """ set all elements of array to zero. """
     memset(self.data.as_chars, 0, Py_SIZE(self) * self.ob_descr.itemsize)

--- a/Cython/Includes/cpython/complex.pxd
+++ b/Cython/Includes/cpython/complex.pxd
@@ -16,11 +16,11 @@ cdef extern from "Python.h":
         cdef Py_complex cval
 
         @property
-        cdef inline double real(self):
+        cdef inline double real(self) noexcept:
             return self.cval.real
 
         @property
-        cdef inline double imag(self):
+        cdef inline double imag(self) noexcept:
             return self.cval.imag
 
     # PyTypeObject PyComplex_Type

--- a/Cython/Includes/cpython/datetime.pxd
+++ b/Cython/Includes/cpython/datetime.pxd
@@ -69,32 +69,32 @@ cdef extern from "datetime.h":
 
     ctypedef extern class datetime.date[object PyDateTime_Date]:
         @property
-        cdef inline int year(self):
+        cdef inline int year(self) noexcept:
             return PyDateTime_GET_YEAR(self)
 
         @property
-        cdef inline int month(self):
+        cdef inline int month(self) noexcept:
             return PyDateTime_GET_MONTH(self)
 
         @property
-        cdef inline int day(self):
+        cdef inline int day(self) noexcept:
             return PyDateTime_GET_DAY(self)
 
     ctypedef extern class datetime.time[object PyDateTime_Time]:
         @property
-        cdef inline int hour(self):
+        cdef inline int hour(self) noexcept:
             return PyDateTime_TIME_GET_HOUR(self)
 
         @property
-        cdef inline int minute(self):
+        cdef inline int minute(self) noexcept:
             return PyDateTime_TIME_GET_MINUTE(self)
 
         @property
-        cdef inline int second(self):
+        cdef inline int second(self) noexcept:
             return PyDateTime_TIME_GET_SECOND(self)
 
         @property
-        cdef inline int microsecond(self):
+        cdef inline int microsecond(self) noexcept:
             return PyDateTime_TIME_GET_MICROSECOND(self)
 
         @property
@@ -102,37 +102,37 @@ cdef extern from "datetime.h":
             return <object>PyDateTime_TIME_GET_TZINFO(self)
 
         @property
-        cdef inline int fold(self):
+        cdef inline int fold(self) noexcept:
             # For Python < 3.6 this returns 0 no matter what
             return PyDateTime_TIME_GET_FOLD(self)
 
     ctypedef extern class datetime.datetime[object PyDateTime_DateTime]:
         @property
-        cdef inline int year(self):
+        cdef inline int year(self) noexcept:
             return PyDateTime_GET_YEAR(self)
 
         @property
-        cdef inline int month(self):
+        cdef inline int month(self) noexcept:
             return PyDateTime_GET_MONTH(self)
 
         @property
-        cdef inline int day(self):
+        cdef inline int day(self) noexcept:
             return PyDateTime_GET_DAY(self)
 
         @property
-        cdef inline int hour(self):
+        cdef inline int hour(self) noexcept:
             return PyDateTime_DATE_GET_HOUR(self)
 
         @property
-        cdef inline int minute(self):
+        cdef inline int minute(self) noexcept:
             return PyDateTime_DATE_GET_MINUTE(self)
 
         @property
-        cdef inline int second(self):
+        cdef inline int second(self) noexcept:
             return PyDateTime_DATE_GET_SECOND(self)
 
         @property
-        cdef inline int microsecond(self):
+        cdef inline int microsecond(self) noexcept:
             return PyDateTime_DATE_GET_MICROSECOND(self)
 
         @property
@@ -140,21 +140,21 @@ cdef extern from "datetime.h":
             return <object>PyDateTime_DATE_GET_TZINFO(self)
 
         @property
-        cdef inline int fold(self):
+        cdef inline int fold(self) noexcept:
             # For Python < 3.6 this returns 0 no matter what
             return PyDateTime_DATE_GET_FOLD(self)
 
     ctypedef extern class datetime.timedelta[object PyDateTime_Delta]:
         @property
-        cdef inline int day(self):
+        cdef inline int day(self) noexcept:
             return PyDateTime_DELTA_GET_DAYS(self)
 
         @property
-        cdef inline int second(self):
+        cdef inline int second(self) noexcept:
             return PyDateTime_DELTA_GET_SECONDS(self)
 
         @property
-        cdef inline int microsecond(self):
+        cdef inline int microsecond(self) noexcept:
             return PyDateTime_DELTA_GET_MICROSECONDS(self)
 
     ctypedef extern class datetime.tzinfo[object PyDateTime_TZInfo]:
@@ -279,7 +279,7 @@ cdef extern from "datetime.h":
 
 # Datetime C API initialization function.
 # You have to call it before any usage of DateTime CAPI functions.
-cdef inline void import_datetime():
+cdef inline void import_datetime() noexcept:
     PyDateTime_IMPORT
 
 # Create date object using DateTime CAPI factory function.
@@ -337,84 +337,84 @@ cdef inline object datetime_tzinfo(object o):
     return <object>PyDateTime_DATE_GET_TZINFO(o)
 
 # Get year of date
-cdef inline int date_year(object o):
+cdef inline int date_year(object o) noexcept:
     return PyDateTime_GET_YEAR(o)
 
 # Get month of date
-cdef inline int date_month(object o):
+cdef inline int date_month(object o) noexcept:
     return PyDateTime_GET_MONTH(o)
 
 # Get day of date
-cdef inline int date_day(object o):
+cdef inline int date_day(object o) noexcept:
     return PyDateTime_GET_DAY(o)
 
 # Get year of datetime
-cdef inline int datetime_year(object o):
+cdef inline int datetime_year(object o) noexcept:
     return PyDateTime_GET_YEAR(o)
 
 # Get month of datetime
-cdef inline int datetime_month(object o):
+cdef inline int datetime_month(object o) noexcept:
     return PyDateTime_GET_MONTH(o)
 
 # Get day of datetime
-cdef inline int datetime_day(object o):
+cdef inline int datetime_day(object o) noexcept:
     return PyDateTime_GET_DAY(o)
 
 # Get hour of time
-cdef inline int time_hour(object o):
+cdef inline int time_hour(object o) noexcept:
     return PyDateTime_TIME_GET_HOUR(o)
 
 # Get minute of time
-cdef inline int time_minute(object o):
+cdef inline int time_minute(object o) noexcept:
     return PyDateTime_TIME_GET_MINUTE(o)
 
 # Get second of time
-cdef inline int time_second(object o):
+cdef inline int time_second(object o) noexcept:
     return PyDateTime_TIME_GET_SECOND(o)
 
 # Get microsecond of time
-cdef inline int time_microsecond(object o):
+cdef inline int time_microsecond(object o) noexcept:
     return PyDateTime_TIME_GET_MICROSECOND(o)
 
 # Get fold of time
-cdef inline int time_fold(object o):
+cdef inline int time_fold(object o) noexcept:
     # For Python < 3.6 this returns 0 no matter what
     return PyDateTime_TIME_GET_FOLD(o)
 
 # Get hour of datetime
-cdef inline int datetime_hour(object o):
+cdef inline int datetime_hour(object o) noexcept:
     return PyDateTime_DATE_GET_HOUR(o)
 
 # Get minute of datetime
-cdef inline int datetime_minute(object o):
+cdef inline int datetime_minute(object o) noexcept:
     return PyDateTime_DATE_GET_MINUTE(o)
 
 # Get second of datetime
-cdef inline int datetime_second(object o):
+cdef inline int datetime_second(object o) noexcept:
     return PyDateTime_DATE_GET_SECOND(o)
 
 # Get microsecond of datetime
-cdef inline int datetime_microsecond(object o):
+cdef inline int datetime_microsecond(object o) noexcept:
     return PyDateTime_DATE_GET_MICROSECOND(o)
 
 # Get fold of datetime
-cdef inline int datetime_fold(object o):
+cdef inline int datetime_fold(object o) noexcept:
     # For Python < 3.6 this returns 0 no matter what
     return PyDateTime_DATE_GET_FOLD(o)
 
 # Get days of timedelta
-cdef inline int timedelta_days(object o):
+cdef inline int timedelta_days(object o) noexcept:
     return (<PyDateTime_Delta*>o).days
 
 # Get seconds of timedelta
-cdef inline int timedelta_seconds(object o):
+cdef inline int timedelta_seconds(object o) noexcept:
     return (<PyDateTime_Delta*>o).seconds
 
 # Get microseconds of timedelta
-cdef inline int timedelta_microseconds(object o):
+cdef inline int timedelta_microseconds(object o) noexcept:
     return (<PyDateTime_Delta*>o).microseconds
 
-cdef inline double total_seconds(timedelta obj):
+cdef inline double total_seconds(timedelta obj) noexcept:
     # Mirrors the "timedelta.total_seconds()" method.
     # Note that this implementation is not guaranteed to give *exactly* the same
     # result as the original method, due to potential differences in floating point rounding.

--- a/Cython/Includes/cpython/time.pxd
+++ b/Cython/Includes/cpython/time.pxd
@@ -26,7 +26,7 @@ from libc.time cimport (
 )
 
 
-cdef inline double time() nogil:
+cdef inline double time() noexcept nogil:
     cdef:
         _PyTime_t tic
 

--- a/tests/run/legacy_implicit_noexcept.pyx
+++ b/tests/run/legacy_implicit_noexcept.pyx
@@ -46,55 +46,51 @@ cdef test_noexcept_warning():
 def func_pure_implicit() -> cython.int:
     raise RuntimeError
 
-@cython.excetval(check=False)
+@cython.exceptval(check=False)
 @cython.cfunc
 def func_pure_noexcept() -> cython.int:
     raise RuntimeError
 
-def return_stderr(func):
+def print_stderr(func):
     @functools.wraps(func)
     def testfunc():
-        old_stderr = sys.stderr
-        stderr = sys.stderr = StringIO()
-        try:
+        from contextlib import redirect_stderr
+        with redirect_stderr(sys.stdout):
             func()
-        finally:
-            sys.stderr = old_stderr
-        return stderr.getvalue().strip()
 
     return testfunc
 
-@return_stderr
+@print_stderr
 def test_noexcept():
     """
-    >>> print(test_noexcept())  # doctest: +ELLIPSIS
+    >>> test_noexcept()  # doctest: +ELLIPSIS
     RuntimeError
     Exception...ignored...
     """
     func_noexcept(3, 5)
 
-@return_stderr
+@print_stderr
 def test_ptr_noexcept():
     """
-    >>> print(test_ptr_noexcept())  # doctest: +ELLIPSIS
+    >>> test_ptr_noexcept()  # doctest: +ELLIPSIS
     RuntimeError
     Exception...ignored...
     """
     ptr_func_noexcept(3, 5)
 
-@return_stderr
+@print_stderr
 def test_implicit():
     """
-    >>> print(test_implicit())  # doctest: +ELLIPSIS
+    >>> test_implicit()  # doctest: +ELLIPSIS
     RuntimeError
     Exception...ignored...
     """
     func_implicit(1, 2)
 
-@return_stderr
+@print_stderr
 def test_ptr_implicit():
     """
-    >>> print(test_ptr_implicit())  # doctest: +ELLIPSIS
+    >>> test_ptr_implicit()  # doctest: +ELLIPSIS
     RuntimeError
     Exception...ignored...
     """
@@ -128,31 +124,30 @@ def test_return_obj_implicit():
     """
     func_return_obj_implicit(1, 2)
 
+@print_stderr
 def test_pure_implicit():
     """
-    >>> test_pure_implicit()
-    Traceback (most recent call last):
-    ...
+    >>> test_pure_implicit()  # doctest: +ELLIPSIS
     RuntimeError
+    Exception...ignored...
     """
     func_pure_implicit()
 
+@print_stderr
 def test_pure_noexcept():
     """
-    >>> test_pure_noexcept()
-    Traceback (most recent call last):
-    ...
+    >>> test_pure_noexcept()  # doctest: +ELLIPSIS
     RuntimeError
+    Exception...ignored...
     """
     func_pure_noexcept()
 
 _WARNINGS = """
 12:5: Unraisable exception in function 'legacy_implicit_noexcept.func_implicit'.
-12:36: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
+12:22: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
 15:5: Unraisable exception in function 'legacy_implicit_noexcept.func_noexcept'.
-24:43: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
-27:38: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
-36:43: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
-39:36: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
-42:28: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
+27:28: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
+45:0: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
+45:0: Unraisable exception in function 'legacy_implicit_noexcept.func_pure_implicit'.
+49:0: Unraisable exception in function 'legacy_implicit_noexcept.func_pure_noexcept'.
 """

--- a/tests/run/legacy_implicit_noexcept.pyx
+++ b/tests/run/legacy_implicit_noexcept.pyx
@@ -142,6 +142,10 @@ def test_pure_noexcept():
     """
     func_pure_noexcept()
 
+# extern functions are implicit noexcept, without warning
+cdef extern int extern_fun()
+cdef extern int extern_fun_fun(int (*f)(int))
+
 _WARNINGS = """
 12:5: Unraisable exception in function 'legacy_implicit_noexcept.func_implicit'.
 12:22: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.


### PR DESCRIPTION
Follow up to: https://github.com/cython/cython/pull/5999#issuecomment-1987520482

Currently, the warning `Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.` gives false positives for functions returning python objects. This is misleading and results in naively adding incorrect `noexcept` clauses (as in https://github.com/sagemath/sage/pull/36507 which added about 40k incorrect ones!).

With #5999, the incorrect `noexcept` clauses are warned, which is good. But it also means that it's not possible to "fix" warnings for some functions (when running in legacy implicit noexcept mode).

For instance in
```
$ cat test_noexcept.pyx 
cdef test_good():
    return 0

cdef test_bad() noexcept:
    return 0
$ cython -3 -X legacy_implicit_noexcept=True test_noexcept.pyx 
warning: test_noexcept.pyx:1:12: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
warning: test_noexcept.pyx:4:10: noexcept clause is ignored for function returning Python object
```
both the good and the bad versions give a warning.

---

**The first commit** in this PR fixes the warning to avoid these false positives, by not giving a warning for functions that return a python object.

Notes on the change:
 - the current implementation of the implicit noexcept mode and the warning happens during parsing, but this is too early to know the return type
 - hence we move handling of the implicit noexcept mode and the warning to the analysis phase
 - the logic is: if we are in implicit noexcept mode, check that the function definition
   - does not return a python type
   - does not have an explicit `except` or `noexcept` clause
   - `self.exception_check` is set, meaning the function would normally check exceptions (this rules out extern definitions; the `visibility != 'extern'` is *not* enough)
 - under the above conditions, trigger implicit noexcept by clearing `self.exception_check` with the corresponding deprecation warning.

---

**The second commit** in this PR adds 44 missing `noexcept` clauses to files in `Cython/Includes`. In fact, currently there are 60 implicit noexcept warnings, of which 16 are false positives and fixed by the first commit.

---

The combination of both commits results in a "clean" `Cython/Includes`. Testing this:

Step 1, create a test file that `cimport`s every include file shipped in cython:
```
$ find Cython/Includes -name '*.pxd' | sed -e 's|^Cython/Includes/|cimport |;s|/|.|;s|\.pxd$||' > test_cimport.pyx
```

Step 2, test with current master:
```
$ PYTHONPATH=Cython/Includes ./cython.py -3+ -X legacy_implicit_noexcept=True test_cimport.pyx |& grep -c "Implicit noexcept"
60
```

Step 3, checkout this branch, run the test *before recompiling*:
```
$ PYTHONPATH=Cython/Includes ./cython.py -3+ -X legacy_implicit_noexcept=True test_cimport.pyx |& grep -c "Implicit noexcept"
16
```
Here we still get 16 false positives since we are using cython from current master.

Step 4, rebuild cython with this branch and run with `-Werror`:
```
$ make
[...]
$ PYTHONPATH=Cython/Includes ./cython.py -3+ -Werror -X legacy_implicit_noexcept=True test_cimport.pyx
$
```
We see no warning at all: neither "implicit noexcept" nor the warning from #5999 which is good.

---

**Final words:** it would be very nice to merge this and make a new release of cython asap. In fact, right now building sagemath with cython 3.0.9 gives ~ 40k warnings coming from #5999. A good warnings, I made 40k mistakes in https://github.com/sagemath/sage/pull/36507. But fixing those 40k mistakes leads to 40k implicit noexcept warnings and doubt (is each of the 40k fixes ok or not ok?).

My hope is that, once we get rid of all the warnings related to `noexcept` (in sagemath and all dependencies, e.g. numpy) we'll be more comfortable switching off the legacy mode.