### PR TITLE
Change hasattr to Python 3 behaviour

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -189,7 +189,7 @@ static CYTHON_INLINE int __Pyx_HasAttr(PyObject *, PyObject *); /*proto*/
 #endif
 
 //////////////////// HasAttr ////////////////////
-//@requires: ObjectHandling.c::GetAttr
+//@requires: ObjectHandling.c::PyObjectGetAttrStrNoError
 
 #if __PYX_LIMITED_VERSION_HEX < 0x030d00A1
 static CYTHON_INLINE int __Pyx_HasAttr(PyObject *o, PyObject *n) {
@@ -199,10 +199,9 @@ static CYTHON_INLINE int __Pyx_HasAttr(PyObject *o, PyObject *n) {
                         "hasattr(): attribute name must be string");
         return -1;
     }
-    r = __Pyx_GetAttr(o, n);
+    r = __Pyx_PyObject_GetAttrStrNoError(o, n);
     if (!r) {
-        PyErr_Clear();
-        return 0;
+        return (unlikely(PyErr_Occurred())) ? -1 : 0;
     } else {
         Py_DECREF(r);
         return 1;

--- a/tests/run/hasattr.py
+++ b/tests/run/hasattr.py
@@ -1,4 +1,5 @@
 # mode: run
+# tag: pure
 
 class Foo:
     @property
@@ -32,12 +33,7 @@ def wrap_hasattr(obj, name):
     >>> Foo().baz   #doctest: +ELLIPSIS
     Traceback (most recent call last):
     ZeroDivisionError: ...
-    >>> import sys
-    >>> if sys.version_info < (3,13): wrap_hasattr(Foo(), "baz")  # doctest: +ELLIPSIS
-    ... else: print(False)
-    False
-    >>> if sys.version_info >= (3,13): wrap_hasattr(Foo(), "baz")  # doctest: +ELLIPSIS
-    ... else: raise ZeroDivisionError
+    >>> wrap_hasattr(Foo(), "baz")  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ZeroDivisionError...
     >>> hasattr(Foo(), None)   #doctest: +ELLIPSIS


### PR DESCRIPTION
For Cython 3.1. Change test to pure-py to demonstrate Python 3 behaviour.