### PR TITLE
Optimize child_attrs property on non-CPython

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -463,7 +463,12 @@ class ExprNode(Node):
 
     constant_result = constant_value_not_set
 
-    child_attrs = property(fget=operator.attrgetter('subexprs'))
+    if sys.implementation.name == "cpython":
+        child_attrs = property(fget=operator.attrgetter('subexprs'))
+    else:
+        @property
+        def child_attrs(self):
+            return self.subexprs
 
     def analyse_annotations(self, env):
         pass


### PR DESCRIPTION
This propery was a measurable issue on GraalPython (profiling says ~17% of the total runtime, although replacing it only gets 9% speedup). PyPy also looks slightly faster with the more straightforward Python code.

As far as I can tell, in CPython this operator.attrgetter ends up in an optimized C code path so is probably worthwhile. In most other implementations it ends up in a slightly slow Python code-path that also loops over a list of attributes.

Since this property is looked up in TreeVisitor._visitchildren it ends up quite significant to the performance.