### PR TITLE
Output import-relative paths in generated C code.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10213,7 +10213,7 @@ class CodeObjectNode(ExprNode):
         if os.path.isabs(file_path):
             file_path = func.pos[0].get_description()
         # Always use / as separator
-        file_path = str(pathlib.Path(file_path).as_posix())
+        file_path = pathlib.Path(file_path).as_posix()
         file_path = StringEncoding.bytes_literal(file_path.encode('utf-8'), 'utf8')
         file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10210,7 +10210,7 @@ class CodeObjectNode(ExprNode):
         # FIXME: better way to get the module file path at module init time? Encoding to use?
         file_path = func.pos[0].get_filenametable_entry()
         if os.path.isabs(file_path):
-            file_path = func.pos[0].get_description()
+            file_path = func.pos[0].get_description().replace('\\', '/')
         file_path = StringEncoding.bytes_literal(file_path.encode('utf-8'), 'utf8')
         file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10210,7 +10210,9 @@ class CodeObjectNode(ExprNode):
         # FIXME: better way to get the module file path at module init time? Encoding to use?
         file_path = func.pos[0].get_filenametable_entry()
         if os.path.isabs(file_path):
-            file_path = func.pos[0].get_description().replace('\\', '/')
+            file_path = func.pos[0].get_description()
+        # Always use / as separator
+        file_path = file_path.replace('\\', '/')
         file_path = StringEncoding.bytes_literal(file_path.encode('utf-8'), 'utf8')
         file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -19,6 +19,7 @@ import re
 import sys
 import copy
 import os.path
+import pathlib
 import operator
 
 from .Errors import (
@@ -10212,7 +10213,7 @@ class CodeObjectNode(ExprNode):
         if os.path.isabs(file_path):
             file_path = func.pos[0].get_description()
         # Always use / as separator
-        file_path = file_path.replace('\\', '/')
+        file_path = str(pathlib.Path(file_path).as_posix())
         file_path = StringEncoding.bytes_literal(file_path.encode('utf-8'), 'utf8')
         file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10208,7 +10208,10 @@ class CodeObjectNode(ExprNode):
         func_name_result = code.get_py_string_const(
             func.name, identifier=True, is_str=False, unicode_value=func.name)
         # FIXME: better way to get the module file path at module init time? Encoding to use?
-        file_path = StringEncoding.bytes_literal(func.pos[0].get_filenametable_entry().encode('utf8'), 'utf8')
+        file_path = func.pos[0].get_filenametable_entry()
+        if os.path.isabs(file_path):
+            file_path = func.pos[0].get_description()
+        file_path = StringEncoding.bytes_literal(file_path.encode('utf-8'), 'utf8')
         file_path_result = code.get_py_string_const(file_path, identifier=False, is_str=True)
 
         # '(CO_OPTIMIZED | CO_NEWLOCALS)' makes CPython create a new dict for "frame.f_locals".

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 import json
 import operator
 import os
+import pathlib
 import re
 import sys
 
@@ -967,7 +968,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     # never include absolute paths
                     file_path = source_desc.get_description()
                 # Always use / as separator
-                file_path = file_path.replace('\\', '/')
+                file_path = str(pathlib.Path(file_path).as_posix())
                 escaped_filename = as_encoded_filename(file_path)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())
         else:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -964,7 +964,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             for source_desc in code.globalstate.filename_list:
                 file_path = source_desc.get_filenametable_entry()
                 if isabs(file_path):
-                    file_path = basename(file_path)  # never include absolute paths
+                    file_path = source_desc.get_description()  # never include absolute paths
                 escaped_filename = file_path.replace("\\", "\\\\").replace('"', r'\"')
                 escaped_filename = as_encoded_filename(escaped_filename)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -968,7 +968,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     # never include absolute paths
                     file_path = source_desc.get_description()
                 # Always use / as separator
