### PR TITLE
Freethreading thread safety

### DIFF
--- a/Cython/Compiler/Code.pxd
+++ b/Cython/Compiler/Code.pxd
@@ -55,6 +55,7 @@ cdef class FunctionState:
     cdef public bint error_without_exception
 
     cdef public bint needs_refnanny
+    cdef public bint uses_scope_mutex
 
     cpdef new_label(self, name=*)
     cpdef tuple get_loop_labels(self)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2494,6 +2494,10 @@ class NameNode(AtomicExprNode):
             return  # There was an error earlier
         if entry.utility_code:
             code.globalstate.use_utility_code(entry.utility_code)
+        #if self.needs_threadsafe_access:
+            #code.putln(entry.scope.get_scope_locking_code())
+            #if entry.scope.scope_locking_utility_code:
+                #code.globalstate.use_utility_code()
         if entry.is_builtin and entry.is_const:
             return  # Lookup already cached
         elif entry.is_pyclass_attr:

--- a/Cython/Compiler/FlowControl.pxd
+++ b/Cython/Compiler/FlowControl.pxd
@@ -35,6 +35,7 @@ cdef class NameAssignment:
     cdef public object bit
     cdef public object inferred_type
     cdef public object rhs_scope
+    cdef public bint in_parallel
 
 cdef class AssignmentList:
     cdef public object bit
@@ -58,6 +59,7 @@ cdef class ControlFlow:
     cdef public dict assmts
 
     cdef public Py_ssize_t in_try_block
+    cdef public Py_ssize_t in_parallel
 
     cpdef newblock(self, ControlBlock parent=*)
     cpdef nextblock(self, ControlBlock parent=*)

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -149,6 +149,8 @@ dataclass_field_default_cname = pyrex_prefix + "dataclass_dflt"
 global_code_object_cache_find = pyrex_prefix + 'find_code_object'
 global_code_object_cache_insert = pyrex_prefix + 'insert_code_object'
 
+scope_mutex_cname = pyrex_prefix + "scope_mutex"
+
 genexpr_id_ref = 'genexpr'
 freelist_name  = 'freelist'
 freecount_name = 'freecount'

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2432,6 +2432,11 @@ class FuncDefNode(StatNode, BlockNode):
             refnanny_setup_code.put_setup_refcount_context(self.entry.name, acquire_gil=refnanny_needs_gil)
             code.put_finish_refcount_context(nogil=not gil_owned['success'])
 
