### PR TITLE
Create standalone cython runtime module package

### DIFF
--- a/cython_shadow/Cython/Shadow.py
+++ b/cython_shadow/Cython/Shadow.py
@@ -1,0 +1,1 @@
+../../Cython/Shadow.py

--- a/cython_shadow/Cython/Shadow.pyi
+++ b/cython_shadow/Cython/Shadow.pyi
@@ -1,0 +1,1 @@
+../../Cython/Shadow.pyi

--- a/cython_shadow/Cython/__init__.py
+++ b/cython_shadow/Cython/__init__.py
@@ -1,0 +1,1 @@
+../../Cython/__init__.py

--- a/cython_shadow/Cython/__init__.pyi
+++ b/cython_shadow/Cython/__init__.pyi
@@ -1,0 +1,1 @@
+../../Cython/__init__.pyi

--- a/cython_shadow/README.md
+++ b/cython_shadow/README.md
@@ -1,0 +1,8 @@
+Cython-Shadow
+=============
+
+The Cython-Shadow package contains the files necessary for `import cython` to work
+but not the Cython compiler itself.  It is intended as a lightweight dependency
+for projects that want to implement an optional Cython-compiled mode using the
+"pure Python" syntax.  Cython-Shadow the non-compiled versions to use
+Cython type annotations and decorators without needing Cython as a dependency.

--- a/cython_shadow/cython.py
+++ b/cython_shadow/cython.py
@@ -1,0 +1,1 @@
+../cython.py

--- a/cython_shadow/pyproject.toml
+++ b/cython_shadow/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Cython-shadow"
+version = "0.0.1"
+authors = [
+  { name="Robert Bradshaw, Stefan Behnel, David Woods, Greg Ewing, et al.", email="cython-devel@python.org" },
+]
+description = "Standalone pure-Python-mode imports for Cython"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://cython.org/"
+Issues = "https://github.com/cython/cython/issues"
+
+#[tool.setuptools.packages.find]
+#include = ["Cython", "cython.py"]
+[tool.setuptools]
+packages = ["Cython"]
+py-modules = ["cython"]


### PR DESCRIPTION
https://github.com/cython/cython/issues/1981

Package is named Cython_shadow. That can probably be changed.

It doesn't attempt to deal with any versioning issues.

It also doesn't do any testing. That'd probably be a case of adding a ci run that makes and installs the wheel and then imports a few example pure-Python modules.

Not sure what else I'm missing.