### PR TITLE
Make 'unraisable exception' warning more visible

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2292,7 +2292,8 @@ class FuncDefNode(StatNode, BlockNode):
             else:
                 warning(self.entry.pos,
                         "Unraisable exception in function '%s'." %
-                        self.entry.qualified_name, 0)
+                        self.entry.qualified_name,
+                        level=2)
                 assure_gil('error')
                 code.put_unraisable(self.entry.qualified_name)
             default_retval = return_type.default_value


### PR DESCRIPTION
When a `noexcept` function raises an exception it becomes "unraisable".

There's a warning to that effect, but it's normally hidden and the only way to
show it is to set `show_all_warnings=True` which is inconvenient.

The warning seems important enough to make it more visible.

It seems at least as important as the "implicit noexcept" warning, so using
`level=2` as well seems reasonable.
