### PR TITLE
Docs: Fix example manual work in parallelization

### DIFF
--- a/docs/examples/tutorial/parallelization/manual_work.pyx
+++ b/docs/examples/tutorial/parallelization/manual_work.pyx
@@ -6,12 +6,12 @@ from openmp cimport omp_get_thread_num
 
 
 
-cdef void long_running_task1() nogil:
+cdef void long_running_task1() noexcept nogil:
     pass
 
 
 
-cdef void long_running_task2() nogil:
+cdef void long_running_task2() noexcept nogil:
     pass
 
 def do_two_tasks():


### PR DESCRIPTION
Fixes the following error:

```
cython -3 docs/examples/tutorial/parallelization/manual_work.pyx

performance hint: docs/examples/tutorial/parallelization/manual_work.pyx:9:5: Exception check on 'long_running_task1' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'long_running_task1' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'long_running_task1' to allow an error code to be returned.
performance hint: docs/examples/tutorial/parallelization/manual_work.pyx:14:5: Exception check on 'long_running_task2' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'long_running_task2' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'long_running_task2' to allow an error code to be returned.
performance hint: docs/examples/tutorial/parallelization/manual_work.pyx:22:30: Exception check after calling 'long_running_task1' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'long_running_task1' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'long_running_task1' to allow an error code to be returned.
performance hint: docs/examples/tutorial/parallelization/manual_work.pyx:24:30: Exception check after calling 'long_running_task2' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'long_running_task2' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'long_running_task2' to allow an error code to be returned.
```