-                file_path = str(pathlib.Path(file_path).as_posix())
+                file_path = pathlib.Path(file_path).as_posix()
                 escaped_filename = as_encoded_filename(file_path)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())
         else:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -965,7 +965,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 file_path = source_desc.get_filenametable_entry()
                 if isabs(file_path):
                     # never include absolute paths
-                    file_path = source_desc.get_description().replace('\\', '/')
+                    file_path = source_desc.get_description()
+                # Always use / as separator
+                file_path = file_path.replace('\\', '/')
                 escaped_filename = as_encoded_filename(file_path)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())
         else:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -964,9 +964,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             for source_desc in code.globalstate.filename_list:
                 file_path = source_desc.get_filenametable_entry()
                 if isabs(file_path):
-                    file_path = source_desc.get_description()  # never include absolute paths
-                escaped_filename = file_path.replace("\\", "\\\\").replace('"', r'\"')
-                escaped_filename = as_encoded_filename(escaped_filename)
+                    # never include absolute paths
+                    file_path = source_desc.get_description().replace('\\', '/')
+                escaped_filename = as_encoded_filename(file_path)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())
         else:
             # Some C compilers don't like an empty array

--- a/runtests.py
+++ b/runtests.py
@@ -2047,7 +2047,7 @@ class EndToEndTest(unittest.TestCase):
                         self.shard_num, c, o, e))
                 sys.stderr.write("Final directory layout of '%s':\n%s\n\n" % (
                     self.name,
-                    '\n'.join(os.path.join(dirpath, filename) for dirpath, dirs, files in os.walk(".") for filename in files),
+                    '\n'.join(os.path.join(dirpath, filename) for dirpath, dirs, files in os.walk(self.workdir) for filename in files),
                 ))
                 self.assertEqual(0, res, "non-zero exit status, last output was:\n%r\n-- stdout:%s\n-- stderr:%s\n" % (
                     ' '.join(command), out[-1], err[-1]))

--- a/runtests.py
+++ b/runtests.py
@@ -2020,6 +2020,9 @@ class EndToEndTest(unittest.TestCase):
                     envvar = None
                 env.pop(envvar, None)
                 continue
+            elif command[0] == 'CD':
+                os.chdir(command[1] if len(command) > 1 else self.workdir)
+                continue
             time_category = 'etoe-build' if (
                 'setup.py' in command or 'cythonize.py' in command or 'cython.py' in command) else 'etoe-run'
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c', time_category):

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -1,18 +1,19 @@
 
 PYTHON check_paths_from_cython.py
 
-######## src/foo/__init__.py ########
+######## src/pkg/__init__.py ########
 
-# foo is a package and foo.bar is the module to build
+# __init__.py is needed because cython uses this to determine the
+# root of the package structure.
 
-######## src/foo/bar.pyx ########
+######## src/pkg/mod.pyx ########
 
 def func(x):
     return 2*x
 
-######## build/src/foo/placeholder.txt ########
+######## build/src/pkg/empty_build_output_directory.txt ########
 
-# Build outputs go in the build directory and cython is run from here.
+# Build outputs go in the "build/" directory and cython is run from there.
 
 ######## check_paths_from_cython.py ########
 
@@ -22,35 +23,24 @@ import subprocess
 python = sys.executable
 
 def cython(cmdstr, cwd=None):
-    argv = [sys.executable, '-m', 'cython'] + cmdstr.split()
+    argv = [python, '-m', 'cython'] + cmdstr.split()
     subprocess.run(argv, check=True, cwd=cwd)
 
-def grep(fname, pattern):
+def grep_paths(fname, pattern):
     with open(fname) as fin:
-        return [line for line in fin if pattern in line]
+        for line in fin:
+            if pattern in line:
+                [part] = [p for p in line.split() if pattern in p]
+                yield part.rstrip(',\n;:01234566789').strip('"')
 
