### PR TITLE
3.0.x fix legacy_implicit_noexcept tests

### DIFF
--- a/tests/run/legacy_implicit_noexcept.pyx
+++ b/tests/run/legacy_implicit_noexcept.pyx
@@ -54,9 +54,13 @@ def func_pure_noexcept() -> cython.int:
 def print_stderr(func):
     @functools.wraps(func)
     def testfunc():
-        from contextlib import redirect_stderr
-        with redirect_stderr(sys.stdout):
+        old_stderr = sys.stderr
+        stderr = sys.stderr = StringIO()
+        try:
             func()
+        finally:
+            sys.stderr = old_stderr
+        print(stderr.getvalue())
 
     return testfunc
 


### PR DESCRIPTION
By keeping the "print_stderr" changes, but not using contextlib.

Supercedes #6103

No real need for review - just checking the CI before merging