### PR TITLE
Add sanity check on import for ABI details

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3079,7 +3079,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         # start of module init/exec function (pre/post PEP 489)
         code.putln("{")
-        
+
         code.putln("#if !CYTHON_PEP489_MULTI_PHASE_INIT")
         code.putln("if (__Pyx_VersionSanityCheck() < 0) return NULL;")
         code.putln("#endif")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3056,9 +3056,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln("#endif")
         code.putln(header3)
 
+        code.globalstate.use_utility_code(
+            UtilityCode.load("PyVersionSanityCheck", "ModuleSetupCode.c")
+        )
+
         # CPython 3.5+ supports multi-phase module initialisation (gives access to __spec__, __file__, etc.)
         code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT")
         code.putln("{")
+        code.putln("if (__Pyx_VersionSanityCheck() < 0) return NULL;")
         code.putln("return PyModuleDef_Init(&%s);" % Naming.pymoduledef_cname)
         code.putln("}")
 
@@ -3074,6 +3079,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         # start of module init/exec function (pre/post PEP 489)
         code.putln("{")
+        
+        code.putln("#if !CYTHON_PEP489_MULTI_PHASE_INIT")
+        code.putln("if (__Pyx_VersionSanityCheck() < 0) return NULL;")
+        code.putln("#endif")
+
         code.putln('int stringtab_initialized = 0;')
         code.putln("#if CYTHON_USE_MODULE_STATE")
         code.putln('int pystate_addmodule_run = 0;')

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2284,8 +2284,7 @@ static int __Pyx_VersionSanityCheck(void) {
       #ifdef Py_GIL_DISABLED
         "not "
       #endif
-      "__import__('sysconfig').get_config_var('Py_GIL_DISABLED'):\n"
-      "  raise ImportError",
+      "__import__('sysconfig').get_config_var('Py_GIL_DISABLED'): raise ImportError",
       NULL
     ) == -1) {
         PyErr_SetString(

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2261,6 +2261,8 @@ static int __Pyx_VersionSanityCheck(void) {
   //  the best we can do.
   //
   #if CYTHON_COMPILING_IN_CPYTHON
+  // from Python 3.8 debug and release builds are ABI compatible so skip the check
+  #if PY_VERSION_HEX < 0x03080000
     if (PySys_GetObject("gettotalrefcount")) {
       #ifndef Py_DEBUG
         PyErr_SetString(
@@ -2278,7 +2280,8 @@ static int __Pyx_VersionSanityCheck(void) {
         return -1;
       #endif
     }
-    #if PY_VERSION_HEX >= 0x030d0000
+  #endif // Py_VERSION_HEX < 0x03080000
+  #if PY_VERSION_HEX >= 0x030d0000
     if (PyRun_SimpleStringFlags(
       "if "
       #ifdef Py_GIL_DISABLED
@@ -2297,7 +2300,7 @@ static int __Pyx_VersionSanityCheck(void) {
         );
       return -1;
     }
-    #endif // version hex 3.13+
+  #endif // version hex 3.13+
     if (PySys_GetObject("getobjects")) {
       #ifndef Py_TRACE_REFS
         PyErr_SetString(

--- a/tests/run/abitests.srctree
+++ b/tests/run/abitests.srctree
@@ -23,11 +23,12 @@ import sys
 if sys.implementation.name != 'cpython':
     exit(0)
 
-try:
-    import debug
-    assert False, "Failed 'debug' test"
-except ImportError:
-    pass
+if sys.version_info < (3, 8):
+    try:
+        import debug
+        assert False, "Failed 'debug' test"
+    except ImportError:
+        pass
     
 if sys.version_info >= (3, 13):
     try:

--- a/tests/run/abitests.srctree
+++ b/tests/run/abitests.srctree
@@ -1,0 +1,82 @@
+# These tests aren't perfect because they just mislead some of the Cython
+# code about the build environment - they don't actually manage to
+# simulate getting the environment wrong in the Python headers (which
+# is potentially a more dramatic problem).
+
+PYTHON setup.py build_ext --inplace
+PYTHON test.py
+
+##################### setup.py #########################
+
+
+from setuptools import setup
+from Cython.Build import cythonize
+
+setup(
+    ext_modules = cythonize("*.pyx")
+)
+
+##################### test.py ###########################
+
+import sys
+
+if sys.implementation.name != 'cpython':
+    exit(0)
+
+try:
+    import debug
+    assert False, "Failed 'debug' test"
+except ImportError:
+    pass
+    
+if sys.version_info >= (3, 13):
+    try:
+        import freethread
+        assert False, "Failed 'freethread' test"
+    except ImportError:
+        pass
+        
+try:
+    import trace
+    assert False, "Failed 'trace' test"
+except ImportError:
+    pass
+
+##################### debug.pyx #########################
+
+cdef extern from *:
+    """
+    #ifdef Py_DEBUG
+    #undef Py_DEBUG
+    #else
+    #define Py_DEBUG
+    #endif
+    """
+    
+something = 1
+
+##################### freethread.pyx ###################
+
+cdef extern from *:
+    """
+    #ifdef Py_GIL_DISABLED
+    #undef Py_GIL_DISABLED
+    #else
+    #define Py_GIL_DISABLED
+    #endif
+    """
+    
+something = 1
+
+#################### trace.pyx #########################
+
+cdef extern from *:
+    """
+    #ifdef Py_TRACE_REFS
+    #undef Py_TRACE_REFS
+    #else
+    #define Py_TRACE_REFS
+    #endif
+    """
+    
+something = 1


### PR DESCRIPTION
What I'm mainly worried building things that look like free-threaded modules with the wrong macros on Windows (since it's actually quite difficult to get it right at the moment).

I think a basic check here will safe us a lot of support questions later.