### PR TITLE
Updated deque.pxd to include two functions from C++11

### DIFF
--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -161,3 +161,5 @@ cdef extern from "<deque>" namespace "std" nogil:
 
         # C++11 methods
         void shrink_to_fit() except +
+        void emplace_front(T&&) except +
+        void emplace_back(T&&) except +

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -69,6 +69,12 @@ def test_deque_functionality():
         deque[int] int_deque = deque[int]()
     int_deque.push_back(77)
     int_deque.shrink_to_fit()
+
+    int_deque.emplace_back(88)
+    int_deque.emplace_front(66)
+    assert int_deque.back() == 88
+    assert int_deque.front() == 66
+
     return "pass"
 
 


### PR DESCRIPTION
I've updated cython/Cython/Includes/libcpp/deque.pxd to include two functions:
emplace_front()
emplace_end()
to move a single T object to the front or back.

I also added test code to cython/tests/run/cpp_stl_cpp11.pyx to test the two functions, under the function:
test_deque_functionality()

Please let me know if something is wrong in both the pull request or code as this is my first time attempting to contribute to an open-source project.