### PR TITLE
[don't merge...] Add thread-safety to some reference counting

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2535,11 +2535,13 @@ class CCodeWriter:
         type.generate_xdecref_clear(self, cname, clear_before_decref=clear_before_decref,
                               nanny=nanny, have_gil=have_gil)
 
-    def put_decref_set(self, cname, type, rhs_cname):
-        type.generate_decref_set(self, cname, rhs_cname)
+    def put_decref_set(self, cname, type, rhs_cname, atomic=False, nanny=True):
+        type.generate_decref_set(self, cname, rhs_cname,
+                                 atomic=atomic, nanny=nanny)
 
-    def put_xdecref_set(self, cname, type, rhs_cname):
-        type.generate_xdecref_set(self, cname, rhs_cname)
+    def put_xdecref_set(self, cname, type, rhs_cname, atomic=False):
+        type.generate_xdecref_set(self, cname, rhs_cname,
+                                  atomic=atomic)
 
     def put_incref_memoryviewslice(self, slice_cname, type, have_gil):
         # TODO ideally this would just be merged into "put_incref"

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -181,6 +181,7 @@ _directive_defaults = {
     'boundscheck' : True,
     'nonecheck' : False,
     'initializedcheck' : True,
+    'threadsafe_reference_counting' : True,
     'embedsignature': False,
     'embedsignature.format': 'c',
     'auto_cpdef': False,

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1358,13 +1358,19 @@ class PyObjectType(PyrexType):
         code.funcstate.needs_refnanny = True
         code.putln("__Pyx_XGIVEREF(%s);" % self.as_pyobject(cname))
 
-    def generate_decref_set(self, code, cname, rhs_cname):
-        code.funcstate.needs_refnanny = True
-        code.putln("__Pyx_DECREF_SET(%s, %s);" % (cname, rhs_cname))
+    def generate_decref_set(self, code, cname, rhs_cname, atomic=False, nanny=True):
+        if nanny:
+            code.funcstate.needs_refnanny = True
+        code.putln("__Pyx_%sDECREF_SET%s(%s, %s);" % (
+            "" if nanny else "Py_",
+            "_ATOMIC" if atomic else "",
+            cname, rhs_cname))
 
-    def generate_xdecref_set(self, code, cname, rhs_cname):
+    def generate_xdecref_set(self, code, cname, rhs_cname, atomic=False):
         code.funcstate.needs_refnanny = True
-        code.putln("__Pyx_XDECREF_SET(%s, %s);" % (cname, rhs_cname))
+        code.putln("__Pyx_XDECREF_SET%s(%s, %s);" % (
+            "_ATOMIC" if atomic else "",
+            cname, rhs_cname))
 
     def _generate_decref(self, code, cname, nanny, null_check=False,
                     clear=False, clear_before_decref=False):

--- a/Cython/Runtime/refnanny.pyx
+++ b/Cython/Runtime/refnanny.pyx
@@ -78,10 +78,10 @@ cdef class Context(object):
     def __dealloc__(self):
         __Pyx_refnanny_free_lock(self.lock)
 
-    cdef acquire_lock(self):
+    cdef acquire_lock(self) noexcept:
         __Pyx_refnanny_lock_acquire(self.lock)
 
-    cdef release_lock(self):
+    cdef release_lock(self) noexcept:
         __Pyx_refnanny_lock_release(self.lock)
 
     cdef regref(self, obj, Py_ssize_t lineno, bint is_null):

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -109,6 +109,7 @@ annotation_typing = returns = wraparound = boundscheck = initializedcheck = \
     auto_cpdef = c_api_binop_methods = \
     allow_none_for_extension_args = callspec = show_performance_hints = \
     cpp_locals = py2_import = iterable_coroutine = remove_unreachable = \
+    threadsafe_reference_counting = \
         lambda _: _EmptyDecoratorAndManager()
 
 # Note that fast_getattr is untested and undocumented!

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1674,13 +1674,48 @@ static CYTHON_INLINE int __Pyx_Is_Little_Endian(void)
         PyObject *tmp = (PyObject *) r;                         \
         r = v; __Pyx_XDECREF(tmp);                              \
     } while (0)
+#define __Pyx_Py_DECREF_SET(r, v) __Pyx_DECREF_SET(r, v)
 #define __Pyx_DECREF_SET(r, v) do {                             \
         PyObject *tmp = (PyObject *) r;                         \
         r = v; __Pyx_DECREF(tmp);                               \
     } while (0)
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+#define __Pyx_Py_XDECREF_SET_ATOMIC(r, v) do {                      \
+        PyObject *tmp = (PyObject*)_Py_atomic_exchange_ptr(&r, v);  \
+        Py_XDECREF(tmp);                                            \
+    } while (0)
+#define __Pyx_XDECREF_SET_ATOMIC(r, v) do {                                \
+        PyObject *tmp = (PyObject*)_Py_atomic_exchange_ptr(&r, v);  \
+        __Pyx_XDECREF(tmp);                                         \
+    } while (0)
+#define __Pyx_Py_DECREF_SET_ATOMIC(r, v) do {                      \
+        PyObject *tmp = (PyObject*)_Py_atomic_exchange_ptr(&r, v);  \
+        Py_DECREF(tmp);                                            \
+    } while (0)
+#define __Pyx_DECREF_SET_ATOMIC(r, v) do {                                 \
+        PyObject *tmp = (PyObject *)_Py_atomic_exchange_ptr(&r, v); \
+        __Pyx_DECREF(tmp);                                          \
+    } while (0)
+#else
+// with the gil atomic is irrelevant
+#define __Pyx_Py_XDECREF_SET_ATOMIC(r, v) __Pyx_Py_XDECREF_SET(r, v)
+#define __Pyx_XDECREF_SET_ATOMIC(r, v) __Pyx_XDECREF_SET(r, v)
+#define __Pyx_DECREF_SET_ATOMIC(r, v) __Pyx_DECREF_SET(r, v)
+#define __Pyx_Py_DECREF_SET_ATOMIC(r, v) __Pyx_Py_DECREF_SET(r, v)
+#endif
 
 #define __Pyx_CLEAR(r)    do { PyObject* tmp = ((PyObject*)(r)); r = NULL; __Pyx_DECREF(tmp);} while(0)
 #define __Pyx_XCLEAR(r)   do { if((r) != NULL) {PyObject* tmp = ((PyObject*)(r)); r = NULL; __Pyx_DECREF(tmp);}} while(0)
