### PR TITLE
wheel CI: Update cibuildwheel to v2.20.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.19.2
+        run: pipx install cibuildwheel==2.20.0
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -111,7 +111,7 @@ jobs:
 
       - name: Build wheels
         # Nb. keep cibuildwheel version pin consistent with generate-matrix job above
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.20.0
         with:
           only: ${{ matrix.only }}
         # TODO: Cython tests take a long time to complete

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.16.5
+        run: pipx install cibuildwheel==2.19.2
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -111,7 +111,7 @@ jobs:
 
       - name: Build wheels
         # Nb. keep cibuildwheel version pin consistent with generate-matrix job above
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.2
         with:
           only: ${{ matrix.only }}
         # TODO: Cython tests take a long time to complete


### PR DESCRIPTION
This commit updates [cibuildwheel](https://github.com/pypa/cibuildwheel) to the latest version ([v2.20.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.20.0)) in the GitHub Actions `wheel.yml` CI workflow.

cibuildwheel 2.20.0 uses the ABI stable Python 3.13.0rc1 and build Python 3.13 wheels by default.

I think it would be really beneficial to automate these updates in some fashion, since they need to happen quite often and can be easily forgotten.