### PR TITLE
Py3.13 support in cpython/time.pxd

### DIFF
--- a/Cython/Includes/cpython/time.pxd
+++ b/Cython/Includes/cpython/time.pxd
@@ -1,5 +1,10 @@
 """
 Cython implementation of (parts of) the standard library time module.
+
+Note: On implementations that lack a C-API for monotonic/perfcounter clocks
+(like PyPy), the fallback code uses the system clock which may return absolute
+time values from a different value range, differing from those provided by
+Python's "time" module.
 """
 
 from libc.stdint cimport int64_t

--- a/Cython/Includes/cpython/time.pxd
+++ b/Cython/Includes/cpython/time.pxd
@@ -7,17 +7,42 @@ from cpython.exc cimport PyErr_SetFromErrno
 
 cdef extern from *:
     """
-    #if PY_VERSION_HEX >= 0x030d00A4
-        #define __Pyx_PyTime_TimeUnchecked()     _PyTime_TimeUnchecked()
+    #if PY_VERSION_HEX >= 0x030d00b1
+        static CYTHON_INLINE PyTime_t __Pyx_PyTime_TimeRaw(void) {
+            PyTime_t tic;
+            (void) PyTime_TimeRaw(&tic);
+            return tic;
+        }
+        static CYTHON_INLINE PyTime_t __Pyx_PyTime_MonotonicRaw(void) {
+            PyTime_t tic;
+            (void) PyTime_MonotonicRaw(&tic);
+            return tic;
+        }
+        static CYTHON_INLINE PyTime_t __Pyx_PyTime_PerfCounterRaw(void) {
+            PyTime_t tic;
+            (void) PyTime_PerfCounterRaw(&tic);
+            return tic;
+        }
         #define __Pyx_PyTime_AsSecondsDouble(t)  PyTime_AsSecondsDouble(t)
+        #define __Pyx_PyTime_t PyTime_t
     #else
-        #define __Pyx_PyTime_TimeUnchecked()  _PyTime_GetSystemClock()
-        #define __Pyx_PyTime_AsSecondsDouble(t)  _PyTime_AsSecondsDouble(t)
+        #define __Pyx_PyTime_TimeRaw()            _PyTime_GetSystemClock()
+        #define __Pyx_PyTime_MonotonicRaw()       _PyTime_GetMonotonicClock()
+        #define __Pyx_PyTime_PerfCounterRaw()     _PyTime_GetPerfCounter()
+        #define __Pyx_PyTime_AsSecondsDouble(t)   _PyTime_AsSecondsDouble(t)
+        #define __Pyx_PyTime_t _PyTime_t
     #endif
     """
