### PR TITLE
Add option to silence IF deprecation warning

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -235,6 +235,7 @@ _directive_defaults = {
     'warn.unused_arg': False,
     'warn.unused_result': False,
     'warn.multiple_declarators': True,
+    'warn.deprecated_if': True,
     'show_performance_hints': True,
 
 # optimizations

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -235,7 +235,7 @@ _directive_defaults = {
     'warn.unused_arg': False,
     'warn.unused_result': False,
     'warn.multiple_declarators': True,
-    # 'warn.deprecated.DEF': True,
+    'warn.deprecated.DEF': False,
     'warn.deprecated.IF': True,
     'show_performance_hints': True,
 

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -235,7 +235,8 @@ _directive_defaults = {
     'warn.unused_arg': False,
     'warn.unused_result': False,
     'warn.multiple_declarators': True,
-    'warn.deprecated_if': True,
+    # 'warn.deprecated.DEF': True,
+    'warn.deprecated.IF': True,
     'show_performance_hints': True,
 
 # optimizations

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2528,6 +2528,7 @@ def p_IF_statement(s: PyrexScanner, ctx):
 @cython.cfunc
 def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = 0):
     cdef_flag = ctx.cdef_flag
+    warn_deprecated_if = s.context.compiler_directives.get("warn.deprecated_if", False)
     decorators = None
     if s.sy == 'ctypedef':
         if ctx.level not in ('module', 'module_pxd'):
@@ -2544,10 +2545,11 @@ def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = 0):
         #         "See https://github.com/cython/cython/issues/4310", level=1)
         return p_DEF_statement(s)
     elif s.sy == 'IF':
-        warning(s.position(),
-                "The 'IF' statement is deprecated and will be removed in a future Cython version. "
-                "Consider using runtime conditions or C macros instead. "
-                "See https://github.com/cython/cython/issues/4310", level=1)
+        if warn_deprecated_if:
+            warning(s.position(),
+                    "The 'IF' statement is deprecated and will be removed in a future Cython version. "
+                    "Consider using runtime conditions or C macros instead. "
+                    "See https://github.com/cython/cython/issues/4310", level=1)
         return p_IF_statement(s, ctx)
     elif s.sy == '@':
         if ctx.level not in ('module', 'class', 'c_class', 'function', 'property', 'module_pxd', 'c_class_pxd', 'other'):

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2528,7 +2528,6 @@ def p_IF_statement(s: PyrexScanner, ctx):
 @cython.cfunc
 def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = 0):
     cdef_flag = ctx.cdef_flag
-    warn_deprecated_if = s.context.compiler_directives.get("warn.deprecated_if", False)
     decorators = None
     if s.sy == 'ctypedef':
         if ctx.level not in ('module', 'module_pxd'):
@@ -2539,13 +2538,14 @@ def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = 0):
     elif s.sy == 'DEF':
         # We used to dep-warn about this but removed the warning again since
         # we don't have a good answer yet for all use cases.
-        # warning(s.position(),
-        #         "The 'DEF' statement is deprecated and will be removed in a future Cython version. "
-        #         "Consider using global variables, constants, and in-place literals instead. "
-        #         "See https://github.com/cython/cython/issues/4310", level=1)
+        # if s.context.compiler_directives.get("warn.deprecated.DEF", True):
+        #     warning(s.position(),
+        #             "The 'DEF' statement  will be removed in a future Cython version. "
+        #             "Consider using global variables, constants, and in-place literals instead. "
+        #             "See https://github.com/cython/cython/issues/4310", level=1)
         return p_DEF_statement(s)
     elif s.sy == 'IF':
-        if warn_deprecated_if:
+        if s.context.compiler_directives.get("warn.deprecated.IF", True):
             warning(s.position(),
                     "The 'IF' statement is deprecated and will be removed in a future Cython version. "
                     "Consider using runtime conditions or C macros instead. "

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2538,11 +2538,11 @@ def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = 0):
     elif s.sy == 'DEF':
         # We used to dep-warn about this but removed the warning again since
         # we don't have a good answer yet for all use cases.