+        if code.funcstate.uses_scope_mutex:
+            tempvardecl_code.putln("#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING")
+            tempvardecl_code.putln(f"PyMutex {code.funcstate.scope.scope_mutex_cname} = {{0}};")
+            tempvardecl_code.putln("#endif")
+
         if acquire_gil or (lenv.nogil and gil_owned['success']):
             # release the GIL (note that with-gil blocks acquire it on exit in their EnsureGILNode)
             code.put_release_ensured_gil()

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -181,6 +181,7 @@ _directive_defaults = {
     'boundscheck' : True,
     'nonecheck' : False,
     'initializedcheck' : True,
+    'threadsafe_variable_access': 'refcounted',
     'embedsignature': False,
     'embedsignature.format': 'c',
     'auto_cpdef': False,
@@ -350,6 +351,7 @@ directive_types = {
     'dataclasses.dataclass': DEFER_ANALYSIS_OF_ARGUMENTS,
     'dataclasses.field': DEFER_ANALYSIS_OF_ARGUMENTS,
     'embedsignature.format': one_of('c', 'clinic', 'python'),
+    'threadsafe_variable_access': one_of('off', 'refcounted', 'full'),
 }
 
 for key, val in _directive_defaults.items():
@@ -380,8 +382,8 @@ directive_scopes = {  # defaults to available everywhere
     'autotestdict.all' : ('module',),
     'autotestdict.cdef' : ('module',),
     'set_initial_path' : ('module',),
-    'test_assert_path_exists' : ('function', 'class', 'cclass'),
-    'test_fail_if_path_exists' : ('function', 'class', 'cclass'),
+    'test_assert_path_exists' : ('function', 'class', 'cclass', 'with statement'),
+    'test_fail_if_path_exists' : ('function', 'class', 'cclass', 'with statement'),
     'test_assert_c_code_has' : ('module',),
     'test_fail_if_c_code_has' : ('module',),
     'freelist': ('cclass',),

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3268,16 +3268,16 @@ class MarkClosureVisitor(CythonTransform):
     # generator iterable and marking them
 
     def visit_ModuleNode(self, node):
-        self.needs_closure = False
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.NO_CLOSURE
         self.excludes = []
         self.visitchildren(node)
         return node
 
     def visit_FuncDefNode(self, node):
-        self.needs_closure = False
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.NO_CLOSURE
         self.visitchildren(node)
         node.needs_closure = self.needs_closure
-        self.needs_closure = True
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.FULL_CLOSURE
 
         collector = YieldNodeCollector(self.excludes)
         collector.visitchildren(node)
@@ -3314,27 +3314,31 @@ class MarkClosureVisitor(CythonTransform):
             gbody=gbody, lambda_name=node.lambda_name,
             return_type_annotation=node.return_type_annotation,
             is_generator_expression=node.is_generator_expression)
+        if node.needs_closure:
+            # We may have determined that we need a "full closure"
+            # so upgrade the coroutine to signal that
+            coroutine.needs_closure = node.needs_closure
         return coroutine
 
     def visit_CFuncDefNode(self, node):
-        self.needs_closure = False
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.NO_CLOSURE
         self.visitchildren(node)
         node.needs_closure = self.needs_closure
-        self.needs_closure = True
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.FULL_CLOSURE
         if node.needs_closure and node.overridable:
             error(node.pos, "closures inside cpdef functions not yet supported")
         return node
 
     def visit_LambdaNode(self, node):
-        self.needs_closure = False
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.NO_CLOSURE
         self.visitchildren(node)
         node.needs_closure = self.needs_closure
-        self.needs_closure = True
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.FULL_CLOSURE
         return node
 
     def visit_ClassDefNode(self, node):
         self.visitchildren(node)
-        self.needs_closure = True
+        self.needs_closure = Nodes.FuncDefNode.NeedsClosure.FULL_CLOSURE
         return node
 
     def visit_GeneratorExpressionNode(self, node):
@@ -3394,7 +3398,7 @@ class CreateClosureClasses(CythonTransform):
         in_closure.sort()
 
         # Now from the beginning
-        node.needs_closure = False
+        node.needs_closure = Nodes.FuncDefNode.NeedsClosure.NO_CLOSURE
         node.needs_outer_scope = False
 
         func_scope = node.local_scope
@@ -3460,7 +3464,7 @@ class CreateClosureClasses(CythonTransform):
                 is_cdef=True)
             if entry.is_declared_generic:
                 closure_entry.is_declared_generic = 1
-        node.needs_closure = True
+        node.needs_closure = Nodes.FuncDefNode.NeedsClosure.FULL_CLOSURE
         # Do it here because other classes are already checked
         target_module_scope.check_c_class(func_scope.scope_class)
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -368,6 +368,7 @@ class Scope:
     is_module_scope = 0
     is_c_dataclass_scope = False
     is_internal = 0
+    scope_needs_threadsafe_lookup = False
     scope_prefix = ""
     in_cinclude = 0
     nogil = 0
@@ -1976,6 +1977,8 @@ class LocalScope(Scope):
 
     # Transient attribute, used for symbol table variable declarations
     _in_with_gil_block = False
+    # Transient attribute in analyse expression, used to work out thread-safety
+    _in_parallel_block = False
 
     def __init__(self, name, outer_scope, parent_scope = None):
         if parent_scope is None:
@@ -2152,8 +2155,10 @@ class ClosureScope(LocalScope):
 
     is_closure_scope = True
 
-    def __init__(self, name, scope_name, outer_scope, parent_scope=None):
+    def __init__(self, name, scope_name, outer_scope, parent_scope=None,
+                 needs_threadsafe_lookup=False):
         LocalScope.__init__(self, name, outer_scope, parent_scope)
+        self.scope_needs_threadsafe_lookup = needs_threadsafe_lookup
         self.closure_cname = "%s%s" % (Naming.closure_scope_prefix, scope_name)
 
 #    def mangle_closure_cnames(self, scope_var):
@@ -2343,6 +2348,7 @@ class CClassScope(ClassScope):
     is_c_class_scope = 1
     is_closure_class_scope = False
     is_defaults_class_scope = False
+    scope_needs_threadsafe_lookup = True
 
     has_pyobject_attrs = False
     has_memoryview_attrs = False

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1341,6 +1341,7 @@ class ModuleScope(Scope):
         '__builtins__', '__name__', '__file__', '__doc__', '__path__',
         '__spec__', '__loader__', '__package__', '__cached__',
     ]
+    scope_mutex_cname = Naming.scope_mutex_cname
 
     def __init__(self, name, parent_module, context, is_package=False):
         from . import Builtin
@@ -1971,6 +1972,8 @@ class ModuleScope(Scope):
 
 class LocalScope(Scope):
     is_local_scope = True
