### PR TITLE
Tidy up of "overloaded c++ methods"

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -8,7 +8,7 @@ import copy
 import operator
 
 from ..Utils import try_finally_contextmanager
-from .Errors import warning, error, InternalError
+from .Errors import warning, error, InternalError, local_errors
 from .StringEncoding import EncodedString
 from . import Options, Naming
 from . import PyrexTypes
@@ -519,24 +519,29 @@ class Scope:
             # If we redefine a C++ class method which is either inherited
             # or automatically generated (base constructor), then it's fine.
             # Otherwise, we shout.
-            for alt_entry in old_entry.all_alternatives():
-                if type.compatible_signature_with(alt_entry.type):
-                    if name == '<init>' and not type.args:
-                        # Cython pre-declares the no-args constructor - allow later user definitions.
-                        cpp_override_allowed = True
-                    elif alt_entry.is_inherited:
-                        # Note that we can override an inherited method with a compatible but not exactly equal signature, as in C++.
-                        cpp_override_allowed = True
-                    if cpp_override_allowed:
-                        # A compatible signature doesn't mean the exact same signature,
-                        # so we're taking the new signature for the entry.
-                        alt_entry.type = type
-                        alt_entry.is_inherited = False
-                        # Updating the entry attributes which can be modified in the method redefinition.
-                        alt_entry.cname = cname
-                        alt_entry.pos = pos
-                        entry = alt_entry
-                    break
+            alt_entry = None
+            arg_types = [arg.type for arg in old_entry.type.args]
+            with local_errors():
+                alt_entry = PyrexTypes.best_match(
+                    arg_types, old_entry.all_alternatives())
+            # best_match is a slightly looser check than compatible_signature_with
+            # so check both.
+            if alt_entry and type.compatible_signature_with(alt_entry.type):
+                if name == '<init>' and not type.args:
+                    # Cython pre-declares the no-args constructor - allow later user definitions.
+                    cpp_override_allowed = True
+                elif alt_entry.is_inherited:
+                    # Note that we can override an inherited method with a compatible but not exactly equal signature, as in C++.
+                    cpp_override_allowed = True
+                if cpp_override_allowed:
+                    # A compatible signature doesn't mean the exact same signature,
+                    # so we're taking the new signature for the entry.
+                    alt_entry.type = type
+                    alt_entry.is_inherited = False
+                    # Updating the entry attributes which can be modified in the method redefinition.
+                    alt_entry.cname = cname
+                    alt_entry.pos = pos
+                    entry = alt_entry
             else:
                 cpp_override_allowed = True
 


### PR DESCRIPTION
This uses the existing approach for matching methods up.

See comment: https://github.com/cython/cython/pull/3235#discussion_r1536631452

I'm not sure how much difference this does make to being deterministic - I think `compatible_signature_with` is probably a stricter check, so it should always end up the same, but does use the existing mechanism.