-cython('-3 src/foo/bar.pyx -o build/src/foo/bar1.pyx.c')
-cython('-3 ../src/foo/bar.pyx -o src/foo/bar2.pyx.c', cwd='build')
+cython('-3 src/pkg/mod.pyx -o build/src/pkg/mod1.pyx.c')
+cython('-3 ../src/pkg/mod.pyx -o src/pkg/mod2.pyx.c', cwd='build')
 
-res1 = grep('build/src/foo/bar1.pyx.c', 'bar.pyx')
-res2 = grep('build/src/foo/bar2.pyx.c', 'bar.pyx')
+res1 = grep_paths('build/src/pkg/mod1.pyx.c', 'mod.pyx')
+res2 = grep_paths('build/src/pkg/mod2.pyx.c', 'mod.pyx')
 
-assert res1 == [
-    # Running cython on a file in CWD uses some paths relative to CWD.
-    '  "src/foo/bar.pyx",\n',
-    'static const char __pyx_k_src_foo_bar_pyx[] = "src/foo/bar.pyx";\n',
-    '/* "foo/bar.pyx":2\n',
-    '  /* "foo/bar.pyx":3\n',
-    '  /* "foo/bar.pyx":2\n',
-    '  /* "foo/bar.pyx":2\n'
-], '\n' + ''.join(res1)
+# Running cython on a file in CWD uses some paths relative to CWD.
+assert set(res1) == {"src/pkg/mod.pyx", "pkg/mod.pyx"}, str(res1)
 
-assert res2 == [
-    # When not in CWD all paths are relative to sys.path.
-    '  "foo/bar.pyx",\n',
-    'static const char __pyx_k_foo_bar_pyx[] = "foo/bar.pyx";\n',
-    '/* "foo/bar.pyx":2\n',
-    '  /* "foo/bar.pyx":3\n',
-    '  /* "foo/bar.pyx":2\n',
-    '  /* "foo/bar.pyx":2\n',
-], '\n' + ''.join(res2)
+# When not in CWD all paths are relative to sys.path.
+assert set(res2) == {"pkg/mod.pyx"}, str(res2)

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -36,11 +36,11 @@ def grep_paths(fname, pattern):
 cython('-3 src/pkg/mod.pyx -o build/src/pkg/mod1.pyx.c')
 cython('-3 ../src/pkg/mod.pyx -o src/pkg/mod2.pyx.c', cwd='build')
 
-res1 = grep_paths('build/src/pkg/mod1.pyx.c', 'mod.pyx')
-res2 = grep_paths('build/src/pkg/mod2.pyx.c', 'mod.pyx')
+res1 = set(grep_paths('build/src/pkg/mod1.pyx.c', 'mod.pyx'))
+res2 = set(grep_paths('build/src/pkg/mod2.pyx.c', 'mod.pyx'))
 
 # Running cython on a file in CWD uses some paths relative to CWD.
-assert set(res1) == {"src/pkg/mod.pyx", "pkg/mod.pyx"}, str(res1)
+assert res1 == {"src/pkg/mod.pyx", "pkg/mod.pyx"}, res1
 
 # When not in CWD all paths are relative to sys.path.
-assert set(res2) == {"pkg/mod.pyx"}, str(res2)
+assert res2 == {"pkg/mod.pyx"}, res2

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -1,4 +1,14 @@
+#
+# Check that when cython is run on a file not in CWD it does not output paths
+# that are either basename or absolute paths in the generated C code. Instead
+# import-relative paths are used like pkg/mod.pyx even if those are not valid
+# relative paths from CWD.
+#
 
+CYTHON src/pkg/mod.pyx -o build/src/pkg/mod1.pyx.c
+CD build
+CYTHON ../src/pkg/mod.pyx -o src/pkg/mod2.pyx.c
+CD ..
 PYTHON check_paths_from_cython.py
 
 ######## src/pkg/__init__.py ########
@@ -17,27 +27,15 @@ def func(x):
 
 ######## check_paths_from_cython.py ########
 
