### PR TITLE
Fix segfault on zero-length slice assignment on memoryview

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -417,7 +417,7 @@ cdef class memoryview:
 
         if have_slices:
             obj = self.is_slice(value)
-            if obj:
+            if obj != None:
                 self.setitem_slice_assignment(self[index], obj)
             else:
                 self.setitem_slice_assign_scalar(self[index], value)

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -417,7 +417,7 @@ cdef class memoryview:
 
         if have_slices:
             obj = self.is_slice(value)
-            if obj != None:
+            if obj is not None:
                 self.setitem_slice_assignment(self[index], obj)
             else:
                 self.setitem_slice_assign_scalar(self[index], value)

--- a/tests/memoryview/memoryview.pyx
+++ b/tests/memoryview/memoryview.pyx
@@ -1081,6 +1081,22 @@ def test_dtype_object_scalar_assignment():
     assert m[0] == m[4] == m[-1] == 3
 
 
+def test_assign_to_slice(obj, start, end):
+    """
+    >>> test_assign_to_slice(b'abc', 0, 3)
+    b'abc'
+    >>> test_assign_to_slice(b'a', 0, 1)
+    b'a'
+    >>> test_assign_to_slice(b'', 0, 0)
+    b''
+    >>> test_assign_to_slice(b'', 5, 5)
+    b''
+    """
+    view = memoryview(bytearray(len(obj)), PyBUF_C_CONTIGUOUS)
+    view[start:end] = obj[start:end]
+    return bytes(view)
+
+
 def test_assignment_in_conditional_expression(bint left):
     """
     >>> test_assignment_in_conditional_expression(True)
@@ -1314,5 +1330,5 @@ def test_untyped_index(i):
 
 _PERFORMANCE_HINTS = """
 243:9: Use boundscheck(False) for faster access
-1313:21: Index should be typed for more efficient access
+1329:21: Index should be typed for more efficient access
 """

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -12,7 +12,6 @@ from cpython.ref cimport Py_INCREF, Py_DECREF, Py_CLEAR, Py_REFCNT
 cimport cython
 from cython cimport view
 from cython.view cimport array
-from cython.view cimport memoryview
 from cython.parallel cimport prange, parallel
 from functools import wraps
 import gc

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -13,6 +13,7 @@ cimport cython
 from cython cimport view
 from cython.view cimport array
 from cython.parallel cimport prange, parallel
+
 from functools import wraps
 import gc
 import sys

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2206,7 +2206,7 @@ def test_slice_assignment_zero_length_slice():
     dest_buf: bytearray = bytearray(1)
 
     # construct a memory view of the destination buffer
-    view = memoryview(dest_buf, PyBUF_C_CONTIGUOUS)
+    cdef char[::1] view = dest_buf
 
     # assign a empty slice — this should noop
     view[0:0] = src_buf[0:0]

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2176,6 +2176,11 @@ cdef _test_slice_assignment_broadcast_strides(slice_1d src, slice_2d dst, slice_
         for j in range(1, 3):
             assert dst[i, j] == dst_f[i, j] == j - 1, (dst[i, j], dst_f[i, j], j - 1)
 
+cdef _test_slice_assignment_single_length_slice(slice_1d src, slice_1d dst):
+    cdef int i = 0
+    cdef int j = 1
+    dst[i:j] = src[i:j]
+
 @testcase
 def test_slice_assignment_single_length_slice():
     """
@@ -2190,9 +2195,14 @@ def test_slice_assignment_single_length_slice():
     # construct a memory view of the destination buffer
     cdef char[::1] view = dest_buf
 
+    _test_slice_assignment_single_length_slice(src_buf, dest_buf)
     # assign a slice of len = 1
-    view[0:1] = src_buf[0:1]
     return dest_buf[0]
+
+cdef _test_slice_assignment_zero_length_slice(slice_1d src, slice_1d dst):
+    cdef int i = 0
+    cdef int j = 0
+    dst[i:j] = src[i:j]
 
 @testcase
 def test_slice_assignment_zero_length_slice():
@@ -2209,7 +2219,7 @@ def test_slice_assignment_zero_length_slice():
     cdef char[::1] view = dest_buf
 
     # assign a empty slice — this should noop