-        # if s.context.compiler_directives.get("warn.deprecated.DEF", True):
-        #     warning(s.position(),
-        #             "The 'DEF' statement  will be removed in a future Cython version. "
-        #             "Consider using global variables, constants, and in-place literals instead. "
-        #             "See https://github.com/cython/cython/issues/4310", level=1)
+        if s.context.compiler_directives.get("warn.deprecated.DEF", False):
+            warning(s.position(),
+                    "The 'DEF' statement  will be removed in a future Cython version. "
+                    "Consider using global variables, constants, and in-place literals instead. "
+                    "See https://github.com/cython/cython/issues/4310", level=1)
         return p_DEF_statement(s)
     elif s.sy == 'IF':
         if s.context.compiler_directives.get("warn.deprecated.IF", True):

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1062,9 +1062,9 @@ to turn the warning on / off.
    For example ``cdef double* a, b`` - which, as in C, declares ``a`` as a pointer, ``b`` as
    a value type, but could be mininterpreted as declaring two pointers.
 
-.. ``warn.deprecated.DEF`` (default True)
-..   Warns about use of the deprecated ``DEF`` statement in Cython code, see
-..  :ref:`conditional_compilation` and :ref:`deprecated_DEF_IF`.
+``warn.deprecated.DEF`` (default False)
+  Warns about use of the deprecated ``DEF`` statement in Cython code, see
+ :ref:`conditional_compilation` and :ref:`deprecated_DEF_IF`.
 
 ``warn.deprecated.IF`` (default True)
   Warns about use of the deprecated ``IF`` statement in Cython code, see

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -787,7 +787,7 @@ Cython code.  Here is the list of currently supported directives:
     Default is True.
 
     .. versionchanged:: 3.0.0
-        Default changed from False to True
+        Default changed from False to True 
 
 ``boundscheck``  (True / False)
     If set to False, Cython is free to assume that indexing operations
@@ -817,9 +817,9 @@ Cython code.  Here is the list of currently supported directives:
 
 ``initializedcheck`` (True / False)
     If set to True, Cython checks that
-     - a memoryview is initialized whenever its elements are accessed
+     - a memoryview is initialized whenever its elements are accessed 
        or assigned to.
-     - a C++ class is initialized when it is accessed
+     - a C++ class is initialized when it is accessed 
        (only when ``cpp_locals`` is on)
 
     Setting this to False disables these checks.
@@ -885,17 +885,17 @@ Cython code.  Here is the list of currently supported directives:
     division is performed with negative operands.  See `CEP 516
     <https://github.com/cython/cython/wiki/enhancements-division>`_.  Default is
     False.
-
+    
 ``cpow`` (True / False)
     ``cpow`` modifies the return type of ``a**b``, as shown in the
     table below:
-
+    
         .. csv-table:: cpow behaviour
             :file: cpow_table.csv
             :header-rows: 1
             :class: longtable
             :widths: 1 1 3 3
-
+    
     The ``cpow==True`` behaviour largely keeps the result type the
     same as the operand types, while the ``cpow==False`` behaviour
     follows Python and returns a flexible type depending on the
@@ -1062,9 +1062,13 @@ to turn the warning on / off.
    For example ``cdef double* a, b`` - which, as in C, declares ``a`` as a pointer, ``b`` as
    a value type, but could be mininterpreted as declaring two pointers.
 
-``warn.deprecated_if`` (default True)
+.. ``warn.deprecated.DEF`` (default True)
+..   Warns about use of the deprecated ``DEF`` statement in Cython code, see
+..  :ref:`conditional_compilation` and :ref:`deprecated_DEF_IF`.
+
+``warn.deprecated.IF`` (default True)
   Warns about use of the deprecated ``IF`` statement in Cython code, see
-  :ref:`conditional_compilation`.
+  :ref:`conditional_compilation` and :ref:`deprecated_DEF_IF`.
 
 ``show_performance_hints`` (default True)
   Show performance hints during compilation pointing to places in the code which can yield performance degradation.
@@ -1156,14 +1160,14 @@ the feature at runtime, at the before mentioned cost of longer C compile times a
 This can be configured with the C macro
 
 ``CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1``
-
+  
 To then change the behaviour at runtime, you can import the special module ``cython_runtime``
 after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
 to either true or false to control the behaviour as your Cython code is being run::
 
     import cython_runtime
     cython_runtime.cline_in_traceback = True
-
+    
     raise ValueError(5)
 
 If both macros are *not* defined by the build setup or ``CFLAGS``, the feature is disabled.
