### PR TITLE
Add bindings for Py_REFCNT and use it in tests and docs

### DIFF
--- a/Cython/Includes/cpython/ref.pxd
+++ b/Cython/Includes/cpython/ref.pxd
@@ -48,3 +48,13 @@ cdef extern from "Python.h":
     # It is a good idea to use this macro whenever decrementing the
     # value of a variable that might be traversed during garbage
     # collection.
+
+    Py_ssize_t Py_REFCNT(PyObject* o)
+    # Get the reference count of the Python object o.
+
+    # Note that the returned value may not actually reflect how many
+    # references to the object are actually held. For example, some
+    # objects are “immortal” and have a very high refcount that does not
+    # reflect the actual number of references. Consequently, do not rely
+    # on the returned value to be accurate, other than a value of 0 or
+    # 1.

--- a/Cython/Includes/cpython/ref.pxd
+++ b/Cython/Includes/cpython/ref.pxd
@@ -49,7 +49,7 @@ cdef extern from "Python.h":
     # value of a variable that might be traversed during garbage
     # collection.
 
-    Py_ssize_t Py_REFCNT(PyObject* o)
+    Py_ssize_t Py_REFCNT(object o)
     # Get the reference count of the Python object o.
 
     # Note that the returned value may not actually reflect how many
@@ -58,3 +58,10 @@ cdef extern from "Python.h":
     # reflect the actual number of references. Consequently, do not rely
     # on the returned value to be accurate, other than a value of 0 or
     # 1.
+
+    Py_ssize_t _Py_REFCNT "Py_REFCNT" (PyObject *ptr)
+    # Get the reference count for the PyObject pointer ptr.
+
+    # This is useful when it would be awkward to create an owned reference just
+    # to get the reference count. See the note for Py_REFCNT above about the
+    # accuracy of reference counts.

--- a/docs/examples/userguide/language_basics/parameter_refcount.py
+++ b/docs/examples/userguide/language_basics/parameter_refcount.py
@@ -1,4 +1,4 @@
-from cython.cimports.cpython.ref import PyObject, Py_REFCNT
+from cython.cimports.cpython.ref import PyObject, _Py_REFCNT
 
 import sys
 
@@ -12,7 +12,9 @@ def owned_reference(obj: object):
 
 @cython.cfunc
 def borrowed_reference(obj: cython.pointer(PyObject)):
-    refcount = Py_REFCNT(obj)
+    # use _Py_REFCNT instead of Py_REFCNT to avoid creating a new owned
+    # reference just to get the reference count
+    refcount = _Py_REFCNT(obj)
     print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
 
 def main():

--- a/docs/examples/userguide/language_basics/parameter_refcount.py
+++ b/docs/examples/userguide/language_basics/parameter_refcount.py
@@ -1,4 +1,4 @@
-from cython.cimports.cpython.ref import PyObject
+from cython.cimports.cpython.ref import PyObject, Py_REFCNT
 
 import sys
 
@@ -12,7 +12,7 @@ def owned_reference(obj: object):
 
 @cython.cfunc
 def borrowed_reference(obj: cython.pointer(PyObject)):
-    refcount = obj.ob_refcnt
+    refcount = Py_REFCNT(obj)
     print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
 
 def main():

--- a/docs/examples/userguide/language_basics/parameter_refcount.pyx
+++ b/docs/examples/userguide/language_basics/parameter_refcount.pyx
@@ -1,4 +1,4 @@
-from cpython.ref cimport PyObject, Py_REFCNT
+from cpython.ref cimport PyObject, _Py_REFCNT
 
 import sys
 
@@ -12,7 +12,9 @@ cdef owned_reference(object obj):
 
 
 cdef borrowed_reference(PyObject * obj):
-    refcount = Py_REFCNT(obj)
+    # use _Py_REFCNT instead of Py_REFCNT to avoid creating a new owned
+    # reference just to get the reference count
+    refcount = _Py_REFCNT(obj)
     print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
 
 

--- a/docs/examples/userguide/language_basics/parameter_refcount.pyx
+++ b/docs/examples/userguide/language_basics/parameter_refcount.pyx
@@ -1,4 +1,4 @@
-from cpython.ref cimport PyObject
+from cpython.ref cimport PyObject, Py_REFCNT
 
 import sys
 
