### PR TITLE
Adds support for `typing.Union`

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -740,7 +740,7 @@ def get_known_standard_library_module_scope(module_name):
             entry.as_variable = var_entry
             entry.known_standard_library_import = "%s.%s" % (module_name, name)
 
-        for name in ['ClassVar', 'Optional']:
+        for name in ['ClassVar', 'Optional', 'Union']:
             name = EncodedString(name)
             indexed_type = PyrexTypes.SpecialPythonTypeConstructor(EncodedString("typing."+name))
             entry = mod.declare_type(name, indexed_type, pos = None)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1249,6 +1249,10 @@ class TemplatedTypeNode(CBaseTypeNode):
 
         template_types = []
         for template_node in self.positional_args:
+
+            if base_type.python_type_constructor_name == 'typing.Union' and template_node.constant_result is None:
+                error(template_node.pos, "typing.Union does not support None parameter")
+                ttype = error_type
             # CBaseTypeNode -> allow C type declarations in a 'cdef' context again
             with env.new_c_type_context(in_c_type_context or isinstance(template_node, CBaseTypeNode)):
                 ttype = template_node.analyse_as_type(env)
@@ -1267,6 +1271,10 @@ class TemplatedTypeNode(CBaseTypeNode):
                     ))
                     ttype = error_type
             template_types.append(ttype)
+
+        if base_type.python_type_constructor_name == 'typing.Optional' and len(template_types) > 1:
+            error(template_node.pos, "typing.Optional requires one parameter")
+            return [error_type]
 
         return template_types
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2641,6 +2641,9 @@ class CFuncDefNode(FuncDefNode):
             if base_type is None:
                 error(self.directive_returns.pos, "Not a type")
                 base_type = PyrexTypes.error_type
+            elif isinstance(base_type, PyrexTypes.UnionType):
+                # Function with annotation of Union return type must return python object
+                base_type = PyrexTypes.py_object_type
         else:
             base_type = self.base_type.analyse(env)
         self.is_static_method = 'staticmethod' in env.directives and not env.lookup_here('staticmethod')

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4758,14 +4758,16 @@ class SpecialPythonTypeConstructor(PyObjectType, PythonTypeConstructorMixin):
         return self
 
     def specialize_here(self, pos, env, template_values=None):
-        if len(template_values) != 1:
-            error(pos, "'%s' takes exactly one template argument." % self.name)
-            return error_type
-        if template_values[0] is None:
-            # FIXME: allowing unknown types for now since we don't recognise all Python types.
+        if len(template_values) == 1:
+            if template_values[0] is None:
+                # FIXME: allowing unknown types for now since we don't recognise all Python types.
+                return None
+            # Replace this type with the actual 'template' argument.
+            return template_values[0].resolve()
+        types = [tv.resolve() for tv in template_values if tv is not None]
+        if len(types) == 0:
             return None
