### PR TITLE
[3.0.x] Modified "pretend_to_initialize" for c++ (#5920)

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -880,7 +880,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         PyrexTypes.c_int_type.create_from_py_utility_code(env)
 
         code.put(Nodes.branch_prediction_macros)
-        code.putln('static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }')
+
+        self._put_setup_code(code, "PretendToInitialize")
         code.putln('')
         code.putln('#if !CYTHON_USE_MODULE_STATE')
         code.putln('static PyObject *%s = NULL;' % env.module_cname)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2348,6 +2348,30 @@ static void __Pyx_FastGilFuncInit(void) {
 
 #endif
 
+///////////////////// PretendToInitialize ////////////////////////
+
+#ifdef __cplusplus
+// In C++ a variable must actually be initialized to make returning
+// it defined behaviour, and there doesn't seem to be a viable compiler trick to
+// avoid that.
+#include <type_traits>
+template <typename T>
+static void __Pyx_pretend_to_initialize(T* ptr) {
+    // In C++11 we have enough introspection to work out which types it's actually
+    // necessary to apply this to (non-trivial types will have been initialized by
+    // the definition). Below C++11 just initialize everything.
+#if __cplusplus > 201103L
+    if ((std::is_trivially_default_constructible<T>::value))
+#endif
+        *ptr = T();
+    (void)ptr;
+}
+#else
+// For C,  taking an address of a variable is enough to make returning it
+// defined behaviour.
+static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }
+#endif
+
 ///////////////////// UtilityCodePragmas /////////////////////////
 
 #ifdef _MSC_VER


### PR DESCRIPTION
In this case we actually have to initialize rather than just do nothing. Fixes #5278.

Backport of #5920 for 3.0.x. This was suggested as something that should be backported and we didn't actually do it (https://github.com/cython/cython/issues/5278#issuecomment-1966245351)