### PR TITLE
Documentation of old buffer syntax options

### DIFF
--- a/docs/src/tutorial/numpy.rst
+++ b/docs/src/tutorial/numpy.rst
@@ -201,3 +201,33 @@ There is some speed penalty to this though (as one makes more assumptions
 compile-time if the type is set to :obj:`cnp.ndarray`, specifically it is
 assumed that the data is stored in pure strided mode and not in indirect
 mode).
+
+Buffer options
+==============
+
+The following options are accepted when creating buffer types:
+
+* ``ndim`` - an integer number of dimensions.
+* ``mode`` - a string from:
+
+  * ``"c"`` - C contiguous array,
+  * ``"fortan"`` - Fortran contiguous array,
+  * ``"strided"`` - non-contiguous lookup into a single block of memory,
+  * ``"full"`` - any valid buffer, including indirect arrays.
+* ``negative_indices`` - boolean value specifying whether negative indexing is allowed, essentially
+  a per-variable version of the compiler directive ``cython.wraparound``.
+* ``cast`` - boolean value specifying whether to allow the user to view the array as a different
+  type. The sizes of the source and destination type must be the same. In C++ this would be
+  equivalent to ``reinterpret_cast``.
+
+In all cases these parameters must be compile-time constants.
+
+As an example of specifying the parameters::
+
+    cdef cnp.ndarray[double, ndim=2, mode="c", cast=True] some_array
+
+``cast`` can be used to get a low-level view of an array with non-native endianess::
+
+    cdef cnp.ndarray[cnp.uint32, cast=True] values = np.arange(10, dtype='>i4')
+
+although correctly interpretting the cast data is the user's responsibility.

--- a/docs/src/tutorial/numpy.rst
+++ b/docs/src/tutorial/numpy.rst
@@ -222,7 +222,7 @@ The following options are accepted when creating buffer types:
 
 In all cases these parameters must be compile-time constants.
 
-As an example of specifying the parameters::
+As an example of how to specify the parameters::
 
     cdef cnp.ndarray[double, ndim=2, mode="c", cast=True] some_array
 

--- a/docs/src/tutorial/numpy.rst
+++ b/docs/src/tutorial/numpy.rst
@@ -211,7 +211,7 @@ The following options are accepted when creating buffer types:
 * ``mode`` - a string from:
 
   * ``"c"`` - C contiguous array,
-  * ``"fortan"`` - Fortran contiguous array,
+  * ``"fortran"`` - Fortran contiguous array,
   * ``"strided"`` - non-contiguous lookup into a single block of memory,
   * ``"full"`` - any valid buffer, including indirect arrays.
 * ``negative_indices`` - boolean value specifying whether negative indexing is allowed, essentially
@@ -226,8 +226,8 @@ As an example of specifying the parameters::
 
     cdef cnp.ndarray[double, ndim=2, mode="c", cast=True] some_array
 
-``cast`` can be used to get a low-level view of an array with non-native endianess::
+``cast`` can be used to get a low-level view of an array with non-native endianness::
 
     cdef cnp.ndarray[cnp.uint32, cast=True] values = np.arange(10, dtype='>i4')
 
-although correctly interpretting the cast data is the user's responsibility.
+although correctly interpreting the cast data is the user's responsibility.


### PR DESCRIPTION
Partial fix for #4641
Partial fix for #6160