### PR TITLE
Remove usages of SHA-1

### DIFF
--- a/Cython/Build/Cache.py
+++ b/Cython/Build/Cache.py
@@ -35,7 +35,7 @@ join_path = cached_function(os.path.join)
 def file_hash(filename):
     path = os.path.normpath(filename)
     prefix = ("%d:%s" % (len(path), path)).encode("UTF-8")
-    m = hashlib.sha1(prefix)
+    m = hashlib.sha256(prefix)
     with open(path, "rb") as f:
         data = f.read(65000)
         while data:
@@ -106,7 +106,7 @@ class Cache:
         incorporate everything that has an influence on the generated code.
         """
         try:
-            m = hashlib.sha1(__version__.encode("UTF-8"))
+            m = hashlib.sha256(__version__.encode("UTF-8"))
             m.update(file_hash(filename).encode("UTF-8"))
             for x in sorted(dependencies):
                 if os.path.splitext(x)[1] not in (".c", ".cpp", ".h"):

--- a/Cython/Build/Inline.py
+++ b/Cython/Build/Inline.py
@@ -140,7 +140,7 @@ def _populate_unbound(kwds, unbound_symbols, locals=None, globals=None):
 
 def _inline_key(orig_code, arg_sigs, language_level):
     key = orig_code, arg_sigs, sys.version_info, sys.executable, language_level, Cython.__version__
-    return hashlib.sha1(str(key).encode('utf-8')).hexdigest()
+    return hashlib.sha256(str(key).encode('utf-8')).hexdigest()
 
 
 def cython_inline(code, get_type=unsafe_type,

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -302,7 +302,7 @@ class CythonMagics(Magics):
         if args.name:
             module_name = str(args.name)  # no-op in Py3
         else:
-            module_name = "_cython_magic_" + hashlib.sha1(str(key).encode('utf-8')).hexdigest()
+            module_name = "_cython_magic_" + hashlib.sha256(str(key).encode('utf-8')).hexdigest()
         html_file = os.path.join(lib_dir, module_name + '.html')
         module_path = os.path.join(lib_dir, module_name + self.so_ext)
 

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2373,15 +2373,15 @@ class CCodeWriter:
     def put_or_include(self, code, name):
         include_dir = self.globalstate.common_utility_include_dir
         if include_dir and len(code) > 1024:
-            include_file = "%s_%s.h" % (
-                name, hashlib.sha1(code.encode('utf8')).hexdigest())
+            hash = hashlib.sha256(code.encode('utf8')).hexdigest()
+            include_file = f"{name}_{hash}.h"
             path = os.path.join(include_dir, include_file)
             if not os.path.exists(path):
-                tmp_path = '%s.tmp%s' % (path, os.getpid())
-                with closing(Utils.open_new_file(tmp_path)) as f:
+                tmp_path = f'{path}.tmp{os.getpid()}'
+                with Utils.open_new_file(tmp_path) as f:
                     f.write(code)
                 shutil.move(tmp_path, path)
-            code = '#include "%s"\n' % path
+            code = f'#include "{path}"\n'
         self.put(code)
 
     def put(self, code):


### PR DESCRIPTION
SHA-1 is excluded by some Python installations due to being non-secure. SHA-256 is used as a replacement, which should be fine for years to come (for our strictly non-cryptographic needs).

I think all of these changes should be ok for Cython 3.1. Given the large changes in the C code in this release, no hash value would remain the same or at least relevant.