### PR TITLE
fix: `cythonize -i src/` command in python3.12

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -781,14 +781,20 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
     elif isinstance(patterns, basestring) or not isinstance(patterns, Iterable):
         patterns = [patterns]
 
-    from setuptools.extension import _Extension
     from setuptools import Extension
 
     # Support setuptools Extension instances as well.
     _extension_classes = [
-        _Extension,
         Extension,
     ]
+
+    try:
+        from setuptools.extension import _Extension
+
+        _extension_classes.append(_Extension)
+    except ImportError:  # python3.12 remove this class
+        pass
+
     try:
         from distutils.extension import Extension as DistutilsExtension
 


### PR DESCRIPTION
`distutils` has been removed in python 3.12 so it will failed.

close https://github.com/cython/cython/issues/5751