### PR TITLE
Add freethreading_compatible directive to set Py_mod_gil slot

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3577,10 +3577,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("{Py_mod_create, (void*)%s}," % Naming.pymodule_create_func_cname)
         code.putln("{Py_mod_exec, (void*)%s}," % exec_func_cname)
         code.putln("#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING")
-        code.putln("{Py_mod_gil, %s}," %
-                   "Py_MOD_GIL_NOT_USED"
-                   if env.directives["freethreading_compatible"]
-                   else "Py_MOD_GIL_USED")
+        gil_option = ("Py_MOD_GIL_NOT_USED"
+                      if env.directives["freethreading_compatible"]
+                      else "Py_MOD_GIL_USED")
+        code.putln("{Py_mod_gil, %s}," % gil_option)
         code.putln("#endif")
         code.putln("{0, NULL}")
         code.putln("};")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3566,6 +3566,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         else:
             cleanup_func = 'NULL'
 
+        freethreading_compatible = env.directives['freethreading_compatible']
+
         code.putln("")
         code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT")
         exec_func_cname = self.module_init_func_cname()
@@ -3576,6 +3578,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("static PyModuleDef_Slot %s[] = {" % Naming.pymoduledef_slots_cname)
         code.putln("{Py_mod_create, (void*)%s}," % Naming.pymodule_create_func_cname)
         code.putln("{Py_mod_exec, (void*)%s}," % exec_func_cname)
+        code.putln("#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING")
+        if freethreading_compatible:
+            code.putln("{Py_mod_gil, Py_MOD_GIL_NOT_USED},")
+        else:
+            code.putln("{Py_mod_gil, Py_MOD_GIL_USED},")
+        code.putln("#endif")
         code.putln("{0, NULL}")
         code.putln("};")
         if not env.module_name.isascii():
@@ -3630,6 +3638,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         else:
             doc = "0"
 
+        freethreading_compatible = env.directives['freethreading_compatible']
+
         code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT")
         code.putln("%s = %s;" % (
             env.module_cname,
@@ -3664,6 +3674,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 env.module_cname,
                 Naming.pymoduledef_cname))
         code.putln(code.error_goto_if_null(env.module_cname, self.pos))
