### PR TITLE
Fix write unraisable followed by interpretter shutdown

### DIFF
--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -745,7 +745,7 @@ static void __Pyx_WriteUnraisable(const char *name, int clineno,
         Py_XINCREF(old_val);
         Py_XINCREF(old_tb);
         __Pyx_ErrRestore(old_exc, old_val, old_tb);
-        PyErr_PrintEx(1);
+        PyErr_PrintEx(0);
     }
     ctx = PyUnicode_FromString(name);
     __Pyx_ErrRestore(old_exc, old_val, old_tb);

--- a/tests/run/dealloc_raise.srctree
+++ b/tests/run/dealloc_raise.srctree
@@ -1,0 +1,45 @@
+# github 6022
+# This used to crash, probably due to a stray reference
+# to a destructed object being kept in stashed exception
+# state on interpreter shutdown.
+
+PYTHON setup.py build_ext --inplace
+PYTHON test_dealloc_raise1.py
+PYTHON test_dealloc_raise2.py
+
+############## setup.py ##########################
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(
+  ext_modules = cythonize("*.pyx"),
+)
+
+############# dealloc_raise.pyx ##################
+
+cdef class Foo:
+    def __dealloc__(self):
+        self.cleanup()  # doesn't exist
+
+############# test_dealloc_raise1.py #############
+
+import dealloc_raise
+
+class Derived(dealloc_raise.Foo):
+    pass
+
+def main():
+    ob = Derived()
+
+main()
+
+############# test_dealloc_raise2.py #############
+
+import dealloc_raise
+
+class Derived(dealloc_raise.Foo):
+    pass
+
+class Main:
+    ob = Derived()


### PR DESCRIPTION
I'm not 100% sure what causes the error, but I think it's that _PyErr_PrintEx stashes away some illicit references to invalid objects on sys.last_exc.

There's no reason to do this, so just do the print without the stash.

Fixes #6022