-        # Replace this type with the actual 'template' argument.
-        return template_values[0].resolve()
+        return FusedType(types)
 
 
 rank_to_type_name = (

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1947,11 +1947,11 @@ class UnionType(FusedType):
         type_list = ','.join([t.typeof_name() for t in sorted(types)])
         super().__init__(sorted(types), f'Union[{type_list}]')
 
-    def __eq__(self, other):
-        return isinstance(other, UnionType) and self.types == other.types and self.name == other.name
-
-    def __hash__(self):
-        return hash((tuple(self.types), self.name))
+    # This is commented to support passing multiple unions to other functions
+    # def __eq__(self, other):
+    #     return isinstance(other, UnionType) and self.types == other.types and self.name == other.name
+    # def __hash__(self):
+    #     return hash((tuple(self.types), self.name))
 
 
 class CVoidType(CType):

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1941,6 +1941,19 @@ class FusedType(CType):
             seen.add(self)
 
 
+class UnionType(FusedType):
+
+    def __init__(self, types):
+        type_list = ','.join([t.typeof_name() for t in sorted(types)])
+        super().__init__(sorted(types), f'Union[{type_list}]')
+
+    def __eq__(self, other):
+        return isinstance(other, UnionType) and self.types == other.types and self.name == other.name
+
+    def __hash__(self):
+        return hash((tuple(self.types), self.name))
+
+
 class CVoidType(CType):
     #
     #   C "void" type
@@ -4767,7 +4780,7 @@ class SpecialPythonTypeConstructor(PyObjectType, PythonTypeConstructorMixin):
         types = [tv.resolve() for tv in template_values if tv is not None]
         if len(types) == 0:
             return None
-        return FusedType(types)
+        return UnionType(types)
 
 
 rank_to_type_name = (

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1924,7 +1924,7 @@ class FusedType(CType):
         raise Exception("This may never happen, please report a bug")
 
     def __repr__(self):
-        return 'FusedType(name=%r)' % self.name
+        return '%s(name=%r)' % (type(self).__name__, self.name)
 
     def specialize(self, values):
         if self in values:

--- a/tests/errors/e_typing_optional.py
+++ b/tests/errors/e_typing_optional.py
@@ -20,6 +20,8 @@ MyStruct = cython.struct(a=cython.int, b=cython.double)
 def optional_cstruct(x: Optional[MyStruct]):
     pass
 
+def optional_multiple_arguments(x: Optional[int, float]):
+    pass
 
 # OK
 
@@ -40,4 +42,5 @@ _ERRORS = """
 14:100: typing.Optional[...] cannot be applied to type long long
 
 20:33: typing.Optional[...] cannot be applied to type MyStruct
+23:49: typing.Optional requires one parameter
 """

--- a/tests/errors/e_typing_union.py
+++ b/tests/errors/e_typing_union.py
@@ -1,0 +1,18 @@
+# mode: error
+
+import cython
+
+try:
+    from typing import Union
+except ImportError:
+    pass
+
+def union_types(a: Union[cython.int, cython.float], b: Union[cython.complex, cython.long]) -> Union[cython.int, cython.float, cython.long]:
+    pass
+
+def union_types_none(a: Union[cython.int, cython.float, None]):
+    pass
+
+_ERRORS = """
+13:56: typing.Union does not support None parameter
+"""

--- a/tests/errors/e_typing_union.py
+++ b/tests/errors/e_typing_union.py
@@ -10,9 +10,56 @@ except ImportError:
 def union_types(a: Union[cython.int, cython.float], b: Union[cython.complex, cython.long]) -> Union[cython.int, cython.float, cython.long]:
     pass
 
+@cython.cfunc
+def union_types_pass_value(a: Union[cython.int, cython.float]) -> Union[cython.int, cython.float]:
+    return a
+
+@cython.cfunc
+def union_types_pass_value_different_order(a: Union[cython.int, cython.float]) -> Union[cython.float, cython.int]:
+    return a
+
+@cython.cfunc
+def union_types_pass_value_incompatible_types(a: Union[cython.int, cython.float]) -> Union[cython.int, str]:
+    return a
+
 def union_types_none(a: Union[cython.int, cython.float, None]):
     pass
 
+@cython.cclass
+class Bar:
+    pass
+
+@cython.cfunc
+def union_types_extension(a: Union[cython.int, Bar]):
+    pass
+
+
+@cython.cfunc
+def union_types_extension_with_return(a: Union[cython.int, Bar]) -> Union[cython.int, Bar]:
+    return a
+
+union_types_extension_with_return(5)
+union_types_extension_with_return(Bar())
+
+@cython.cfunc
+def union_types_extension_with_return_reversed_order(a: Union[cython.int, Bar]) -> Union[Bar, cython.int]:
+    return a
+
+union_types_extension_with_return_reversed_order(5)
+union_types_extension_with_return_reversed_order(Bar())
+
+@cython.cfunc
+def union_types_extension_not_matching(a: Union[cython.int, Bar]) -> Union[Bar, str]:
+    return a
+
+union_types_extension_not_matching(5)
+
 _ERRORS = """
-13:56: typing.Union does not support None parameter
+21:0: Return type is a fused type that cannot be determined from the function arguments
+25:56: typing.Union does not support None parameter
+51:0: Return type is a fused type that cannot be determined from the function arguments
+55:0: Invalid use of fused types, type cannot be specialized
+"""
+
+_WARNINGS = """
 """

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -68,6 +68,12 @@ class TestCls:
 def _union(arg1: Union[cython.int, str], arg2: Union[cython.int, str]):
     return cython.typeof(arg1), cython.typeof(arg2)
 
+@cython.cfunc
+def return_union(t: cython.int) -> Union[cython.int, cython.float]:
+    if t == 1:
+        return 2
+    else:
+        return 1.0
 
 class TestUnion:
 
@@ -80,15 +86,26 @@ class TestUnion:
         """
         return cython.typeof(arg)
 
-    def annotation_return(self, arg: Union[cython.int, cython.float]) -> Union[cython.int, cython.float]:
-        # FIXME: Returning Union must be failing
-        """
-        >>> TestUnion().annotation_return(1.0)
-        1.0
-        >>> TestUnion().annotation_return(2)
-        2
-        """
-        return arg
+    if cython.compiled:
+        def annotation_return(self, arg):
+            """
+            >>> TestUnion().annotation_return(1)
+            (2, 'Python object')
+            >>> TestUnion().annotation_return(2)
+            (1.0, 'Python object')
+            """
+            ret = return_union(arg)
+            return ret, cython.typeof(ret)
+    else:
+        def annotation_return(self, arg):
+            """
+            >>> TestUnion().annotation_return(1)
+            (2, 'int')
+            >>> TestUnion().annotation_return(2)
+            (1.0, 'float')
+            """
+            ret = return_union(arg)
+            return ret, cython.typeof(ret)
 
     if cython.compiled:
         def annotation_multiple_args(self, arg1: Union[cython.int, str], arg2: Union[cython.int, str]):

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -4,6 +4,7 @@
 #cython: annotation_typing=True
 
 import cython
+from typing import Union
 
 InPy = cython.fused_type(cython.int, cython.float)
 
@@ -61,4 +62,31 @@ class TestCls:
         'int'
         """
         loc = arg
+        return cython.typeof(arg)
+
+    def annotation(self, arg: Union[cython.int, cython.float]):
+        """
+        >>> TestCls().annotation(1.0)
+        'float'
+        >>> TestCls().annotation(2)
+        'int'
+        """
+        return cython.typeof(arg)
+
+    def annotation_return(self, arg: Union[cython.int, cython.float]) -> Union[cython.int, cython.float]:
+        """
+        >>> TestCls().annotation_return(1.0)
+        1.0
+        >>> TestCls().annotation_return(2)
+        2
+        """
+        return arg
+
+    def annotation_None_ignored(self, arg: Union[cython.int, cython.float, None]):
+        """
+        >>> TestCls().annotation_None_ignored(1.0)
+        'float'
+        >>> TestCls().annotation_None_ignored(2)
+        'int'
+        """
         return cython.typeof(arg)

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -81,12 +81,3 @@ class TestCls:
         2
         """
         return arg
-
-    def annotation_None_ignored(self, arg: Union[cython.int, cython.float, None]):
-        """
-        >>> TestCls().annotation_None_ignored(1.0)
-        'float'
-        >>> TestCls().annotation_None_ignored(2)
-        'int'
-        """
-        return cython.typeof(arg)

--- a/tests/run/pure_fused.py
+++ b/tests/run/pure_fused.py
@@ -64,20 +64,38 @@ class TestCls:
         loc = arg
         return cython.typeof(arg)
 
+@cython.cfunc
+def _union(arg1: Union[cython.int, str], arg2: Union[cython.int, str]):
+    return cython.typeof(arg1), cython.typeof(arg2)
+
+
+class TestUnion:
+
     def annotation(self, arg: Union[cython.int, cython.float]):
         """
-        >>> TestCls().annotation(1.0)
+        >>> TestUnion().annotation(1.0)
         'float'
-        >>> TestCls().annotation(2)
+        >>> TestUnion().annotation(2)
         'int'
         """
         return cython.typeof(arg)
 
     def annotation_return(self, arg: Union[cython.int, cython.float]) -> Union[cython.int, cython.float]:
+        # FIXME: Returning Union must be failing
         """
-        >>> TestCls().annotation_return(1.0)
+        >>> TestUnion().annotation_return(1.0)
         1.0
-        >>> TestCls().annotation_return(2)
+        >>> TestUnion().annotation_return(2)
         2
         """
         return arg
+
+    if cython.compiled:
+        def annotation_multiple_args(self, arg1: Union[cython.int, str], arg2: Union[cython.int, str]):
+            """
+            >>> TestUnion().annotation_multiple_args(5, 'mystr')
+            ('int', 'str object')
+            >>> TestUnion().annotation_multiple_args('mystr', 3)
+            ('str object', 'int')
+            """
+            return _union(arg1, arg2)


### PR DESCRIPTION
This PR adds support of `typing.Union`. It is optimised to fused type.

> [!NOTE]  
> This PR does not support `Union` of `None`. Hence `Union[int, None]` will trigger an error.

Currently only as a draft. The test suite is passing but needs #6204 merged to master.