+        code.putln("#endif")  # CYTHON_USE_MODULE_STATE
+        code.putln("#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING")
+        if freethreading_compatible:
+            code.putln("PyUnstable_Module_SetGIL(%s, Py_MOD_GIL_NOT_USED);" % env.module_cname)
+        else:
+            code.putln("PyUnstable_Module_SetGIL(%s, Py_MOD_GIL_USED);" % env.module_cname)
         code.putln("#endif")
         code.putln("#endif")  # CYTHON_PEP489_MULTI_PHASE_INIT
         code.putln("CYTHON_UNUSED_VAR(%s);" % module_temp)  # only used in limited API

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -351,7 +351,6 @@ directive_types = {
     'dataclasses.dataclass': DEFER_ANALYSIS_OF_ARGUMENTS,
     'dataclasses.field': DEFER_ANALYSIS_OF_ARGUMENTS,
     'embedsignature.format': one_of('c', 'clinic', 'python'),
-    'freethreading_compatible': bool,
 }
 
 for key, val in _directive_defaults.items():

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -181,6 +181,7 @@ _directive_defaults = {
     'boundscheck' : True,
     'nonecheck' : False,
     'initializedcheck' : True,
+    'freethreading_compatible': False,
     'embedsignature': False,
     'embedsignature.format': 'c',
     'auto_cpdef': False,
@@ -350,6 +351,7 @@ directive_types = {
     'dataclasses.dataclass': DEFER_ANALYSIS_OF_ARGUMENTS,
     'dataclasses.field': DEFER_ANALYSIS_OF_ARGUMENTS,
     'embedsignature.format': one_of('c', 'clinic', 'python'),
+    'freethreading_compatible': bool,
 }
 
 for key, val in _directive_defaults.items():

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -409,6 +409,7 @@ directive_scopes = {  # defaults to available everywhere
     'legacy_implicit_noexcept': ('module', ),
     'control_flow.dot_output': ('module',),
     'control_flow.dot_annotate_defs': ('module',),
+    'freethreading_compatible': ('module',)
 }
 
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -833,6 +833,14 @@ Cython code.  Here is the list of currently supported directives:
     appropriate exception is raised. This is off by default for
     performance reasons.  Default is False.
 
+``freethreading_compatible``  (True / False)
+    If set to True, Cython sets the ``Py_mod_gil`` slot to
+    ``Py_MOD_GIL_NOT_USED`` to signal that the module is safe to run
+    without an active GIL and prevent the GIL from being enabled
+    when the module is imported. Otherwise the slot is set to
+    ``Py_MOD_GIL_USED`` which will cause the GIL to be automatically
+    enabled. Default is False.
+
 ``overflowcheck`` (True / False)
     If set to True, raise errors on overflowing C integer arithmetic
     operations.  Incurs a modest runtime penalty, but is much faster than

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -839,7 +839,9 @@ Cython code.  Here is the list of currently supported directives:
     without an active GIL and prevent the GIL from being enabled
     when the module is imported. Otherwise the slot is set to
     ``Py_MOD_GIL_USED`` which will cause the GIL to be automatically
-    enabled. Default is False.
+    enabled. Setting this to True does not itself make the module safe
+    to run without the GIL; it merely confirms that you have checked
+    the logic and consider it safe to run. Default is False.
 
 ``overflowcheck`` (True / False)
     If set to True, raise errors on overflowing C integer arithmetic

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -841,7 +841,9 @@ Cython code.  Here is the list of currently supported directives:
     ``Py_MOD_GIL_USED`` which will cause the GIL to be automatically
     enabled. Setting this to True does not itself make the module safe
     to run without the GIL; it merely confirms that you have checked
-    the logic and consider it safe to run. Default is False.
+    the logic and consider it safe to run. Since free-threading support
+    is still experimental itself, this is also an experimental directive that
+    might be changed or removed in future releases. Default is False.
 
 ``overflowcheck`` (True / False)
     If set to True, raise errors on overflowing C integer arithmetic

--- a/tests/run/freethreading_compatible.srctree
+++ b/tests/run/freethreading_compatible.srctree
@@ -1,0 +1,40 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import default; default.test()"
+PYTHON -c "import compatible; compatible.test()"
+PYTHON -c "import incompatible; incompatible.test()"
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+ext_modules = []
+
+# Test language_level specified in the cythonize() call
+ext_modules += cythonize("default.py")
+ext_modules += cythonize("compatible.py")
+ext_modules += cythonize("incompatible.py")
+
+setup(ext_modules=ext_modules)
+
+######## default.py ########
+
+def test():
+    import sys
+    assert sys._is_gil_enabled()
+
+######## compatible.py ########
+
+# cython: freethreading_compatible=True
+
+def test():
+    import sys
+    assert not sys._is_gil_enabled()
+
+######## incompatible.py ########
+
+# cython: freethreading_compatible=False
+
+def test():
+    import sys
+    assert sys._is_gil_enabled()

--- a/tests/run/freethreading_compatible.srctree
+++ b/tests/run/freethreading_compatible.srctree
@@ -21,6 +21,9 @@ setup(ext_modules=ext_modules)
 
 def test():
     import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
     assert sys._is_gil_enabled()
 
 ######## compatible.py ########
@@ -29,6 +32,9 @@ def test():
 
 def test():
     import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
     assert not sys._is_gil_enabled()
 
 ######## incompatible.py ########
@@ -37,4 +43,7 @@ def test():
 
 def test():
     import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
     assert sys._is_gil_enabled()

--- a/tests/run/freethreading_compatible.srctree
+++ b/tests/run/freethreading_compatible.srctree
@@ -2,20 +2,31 @@ PYTHON setup.py build_ext --inplace
 PYTHON -c "import default; default.test()"
 PYTHON -c "import compatible; compatible.test()"
 PYTHON -c "import incompatible; incompatible.test()"
+PYTHON -c "import default_single; default_single.test()"
+PYTHON -c "import compatible_single; compatible_single.test()"
+PYTHON -c "import incompatible_single; incompatible_single.test()"
 
 ######## setup.py ########
 
-from Cython.Build.Dependencies import cythonize
-from distutils.core import setup
+from Cython.Build import cythonize
+from setuptools import setup, Extension
 
-ext_modules = []
+ext_modules = [
+    Extension('default', ['default.py']),
+    Extension('compatible', ['compatible.py']),
+    Extension('incompatible', ['incompatible.py']),
+    Extension('default_single',
+              ['default_single.py'],
+              define_macros=[('CYTHON_PEP489_MULTI_PHASE_INIT', '0')]),
+    Extension('compatible_single',
+              ['compatible_single.py'],
+              define_macros=[('CYTHON_PEP489_MULTI_PHASE_INIT', '0')]),
+    Extension('incompatible_single',
+              ['incompatible_single.py'],
+              define_macros=[('CYTHON_PEP489_MULTI_PHASE_INIT', '0')]),
+]
 
-# Test language_level specified in the cythonize() call
-ext_modules += cythonize("default.py")
-ext_modules += cythonize("compatible.py")
-ext_modules += cythonize("incompatible.py")
-
-setup(ext_modules=ext_modules)
+setup(ext_modules=cythonize(ext_modules))
 
 ######## default.py ########
 
@@ -38,6 +49,37 @@ def test():
     assert not sys._is_gil_enabled()
 
 ######## incompatible.py ########
+
+# cython: freethreading_compatible=False
+
+def test():
+    import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
+    assert sys._is_gil_enabled()
+
+######## default_single.py ########
+
+def test():
+    import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
+    assert sys._is_gil_enabled()
+
+######## compatible_single.py ########
+
+# cython: freethreading_compatible=True
+
+def test():
+    import sys
+    import sysconfig
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
+    assert not sys._is_gil_enabled()
+
+######## incompatible_single.py ########
 
 # cython: freethreading_compatible=False
 


### PR DESCRIPTION
Closes #6239.

The reason this is still a draft is that the test should only run under the free-threaded build. Is that something we can do easily? I saw the mechanism that includes limited api tests, but that seems more complex.