### PR TITLE
Fixes for cdef subclasses of int/complex builtin types

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -617,6 +617,8 @@ def init_builtin_types():
             objstruct_cname = 'PySetObject'
         elif name == 'bytearray':
             objstruct_cname = 'PyByteArrayObject'
+        elif name == 'int':
+            objstruct_cname = 'PyLongObject'
         elif name == 'bool':
             objstruct_cname = None
         elif name == 'BaseException':

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5483,6 +5483,9 @@ class CClassDefNode(ClassDefNode):
             if base_type in (PyrexTypes.c_int_type, PyrexTypes.c_long_type, PyrexTypes.c_float_type):
                 # Use the Python rather than C variant of these types.
                 base_type = env.lookup(base_type.sign_and_name()).type
+            if base_type is PyrexTypes.c_double_complex_type:
+                # Use the Python rather than C variant of this type.
+                base_type = Builtin.builtin_scope.lookup('complex').type
             if base_type is None:
                 error(base.pos, "First base of '%s' is not an extension type" % self.class_name)
             elif base_type == PyrexTypes.py_object_type:

--- a/tests/run/cdef_subclass_builtin.pyx
+++ b/tests/run/cdef_subclass_builtin.pyx
@@ -1,0 +1,25 @@
+# mode: run
+
+"""
+>>> issubclass(Int, int)
+True
+>>> issubclass(Float, float)
+True
+>>> issubclass(Complex, complex)
+True
+
+>>> issubclass(List, list)
+True
+>>> issubclass(Set, set)
+True
+>>> issubclass(Dict, dict)
+True
+"""
+
+cdef class Int(int): pass
+cdef class Float(float): pass
+cdef class Complex(complex): pass
+
+cdef class List(list): pass
+cdef class Set(set): pass
+cdef class Dict(dict): pass


### PR DESCRIPTION
1. Support subclasses of `complex`
```cython
cdef class Complex(complex): pass
```

2. Fix code generation for subclasses of `int` (generated C code used `PyIntObject` instead of `PyLongObject`)
```cython
cdef class Int(int): pass
``` 