+    # append "local" just to distinuish from any global macro
+    scope_mutex_cname = Naming.scope_mutex_cname + "_local"
 
     # Does the function have a 'with gil:' block?
     has_with_gil_block = False

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2241,6 +2241,18 @@ done:
 #include "internal/pycore_lock.h"
 #endif
 
+/////////////////////////// AccessCriticalSectionForFreeThreading.proto ////////////
+
+// Unfortunately we aren't yet in a position to use this fully because
+// critical sections aren't yet public API, and trying to include them from
+// the internal API ends up requring "mimalloc.h".
+// Therefore just simulate something so that code is ready for when it
+// is available
+#ifndef Py_BEGIN_CRITICAL_SECTION
+#define Py_BEGIN_CRITICAL_SECTION(x) { (void)x
+#define Py_END_CRITICAL_SECTION(x) (void)x; }
+#endif
+
 ////////////////////////// SharedInFreeThreading.proto //////////////////
 
 #if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -832,6 +832,23 @@ Cython code.  Here is the list of currently supported directives:
     set to ``None``. Otherwise a check is inserted and the
     appropriate exception is raised. This is off by default for
     performance reasons.  Default is False.
+    
+``threadsafe_variable_access`` ("off" / "refcounted", "full")
+    Defines how Cython will try to ensure thread-safety in freethreading
+    Python builds.  If set to "off" (the fastest) then Cython will not
+    do anything to ensure thread-safety.  If set to "refcounted" then
+    Cython will ensure the internal consistency of reference counting
+    for Python objects and typed memoryviews.  If set to "full" then
+    Cython will also guard access to C types (int, float, etc) so they
+    should be read and written atomically.
+    These guards are only enabled in places when Cython holds
+    the GIL (or would, if it existed).
+    Leaving this on will have some cost on a non-freethreaded build,
+    especially for attribute access of extension types.
+    Therefore it may be worth disabling if you are only building for
+    the regular non-freethreaded Python.
+    Default is "refcounted".
+    
 
 ``overflowcheck`` (True / False)
     If set to True, raise errors on overflowing C integer arithmetic

