### PR TITLE
Fix arg=str() default argument

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10151,7 +10151,7 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
             defaults = '__Pyx_CyFunction_Defaults(struct %s, %s)' % (
                 self.defaults_entry.type.objstruct_cname, self.result())
             for arg, entry in self.defaults:
-                arg.generate_assignment_code(code, target='%s->%s' % (
+                arg.generate_assignment_code(code, cyfunc_struct_target='%s->%s' % (
                     defaults, entry.cname))
 
         if self.defaults_tuple:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1031,10 +1031,23 @@ class CArgDeclNode(Node):
         if self.default:
             self.default.annotate(code)
 
-    def generate_assignment_code(self, code, target=None, overloaded_assignment=False):
+    def generate_assignment_code(self, code, overloaded_assignment=False,
+                                 cyfunc_struct_target=None):
         default = self.default
-        if default is None or default.is_literal:
+        if default is None:
             return
+        if cyfunc_struct_target is not None:
+            if not self.is_dynamic:
+                # We've already determined that this *isn't* part of the default
+                # struct. Note that the argument may still be a literal though,
+                # if it's been optimized to be a literal after is_dynamic was
+                # calculated.
+                return
+        elif default.is_literal:
+            return
+        # Note that even if self.is_dynamic, default may be a literal if it's been
+        # optimized into a literal after analyse_expressions
+        target = cyfunc_struct_target
         if target is None:
             target = self.calculate_default_value_code(code)
         default.generate_evaluation_code(code)

--- a/tests/run/cyfunction_defaults.pyx
+++ b/tests/run/cyfunction_defaults.pyx
@@ -290,6 +290,17 @@ def test_func_default_scope_local():
     print i  # genexprs don't leak
     return func
 
+
+def test_str_call(arg=str()):
+    """
+    The call to str() is optimized into a literal late in the process.
+    This shouldn't break the usage.
+    >>> test_str_call()
+    ''
+    """
+    return arg
+
+
 cdef class C:
     def f1(self, a, b=1, c=[]):
         pass


### PR DESCRIPTION
Fixes #6192.

The basic issue is that the argument is deduced to be dynamic default argument, and then at a late stage is optimized into an empty string literal.

This means that correct handling code for the literal is skipped because is has "is_dynamic" set, and the correct assignment code into the dynamic struct is skipped because it's a literal.

I think the solution is to make the code that writes into the dynamic struct more tolerant of literals.