### PR TITLE
malloc -> PyMem_Malloc in MergeVTables

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -765,12 +765,6 @@ bad:
 /////////////// MergeVTables.proto ///////////////
 //@requires: GetVTable
 
-#ifdef __cplusplus
-#include <cstdlib>
-#else
-#include <stdlib.h>
-#endif
-
 static int __Pyx_MergeVtables(PyTypeObject *type); /*proto*/
 
 /////////////// MergeVTables ///////////////

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -765,6 +765,12 @@ bad:
 /////////////// MergeVTables.proto ///////////////
 //@requires: GetVTable
 
+#ifdef __cplusplus
+#include <cstdlib>
+#else
+#include <stdlib.h>
+#endif
+
 static int __Pyx_MergeVtables(PyTypeObject *type); /*proto*/
 
 /////////////// MergeVTables ///////////////

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -785,7 +785,7 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
             base = __Pyx_PyType_GetSlot(base, tp_base, PyTypeObject*);
         }
     }
-    base_vtables = (void**) malloc(sizeof(void*) * (size_t)(base_depth + 1));
+    base_vtables = (void**) PyMem_Malloc(sizeof(void*) * (size_t)(base_depth + 1));
     base_vtables[0] = unknown;
     // Could do MRO resolution of individual methods in the future, assuming
     // compatible vtables, but for now simply require a common vtable base.
@@ -834,7 +834,7 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
         }
     }
     PyErr_Clear();
-    free(base_vtables);
+    PyMem_Free(base_vtables);
     return 0;
 bad:
     {
@@ -865,7 +865,7 @@ really_bad: // bad has failed!
 #if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_AVOID_BORROWED_REFS || !CYTHON_ASSUME_SAFE_MACROS
 other_failure:
 #endif
-    free(base_vtables);
+    PyMem_Free(base_vtables);
     return -1;
 }
 


### PR DESCRIPTION
`malloc` was generating warnings in some limited API builds because it wasn't included (so we'd need to have included in directly). Use `PyMem_Malloc` instead.