### PR TITLE
Simply macros to enable Limited API mode

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -4,7 +4,7 @@
   // Use Py_LIMITED_API as the main control for Cython's limited API mode.
   // However it's still possible to define CYTHON_LIMITED_API alone to
   // force Cython to use Limited-API code without enforcing it in Python.
-  #define CYTHON_LIMITED_API
+  #define CYTHON_LIMITED_API 1
 #endif
 
 /////////////// CModulePreamble ///////////////

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1,15 +1,11 @@
 /////////////// InitLimitedAPI ///////////////
 
-#if defined(CYTHON_LIMITED_API) && 0  /* disabled: enabling Py_LIMITED_API needs more work */
-  #ifndef Py_LIMITED_API
-    #if CYTHON_LIMITED_API+0 > 0x03070000
-      #define Py_LIMITED_API CYTHON_LIMITED_API
-    #else
-      #define Py_LIMITED_API 0x03070000
-    #endif
-  #endif
+#if defined(Py_LIMITED_API) && !defined(CYTHON_LIMITED_API)
+  // Use Py_LIMITED_API as the main control for Cython's limited API mode.
+  // However it's still possible to define CYTHON_LIMITED_API alone to
+  // force Cython to use Limited-API code without enforcing it in Python.
+  #define CYTHON_LIMITED_API
 #endif
-
 
 /////////////// CModulePreamble ///////////////
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1195,13 +1195,16 @@ can happily ignore.  Not all combinations of macros are compatible or tested, an
 some change the default value of other macros.  They are listed below in rough order from
 most important to least important:
 
-``CYTHON_LIMITED_API``
+``Py_LIMITED_API``
     Turns on Cython's experimental Limited API support, meaning that one compiled module
     can be used by many Python interpreter versions (at the cost of some performance).
-    At this stage many features do not work in the Limited API.  If you use this macro
-    you should also set the macro ``Py_LIMITED_API`` to be the version hex for the
+    At this stage many features do not work in the Limited API.  You should set this
+    macro to be the version hex for the
     minimum Python version you want to support (>=3.7).  ``0x03070000`` will support
     Python 3.7 upwards.
+    Note that this is a `Python macro <https://docs.python.org/3/c-api/stable.html#c.Py_LIMITED_API>`_,
+    rather than just a Cython macro, and so it changes what parts of the Python headers
+    are visible too.
 
 ``CYTHON_PEP489_MULTI_PHASE_INIT``
     Uses multi-phase module initialization as described in PEP489.  This improves

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,6 @@ def compile_cython_modules(profile=False, coverage=False, compile_minimal=False,
     extra_extension_args = {}
     if cython_limited_api:
         defines += [
-            ('CYTHON_LIMITED_API', 1),
             ('Py_LIMITED_API', 0x03070000),
         ]
         extra_extension_args['py_limited_api'] = True

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -87,7 +87,7 @@ assert limited.float_equals(decimal.Decimal("1.5"))
 
 ##################### limited.pyx #############################
 
-# distutils: extra_compile_args = -DCYTHON_LIMITED_API=1 -DPy_LIMITED_API=0x030700f0
+# distutils: extra_compile_args = -DPy_LIMITED_API=0x030700f0
 
 import cython
 


### PR DESCRIPTION
Essentially:
* Py_LIMITED_API is sufficient to enable Limited API mode on Cython too since

  1. It isn't going to build without it.
  2. Most build systems are geared to defining this, so let's make it easy for them!

* CYTHON_LIMITED_API exists are an undocumented intermediate mode which turns on Limited API code generation in Cython, but doesn't affect the Python headers.