@@ -12,7 +12,7 @@ cdef owned_reference(object obj):
 
 
 cdef borrowed_reference(PyObject * obj):
-    refcount = obj.ob_refcnt
+    refcount = Py_REFCNT(obj)
     print('Inside borrowed_reference: {refcount}'.format(refcount=refcount))
 
 

--- a/tests/buffers/bufaccess.pyx
+++ b/tests/buffers/bufaccess.pyx
@@ -959,7 +959,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return Py_REFCNT((<PyObject*>x))
+    return Py_REFCNT(x)
 
 @testcase
 def printbuf_object(object[object] buf, shape):
@@ -985,7 +985,7 @@ def printbuf_object(object[object] buf, shape):
     """
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), Py_REFCNT((<PyObject*>buf[i]))
+        print repr(buf[i]), Py_REFCNT(buf[i])
 
 @testcase
 def assign_to_object(object[object] buf, int idx, obj):

--- a/tests/buffers/bufaccess.pyx
+++ b/tests/buffers/bufaccess.pyx
@@ -10,7 +10,7 @@
 from __future__ import unicode_literals
 
 from cpython.object cimport PyObject
-from cpython.ref cimport Py_INCREF, Py_DECREF, Py_CLEAR
+from cpython.ref cimport Py_INCREF, Py_DECREF, Py_CLEAR, Py_REFCNT
 cimport cython
 
 import sys
@@ -959,7 +959,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return (<PyObject*>x).ob_refcnt
+    return Py_REFCNT((<PyObject*>x))
 
 @testcase
 def printbuf_object(object[object] buf, shape):
@@ -985,7 +985,7 @@ def printbuf_object(object[object] buf, shape):
     """
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), (<PyObject*>buf[i]).ob_refcnt
+        print repr(buf[i]), Py_REFCNT((<PyObject*>buf[i]))
 
 @testcase
 def assign_to_object(object[object] buf, int idx, obj):

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -14,7 +14,7 @@ from cython.view cimport memoryview, array
 from cython cimport view
 
 from cpython.object cimport PyObject
-from cpython.ref cimport Py_INCREF, Py_DECREF
+from cpython.ref cimport Py_INCREF, Py_DECREF, Py_REFCNT
 cimport cython
 
 import array as pyarray
@@ -672,7 +672,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return (<PyObject*>x).ob_refcnt
+    return Py_REFCNT(<PyObject*>x)
 
 def printbuf_object(object[:] mslice, shape):
     """
@@ -698,7 +698,7 @@ def printbuf_object(object[:] mslice, shape):
     cdef object buf = mslice
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), (<PyObject*>buf[i]).ob_refcnt
+        print repr(buf[i]), Py_REFCNT(<PyObject*>buf[i])
 
 def assign_to_object(object[:] mslice, int idx, obj):
     """

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -672,7 +672,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return Py_REFCNT(<PyObject*>x)
+    return Py_REFCNT(x)
 
 def printbuf_object(object[:] mslice, shape):
     """
@@ -698,7 +698,7 @@ def printbuf_object(object[:] mslice, shape):
     cdef object buf = mslice
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), Py_REFCNT(<PyObject*>buf[i])
+        print repr(buf[i]), Py_REFCNT(buf[i])
 
 def assign_to_object(object[:] mslice, int idx, obj):
     """

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -1066,7 +1066,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return Py_REFCNT(<PyObject*>x)
+    return Py_REFCNT(x)
 
 @testcase
 def printbuf_object(object[:] buf, shape):
@@ -1092,7 +1092,7 @@ def printbuf_object(object[:] buf, shape):
     """
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), Py_REFCNT(<PyObject*>buf[i])
+        print repr(buf[i]), Py_REFCNT(buf[i])
 
 @testcase
 def assign_to_object(object[:] buf, int idx, obj):

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -7,7 +7,7 @@
 from __future__ import unicode_literals
 
 from cpython.object cimport PyObject
-from cpython.ref cimport Py_INCREF, Py_DECREF, Py_CLEAR
+from cpython.ref cimport Py_INCREF, Py_DECREF, Py_CLEAR, Py_REFCNT
 
 cimport cython
 from cython cimport view
@@ -1066,7 +1066,7 @@ def decref(*args):
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(x):
-    return (<PyObject*>x).ob_refcnt
+    return Py_REFCNT(<PyObject*>x)
 
 @testcase
 def printbuf_object(object[:] buf, shape):
@@ -1092,7 +1092,7 @@ def printbuf_object(object[:] buf, shape):
     """
     cdef int i
     for i in range(shape[0]):
