### PR TITLE
[3.0.x] Fix c++ complex double_proj test

### DIFF
--- a/tests/run/complex_numbers_cpp.pyx
+++ b/tests/run/complex_numbers_cpp.pyx
@@ -235,18 +235,9 @@ def double_proj(complex_class[double] a):
     >>> double_proj(5 + 4j)
     (5+4j)
     >>> double_proj(-float("infinity") + 4j)
-    (-inf+0j)
+    (inf+0j)
     >>> double_proj(5 - float("infinity")*1j)
-    (inf+0j)
-    """
-    return cppcomplex.proj(a)
-
-def double_proj(complex_class[double] a):
-    """
-    >>> double_proj(5 + 4j)
-    (5+4j)
-    >>> double_proj(5 + float("infinity")*1j)
-    (inf+0j)
+    (inf-0j)
     """
     return cppcomplex.proj(a)
 


### PR DESCRIPTION
I think the issue was partly that the function was defined twice with slightly different tests and that this was behaving differently on Py2.7, but not completely sure.

Either way, it's testing the standard library rather than our code, so we probably don't have to make it too detailed beyond that it compiles.