### PR TITLE
Change C code encoding from Latin-1 to UTF-8

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2322,7 +2322,7 @@ class CCodeWriter:
             self.emit_marker()
         if self.code_config.emit_linenums and self.last_marked_pos:
             source_desc, line, _ = self.last_marked_pos
-            self._write_lines('\n#line %s "%s"\n' % (line, source_desc.get_escaped_description()))
+            self._write_lines(f'\n#line {line} "{source_desc.get_escaped_description()}"\n')
         if code:
             if safe:
                 self.put_safe(code)
@@ -2345,7 +2345,7 @@ class CCodeWriter:
         self._write_lines("\n")
         if self.code_config.emit_code_comments:
             self.indent()
-            self._write_lines("/* %s */\n" % self._build_marker(pos))
+            self._write_lines(self._build_marker(pos))
         if trace:
             self.write_trace_line(pos)
 
@@ -2362,7 +2362,8 @@ class CCodeWriter:
         lines = contents[max(0, line-3):line]  # line numbers start at 1
         lines[-1] += '             # <<<<<<<<<<<<<<'
         lines += contents[line:line+2]
-        return '"%s":%d\n%s\n' % (source_desc.get_escaped_description(), line, '\n'.join(lines))
+        code = "\n".join(lines)
+        return f'/* "{source_desc.get_escaped_description()}":{line:d}\n{code}\n*/\n'
 
     def put_safe(self, code):
         # put code, but ignore {}

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -217,7 +217,7 @@ class FileSourceDescriptor(SourceDescriptor):
             pass
 
         with Utils.open_source_file(self.filename, encoding=encoding, error_handling=error_handling) as f:
-            lines = list(f)
+            lines = f.readlines()
 
         if key in self._lines:
             self._lines[key] = lines

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -148,11 +148,9 @@ class SourceDescriptor:
 
     def get_escaped_description(self):
         if self._escaped_description is None:
-            esc_desc = \
-                self.get_description().encode('ASCII', 'replace').decode("ASCII")
             # Use forward slashes on Windows since these paths
             # will be used in the #line directives in the C/C++ files.
-            self._escaped_description = esc_desc.replace('\\', '/')
+            self._escaped_description = self.get_description().replace('\\', '/')
         return self._escaped_description
 
     def __gt__(self, other):
@@ -193,8 +191,13 @@ class FileSourceDescriptor(SourceDescriptor):
     """
     def __init__(self, filename, path_description=None):
         filename = Utils.decode_filename(filename)
-        self.path_description = path_description or filename
         self.filename = filename
+        self.path_description = path_description or filename
+        try:
+            self._short_path_description = os.path.relpath(self.path_description)
+        except ValueError:
+            # path not under current directory => use complete file path
+            self._short_path_description = self.path_description
         # Prefer relative paths to current directory (which is most likely the project root) over absolute paths.
         workdir = os.path.abspath('.') + os.sep
         self.file_path = filename[len(workdir):] if filename.startswith(workdir) else filename
@@ -225,11 +228,7 @@ class FileSourceDescriptor(SourceDescriptor):
         return lines
 
     def get_description(self):
-        try:
-            return os.path.relpath(self.path_description)
-        except ValueError:
-            # path not under current directory => use complete file path
-            return self.path_description
+        return self._short_path_description
 
     def get_error_description(self):
         path = self.filename

--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -245,7 +245,7 @@ def _to_escape_sequence(s):
         return r'\\'
     else:
         # within a character sequence, oct passes much better than hex
-        return ''.join(['\\%03o' % ord(c) for c in s])
+        return ''.join([f'\\{ord(c):03o}' for c in s])
 
 
 def _build_specials_replacer():
@@ -281,7 +281,7 @@ def escape_char(c):
 def escape_byte_string(s):
     """Escape a byte string so that it can be written into C code.
     Note that this returns a Unicode string instead which, when
-    encoded as ISO-8859-1, will result in the correct byte sequence
+    encoded as ASCII, will result in the correct byte sequence
     being written.
     """
     s = _replace_specials(s)
@@ -293,10 +293,10 @@ def escape_byte_string(s):
     append, extend = s_new.append, s_new.extend
     for b in s:
         if b >= 128:
-            extend(('\\%3o' % b).encode('ASCII'))
+            extend((f'\\{b:03o}').encode('ASCII'))
         else:
             append(b)
-    return s_new.decode('ISO-8859-1')
+    return s_new.decode('ASCII')
 
 def split_string_literal(s, limit=2000):
     # MSVC can't handle long string literals.

--- a/Cython/Coverage.py
+++ b/Cython/Coverage.py
@@ -305,7 +305,7 @@ class Plugin(CoveragePlugin):
         if self._excluded_lines_map is None:
             self._excluded_lines_map = defaultdict(set)
 
-        with open(c_file) as lines:
+        with open(c_file, encoding='utf8') as lines:
             lines = iter(lines)
             for line in lines:
                 match = match_source_path_line(line)

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -152,12 +152,9 @@ def open_new_file(path):
         # safely hard link the output files.
         os.unlink(path)
 
-    # we use the ISO-8859-1 encoding here because we only write pure
-    # ASCII strings or (e.g. for file names) byte encoded strings as
-    # Unicode, so we need a direct mapping from the first 256 Unicode
-    # characters to a byte sequence, which ISO-8859-1 provides
-
-    return open(path, "w", encoding="ISO-8859-1")
+    # We only write pure ASCII code strings, but need to write file paths in position comments.
+    # Those are encoded in UTF-8 so that tools can parse them out again.
+    return open(path, "w", encoding="UTF-8")
 
 
 def castrate_file(path, st):


### PR DESCRIPTION
I don't think there's a reason to produce plain ASCII in comments, as long as the actual C code (including string literals) that we generate is ASCII.