--- a/tests/compile/threadsafe_access.pyx
+++ b/tests/compile/threadsafe_access.pyx
@@ -1,0 +1,192 @@
+# mode: compile
+
+import cython
+from cython.parallel import parallel
+
+@cython.test_assert_path_exists("//NameNode[@name = 'x' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'x' and @needs_threadsafe_access=False]")
+def obj_in_parallel():
+    with nogil, parallel():
+        with gil:
+            x = object()
+
+# In this case o is never assigned, so we don't need thread-safe access
+@cython.test_assert_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=True]")
+def no_assignment_in_parallel1(o):
+    with nogil, parallel():
+        with gil:
+            print(o)
+
+
+# In this case o is not assigned in the parallel block, so we don't need thread-safe access
+@cython.test_assert_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=True]")
+def no_assignment_in_parallel2():
+    o = "String"
+    with nogil, parallel():
+        with gil:
+            print(o)
+
+# Deletion is an assignment
+@cython.test_assert_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=False]")
+def parallel_deletion(o):
+    with nogil, parallel():
+        with gil:
+            del o
+
+@cython.test_assert_path_exists("//NameNode[@name = 'i' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'i' and @needs_threadsafe_access=True]")
+@cython.threadsafe_variable_access("full")
+def c_type_in_parallel():
+    # Even though we're on "full" mode, c types are already thread private, so don't need locking
+    cdef int i
+    with nogil, parallel():
+        i = 10
+
+cdef global_obj = object()
+cdef int global_int = 20
+not_cdef = 1.5
+
+@cython.test_assert_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=False]")
+@cython.test_assert_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=True]")
+def access_globals():
+    print(global_obj, global_int, not_cdef)
+
+@cython.test_assert_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=True]")
+@cython.threadsafe_variable_access("full")
+def access_globals_full():
+    print(global_obj, global_int, not_cdef)
+
+@cython.test_assert_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=False]")
+@cython.test_assert_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=False]")
+@cython.test_assert_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_obj' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'global_int' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'not_cdef' and @needs_threadsafe_access=True]")
+@cython.threadsafe_variable_access("off")
+def access_globals_off():
+    print(global_obj, global_int, not_cdef)
+
+cdef cfunc():
+    pass
+
+cpdef cpfunc():
+    pass
+
+@cython.test_fail_if_path_exists("//NameNode[@name = 'cfunc' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'cpfunc' and @needs_threadsafe_access=True]")
+def access_global_cfuncs():
+    cfunc()
+    cpfunc()
+
+cdef class C:
+    cdef py_attr
+    cdef double c_attr
+    cdef void c_func(self):
+        pass
+    cpdef void cp_func(self):
+        pass
+    def py_func(self):
+        pass
+
+# C is a function local, so doesn't need threadsafe access
+@cython.test_assert_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=True]")
+def access_cclass(C c):
+    print(c.py_attr, c.c_attr)
+
+@cython.test_assert_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=False]")
+@cython.threadsafe_variable_access("full")
+def access_cclass_full(C c):
+    print(c.py_attr, c.c_attr)
+
+@cython.test_assert_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'c' and @needs_threadsafe_access=True]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=False]")
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'py_attr' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'c_attr' and @needs_threadsafe_access=True]")
+@cython.threadsafe_variable_access("off")
+def access_cclass_off(C c):
+    print(c.py_attr, c.c_attr)
+
+# access to C funcs doesn't need locking (because they're immutable).
+# access to py_funcs goes through a dictionary and this provides the thread safety rather than Cython.
+# They're transformed out anyway, so we can't directly check for the attribute nodes
+@cython.test_fail_if_path_exists("AttributeNode[@attribute = 'func' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("AttributeNode[@attribute = 'cp_func' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("AttributeNode[@attribute = 'py_func' and @needs_threadsafe_access=True]")
+def access_cclass_func(C c):
+    c.c_func()
+    c.cp_func()
+    c.py_func()
+
+# Python attributes go through a dictionary lookup so don't need special locking
+@cython.test_assert_path_exists("//AttributeNode[@attribute = 'some_attribute' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//AttributeNode[@attribute = 'some_attribute' and @needs_threadsafe_access=True]")
+def access_pyclass(c):
+    print(c.some_attribute)
+
+
+def closure():
+    # In principle it should probably be possible to work out that this is safe, but in practice
+    # it's hard, so don't assert anything about it
+    o = object()
+
+    # once it's in a closure, it does need thread safe access
+    @cython.test_assert_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=True]")
+    @cython.test_fail_if_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=False]")
+    def inner():
+        print(o)
+
+    # hard to reason about the value here
+    with (cython.test_assert_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=True]"),
+          cython.test_fail_if_path_exists("//NameNode[@name = 'o' and @needs_threadsafe_access=False]")):
+        print(o)
+
+
+# Simple generators are guarded to make sure that they can't be called when they're already running
+# and thus don't need checks
+@cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
+def basic_generator():
+    a = object()
+    yield a
+
+def h(a):
+    # This generator has a closure variable, so can't reason about whether other threads can access it
+    @cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
+    @cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
+    def inner_gen():
+        yield a
+
+# This generator has a variable that's shared with a closure, so can't reason about whether other threads can access it
+@cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
+@cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
+def i(a):
+    @cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
+    @cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
+    def inner():
+        nonlocal a
+        a = 1
+    yield a

--- a/tests/compile/threadsafe_access.pyx
+++ b/tests/compile/threadsafe_access.pyx
@@ -173,7 +173,7 @@ def basic_generator():
     a = object()
     yield a
 
-def h(a):
+def func_with_inner_gen(a):
     # This generator has a closure variable, so can't reason about whether other threads can access it
     @cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
     @cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
@@ -183,10 +183,17 @@ def h(a):
 # This generator has a variable that's shared with a closure, so can't reason about whether other threads can access it
 @cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
 @cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
-def i(a):
+def gen_with_inner_func(a):
     @cython.test_assert_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=True]")
     @cython.test_fail_if_path_exists("//NameNode[@name = 'a' and @needs_threadsafe_access=False]")
     def inner():
         nonlocal a
         a = 1
     yield a
+
+cdef class Nested:
+    cdef Nested attr
+
+def deep_lookup(Nested n1, Nested n2):
+    # Just test that this compiles sensibly, since they get factored out into temps
+    n1.attr.attr.attr.attr.attr = n2.attr.attr.attr


### PR DESCRIPTION
Closes https://github.com/cython/cython/issues/6221 (and obsoletes https://github.com/cython/cython/issues/6215)

In principle this should cover a large chunk of thread safety issues in Cython. It applies to anywhere where we hold the GIL. There's three levels:
* off
* refcounted - only applies to reference counted types (PyObject/typed memoryview)
* full - applies to all types, so read/write should at least appear "atomic".

I've made the default "refcounted", but that could be up for debate.

It has some cost in the non-free-threaded builds because:
* it unchains cdef class attribute lookups so that they go via temps.
* It makes some error handling more complicated.

Right now the main limitation is that we don't yet have access to critical sections - see https://github.com/python/cpython/issues/119344. I've put placeholders there for now, but they really don't do anything. This means that `cdef classes` and closure scopes aren't guarded properly.