### PR TITLE
Pre-clean docstrings when running EmbedSignature transform

### DIFF
--- a/Cython/Compiler/AutoDocTransforms.py
+++ b/Cython/Compiler/AutoDocTransforms.py
@@ -1,4 +1,5 @@
 import inspect
+
 from .Visitor import CythonTransform
 from .StringEncoding import EncodedString
 from . import Options

--- a/Cython/Compiler/AutoDocTransforms.py
+++ b/Cython/Compiler/AutoDocTransforms.py
@@ -1,3 +1,4 @@
+import inspect
 from .Visitor import CythonTransform
 from .StringEncoding import EncodedString
 from . import Options
@@ -177,6 +178,7 @@ class EmbedSignature(CythonTransform):
                 docfmt = "%s\n--\n\n%s"
             else:
                 docfmt = "%s\n%s"
+            node_doc = inspect.cleandoc(node_doc)
             return docfmt % (signature, node_doc)
         else:
             if self.is_format_clinic:

--- a/tests/run/embedsignatures.pyx
+++ b/tests/run/embedsignatures.pyx
@@ -107,13 +107,13 @@ __doc__ = ur"""
     'with_doc_1(a, b, c)\nExisting string'
 
     >>> funcdoc(with_doc_2)
-    'with_doc_2(a, b, c)\n\n    Existing string\n    '
+    'with_doc_2(a, b, c)\nExisting string'
 
     >>> funcdoc(with_doc_3)
     'with_doc_3(a, b, c)\nExisting string'
 
     >>> funcdoc(with_doc_4)
-    'with_doc_4(int a, str b, list c) -> str\n\n    Existing string\n    '
+    'with_doc_4(int a, str b, list c) -> str\nExisting string'
 
     >>> funcdoc(f_sd)
     "f_sd(str s='spam')"


### PR DESCRIPTION
PEP257 documents rules for stripping inline docstrings such that they may be formatted at the REPL using help.

Broadly, this is "strip whitespace from the first line, and dedent all subsequent lines by the minimum common whitespace prefix".

This allows writing a docstring as:

```python
def function(*args) -> result:
    """This is the first line.

    Here is a long description.
    """
```

and having it rendered as:

```
This is the first line.

Here is a long description.
```

Similarly to if the docstring were:

```python
def function(*args) -> result:
    """
    This is the first line.

    Here is a long description.
    """
```

When compiling Cython files with embedsignature=True, the insertion of the function signature breaks the normal cleaning rules, since the raw docstring becomes:

```python
def function(*args) -> result:
    """function(*args) -> result
This is the first line.

    Here is a long description.
    """
```

Which is then rendered in the REPL as:

```
function(*args) -> result
This is the first line.

    Here is a long description.
```

Note the over-indented long description.

To fix this, change signature embedding to pre-clean the input docstring (via inspect.cleandoc) before prepending the signature. The above example is then embedded as:

```python
def function(*args) -> result:
    """function(*args) -> result
This is the first line.

Here is a long description.
"""
```
which is then rendered correctly.