### PR TITLE
Add warning about thread safety in free-threading Python

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8744,6 +8744,8 @@ class GILStatNode(NogilTryFinallyStatNode):
         env._in_with_gil_block = (self.state == 'gil')
         if self.state == 'gil':
             env.has_with_gil_block = True
+            env.use_utility_code(
+                UtilityCode.load_cached("WarnFreethreadingWithGIL", "ModuleSetupCode.c"))
 
         if self.condition is not None:
             self.condition.analyse_declarations(env)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2233,7 +2233,7 @@ done:
 
 /////////////////////////// WarnFreethreadingWithGIL.init ////////////
 
-#if CYTHON_COMPILING_IN_CPYTHON_NOGIL && \
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && \
     !(defined(CYTHON_DISABLE_THREAD_SAFETY_WARNING_AT_YOUR_OWN_RISK) && CYTHON_DISABLE_THREAD_SAFETY_WARNING_AT_YOUR_OWN_RISK)
 {
     PyObject *gil_check_function, *gil_check_result;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2245,7 +2245,7 @@ done:
     gil_check_is_true = PyObject_IsTrue(gil_check_result);
     Py_DECREF(gil_check_result);
     if (gil_check_is_true == 0) {
-        PyErr_WarnEx(PyExc_UserWarning, "Module uses the Cython-feature `with gil:` block and is running in the "
+        PyErr_WarnEx(PyExc_UserWarning, "Module uses the Cython-feature `with gil:` block and is running in "
             "a Python \"free-threading\" build with the global interpreter lock disabled. "
             "Cython does not currently generate thread-safe code so this is unsupported and may "
             "lead to errors.", 2);

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2245,10 +2245,14 @@ done:
     gil_check_is_true = PyObject_IsTrue(gil_check_result);
     Py_DECREF(gil_check_result);
     if (gil_check_is_true == 0) {
-        PyErr_WarnEx(PyExc_UserWarning, "Module uses the Cython-feature `with gil:` block and is running in "
+        PyErr_WarnEx(PyExc_UserWarning,
+            "Module uses the Cython-feature `with gil:` block and is running in "
             "a Python \"free-threading\" build with the global interpreter lock disabled. "
-            "Cython does not currently generate thread-safe code so this is unsupported and may "
-            "lead to errors.", 2);
+            "Cython does not currently generate thread-safe code. Likely issues are:\n"
+            " 1. If you were using `with gil` as a synchronization mechanism to ensure "
+            "that only one thread can access certain resources, this is no longer true.\n"
+            " 2. If multiple threads are accessing the same Python objects simultaneous then "
+            "it is likely the interpreter state will be corrupted.", 1);
     } else if (unlikely(gil_check_is_true == -1)) {
 end_gil_check:
         PyErr_Clear();


### PR DESCRIPTION
Expectations management...

---------------------------

I guess it's debatable whether we want this and how long we want to keep it, but for now I think it's a good idea. It only appears if people use `with gil:` blocks which I think is probably the main opportunity to end up with problems. (There's other ways of spawning multiple threads of course, but they're less likely to be pointed at the same data).