### PR TITLE
Fix use of __Pyx_TEST_large_func_pointers

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -588,7 +588,7 @@ static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcnam
              PyModule_GetName(module), funcname, sig, PyCapsule_GetName(cobj));
         goto bad;
     }
-    *f = __Pyx_capsule_to_c_func_ptr(cobj, sig);
+    *f = __Pyx_capsule_to_c_func_ptr_$cyversion(cobj, sig);
     if (!(*f))
         goto bad;
     Py_DECREF(d);

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -390,12 +390,6 @@
 /* Whether to use METH_FASTCALL with a fake backported implementation of vectorcall */
 #define CYTHON_BACKPORT_VECTORCALL (CYTHON_METH_FASTCALL && PY_VERSION_HEX < 0x030800B1)
 
-#if !defined(__Pyx_TEST_large_func_pointers)
-// This can be defined to force an alternate code-path for testing purposes
-// There's no other reason to use it
-#define __Pyx_TEST_large_func_pointers 0
-#endif
-
 #if CYTHON_USE_PYLONG_INTERNALS
   /* These short defines from the PyLong header can easily conflict with other code */
   #undef SHIFT

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -1157,6 +1157,7 @@ typedef void (*__Pyx_generic_func_pointer_$cyversion)(void);
 
 /////////////// CFuncPtrToPy.proto ///////////////
 //@requires: CFuncPtrTypedef
+//@substitute: naming
 
 static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer_$cyversion funcptr, const char* name); /* proto */
 

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -1163,6 +1163,7 @@ static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer_$cyversi
 
 /////////////// CFuncPtrToPy ///////////////
 //@requires: StringTools.c::IncludeStringH
+//@substitute: naming
 
 static void __Pyx_destroy_c_func_ptr_capsule(PyObject *capsule) {
     void* ptr = PyCapsule_GetPointer(capsule, PyCapsule_GetName(capsule));

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -1148,13 +1148,17 @@ raise_neg_overflow:
 }
 
 /////////////// CFuncPtrTypedef.proto ///////////////
+//@substitute: naming
 
-typedef void (*__Pyx_generic_func_pointer)(void);
+#ifndef __PYX_HAVE_RT_CFuncPtrTypedef_$cyversion
+#define __PYX_HAVE_RT_CFuncPtrTypedef_$cyversion
+typedef void (*__Pyx_generic_func_pointer_$cyversion)(void);
+#endif
 
 /////////////// CFuncPtrToPy.proto ///////////////
 //@requires: CFuncPtrTypedef
 
-static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer funcptr, const char* name); /* proto */
+static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer_$cyversion funcptr, const char* name); /* proto */
 
 /////////////// CFuncPtrToPy ///////////////
 //@requires: StringTools.c::IncludeStringH
@@ -1164,11 +1168,17 @@ static void __Pyx_destroy_c_func_ptr_capsule(PyObject *capsule) {
     PyMem_Free(ptr);
 }
 
-static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer funcptr, const char* name) {
-    if (sizeof(funcptr) > sizeof(void*) || __Pyx_TEST_large_func_pointers) {
+static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer_$cyversion funcptr, const char* name) {
+    // __Pyx_TEST_large_func_pointers exists just to force an alternative code-path in testing
+#if defined(__Pyx_TEST_large_func_pointers) && __Pyx_TEST_large_func_pointers
+    if ((1))
+#else
+    if (sizeof(funcptr) > sizeof(void*))
+#endif
+    {
         // The C standard does not guarantee that a function pointer fits inside a regular pointer
         // (and on some platforms it doesn't). On these, we need to allocate space to store the function pointer
-        __Pyx_generic_func_pointer *copy_into = (__Pyx_generic_func_pointer*) PyMem_Malloc(sizeof(funcptr));
+        __Pyx_generic_func_pointer_$cyversion *copy_into = (__Pyx_generic_func_pointer_$cyversion*) PyMem_Malloc(sizeof(funcptr));
         *copy_into = funcptr;
         return PyCapsule_New(copy_into, name, __Pyx_destroy_c_func_ptr_capsule);
     } else {
@@ -1185,17 +1195,26 @@ static PyObject *__Pyx_c_func_ptr_to_capsule(__Pyx_generic_func_pointer funcptr,
 /////////////// CFuncPtrFromPy.proto ///////////////
 //@requires: CFuncPtrTypedef
 
-static __Pyx_generic_func_pointer __Pyx_capsule_to_c_func_ptr(PyObject *capsule, const char* name); /* proto */
+static __Pyx_generic_func_pointer_$cyversion __Pyx_capsule_to_c_func_ptr_$cyversion(PyObject *capsule, const char* name); /* proto */
 
 /////////////// CFuncPtrFromPy.proto ///////////////
+//@substitute: naming
 
-static __Pyx_generic_func_pointer __Pyx_capsule_to_c_func_ptr(PyObject *capsule, const char* name) {
+#ifndef __PYX_HAVE_RT_CFuncPtrFromPy_$cyversion
+#define __PYX_HAVE_RT_CFuncPtrFromPy_$cyversion
+static __Pyx_generic_func_pointer_$cyversion __Pyx_capsule_to_c_func_ptr_$cyversion(PyObject *capsule, const char* name) {
     void *data = PyCapsule_GetPointer(capsule, name);
-    __Pyx_generic_func_pointer funcptr;
-    if (sizeof(funcptr) > sizeof(void*) || __Pyx_TEST_large_func_pointers) {
-        funcptr = *((__Pyx_generic_func_pointer*)data);
+    __Pyx_generic_func_pointer_$cyversion funcptr;
+#if defined(__Pyx_TEST_large_func_pointers) && __Pyx_TEST_large_func_pointers
+    if ((1))
+#else
+    if (sizeof(funcptr) > sizeof(void*))
+#endif
+    {
+        funcptr = *((__Pyx_generic_func_pointer_$cyversion*)data);
     } else {
         memcpy((void*)&funcptr, (void*)&data, sizeof(funcptr));
     }
     return funcptr;
 }
+#endif


### PR DESCRIPTION
Fixes #6236. It was defined in the main ModuleSetupCode which meant it wasn't available in headers. Now it's no longer required to be defined.

Also noted that __Pyx_capsule_to_c_func_ptr ends up in _api.h files. Therefore gave it a version tag and an include guard so that it's not required to be perpetually compatible.

I'm a little worried that the _api.h headers aren't tested well enough and that we probably only use them from other Cython modules rather than from an isolated C program.