### PR TITLE
Docs: Fix string examples

### DIFF
--- a/docs/examples/tutorial/string/cpp_string.pyx
+++ b/docs/examples/tutorial/string/cpp_string.pyx
@@ -6,7 +6,7 @@ def get_bytes():
     py_bytes_object = b'hello world'
     cdef string s = py_bytes_object
 
-    s.append('abc')
+    s.append(b'abc')
     py_bytes_object = s
     return py_bytes_object
 

--- a/docs/examples/tutorial/string/for_bytes.pyx
+++ b/docs/examples/tutorial/string/for_bytes.pyx
@@ -1,6 +1,6 @@
 cdef bytes bytes_string = b"hello to A bytes' world"
 
-cdef char c
+cdef Py_UCS4 c
 for c in bytes_string:
     if c == 'A':
         print("Found the letter A")

--- a/docs/examples/tutorial/string/for_bytes.pyx
+++ b/docs/examples/tutorial/string/for_bytes.pyx
@@ -1,6 +1,6 @@
 cdef bytes bytes_string = b"hello to A bytes' world"
 
-cdef Py_UCS4 c
+cdef char c
 for c in bytes_string:
-    if c == 'A':
+    if c == b'A':
         print("Found the letter A")

--- a/docs/examples/tutorial/string/for_char.pyx
+++ b/docs/examples/tutorial/string/for_char.pyx
@@ -2,5 +2,5 @@ cdef char* c_string = "Hello to A C-string's world"
 
 cdef char c
 for c in c_string[:11]:
-    if c == 'A':
+    if c == b'A':
         print("Found the letter A")


### PR DESCRIPTION
Fixes the following examples: 

```
cython -3 -+ docs/examples/tutorial/string/*.pyx

Error compiling Cython file:
------------------------------------------------------------
...

def get_bytes():
    py_bytes_object = b'hello world'
    cdef string s = py_bytes_object

    s.append('abc')
            ^
------------------------------------------------------------

docs/examples/tutorial/string/cpp_string.pyx:9:12: no suitable method found

Error compiling Cython file:
------------------------------------------------------------
...
cdef bytes bytes_string = b"hello to A bytes' world"

cdef char c
for c in bytes_string:
    if c == 'A':
            ^
------------------------------------------------------------

docs/examples/tutorial/string/for_bytes.pyx:5:12: Unicode literals do not support coercion to C types other than Py_UNICODE/Py_UCS4 (for characters) or Py_UNICODE* (for strings).

Error compiling Cython file:
------------------------------------------------------------
...
cdef char* c_string = "Hello to A C-string's world"

cdef char c
for c in c_string[:11]:
    if c == 'A':
            ^
------------------------------------------------------------

docs/examples/tutorial/string/for_char.pyx:5:12: Unicode literals do not support coercion to C types other than Py_UNICODE/Py_UCS4 (for characters) or Py_UNICODE* (for strings).
```