@@ -1215,7 +1219,7 @@ most important to least important:
     Defines ``cdef classes`` as `"heap types" <https://docs.python.org/3/c-api/typeobj.html#heap-types>`_
     rather than "static types".  Practically this does not change a lot from a user
     point of view, but it is needed to implement Limited API support.
-
+    
 ``CYTHON_EXTERN_C``
     Slightly different to the other macros, this controls how ``cdef public``
     functions appear to C++ code. See :ref:`CYTHON_EXTERN_C` for full details.
@@ -1223,7 +1227,7 @@ most important to least important:
 ``CYTHON_CLINE_IN_TRACEBACK``
     Controls whether C lines numbers appear in tracebacks.
     See :ref:`cline_in_traceback` for a complete description.
-
+    
 There is a further list of macros which turn off various optimizations or language
 features.  Under normal circumstance Cython enables these automatically based on the
 version of Python you are compiling for so there is no need to use them
@@ -1235,73 +1239,73 @@ hidden by default since most users will be uninterested in changing them.
 
 .. tabs::
     .. tab:: Hide
-
+    
     .. tab:: Show
-
+        
         ``CYTHON_USE_TYPE_SLOTS``
             If enabled, Cython will directly access members of the ``PyTypeObject``
             struct.
-
+            
         ``CYTHON_USE_PYTYPE_LOOKUP``
             Use the internal `_PyType_Lookup()` function for more efficient access
             to properties of C classes.
-
+            
         ``CYTHON_USE_ASYNC_SLOTS``
             Support the ``tp_as_async`` attribute on type objects.
-
+            
         ``CYTHON_USE_PYLONG_INTERNALS``/``CYTHON_USE_PYLIST_INTERNALS``/``CYTHON_USE_UNICODE_INTERNALS``
             Enable optimizations based on direct access into the internals of Python
             ``int``/``list``/``unicode`` objects respectively.
-
+            
         ``CYTHON_USE_UNICODE_WRITER``
             Use a faster (but internal) mechanism for building unicode strings, for
             example in f-strings.
-
+            
         ``CYTHON_AVOID_BORROWED_REFS``
             Avoid using "borrowed references" and ensure that Cython always holds
             a reference to objects it manipulates.  Most useful for
             non-reference-counted implementations of Python, like PyPy
             (where it is enabled by default).
-
+            
         ``CYTHON_ASSUME_SAFE_MACROS``
             Use some C-API macros that increase performance by skipping error checking,
             which may not be safe on all Python implementations (e.g. PyPy).
-
+            
         ``CYTHON_ASSUME_SAFE_SIZE``
             Prefer the ``Py*_GET_SIZE()`` C-API macros / inline-functions for builtin types
             over their ``Py*_GetSize()`` counterparts if errors are not expected.
 
         ``CYTHON_FAST_GIL``
             On some Python versions this speeds up getting/releasing the GIL.
-
+            
         ``CYTHON_UNPACK_METHODS``
             Try to speed up method calls at the cost of code-size.  Linked to
             the ``optimize.unpack_method_calls`` compiler directive - this macro
             is used to selectively enable the compiler directive only on versions
             of Python that support it.
-
+            
         ``CYTHON_METH_FASTCALL``/``CYTHON_FAST_PYCALL``
             These are used internally to incrementally enable the vectorcall calling
             mechanism on older Python versions (<3.8).
-
+            
         ``CYTHON_PEP487_INIT_SUBCLASS``
             Enable `PEP-487 <https://peps.python.org/pep-0487/>`_ ``__init_subclass__`` behaviour.
-
+            
         ``CYTHON_USE_TP_FINALIZE``
             Use the ``tp_finalize`` type-slot instead of ``tp_dealloc``,
             as described in `PEP-442 <https://peps.python.org/pep-0442/>`_.
-
+            
         ``CYTHON_USE_DICT_VERSIONS``
             Try to optimize attribute lookup by using versioned dictionaries
             where supported.
-
+            
         ``CYTHON_USE_EXC_INFO_STACK``
             Use an internal structure to track exception state,
             used in CPython 3.7 and later.
-
+            
         ``CYTHON_UPDATE_DESCRIPTOR_DOC``
             Attempt to provide docstrings also for special (double underscore) methods.
-
+            
         ``CYTHON_USE_FREELISTS``
             Enable the use of freelists on extension types with
             :ref:`the @cython.freelist decorator<freelist>`.
