### PR TITLE
Make C++ conversion lengthhint limited-api friendly

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -512,17 +512,13 @@ class UtilityCodeBase:
                     continue
                 # only pass lists when we have to: most argument expect one value or None
                 if name == 'requires':
-                    def load_dep(dep):
-                        if cls.is_cython_utility and re.search("[.]c(pp)?::", dep):
-                            # Allow loading of C utility code from Cython utility code.
-                            # Note that we don't current propagate things like tempita context.
-                            return UtilityCode.load_cached(dep, from_file)
-                        if orig_kwargs:
-                            return cls.load(dep, from_file, **orig_kwargs)
-                        else:
-                            return cls.load_cached(dep, from_file)
-
-                    values = [load_dep(dep) for dep in sorted(values)]
+                    if orig_kwargs:
+                        values = [cls.load(dep, from_file, **orig_kwargs)
+                                  for dep in sorted(values)]
+                    else:
+                        # dependencies are rarely unique, so use load_cached() when we can
+                        values = [cls.load_cached(dep, from_file)
+                                  for dep in sorted(values)]
                 elif name == 'substitute':
                     # don't want to pass "naming" or "tempita" to the constructor
                     # since these will have been handled

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -512,13 +512,17 @@ class UtilityCodeBase:
                     continue
                 # only pass lists when we have to: most argument expect one value or None
                 if name == 'requires':
-                    if orig_kwargs:
-                        values = [cls.load(dep, from_file, **orig_kwargs)
-                                  for dep in sorted(values)]
-                    else:
-                        # dependencies are rarely unique, so use load_cached() when we can
-                        values = [cls.load_cached(dep, from_file)
-                                  for dep in sorted(values)]
+                    def load_dep(dep):
+                        if cls.is_cython_utility and re.search("[.]c(pp)?::", dep):
+                            # Allow loading of C utility code from Cython utility code.
+                            # Note that we don't current propagate things like tempita context.
+                            return UtilityCode.load_cached(dep, from_file)
+                        if orig_kwargs:
+                            return cls.load(dep, from_file, **orig_kwargs)
+                        else:
+                            return cls.load_cached(dep, from_file)
+
+                    values = [load_dep(dep) for dep in sorted(values)]
                 elif name == 'substitute':
                     # don't want to pass "naming" or "tempita" to the constructor
                     # since these will have been handled

--- a/Cython/Compiler/UtilityCode.py
+++ b/Cython/Compiler/UtilityCode.py
@@ -3,6 +3,8 @@ from . import Symtab
 from . import Naming
 from . import Code
 
+import re
+
 
 class NonManglingModuleScope(Symtab.ModuleScope):
 
@@ -195,6 +197,14 @@ class CythonUtilityCode(Code.UtilityCodeBase):
 
     def put_code(self, output):
         pass
+
+    @classmethod
+    def load(cls, util_code_name, from_file, **kwargs):
+        if re.search("[.]c(pp)?::", util_code_name):
+            # We're trying to load a C/C++ utility code.
+            # For now, just handle the simple case with no tempita
+            return Code.UtilityCode.load_cached(util_code_name, from_file)
+        return super().load(util_code_name, from_file, **kwargs)
 
     @classmethod
     def load_as_string(cls, util_code_name, from_file=None, **kwargs):

--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -36,19 +36,20 @@ cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const string& s):
 
 
 #################### vector.from_py ####################
+#@requires: ObjectHandling.c::LengthHint
 
 cdef extern from *:
     cdef cppclass vector "std::vector" [T]:
         void push_back(T&) except +
         void reserve(size_t) except +
 
-    cdef Py_ssize_t PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
+    cdef Py_ssize_t __Pyx_PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
 
 @cname("{{cname}}")
 cdef vector[X] {{cname}}(object o) except *:
 
     cdef vector[X] v
-    cdef Py_ssize_t s = PyObject_LengthHint(o, 0)
+    cdef Py_ssize_t s = __Pyx_PyObject_LengthHint(o, 0)
 
     if s > 0:
         v.reserve(<size_t> s)

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2929,3 +2929,13 @@ static PyObject *__Pyx_PyList_Pack(Py_ssize_t n, ...) {
     va_end(va);
     return l;
 }
+
+/////////////// LengthHint.proto //////////////////////////////////////
+
+#if !CYTHON_COMPILING_IN_LIMITED_API
+#define __Pyx_PyObject_LengthHint(o, defaultval) PyObject_LengthHint(o, defaultval)
+#else
+// We could reimplement it fully, however since it's only an optimization
+// the simpler version is to make it the default.
+#define __Pyx_PyObject_LengthHint(o, defaultval) defaultval
+#endif

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2932,10 +2932,10 @@ static PyObject *__Pyx_PyList_Pack(Py_ssize_t n, ...) {
 
 /////////////// LengthHint.proto //////////////////////////////////////
 
-#if !CYTHON_COMPILING_IN_LIMITED_API
-#define __Pyx_PyObject_LengthHint(o, defaultval) PyObject_LengthHint(o, defaultval)
-#else
+#if CYTHON_COMPILING_IN_LIMITED_API
 // We could reimplement it fully, however since it's only an optimization
 // the simpler version is to make it the default.
-#define __Pyx_PyObject_LengthHint(o, defaultval) defaultval
+#define __Pyx_PyObject_LengthHint(o, defaultval)  (defaultval)
+#else
+#define __Pyx_PyObject_LengthHint(o, defaultval)  PyObject_LengthHint(o, defaultval)
 #endif


### PR DESCRIPTION
Follow up to https://github.com/cython/cython/pull/6077.

I've had to make a change to allow Cython utility code to require C utility code - I think that's worthwhile but there's other ways rounds the problem if we don't want to do that (e.g. just putting __Pyx_PyObject_LengthHint in the universal module setup code).

I've picked the easy route and not implemented a limited API version of length hint. It'd be perfectly possible to do this, but it doesn't really seem like a priority.