### PR TITLE
More robust Limited API SetItemOnTypeDict

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -729,7 +729,7 @@ static PyObject *__Pyx_GetTypeDict(PyTypeObject *tp) {
     // TODO - if we ever support custom metatypes for extension types then
     // we have to modify this caching.
     static Py_ssize_t tp_dictoffset = 0;
-    if (tp_dictoffset == 0) {
+    if (unlikely(tp_dictoffset == 0)) {
         tp_dictoffset = __Pyx_GetTypeDictOffset();
         // Note that negative dictoffsets are definitely allowed.
         // A dictoffset of -1 seems unlikely but isn't obviously forbidden.

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -733,6 +733,7 @@ static int __Pyx__SetItemOnTypeDict(PyTypeObject *tp, PyObject *k, PyObject *v) 
     PyObject *tp_dict;
 #if CYTHON_COMPILING_IN_LIMITED_API
     tp_dict = __Pyx_GetTypeDict(tp);
+    if (unlikely(!tp_dict)) return -1;
 #else
     tp_dict = tp->tp_dict;
 #endif
@@ -762,10 +763,11 @@ static int __Pyx__DelItemOnTypeDict(PyTypeObject *tp, PyObject *k) {
     PyObject *tp_dict;
 #if CYTHON_COMPILING_IN_LIMITED_API
     tp_dict = __Pyx_GetTypeDict(tp);
-    if (unlikely(!tp_dict)) return NULL;
+    if (unlikely(!tp_dict)) return -1;
 #else
-    result = PyDict_DelItem(tp->tp_dict, k);
+    tp_dict = tp->tp_dict;
 #endif
+    result = PyDict_DelItem(tp_dict, k);
     if (likely(!result)) PyType_Modified(tp);
     return result;
 }

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -685,7 +685,7 @@ static int __Pyx_call_type_traverse(PyObject *o, int always_call, visitproc visi
 
 #if CYTHON_COMPILING_IN_LIMITED_API
 // This is a little hacky - the Limited API works quite hard to stop us getting
-// the dict of a type object. But apparently not not hard enough...
+// the dict of a type object. But apparently not hard enough...
 //
 // In future we should prefer to work with mutable types, and then make them immutable
 // once we're done (pending C API support for this).

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -762,6 +762,7 @@ static int __Pyx__DelItemOnTypeDict(PyTypeObject *tp, PyObject *k) {
     PyObject *tp_dict;
 #if CYTHON_COMPILING_IN_LIMITED_API
     tp_dict = __Pyx_GetTypeDict(tp);
+    if (unlikely(!tp_dict)) return NULL;
 #else
     result = PyDict_DelItem(tp->tp_dict, k);
 #endif

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -696,25 +696,46 @@ static PyObject *__Pyx_GetTypeDict(PyTypeObject *tp); /* proto */
 
 #if CYTHON_COMPILING_IN_LIMITED_API
 static Py_ssize_t __Pyx_GetTypeDictOffset(void) {
-    // TODO - if we ever support custom metatypes for extension types then
-    // we have to drop this caching.
-    static Py_ssize_t tp_dictoffset = 0;
-    if (tp_dictoffset == 0) {
-        PyObject *tp_dictoffset_o = NULL;
-        tp_dictoffset_o = PyObject_GetAttrString((PyObject*)(&PyType_Type), "__dictoffset__");
-        if (unlikely(!tp_dictoffset_o)) return -1;
-        tp_dictoffset = PyLong_AsSsize_t(tp_dictoffset_o);
-        if (unlikely(tp_dictoffset == -1 && PyErr_Occurred())) {
-            tp_dictoffset = 0; // try again next time
-            return -1;
-        }
-    }
-    return tp_dictoffset;
+    PyObject *tp_dictoffset_o;
+    Py_ssize_t result;
+    tp_dictoffset_o = PyObject_GetAttrString((PyObject*)(&PyType_Type), "__dictoffset__");
+    if (unlikely(!tp_dictoffset_o)) return -1;
+    result = PyLong_AsSsize_t(tp_dictoffset_o);
+    Py_DECREF(tp_dictoffset_o);
+    return result;
 }
 
 static PyObject *__Pyx_GetTypeDict(PyTypeObject *tp) {
-    Py_ssize_t tp_dictoffset = __Pyx_GetTypeDictOffset();
-    if (unlikely(tp_dictoffset == -1 && PyErr_Occurred())) return NULL;
+    // TODO - if we ever support custom metatypes for extension types then
+    // we have to modify this caching.
+    static Py_ssize_t tp_dictoffset = 0;
+    if (tp_dictoffset == 0) {
+        tp_dictoffset = __Pyx_GetTypeDictOffset();
+        // Note that negative dictoffsets are definitely allowed.
+        // A dictoffset of -1 seems unlikely but isn't obviously
+        // forbidden.
+        if (unlikely(tp_dictoffset == -1 && PyErr_Occurred())) {
+            tp_dictoffset = 0; // try again next time?
+            return NULL;
+        }
+    }
+    if (unlikely(tp_dictoffset == 0)) {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "'type' doesn't have a dictoffset");
+        return NULL;
+    } else if (unlikely(tp_dictoffset < 0)) {
+        // This isn't completely future proof. dictoffset can be
+        // negative, but isn't in Python <=3.13 (current at time
+        // of writing).  It's awkward to calculate in the limited 
+        // API because we need to know the object size.  For now
+        // just raise an error and fix it if it every changes.
+        PyErr_SetString(
+            PyExc_TypeError,
+            "'type' has an unexpected negative dictoffset. "
+            "Report this as Cython bug");
+        return NULL;
+    }
     return *(PyObject**)((char*)tp + tp_dictoffset);
 }
 #endif


### PR DESCRIPTION
Instead of relying of PyObject_GenericSetAttr (which looks to have been updated in Python 3.14 to ban this usage) we instead work out where the type dict is from `__dictoffset__` and manipulate that.

Fixes #6323