-    ctypedef int64_t _PyTime_t
-    _PyTime_t PyTime_TimeUnchecked "__Pyx_PyTime_TimeUnchecked" () nogil
-    double PyTime_AsSecondsDouble "__Pyx_PyTime_AsSecondsDouble" (_PyTime_t t) nogil
+    ctypedef int64_t PyTime_t "__Pyx_PyTime_t"
+
+    ctypedef PyTime_t _PyTime_t "__Pyx_PyTime_t"  # legacy, use "PyTime_t" instead
+    PyTime_t PyTime_TimeUnchecked "__Pyx_PyTime_TimeRaw" ()  # legacy, use "PyTime_TimeRaw" instead
+
+    PyTime_t PyTime_TimeRaw "__Pyx_PyTime_TimeRaw" () noexcept nogil
+    PyTime_t PyTime_MonotonicRaw "__Pyx_PyTime_MonotonicRaw" () noexcept nogil
+    PyTime_t PyTime_PerfCounterRaw "__Pyx_PyTime_PerfCounterRaw" () noexcept nogil
+    double PyTime_AsSecondsDouble "__Pyx_PyTime_AsSecondsDouble" (PyTime_t t) noexcept nogil
+
 
 from libc.time cimport (
     tm,
@@ -27,11 +52,30 @@ from libc.time cimport (
 
 
 cdef inline double time() noexcept nogil:
-    cdef:
-        _PyTime_t tic
-
-    tic = PyTime_TimeUnchecked()
+    cdef PyTime_t tic = PyTime_TimeRaw()
     return PyTime_AsSecondsDouble(tic)
+
+
+cdef inline int64_t time_ns() noexcept nogil:
+    return <int64_t> PyTime_TimeRaw()
+
+
+cdef inline double perf_counter() noexcept nogil:
+    cdef PyTime_t tic = PyTime_PerfCounterRaw()
+    return PyTime_AsSecondsDouble(tic)
+
+
+cdef inline int64_t perf_counter_ns() noexcept nogil:
+    return <int64_t> PyTime_PerfCounterRaw()
+
+
+cdef inline double monotonic() noexcept nogil:
+    cdef PyTime_t tic = PyTime_MonotonicRaw()
+    return PyTime_AsSecondsDouble(tic)
+
+
+cdef inline int64_t monotonic_ns() noexcept nogil:
+    return <int64_t> PyTime_MonotonicRaw()
 
 
 cdef inline int _raise_from_errno() except -1 with gil:

--- a/tests/run/time_pxd.pyx
+++ b/tests/run/time_pxd.pyx
@@ -9,17 +9,107 @@ from cpython cimport time as ctime
 def test_time():
     """
     >>> tic1, tic2, tic3 = test_time()
-    >>> tic1 <= tic3  # sanity check
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
     True
-    >>> tic1 <= tic2
+    >>> tic1 <= tic2  or  (tic1, tic2)
     True
-    >>> tic2 <= tic3
+    >>> tic2 <= tic3  or  (tic2, tic3)
     True
     """
-    # check that ctime.time() matches time.time() to within call-time tolerance
+    # check that C-API matches Py-API to within call-time tolerance
     tic1 = time.time()
     tic2 = ctime.time()
     tic3 = time.time()
+
+    return tic1, tic2, tic3
+
+
+def test_time_ns():
+    """
+    >>> tic1, tic2, tic3 = test_time_ns()
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
+    True
+    >>> tic1 <= tic2  or  (tic1, tic2)
+    True
+    >>> tic2 <= tic3  or  (tic2, tic3)
+    True
+    """
+    # check that C-API matches Py-API to within call-time tolerance
+    tic1 = time.time_ns()
+    tic2 = ctime.time_ns()
+    tic3 = time.time_ns()
+
+    return tic1, tic2, tic3
+
+
+def test_perf_counter():
+    """
+    >>> tic1, tic2, tic3 = test_perf_counter()
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
+    True
+    >>> tic1 <= tic2  or  (tic1, tic2)
+    True
+    >>> tic2 <= tic3  or  (tic2, tic3)
+    True
+    """
+    # check that C-API matches Py-API to within call-time tolerance
+    tic1 = time.perf_counter()
+    tic2 = ctime.perf_counter()
+    tic3 = time.perf_counter()
+
+    return tic1, tic2, tic3
+
+
+def test_perf_counter_ns():
+    """
+    >>> tic1, tic2, tic3 = test_perf_counter_ns()
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
+    True
+    >>> tic1 <= tic2  or  (tic1, tic2)
+    True
+    >>> tic2 <= tic3  or  (tic2, tic3)
+    True
+    """
+    # check that C-API matches Py-API to within call-time tolerance
+    tic1 = time.perf_counter_ns()
+    tic2 = ctime.perf_counter_ns()
+    tic3 = time.perf_counter_ns()
+
+    return tic1, tic2, tic3
+
+
+def test_monotonic():
+    """
+    >>> tic1, tic2, tic3 = test_monotonic()
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
+    True
+    >>> tic1 <= tic2  or  (tic1, tic2)
+    True
+    >>> tic2 <= tic3  or  (tic2, tic3)
+    True
+    """
+    # check that C-API matches Py-API to within call-time tolerance
+    tic1 = time.monotonic()
+    tic2 = ctime.monotonic()
+    tic3 = time.monotonic()
+
+    return tic1, tic2, tic3
+
+
+def test_monotonic_ns():
+    """
+    >>> tic1, tic2, tic3 = test_monotonic_ns()
+    >>> tic1 <= tic3  or  (tic1, tic3)  # sanity check
+    True
+    >>> tic1 <= tic2  or  (tic1, tic2)
+    True
+    >>> tic2 <= tic3  or  (tic2, tic3)
+    True
+    """
+    # check that C-API matches Py-API to within call-time tolerance
+    tic1 = time.monotonic_ns()
+    tic2 = ctime.monotonic_ns()
+    tic3 = time.monotonic_ns()
 
     return tic1, tic2, tic3
 

--- a/tests/run/time_pxd.pyx
+++ b/tests/run/time_pxd.pyx
@@ -5,6 +5,9 @@ import time
 
 from cpython cimport time as ctime
 
+import sys
+cdef bint IS_PYPY = hasattr(sys, 'pypy_version_info')
+
 
 def test_time():
     """
@@ -53,9 +56,9 @@ def test_perf_counter():
     True
     """
     # check that C-API matches Py-API to within call-time tolerance
-    tic1 = time.perf_counter()
+    tic1 = time.perf_counter()  if not IS_PYPY else  ctime.perf_counter()
     tic2 = ctime.perf_counter()
-    tic3 = time.perf_counter()
+    tic3 = time.perf_counter()  if not IS_PYPY else  ctime.perf_counter()
 
     return tic1, tic2, tic3
 
@@ -71,9 +74,9 @@ def test_perf_counter_ns():
     True
     """
     # check that C-API matches Py-API to within call-time tolerance
-    tic1 = time.perf_counter_ns()
+    tic1 = time.perf_counter_ns()  if not IS_PYPY else  ctime.perf_counter_ns()
     tic2 = ctime.perf_counter_ns()
-    tic3 = time.perf_counter_ns()
+    tic3 = time.perf_counter_ns()  if not IS_PYPY else  ctime.perf_counter_ns()
 
     return tic1, tic2, tic3
 
@@ -89,9 +92,9 @@ def test_monotonic():
     True
     """
     # check that C-API matches Py-API to within call-time tolerance
-    tic1 = time.monotonic()
+    tic1 = time.monotonic()  if not IS_PYPY else  ctime.monotonic()
     tic2 = ctime.monotonic()
-    tic3 = time.monotonic()
+    tic3 = time.monotonic()  if not IS_PYPY else  ctime.monotonic()
 
     return tic1, tic2, tic3
 
@@ -107,9 +110,9 @@ def test_monotonic_ns():
     True
     """
     # check that C-API matches Py-API to within call-time tolerance
-    tic1 = time.monotonic_ns()
+    tic1 = time.monotonic_ns()  if not IS_PYPY else  ctime.monotonic_ns()
     tic2 = ctime.monotonic_ns()
-    tic3 = time.monotonic_ns()
+    tic3 = time.monotonic_ns()  if not IS_PYPY else  ctime.monotonic_ns()
 
     return tic1, tic2, tic3
 


### PR DESCRIPTION
Raw time functions that do not require the GIL were added to the C-API in Py3.13.

See https://github.com/python/cpython/pull/115215
See https://github.com/python/cpython/issues/110850
