### PR TITLE
Unset PYTHON_GIL env variable in freethreading_compatible tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2012,6 +2012,13 @@ class EndToEndTest(unittest.TestCase):
         out = []
         err = []
         for command_no, command in enumerate(self.commands, 1):
+            if command[0] == "UNSET":
+                try:
+                    envvar = command[1]
+                except KeyError:
+                    envvar = None
+                env.pop(envvar, None)
+                continue
             time_category = 'etoe-build' if (
                 'setup.py' in command or 'cythonize.py' in command or 'cython.py' in command) else 'etoe-run'
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c', time_category):

--- a/tests/run/freethreading_compatible.srctree
+++ b/tests/run/freethreading_compatible.srctree
@@ -1,3 +1,4 @@
+UNSET PYTHON_GIL
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import default; default.test()"
 PYTHON -c "import compatible; compatible.test()"


### PR DESCRIPTION
This adds a mechanism to be able to unset environment variables in end-to-end tests and unsets `PYTHON_GIL` in `freethreading_compatible`. Not sure if it's the best solution.