-    view[0:0] = src_buf[0:0]
+    _test_slice_assignment_zero_length_slice(src_buf, dest_buf)
     return dest_buf[0]
 
 @testcase

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2188,7 +2188,7 @@ def test_slice_assignment_single_length_slice():
     dest_buf: bytearray = bytearray(1)
 
     # construct a memory view of the destination buffer
-    view = memoryview(dest_buf, PyBUF_C_CONTIGUOUS)
+    cdef char[::1] view = dest_buf
 
     # assign a slice of len = 1
     view[0:1] = src_buf[0:1]

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -19,9 +19,6 @@ import sys
 
 import builtins
 
-cdef extern from "Python.h":
-    cdef int PyBUF_C_CONTIGUOUS
-
 try:
     from Cython.Tests.this_module_does_not_exist import *
 except ImportError:

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2180,6 +2180,7 @@ cdef _test_slice_assignment_broadcast_strides(slice_1d src, slice_2d dst, slice_
         for j in range(1, 3):
             assert dst[i, j] == dst_f[i, j] == j - 1, (dst[i, j], dst_f[i, j], j - 1)
 
+@testcase
 def test_slice_assignment_single_length_slice():
     """
     >>> test_slice_assignment_single_length_slice()
@@ -2195,8 +2196,9 @@ def test_slice_assignment_single_length_slice():
 
     # assign a slice of len = 1
     view[0:1] = src_buf[0:1]
-    print(dest_buf[0])
+    return dest_buf[0]
 
+@testcase
 def test_slice_assignment_zero_length_slice():
     """
     >>> test_slice_assignment_zero_length_slice()
@@ -2212,7 +2214,7 @@ def test_slice_assignment_zero_length_slice():
 
     # assign a empty slice — this should noop
     view[0:0] = src_buf[0:0]
-    print(dest_buf[0])
+    return dest_buf[0]
 
 @testcase
 def test_borrowed_slice():

--- a/tests/memoryview/memslice.pyx
+++ b/tests/memoryview/memslice.pyx
@@ -2176,52 +2176,6 @@ cdef _test_slice_assignment_broadcast_strides(slice_1d src, slice_2d dst, slice_
         for j in range(1, 3):
             assert dst[i, j] == dst_f[i, j] == j - 1, (dst[i, j], dst_f[i, j], j - 1)
 
-cdef _test_slice_assignment_single_length_slice(slice_1d src, slice_1d dst):
-    cdef int i = 0
-    cdef int j = 1
-    dst[i:j] = src[i:j]
-
-@testcase
-def test_slice_assignment_single_length_slice():
-    """
-    >>> test_slice_assignment_single_length_slice()
-    1
-    """
-    cdef char[1] src_buf
-    src_buf[0] = 0x01
-
-    dest_buf: bytearray = bytearray(1)
-
-    # construct a memory view of the destination buffer
-    cdef char[::1] view = dest_buf
-
-    _test_slice_assignment_single_length_slice(src_buf, dest_buf)
-    # assign a slice of len = 1
-    return dest_buf[0]
-
-cdef _test_slice_assignment_zero_length_slice(slice_1d src, slice_1d dst):
-    cdef int i = 0
-    cdef int j = 0
-    dst[i:j] = src[i:j]
-
-@testcase
-def test_slice_assignment_zero_length_slice():
-    """
-    >>> test_slice_assignment_zero_length_slice()
-    0
-    """
-    cdef char[1] src_buf
-    src_buf[0] = 0x01
-
-    dest_buf: bytearray = bytearray(1)
-
-    # construct a memory view of the destination buffer
-    cdef char[::1] view = dest_buf
-
-    # assign a empty slice — this should noop
-    _test_slice_assignment_zero_length_slice(src_buf, dest_buf)
-    return dest_buf[0]
-
 @testcase
 def test_borrowed_slice():
     """


### PR DESCRIPTION
As outlined in #6227 — we have experienced an issue in production where attempting to write a folly:IOBuf with zero-length backing buffers is triggering a SIGSEGV.

The specific issue actual has to do with how `memoryview` attempts to use scalar assignment instead of slice assignment in the case where the source buffer (in this case, an empty slice) has `len == 0`. By fixing the fork to properly use slice assignment, we avoid the SIGSEGV when we string format the view format (which is NULL).

This PR also adds two additional tests for writing either a single byte or an empty slice to a `memoryview`.

Tested via: `python runtests.py memslice -vv` (which includes the two new tests)

fixes #6227 

 