### PR TITLE
Mark `libcpp.optional.optional.value()` as `except +`

### DIFF
--- a/Cython/Includes/libcpp/optional.pxd
+++ b/Cython/Includes/libcpp/optional.pxd
@@ -13,7 +13,7 @@ cdef extern from "<optional>" namespace "std" nogil:
         optional(optional&) except +
         optional(T&) except +
         bool has_value()
-        T& value()
+        T& value() except +
         T& value_or[U](U& default_value)
         void swap(optional&)
         void reset()

--- a/tests/run/cpp_stl_optional.pyx
+++ b/tests/run/cpp_stl_optional.pyx
@@ -13,6 +13,12 @@ def simple_test():
     """
     cdef optional[int] o
     assert(not o.has_value())
+    try:
+        o.value()
+    except Exception as err:
+        pass
+    else:
+        assert False, "value() did not raise a catchable error"
     o = 5
     assert(o.has_value())
     assert(o.value()==5)


### PR DESCRIPTION
`std::optional::value()` raises a `std::bad_optional_access` if it does not contain a value. See [std::optional::value()](https://en.cppreference.com/w/cpp/utility/optional/value).