-import sys
-import subprocess
-
-python = sys.executable
-
-def cython(cmdstr, cwd=None):
-    argv = [python, '-m', 'cython'] + cmdstr.split()
-    subprocess.run(argv, check=True, cwd=cwd)
-
-def grep_paths(fname, pattern):
+def grep_paths(basename, fname):
     with open(fname) as fin:
         for line in fin:
-            if pattern in line:
-                [part] = [p for p in line.split() if pattern in p]
+            if basename in line:
+                [part] = [p for p in line.split() if basename in p]
                 yield part.rstrip(',\n;:01234566789').strip('"')
 
-cython('-3 src/pkg/mod.pyx -o build/src/pkg/mod1.pyx.c')
-cython('-3 ../src/pkg/mod.pyx -o src/pkg/mod2.pyx.c', cwd='build')
-
-res1 = set(grep_paths('build/src/pkg/mod1.pyx.c', 'mod.pyx'))
-res2 = set(grep_paths('build/src/pkg/mod2.pyx.c', 'mod.pyx'))
+res1 = set(grep_paths('mod.pyx', 'build/src/pkg/mod1.pyx.c'))
+res2 = set(grep_paths('mod.pyx', 'build/src/pkg/mod2.pyx.c'))
 
 # Running cython on a file in CWD uses some paths relative to CWD.
 assert res1 == {"src/pkg/mod.pyx", "pkg/mod.pyx"}, res1

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -1,0 +1,56 @@
+
+PYTHON check_paths_from_cython.py
+
+######## src/foo/__init__.py ########
+
+# foo is a package and foo.bar is the module to build
+
+######## src/foo/bar.pyx ########
+
+def func(x):
+    return 2*x
+
+######## build/src/foo/placeholder.txt ########
+
+# Build outputs go in the build directory and cython is run from here.
+
+######## check_paths_from_cython.py ########
+
+import sys
+import subprocess
+
+python = sys.executable
+
+def cython(cmdstr, cwd=None):
+    argv = [sys.executable, '-m', 'cython'] + cmdstr.split()
+    subprocess.run(argv, check=True, cwd=cwd)
+
+def grep(fname, pattern):
+    with open(fname) as fin:
+        return [line for line in fin if pattern in line]
+
+cython('-3 src/foo/bar.pyx -o build/src/foo/bar1.pyx.c')
+cython('-3 ../src/foo/bar.pyx -o src/foo/bar2.pyx.c', cwd='build')
+
+res1 = grep('build/src/foo/bar1.pyx.c', 'bar.pyx')
+res2 = grep('build/src/foo/bar2.pyx.c', 'bar.pyx')
+
+assert res1 == [
+    # Running cython on a file in CWD uses some paths relative to CWD.
+    '  "src/foo/bar.pyx",\n',
+    'static const char __pyx_k_src_foo_bar_pyx[] = "src/foo/bar.pyx";\n',
+    '/* "foo/bar.pyx":2\n',
+    '  /* "foo/bar.pyx":3\n',
+    '  /* "foo/bar.pyx":2\n',
+    '  /* "foo/bar.pyx":2\n'
+], str(res1)
+
+assert res2 == [
+    # When not in CWD all paths are relative to sys.path.
+    '  "foo/bar.pyx",\n',
+    'static const char __pyx_k_foo_bar_pyx[] = "foo/bar.pyx";\n',
+    '/* "foo/bar.pyx":2\n',
+    '  /* "foo/bar.pyx":3\n',
+    '  /* "foo/bar.pyx":2\n',
+    '  /* "foo/bar.pyx":2\n',
+], str(res2)

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -27,7 +27,7 @@ def cython(cmdstr, cwd=None):
 
 def grep(fname, pattern):
     with open(fname) as fin:
