### PR TITLE
Add tests to cover Node analyse expressions

### DIFF
--- a/tests/run/analyse_expressions.srctree
+++ b/tests/run/analyse_expressions.srctree
@@ -1,0 +1,43 @@
+# mode: run
+
+PYTHON setup.py build_ext --inplace
+
+######## moda.pyx ########
+
+cpdef mod_name():
+    return "mod A"
+
+cdef class ClassA:
+    cpdef class_name(self):
+        return "Class A"
+
+cdef class ClassB(ClassA):
+    cpdef class_name(self):
+        return "Class B"
+
+######## modb.pyx ########
+
+import moda
+
+cpdef mod_name_override():
+    return "I was overridden"
+
+moda.mod_name = mod_name_override
+
+######## setup.py ########
+
+from setuptools import setup
+from Cython.Build import cythonize
+import Cython.Compiler.Options
+
+Cython.Compiler.Options.lookup_module_cpdef = True
+
+setup(
+        ext_modules = cythonize(["moda.pyx", "modb.pyx"],
+            compiler_directives={'language_level': 3})
+)
+
+import moda, modb
+
+assert moda.mod_name == modb.mod_name_override
+assert moda.ClassA.class_name != moda.ClassB.class_name

--- a/tests/run/analyse_expressions.srctree
+++ b/tests/run/analyse_expressions.srctree
@@ -1,6 +1,7 @@
 # mode: run
 
 PYTHON setup.py build_ext --inplace
+PYTHON main.py
 
 ######## moda.pyx ########
 
@@ -37,7 +38,10 @@ setup(
             compiler_directives={'language_level': 3})
 )
 
+######## main.py ########
+
 import moda, modb
 
+assert moda.mod_name() == "I was overridden"
 assert moda.mod_name == modb.mod_name_override
 assert moda.ClassA.class_name != moda.ClassB.class_name


### PR DESCRIPTION
Including a .srctree file with modules A and B to validate the overriding behaviour of `analyse_expressions` method.

Fix to #4163 

```python
4644    def analyse_expressions(self, env): 
4645        self.args = env.arg_entries 
4646        if self.py_func.is_module_scope:  # 4646 ↛ 4647
4647            first_arg = 0 
```