### PR TITLE
CI: Pin Numpy<2 in test dependencies.

### DIFF
--- a/test-requirements-312.txt
+++ b/test-requirements-312.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 coverage
 pycodestyle
 setuptools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 coverage
 pycodestyle
 setuptools<60


### PR DESCRIPTION
Backport a799b1b to 3.0.x, see [this thread](https://github.com/cython/cython/pull/6100#issuecomment-2016711585) in cython/cython#6100.

Once NumPy releases 2.0.0rc1, these pins should be reverted.