### PR TITLE
Fix module cleanup for global memoryview slices.

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1689,6 +1689,14 @@ class GlobalState:
                 # which aren't necessarily PyObjects, so aren't appropriate
                 # to clear.
                 continue
+            if c.type.is_memoryviewslice:
+                self.parts['module_state_clear'].put_xdecref_clear(
+                    f"clear_module_state->{cname}",
+                    c.type,
+                    nanny=False,
+                )
+                continue
+
             self.parts['module_state_clear'].putln(
                 "Py_CLEAR(clear_module_state->%s);" % cname)
             self.parts['module_state_traverse'].putln(

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1689,18 +1689,20 @@ class GlobalState:
                 # which aren't necessarily PyObjects, so aren't appropriate
                 # to clear.
                 continue
-            if c.type.is_memoryviewslice:
-                self.parts['module_state_clear'].put_xdecref_clear(
-                    f"clear_module_state->{cname}",
-                    c.type,
-                    nanny=False,
-                )
-                continue
 
-            self.parts['module_state_clear'].putln(
-                "Py_CLEAR(clear_module_state->%s);" % cname)
+            self.parts['module_state_clear'].put_xdecref_clear(
+                f"clear_module_state->{cname}",
+                c.type,
+                clear_before_decref=True,
+                nanny=False,
+            )
+
+            if c.type.is_memoryviewslice:
+                # TODO: Implement specific to type like CodeWriter.put_xdecref_clear()
+                cname += "->memview"
+
             self.parts['module_state_traverse'].putln(
-                "Py_VISIT(traverse_module_state->%s);" % cname)
+                f"Py_VISIT(traverse_module_state->{cname});")
 
         for prefix, count in sorted(self.const_array_counters.items()):
             # name the struct attribute and the global "define" slightly differently


### PR DESCRIPTION
Previously, we called Py_VISIT() and Py_CLEAR() on them, which is wrong.

Probably needs backporting to 3.0.x.