### PR TITLE
Categorise memoryview tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2765,13 +2765,21 @@ def runtests(options, cmd_args, coverage=None):
             ('limited_api_bugs.txt', options.limited_api),
             ('windows_bugs.txt', sys.platform == 'win32'),
             ('cygwin_bugs.txt', sys.platform == 'cygwin'),
-            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9))
+            ('windows_bugs_39.txt', sys.platform == 'win32' and sys.version_info[:2] == (3, 9)),
         ]
 
         exclude_selectors += [
             FileListExcluder(os.path.join(ROOTDIR, bugs_file_name),
                              verbose=verbose_excludes)
             for bugs_file_name, condition in bug_files if condition
+        ]
+
+    if sys.version_info < (3, 11) and options.limited_api:
+        # exclude everything with memoryviews in since this is a big
+        # missing feature from the limited API in these versions
+        exclude_selectors += [
+            TagsSelector('tag', 'memoryview'),
+            FileListExcluder(os.path.join(ROOTDIR, "memoryview_tests.txt")),
         ]
 
     global COMPILER

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -6,6 +6,13 @@ dict_animal
 not_none
 queue3
 test_queue
-memoryview
-memview
-buffer
+
+# example in docs that use features unavailable in the limited API
+# (and it's a decision for the docs writers rather than a limitation
+# of Cython's support)
+embedded
+extension_types.c_property
+array.resize
+array.safe_usage
+array.unsafe_usage
+wrapping_CPlusPlus.python_to_cpp

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -1,0 +1,25 @@
+# Tests that involve memoryviews and aren't caught by filename or
+# tag. These should be excluded from Limited API < 3.11
+
+# TODO these are mostly "array" rather than memoryview. Revisit if
+# they are separated.
+array.clone
+array.overhead
+array.resize
+array.safe_usage
+array.unsafe_usage
+
+parallelization.manual_work
+parallelization.median
+parallelization.norm.*
+parallelization.parallel_sin
+string.to_char
+numpy_tutorial.compute_fused_types
+numpy_tutorial.compute_infer_types
+numpy_tutorial.compute_prange
+
+# generic filters
+buffer
+memoryview
+memview
+mview


### PR DESCRIPTION
These are a big chunk of tests that need to be run/not run in Limited API mode depending on the Python version.

This categorization isn't hugely useful right now, but should become more useful as we're able to test more with the limited API.