@@ -1309,3 +1313,5 @@ hidden by default since most users will be uninterested in changing them.
         ``CYTHON_ATOMICS``
             Enable the use of atomic reference counting (as opposed to locking then
             reference counting) in Cython typed memoryviews.
+            
+            

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -787,7 +787,7 @@ Cython code.  Here is the list of currently supported directives:
     Default is True.
 
     .. versionchanged:: 3.0.0
-        Default changed from False to True 
+        Default changed from False to True
 
 ``boundscheck``  (True / False)
     If set to False, Cython is free to assume that indexing operations
@@ -817,9 +817,9 @@ Cython code.  Here is the list of currently supported directives:
 
 ``initializedcheck`` (True / False)
     If set to True, Cython checks that
-     - a memoryview is initialized whenever its elements are accessed 
+     - a memoryview is initialized whenever its elements are accessed
        or assigned to.
-     - a C++ class is initialized when it is accessed 
+     - a C++ class is initialized when it is accessed
        (only when ``cpp_locals`` is on)
 
     Setting this to False disables these checks.
@@ -885,17 +885,17 @@ Cython code.  Here is the list of currently supported directives:
     division is performed with negative operands.  See `CEP 516
     <https://github.com/cython/cython/wiki/enhancements-division>`_.  Default is
     False.
-    
+
 ``cpow`` (True / False)
     ``cpow`` modifies the return type of ``a**b``, as shown in the
     table below:
-    
+
         .. csv-table:: cpow behaviour
             :file: cpow_table.csv
             :header-rows: 1
             :class: longtable
             :widths: 1 1 3 3
-    
+
     The ``cpow==True`` behaviour largely keeps the result type the
     same as the operand types, while the ``cpow==False`` behaviour
     follows Python and returns a flexible type depending on the
@@ -1061,7 +1061,11 @@ to turn the warning on / off.
    Warns about multiple variables declared on the same line with at least one pointer type.
    For example ``cdef double* a, b`` - which, as in C, declares ``a`` as a pointer, ``b`` as
    a value type, but could be mininterpreted as declaring two pointers.
-   
+
+``warn.deprecated_if`` (default True)
+  Warns about use of the deprecated ``IF`` statement in Cython code, see
+  :ref:`conditional_compilation`.
+
 ``show_performance_hints`` (default True)
   Show performance hints during compilation pointing to places in the code which can yield performance degradation.
   Note that performance hints are not warnings and hence the directives starting with ``warn.`` above do not affect them
@@ -1152,14 +1156,14 @@ the feature at runtime, at the before mentioned cost of longer C compile times a
 This can be configured with the C macro
 
 ``CYTHON_CLINE_IN_TRACEBACK_RUNTIME=1``
-  
+
 To then change the behaviour at runtime, you can import the special module ``cython_runtime``
 after loading a Cython module and set the attribute ``cline_in_traceback`` in that module
 to either true or false to control the behaviour as your Cython code is being run::
 
     import cython_runtime
     cython_runtime.cline_in_traceback = True
-    
+
     raise ValueError(5)
 
 If both macros are *not* defined by the build setup or ``CFLAGS``, the feature is disabled.
@@ -1211,7 +1215,7 @@ most important to least important:
     Defines ``cdef classes`` as `"heap types" <https://docs.python.org/3/c-api/typeobj.html#heap-types>`_
     rather than "static types".  Practically this does not change a lot from a user
     point of view, but it is needed to implement Limited API support.
-    
+
 ``CYTHON_EXTERN_C``
     Slightly different to the other macros, this controls how ``cdef public``
     functions appear to C++ code. See :ref:`CYTHON_EXTERN_C` for full details.
@@ -1219,7 +1223,7 @@ most important to least important:
 ``CYTHON_CLINE_IN_TRACEBACK``
     Controls whether C lines numbers appear in tracebacks.
     See :ref:`cline_in_traceback` for a complete description.
-    
+
 There is a further list of macros which turn off various optimizations or language
 features.  Under normal circumstance Cython enables these automatically based on the
 version of Python you are compiling for so there is no need to use them
@@ -1231,73 +1235,73 @@ hidden by default since most users will be uninterested in changing them.
 
 .. tabs::
     .. tab:: Hide
-    
+
     .. tab:: Show
-        
+
         ``CYTHON_USE_TYPE_SLOTS``
             If enabled, Cython will directly access members of the ``PyTypeObject``
             struct.
