### PR TITLE
Move more generated init code after user code

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2839,7 +2839,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
     def generate_import_star(self, env, code):
         env.use_utility_code(UtilityCode.load_cached("CStringEquals", "StringTools.c"))
-        code.start_initcfunc("int %s(PyObject *o, PyObject* py_name, const char *name)" % Naming.import_star_set)
+        code.start_initcfunc(f"int {Naming.import_star_set}(PyObject *o, PyObject* py_name, const char *name)")
 
         code.putln("static const char* internal_type_names[] = {")
         for name, entry in sorted(env.entries.items()):
@@ -3335,7 +3335,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             def __enter__(self):
                 self.call_code = orig_code.insertion_point()
                 code = function_code
-                code.start_initcfunc("int %s(void)" % self.cfunc_name, scope, refnanny=True)
+                code.start_initcfunc(f"int {self.cfunc_name}(void)", scope, refnanny=True)
                 self.tempdecl_code = code.insertion_point()
                 code.put_setup_refcount_context(EncodedString(self.cfunc_name))
                 # Leave a grepable marker that makes it easy to find the generator source.

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2020,6 +2020,7 @@ static CYTHON_INLINE void __Pyx_pretend_to_initialize(void* ptr) { (void)ptr; }
 
 
 //////////////////// NewCodeObj.proto ////////////////////////
+//@proto_block: init_codeobjects
 
 static PyObject* __Pyx_PyCode_New(
         //int argcount,

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -48,6 +48,7 @@ static CYTHON_INLINE size_t __Pyx_Py_UNICODE_strlen(const Py_UNICODE *u)
 
 
 //////////////////// InitStrings.proto ////////////////////
+//@proto_block: pystring_table
 
 static int __Pyx_InitStrings(__Pyx_StringTabEntry const *t, PyObject **target, const char* const* encoding_names); /*proto*/
 


### PR DESCRIPTION
Moves boilerplate code out of sight for users, more towards the end of the C file.
Refactors some of the code generation to use more f-strings and avoid repetition.