-        return [line for line in fin if pattern in line]
+        return [line.replace('\\', '/') for line in fin if pattern in line]
 
 cython('-3 src/foo/bar.pyx -o build/src/foo/bar1.pyx.c')
 cython('-3 ../src/foo/bar.pyx -o src/foo/bar2.pyx.c', cwd='build')

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -27,7 +27,7 @@ def cython(cmdstr, cwd=None):
 
 def grep(fname, pattern):
     with open(fname) as fin:
-        return [line.replace('\\', '/') for line in fin if pattern in line]
+        return [line for line in fin if pattern in line]
 
 cython('-3 src/foo/bar.pyx -o build/src/foo/bar1.pyx.c')
 cython('-3 ../src/foo/bar.pyx -o src/foo/bar2.pyx.c', cwd='build')
@@ -43,7 +43,7 @@ assert res1 == [
     '  /* "foo/bar.pyx":3\n',
     '  /* "foo/bar.pyx":2\n',
     '  /* "foo/bar.pyx":2\n'
-], str(res1)
+], '\n' + ''.join(res1)
 
 assert res2 == [
     # When not in CWD all paths are relative to sys.path.
@@ -53,4 +53,4 @@ assert res2 == [
     '  /* "foo/bar.pyx":3\n',
     '  /* "foo/bar.pyx":2\n',
     '  /* "foo/bar.pyx":2\n',
-], str(res2)
+], '\n' + ''.join(res2)


### PR DESCRIPTION
When cython is run on a file that is not in the current working directory it outputs filepaths that are either absolute or are basenames. It is not good to output absolute paths in the generated C code and outputing only basenames messes up coverage measurement.

Partial fix for gh-6186. In combination with https://github.com/flintlib/python-flint/pull/188 this makes it possible to measure coverage of Cython for for python-flint which uses meson as its build system.

The two places changed here were inconsistent. In ModuleNodes.py the code detects an absolute path and then outputs `basename(path)` instead. The path in question will usually not be absolute but it will be absolute if the source file being compiled is not in CWD and so in that case it is the basename that is emitted to the generated C code. The case in ExprNodes.py outputs the path without checking but again that will be an absolute path if the source file is not iin CWD.

Here in both cases we instead output the "description" which is the path relative to import root. If the project has a `src` directory then the path output for `src/foo/bar.pyx` (module `foo.bar`) would be `foo/bar.pyx` i.e. it is the path relative to the `src` directory or more generally the path of the source file relative to `sys.path`. In both cases we only do this if we would otherwise output an absolute path which in turn is a case that arises from compiling a `.pyx` file in another directory sort of like:
```
cd build && cython ../src/foo/bar.pyx
```
This change is needed to make coverage measurement work in a meson build. In https://github.com/flintlib/python-flint/pull/188 I have almost entirely rewritten Cython's coverage plugin: 
https://github.com/cython/cython/blob/master/Cython/Coverage.py.
This PR for Cython and that one for python-flint together make it so that I can measure coverage in python-flint's meson build. (This is the last outstanding item for us to drop the setuptools build.)

The only significant thing I have kept in the rewritten plugin is the function for parsing the .c files. The rest of the code is just for discovering the source files and implementing the coverage plugin interface. A lot of that is meson-specific because it is a lot easier to implement those parts if you make use of the information provided by the build system (much of the complexity in Cython's plugin comes from just not knowing where exactly the .c and .pyx etc files are).

I would like to upstream that plugin somehow but I'm not sure that Cython itself is the right place for it because a lot of it is meson specific. I also think that changing anything about Cython's coverage plugin looks quite hairy because there are a lot of heuristics in there to make different (setuptools-based) situations just about work and I expect that any change will break someone.

For now though, this PR which fixes the paths that Cython stores in the .c files is the minimum that is needed to get coverage working for a meson build. This is needed because there's only so much a plugin can do if the paths in the trace events are not right. At least under the conditions that I am running Cython the change in this PR ensures that all the paths provided from coverage to the plugin are exactly of a predictable form that the plugin can handle without heuristics.