-            
+
         ``CYTHON_USE_PYTYPE_LOOKUP``
             Use the internal `_PyType_Lookup()` function for more efficient access
             to properties of C classes.
-            
+
         ``CYTHON_USE_ASYNC_SLOTS``
             Support the ``tp_as_async`` attribute on type objects.
-            
+
         ``CYTHON_USE_PYLONG_INTERNALS``/``CYTHON_USE_PYLIST_INTERNALS``/``CYTHON_USE_UNICODE_INTERNALS``
             Enable optimizations based on direct access into the internals of Python
             ``int``/``list``/``unicode`` objects respectively.
-            
+
         ``CYTHON_USE_UNICODE_WRITER``
             Use a faster (but internal) mechanism for building unicode strings, for
             example in f-strings.
-            
+
         ``CYTHON_AVOID_BORROWED_REFS``
             Avoid using "borrowed references" and ensure that Cython always holds
             a reference to objects it manipulates.  Most useful for
             non-reference-counted implementations of Python, like PyPy
             (where it is enabled by default).
-            
+
         ``CYTHON_ASSUME_SAFE_MACROS``
             Use some C-API macros that increase performance by skipping error checking,
             which may not be safe on all Python implementations (e.g. PyPy).
-            
+
         ``CYTHON_ASSUME_SAFE_SIZE``
             Prefer the ``Py*_GET_SIZE()`` C-API macros / inline-functions for builtin types
             over their ``Py*_GetSize()`` counterparts if errors are not expected.
 
         ``CYTHON_FAST_GIL``
             On some Python versions this speeds up getting/releasing the GIL.
-            
+
         ``CYTHON_UNPACK_METHODS``
             Try to speed up method calls at the cost of code-size.  Linked to
             the ``optimize.unpack_method_calls`` compiler directive - this macro
             is used to selectively enable the compiler directive only on versions
             of Python that support it.
-            
+
         ``CYTHON_METH_FASTCALL``/``CYTHON_FAST_PYCALL``
             These are used internally to incrementally enable the vectorcall calling
             mechanism on older Python versions (<3.8).
-            
+
         ``CYTHON_PEP487_INIT_SUBCLASS``
             Enable `PEP-487 <https://peps.python.org/pep-0487/>`_ ``__init_subclass__`` behaviour.
-            
+
         ``CYTHON_USE_TP_FINALIZE``
             Use the ``tp_finalize`` type-slot instead of ``tp_dealloc``,
             as described in `PEP-442 <https://peps.python.org/pep-0442/>`_.
-            
+
         ``CYTHON_USE_DICT_VERSIONS``
             Try to optimize attribute lookup by using versioned dictionaries
             where supported.
-            
+
         ``CYTHON_USE_EXC_INFO_STACK``
             Use an internal structure to track exception state,
             used in CPython 3.7 and later.
-            
+
         ``CYTHON_UPDATE_DESCRIPTOR_DOC``
             Attempt to provide docstrings also for special (double underscore) methods.
-            
+
         ``CYTHON_USE_FREELISTS``
             Enable the use of freelists on extension types with
             :ref:`the @cython.freelist decorator<freelist>`.
@@ -1305,5 +1309,3 @@ hidden by default since most users will be uninterested in changing them.
         ``CYTHON_ATOMICS``
             Enable the use of atomic reference counting (as opposed to locking then
             reference counting) in Cython typed memoryviews.
-            
-            


### PR DESCRIPTION
Over in https://github.com/h5py/h5py/pull/2444 the GitHub actions logs get clogged with hundreds/thousands of:
```
  warning: h5py/api_types_hdf5.pxd:710:2: The 'IF' statement is deprecated and will be removed in a future Cython version. Consider using runtime conditions or C macros instead. See https://github.com/cython/cython/issues/4310
```
The proper solution is to fix these. But in the meantime, it would be nice if I could:

1. Open a GitHub issue about it for `h5py` to keep track of it with milestones etc., and
2. Silence the warnings in the meantime so the build logs are more readable

This PR moves toward (2). Consider it a proposal-as-PR so feel free to close if it's not the way to go -- I wanted to see if it was doable *at all* and it turned out not to be too bad to get something that worked for h5py at least, where we could with this PR do `cythonize(..., compiler_directives={'warn.deprecated_if': False})`.
