### PR TITLE
Warn on use of the old Py2 buffer protocol

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -237,8 +237,7 @@ uncachable_builtins = [
 special_py_methods = cython.declare(frozenset, frozenset((
     '__cinit__', '__dealloc__', '__richcmp__', '__next__',
     '__await__', '__aiter__', '__anext__',
-    '__getreadbuffer__', '__getwritebuffer__', '__getsegcount__',
-    '__getcharbuffer__', '__getbuffer__', '__releasebuffer__',
+    '__getbuffer__', '__releasebuffer__',
 )))
 
 modifier_output_mapper = {

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -407,6 +407,14 @@ class PostParse(ScopeTrackingTransform):
         self.visitchildren(node)
         return node
 
+    def visit_DefNode(self, node):
+        if (self.scope_type == "cclass" and
+                node.name in ["__getreadbuffer__", "__getwritebuffer__", "__getsegcount__", "__getcharbuffer__"]):
+            warning(node.pos, f"'{node.name}' relates to the old Python 2 buffer protocol "
+                    "and is no longer used.", 2)
+            return None  # drop the node - the arguments are invalid for a def node
+        return self.visit_FuncDefNode(node)
+
 
 class _AssignmentExpressionTargetNameFinder(TreeVisitor):
     def __init__(self):

--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -485,21 +485,6 @@ Buffer interface [:PEP:`3118`] (no Python equivalents - see note 1)
 | __releasebuffer__     | self, Py_buffer `*view`               |             |                                                     |
 +-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
 
-Buffer interface [legacy] (no Python equivalents - see note 1)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-+-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
-| Name                  | Parameters                            | Return type |         Description                                 |
-+=======================+=======================================+=============+=====================================================+
-| __getreadbuffer__     | self, Py_ssize_t i, void `**p`        |             |                                                     |
-+-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
-| __getwritebuffer__    | self, Py_ssize_t i, void `**p`        |             |                                                     |
-+-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
-| __getsegcount__       | self, Py_ssize_t `*p`                 |             |                                                     |
-+-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
-| __getcharbuffer__     | self, Py_ssize_t i, char `**p`        |             |                                                     |
-+-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
-
 Descriptor objects (see note 2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -516,10 +501,10 @@ https://docs.python.org/3/reference/datamodel.html#emulating-container-types
 +-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
 
 .. note:: (1) The buffer interface was intended for use by C code and is not directly
-        accessible from Python. It is described in the Python/C API Reference Manual
-        of Python 2.x under sections 6.6 and 10.6. It was superseded by the new
-        :PEP:`3118` buffer protocol in Python 2.6 and is no longer available in Python 3.
-        For a how-to guide to the new API, see :ref:`buffer`.
+        accessible from Python.  For a how-to guide to the new API, see :ref:`buffer`.
+        The old Python 2 buffer protocol (```__getreadbuffer__``, ``__getwritebuffer__``,
+        ``__getsegcount__``, ``__getcharbuffer__``) is no longer supported from Cython 3.1
+        since Python 2 is no longer supported.
 
 .. note:: (2) Descriptor objects are part of the support mechanism for new-style
         Python classes. See the discussion of descriptors in the Python documentation.


### PR DESCRIPTION
Instead of complaining about conversion of arguments.

Update the docs.

Fixes #6174