### PR TITLE
Fix test_dataclasses for Python 3.13

### DIFF
--- a/Tools/dataclass_test_data/test_dataclasses.py
+++ b/Tools/dataclass_test_data/test_dataclasses.py
@@ -3739,10 +3739,11 @@ class TestReplace(unittest.TestCase):
         self.assertEqual((c1.x, c1.y), (5, 10))
 
         # Trying to replace y is an error.
-        with self.assertRaisesRegex(ValueError, 'init=False'):
+        # Tests modified to account for changed exception in Python 3.13
+        with self.assertRaisesRegex((ValueError, TypeError), 'init=False'):
             replace(c, x=2, y=30)
 
-        with self.assertRaisesRegex(ValueError, 'init=False'):
+        with self.assertRaisesRegex((ValueError, TypeError), 'init=False'):
             replace(c, y=30)
 
     def test_classvar(self):
@@ -3775,7 +3776,8 @@ class TestReplace(unittest.TestCase):
 
         c = C(1, 10)
         self.assertEqual(c.x, 10)
-        with self.assertRaisesRegex(ValueError, r"InitVar 'y' must be "
+        # Note - test modified to account for change in exception in Python 3.13
+        with self.assertRaisesRegex((ValueError, TypeError), r"InitVar 'y' must be "
                                     "specified with replace()"):
             replace(c, x=3)
         c = replace(c, x=3, y=5)

--- a/tests/run/test_dataclasses.pyx
+++ b/tests/run/test_dataclasses.pyx
@@ -1219,9 +1219,9 @@ class TestReplace(unittest.TestCase):
         c.y = 20
         c1 = replace(c, x=5)
         self.assertEqual((c1.x, c1.y), (5, 10))
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, TypeError)):
             replace(c, x=2, y=30)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, TypeError)):
             replace(c, y=30)
 
     def test_classvar(self):
@@ -1238,7 +1238,7 @@ class TestReplace(unittest.TestCase):
         C = C_TestReplace_test_initvar_is_specified
         c = C(1, 10)
         self.assertEqual(c.x, 10)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, TypeError)):
             replace(c, x=3)
         c = replace(c, x=3, y=5)
         self.assertEqual(c.x, 15)


### PR DESCRIPTION
An exception changed.

Part of #6251