-        print repr(buf[i]), (<PyObject*>buf[i]).ob_refcnt
+        print repr(buf[i]), Py_REFCNT(<PyObject*>buf[i])
 
 @testcase
 def assign_to_object(object[:] buf, int idx, obj):

--- a/tests/run/exceptionrefcount.pyx
+++ b/tests/run/exceptionrefcount.pyx
@@ -30,12 +30,12 @@
 """
 
 cimport cython
-from cpython.ref cimport PyObject
+from cpython.ref cimport PyObject, Py_REFCNT
 
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(obj):
-    return (<PyObject*>obj).ob_refcnt
+    return Py_REFCNT(<PyObject*>obj)
 
 def test_no_exception():
     try:

--- a/tests/run/exceptionrefcount.pyx
+++ b/tests/run/exceptionrefcount.pyx
@@ -35,7 +35,7 @@ from cpython.ref cimport PyObject, Py_REFCNT
 @cython.binding(False)
 @cython.always_allow_keywords(False)
 def get_refcount(obj):
-    return Py_REFCNT(<PyObject*>obj)
+    return Py_REFCNT(obj)
 
 def test_no_exception():
     try:

--- a/tests/run/refcount_in_meth.pyx
+++ b/tests/run/refcount_in_meth.pyx
@@ -13,11 +13,11 @@ True
 """
 
 cimport cython
-from cpython.ref cimport PyObject
+from cpython.ref cimport PyObject, Py_REFCNT
 
 @cython.always_allow_keywords(False)
 def get_refcount(obj):
-    return (<PyObject*>obj).ob_refcnt
+    return Py_REFCNT(<PyObject*>obj)
 
 cdef class RefCountInMeth(object):
     cdef double value

--- a/tests/run/refcount_in_meth.pyx
+++ b/tests/run/refcount_in_meth.pyx
@@ -17,7 +17,7 @@ from cpython.ref cimport PyObject, Py_REFCNT
 
 @cython.always_allow_keywords(False)
 def get_refcount(obj):
-    return Py_REFCNT(<PyObject*>obj)
+    return Py_REFCNT(obj)
 
 cdef class RefCountInMeth(object):
     cdef double value

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -62,12 +62,12 @@ except ImportError:
 try:
     from sys import getrefcount
 except ImportError:
-    from cpython.ref cimport PyObject
+    from cpython.ref cimport PyObject, Py_REFCNT
     def getrefcount(obj):
         gc.collect()
         # PyPy needs to execute a bytecode to run the finalizers
         exec('', {}, {})
-        return (<PyObject*>obj).ob_refcnt
+        return Py_REFCNT(<PyObject*>obj)
 
 
 def no_pypy(f):

--- a/tests/run/test_coroutines_pep492.pyx
+++ b/tests/run/test_coroutines_pep492.pyx
@@ -67,7 +67,7 @@ except ImportError:
         gc.collect()
         # PyPy needs to execute a bytecode to run the finalizers
         exec('', {}, {})
-        return Py_REFCNT(<PyObject*>obj)
+        return Py_REFCNT(obj)
 
 
 def no_pypy(f):


### PR DESCRIPTION
In the nogil build, the `PyObject` struct doesn't have an `ob_refcnt` field. This adds bindings for `Py_REFCNT` to the `cpython.ref` namespace and replaces all usages of `ob_refcnt` in the tests and docs with the new bindings for the macro.

Note there are still `ob_refcnt` usages in the cython implementation:

https://github.com/cython/cython/blob/023d4af351042a3b6241dbe06cbb003b3ce1fb58/Cython/Utility/Coroutine.c#L1283

However it's guarded by a `#if !CYTHON_USE_TP_FINALIZE` so in practice the nogil build doesn't hit it. It also wasn't clear to me what to do about a usage that mutates the refcount but explicitly can't use the refcounting macros.