### PR TITLE
[3.0.x] Revert changes to hasattr for Py3.13

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -170,16 +170,11 @@ static CYTHON_INLINE PyObject *__Pyx_GetAttr3(PyObject *o, PyObject *n, PyObject
 
 //////////////////// HasAttr.proto ////////////////////
 
-#if __PYX_LIMITED_VERSION_HEX >= 0x030d00A1
-#define __Pyx_HasAttr(o, n)  PyObject_HasAttrWithError(o, n)
-#else
 static CYTHON_INLINE int __Pyx_HasAttr(PyObject *, PyObject *); /*proto*/
-#endif
 
 //////////////////// HasAttr ////////////////////
 //@requires: ObjectHandling.c::GetAttr
 
-#if __PYX_LIMITED_VERSION_HEX < 0x030d00A1
 static CYTHON_INLINE int __Pyx_HasAttr(PyObject *o, PyObject *n) {
     PyObject *r;
     if (unlikely(!__Pyx_PyBaseString_Check(n))) {
@@ -196,7 +191,6 @@ static CYTHON_INLINE int __Pyx_HasAttr(PyObject *o, PyObject *n) {
         return 1;
     }
 }
-#endif
 
 //////////////////// Intern.proto ////////////////////
 


### PR DESCRIPTION
Revert one of the changes in fd9644342c0a7af885e103677e407173428162b9. This leads to the behaviour of hasattr being inconsistent between Python 3.13 and earlier versions since in 3.13 it propagates exceptions.

Part of #6251