### PR TITLE
Updated deque.pxd to include two functions from C++11

### DIFF
--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -161,5 +161,5 @@ cdef extern from "<deque>" namespace "std" nogil:
 
         # C++11 methods
         void shrink_to_fit() except +
-        void emplace_front(T&&) except +
-        void emplace_back(T&&) except +
+        cdef void emplace_front(...) except +
+        cdef void emplace_back(...) except +

--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -161,3 +161,5 @@ cdef extern from "<deque>" namespace "std" nogil:
 
         # C++11 methods
         void shrink_to_fit() except +
+        void emplace_front(T&&) except +
+        void emplace_back(T&&) except +

--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -161,5 +161,6 @@ cdef extern from "<deque>" namespace "std" nogil:
 
         # C++11 methods
         void shrink_to_fit() except +
-        cdef void emplace_front(...) except +
-        cdef void emplace_back(...) except +
+        T& emplace_front(...) except +
+        T& emplace_back(...) except +
+        

--- a/Cython/Includes/libcpp/deque.pxd
+++ b/Cython/Includes/libcpp/deque.pxd
@@ -163,4 +163,3 @@ cdef extern from "<deque>" namespace "std" nogil:
         void shrink_to_fit() except +
         T& emplace_front(...) except +
         T& emplace_back(...) except +
-        

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -70,12 +70,6 @@ def test_deque_functionality():
     int_deque.push_back(77)
     int_deque.shrink_to_fit()
 
-    int_deque.emplace_front(66)
-    int_deque.emplace_back(88)
-
-    assert int_deque.front() == 66
-    assert int_deque.back() == 88
-
     return "pass"
 
 

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -69,7 +69,6 @@ def test_deque_functionality():
         deque[int] int_deque = deque[int]()
     int_deque.push_back(77)
     int_deque.shrink_to_fit()
-
     return "pass"
 
 

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -57,6 +57,11 @@ def test_queue_functionality():
     int_queue.swap(int_queue2)
     assert int_queue.size() == 0
     assert int_queue2.size() == 1
+
+    int_deque.emplace_front(66)
+    int_deque.emplace_back(88)
+    assert int_deque.front() == 66
+    assert int_deque.back() == 88
     return "pass"
 
 

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -57,11 +57,6 @@ def test_queue_functionality():
     int_queue.swap(int_queue2)
     assert int_queue.size() == 0
     assert int_queue2.size() == 1
-
-    int_deque.emplace_front(66)
-    int_deque.emplace_back(88)
-    assert int_deque.front() == 66
-    assert int_deque.back() == 88
     return "pass"
 
 
@@ -74,6 +69,11 @@ def test_deque_functionality():
         deque[int] int_deque = deque[int]()
     int_deque.push_back(77)
     int_deque.shrink_to_fit()
+
+    int_deque.emplace_front(66)
+    int_deque.emplace_back(88)
+    assert int_deque.front() == 66
+    assert int_deque.back() == 88
     return "pass"
 
 

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -69,6 +69,13 @@ def test_deque_functionality():
         deque[int] int_deque = deque[int]()
     int_deque.push_back(77)
     int_deque.shrink_to_fit()
+
+    int_deque.emplace_front(66)
+    int_deque.emplace_back(88)
+
+    assert int_deque.front() == 66
+    assert int_deque.back() == 88
+
     return "pass"
 
 


### PR DESCRIPTION
I've updated cython/Cython/Includes/libcpp/deque.pxd to include two functions to move a single T object to the front or back:
emplace_front()
emplace_back()

I also added test code to cython/tests/run/cpp_stl_cpp11.pyx to test the two new functions, under the test function:
test_deque_functionality()

Please let me know if something is wrong with both the pull request or code as this is my first time attempting to contribute to an open-source project.