### PR TITLE
Call `__set_name__` during setting type attribute.

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -655,7 +655,6 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v);
 
 static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) {
     int result;
-    PyObject *setNameResult;
 #if CYTHON_COMPILING_IN_LIMITED_API
     // Using PyObject_GenericSetAttr to bypass types immutability protection feels
     // a little hacky, but it does work in the limited API .
@@ -667,7 +666,7 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) 
     if (likely(!result)) {
         PyType_Modified(tp);
         if (unlikely(PyObject_HasAttr(v, PYIDENT("__set_name__")))) {
-            setNameResult = PyObject_CallMethodObjArgs(v, PYIDENT("__set_name__"),  (PyObject *) tp, k, NULL);
+            PyObject *setNameResult = PyObject_CallMethodObjArgs(v, PYIDENT("__set_name__"),  (PyObject *) tp, k, NULL);
             if (!setNameResult) return -1;
             Py_DECREF(setNameResult);
         }

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -655,6 +655,7 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v);
 
 static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) {
     int result;
+    PyObject *setNameResult;
 #if CYTHON_COMPILING_IN_LIMITED_API
     // Using PyObject_GenericSetAttr to bypass types immutability protection feels
     // a little hacky, but it does work in the limited API .
@@ -665,8 +666,10 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) 
 #endif
     if (likely(!result)) {
         PyType_Modified(tp);
-        if (PyObject_HasAttrString(v, "__set_name__")) {
-            PyObject_CallMethod(v, "__set_name__", "OO", (PyObject *) tp, k);
+        if (unlikely(PyObject_HasAttr(v, PYIDENT("__set_name__")))) {
+            setNameResult = PyObject_CallMethodObjArgs(v, PYIDENT("__set_name__"),  (PyObject *) tp, k, NULL);
+            if (!setNameResult) return -1;
+            Py_DECREF(setNameResult);
         }
     }
     return result;

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -663,7 +663,12 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) 
 #else
     result = PyDict_SetItem(tp->tp_dict, k, v);
 #endif
-    if (likely(!result)) PyType_Modified(tp);
+    if (likely(!result)) {
+        PyType_Modified(tp);
+        if (PyObject_HasAttrString(v, "__set_name__")) {
+            PyObject_CallMethod(v, "__set_name__", "OO", (PyObject *) tp, k);
+        }
+    }
     return result;
 }
 

--- a/docs/src/userguide/special_methods.rst
+++ b/docs/src/userguide/special_methods.rst
@@ -485,10 +485,20 @@ Buffer interface [:PEP:`3118`] (no Python equivalents - see note 1)
 | __releasebuffer__     | self, Py_buffer `*view`               |             |                                                     |
 +-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
 
+Customizing class creation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+https://docs.python.org/3/reference/datamodel.html#customizing-class-creation
+
++-----------------------+---------------------------------------+-------------+----------------------------------------------------------------------+
+| Name                  | Parameters                            | Return type |         Description                                                  |
++=======================+=======================================+=============+======================================================================+
+| __set_name__          | self, owner, name                     |             |  Automatically called at the time the owning class owner is created. |
++-----------------------+---------------------------------------+-------------+----------------------------------------------------------------------+
+
 Descriptor objects (see note 2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-https://docs.python.org/3/reference/datamodel.html#emulating-container-types
+https://docs.python.org/3/reference/datamodel.html#implementing-descriptors
 
 +-----------------------+---------------------------------------+-------------+-----------------------------------------------------+
 | Name 	                | Parameters                            | Return type | 	Description                                 |

--- a/tests/run/module_init_error.srctree
+++ b/tests/run/module_init_error.srctree
@@ -8,7 +8,7 @@ from Cython.Build.Dependencies import cythonize
 from distutils.core import setup
 
 setup(
-    ext_modules = cythonize("fail_in_init*.pyx")
+    ext_modules = cythonize("fail_in_*.pyx")
 )
 
 ######## test_fail_in_init.py ########
@@ -32,6 +32,13 @@ def try_import():
             pass  # this is what we had expected
         else:
             raise RuntimeError("expected ValueError from call through sys.modules")
+
+    try:
+        import fail_in_set_name
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError("expected ValueError from __set_name__")
 
 ######## fail_in_init.pyx ########
 
@@ -67,3 +74,13 @@ def fail():
     raise ValueError("holla!")
 
 fail()
+
+######## fail_in_set_name.pyx ########
+
+class SetName:
+
+    def __set_name__(self, owner, name):
+        raise ValueError()
+
+cdef class Klass:
+    attr = SetName()

--- a/tests/run/special_methods_T561.pyx
+++ b/tests/run/special_methods_T561.pyx
@@ -94,6 +94,8 @@ __doc__ = u"""
     >>> vs0_index = vs0.__index__
     >>> vs0_index()
     VS __index__ 0
+    >>> set_name = SetName()
+    >>> assert "SetName 'SetName' 'attr'" == set_name.attr, set_name.attr
 """
 
 cdef extern from *:
@@ -549,6 +551,20 @@ cdef class SetDelete:
 cdef class Long:
     def __long__(self):
         print "Long __long__"
+
+class _SetName:
+
+    def __init__(self):
+        self.set_name = None
+
+    def __set_name__(self, owner, name):
+        self.set_name = "SetName %r %r" % (owner.__name__, name)
+
+    def __get__(self, inst, own):
+        return self.set_name
+
+cdef class SetName:
+    attr = _SetName()
 
 cdef class GetAttrGetItemRedirect:
     """


### PR DESCRIPTION
Based on https://docs.python.org/3/reference/datamodel.html#object.__set_name__

Fixes #5523