+
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+#define __Pyx_atomic_exchange_ptr(a, b) (PyObject*)_Py_atomic_exchange_ptr(a, b)
+#else
+static CYTHON_INLINE PyObject *__Pyx_atomic_exchange_ptr(PyObject **a, PyObject *b) {
+    PyObject *tmp = *a;
+    *a = b;
+    return tmp;
+}
+#endif
 
 /////////////// Refnanny ///////////////
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -845,6 +845,15 @@ Cython code.  Here is the list of currently supported directives:
     this may help or hurt performance.  A simple suite of benchmarks can be
     found in ``Demos/overflow_perf.pyx``.  Default is True.
 
+``threadsafe_reference_counting`` (True / False)
+    If set to true then reference counting of Python objects is thread-safe
+    which may be slightly slower.  This setting only makes a significant
+    difference to Python 3.13+ free-threading builds - if you are not using
+    this build then thread-safety is assured by the Global
+    Interpreter Lock and the code that Cython generates is close to
+    identical.  Default is True.  Note that thread-safety is
+    currently a work-in-progress.
+
 ``embedsignature`` (True / False)
     If set to True, Cython will embed a textual copy of the call
     signature in the docstring of all Python visible functions and


### PR DESCRIPTION
Add a compiler directive to turn it off. Also turn it off in the common case where a variable is completely local to a function without a parallel block.

Implement DECREF_SET (and similar) using atomic swap so that we know that the variable getting decrefed is the same one that got swapped out. I've used the
(currently private) atomic operations built in to
Python since it seemed like the easiest option.

Also handle `del x`.

This is by no means complete (e.g. I think we'll have to wrap reads in an atomic read too).