### PR TITLE
Better fix for #6122 to avoid #6535

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -710,10 +710,8 @@ class CFuncDeclaratorNode(CDeclaratorNode):
                 and not self.has_explicit_exc_clause
                 and self.exception_check
                 and visibility != 'extern'):
-            # If function is already declared from pxd, the exception_check has already correct value.
-            if not (self.declared_name() in env.entries and not in_pxd):
-                self.exception_check = False
             # implicit noexcept, with a warning
+            self.exception_check = False
             warning(self.pos,
                     "Implicit noexcept declaration is deprecated."
                     " Function declaration should contain 'noexcept' keyword.",
@@ -3128,6 +3126,7 @@ class DefNode(FuncDefNode):
             if scope is None:
                 scope = cfunc.scope
             cfunc_type = cfunc.type
+            has_explicit_exc_clause=True
             if len(self.args) != len(cfunc_type.args) or cfunc_type.has_varargs:
                 error(self.pos, "wrong number of arguments")
                 error(cfunc.pos, "previous declaration here")

--- a/tests/run/legacy_implicit_noexcept_build.srctree
+++ b/tests/run/legacy_implicit_noexcept_build.srctree
@@ -179,6 +179,10 @@ try: aa.r3(True)
 except ValueError: assert False, "ValueError not raised"
 else:              pass
 
+######## bar.pxd ########
+cdef int func_noexcept_declared_in_pxd() noexcept
+cdef int func_implicit_declared_in_pxd()
+
 ######## bar.pyx ########
 
 cdef int func_noexcept() noexcept:
@@ -187,11 +191,20 @@ cdef int func_noexcept() noexcept:
 cdef int func_implicit():
     raise RuntimeError()
 
+cdef int func_noexcept_declared_in_pxd():
+    raise RuntimeError()
+
+cdef int func_implicit_declared_in_pxd():
+    raise RuntimeError()
+
 cdef int func_return_value() except -1:
     raise RuntimeError()
 
 func_noexcept()
 func_implicit()
+
+func_noexcept_declared_in_pxd()
+func_implicit_declared_in_pxd()
 
 try:
     func_return_value()


### PR DESCRIPTION
The change in #6124 introduces a regression with functions that are
implicit noexcept in a pxd file.

Here we implement a different fix for #6122 that doesn't cause the regression.
See the discussion in https://github.com/cython/cython/pull/6124#issuecomment-2282955499

Fixes: #6335
