### PR TITLE
[3.0.x] Fix type of str call

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2450,13 +2450,12 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
     def _handle_simple_function_str(self, node, function, pos_args):
         """Optimize single argument calls to str().
         """
+        if node.type is Builtin.unicode_type:
+            # type already deduced as unicode (language_level=3)
+            return self._handle_simple_function_unicode(node, function, pos_args)
         if len(pos_args) != 1:
             if len(pos_args) == 0:
-                if node.type is Builtin.unicode_type:
-                    node_type = ExprNodes.UnicodeNode
-                else:
-                    node_type = ExprNodes.BytesNode
-                return node_type(node.pos, value=EncodedString(), constant_result='')
+                return ExprNodes.StringNode(node.pos, value=EncodedString(), constant_result='')
             return node
         arg = pos_args[0]
 
@@ -2472,7 +2471,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
 
         return ExprNodes.PythonCapiCallNode(
             node.pos, cname,
-            self.PyObject_Unicode_func_type if node.type is Builtin.unicode_type else self.PyObject_String_func_type,
+            self.PyObject_String_func_type,
             args=pos_args,
             is_temp=node.is_temp,
             utility_code=utility_code,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2470,8 +2470,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             utility_code = UtilityCode.load_cached('PyObject_Str', 'StringTools.c')
 
         return ExprNodes.PythonCapiCallNode(
-            node.pos, cname,
-            self.PyObject_String_func_type,
+            node.pos, cname, self.PyObject_String_func_type,
             args=pos_args,
             is_temp=node.is_temp,
             utility_code=utility_code,

--- a/tests/run/cython3.pyx
+++ b/tests/run/cython3.pyx
@@ -676,3 +676,31 @@ async def async_def_annotations(x: 'int') -> 'float':
     'int'
     """
     return float(x)
+
+
+@cython.test_fail_if_path_exists(
+    "//CoerceToPyTypeNode",
+)
+@cython.test_assert_path_exists(
+    "//MulNode[@is_sequence_mul = True]",
+)
+def string_multiply(str s, int N):
+    """
+    >>> print(string_multiply(u"abc", 3))
+    abcabcabc
+    """
+    return s * N
+
+
+@cython.test_fail_if_path_exists(
+    "//CoerceToPyTypeNode",
+)
+@cython.test_assert_path_exists(
+    "//MulNode[@is_sequence_mul = True]",
+)
+def string_multiply_call(s, int N):
+    """
+    >>> print(string_multiply_call(u"abc", 3))
+    abcabcabc
+    """
+    return str(s) * N

--- a/tests/run/unicodemethods.pyx
+++ b/tests/run/unicodemethods.pyx
@@ -820,6 +820,25 @@ def multiply(unicode ustring, int mul):
     return ustring * mul
 
 
+@cython.test_fail_if_path_exists(
+    "//CoerceToPyTypeNode",
+)
+@cython.test_assert_path_exists(
+    "//MulNode[@is_sequence_mul = True]",
+)
+def multiply_call(ustring, int mul):
+    """
+    >>> astr = u"abc"
+    >>> ustr = u"abcüöä\\U0001F642"
+
+    >>> print(multiply_call(astr, 2))
+    abcabc
+    >>> print(multiply_call(ustr, 2))
+    abcüöä\U0001F642abcüöä\U0001F642
+    """
+    return unicode(ustring) * mul
+
+
 #@cython.test_fail_if_path_exists(
 #    "//CoerceToPyTypeNode",
 #    "//CastNode", "//TypecastNode")


### PR DESCRIPTION
If the type of a call to `str` has already been deduced as unicode (because of language_level=3), then keep that type.

This was causing optimizations to fail, where the optimization was made on the basis that the type was unicode and then that was reversed by the replacement of `str`.

Fixes #6166.

Most of this doesn't need to go into 3.1.