### PR TITLE
Use forward slashes in include file paths to the common include directory

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2383,7 +2383,7 @@ class CCodeWriter:
                 shutil.move(tmp_path, path)
             # We use forward slashes in the include path to assure identical code generation
             # under Windows and Posix.  C/C++ compilers should still understand it.
-            c_path = path.replace(os.sep, '/')
+            c_path = path.replace('\\', '/')
             code = f'#include "{c_path}"\n'
         self.put(code)
 

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2381,7 +2381,10 @@ class CCodeWriter:
                 with Utils.open_new_file(tmp_path) as f:
                     f.write(code)
                 shutil.move(tmp_path, path)
-            code = f'#include "{path}"\n'
+            # We use forward slashes in the include path to assure identical code generation
+            # under Windows and Posix.  C/C++ compilers should still understand it.
+            c_path = path.replace(os.sep, '/')
+            code = f'#include "{c_path}"\n'
         self.put(code)
 
     def put(self, code):

--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -26,8 +26,9 @@ osx_on_ci = (sys.platform == "darwin" and os.getenv("CI"))
 # Test concurrent safety if multiprocessing is available.
 # (In particular, CI providers like Travis and Github Actions do not support spawning processes from tests.)
 nthreads = 0
-if not (hasattr(sys, 'pypy_version_info') or 
+if not (hasattr(sys, 'pypy_version_info') or
         (hasattr(sys, 'implementation') and sys.implementation.name == 'graalpython') or
+        sys.platform == 'win32' or
         osx_on_ci):
     try:
         import multiprocessing

--- a/tests/windows_bugs.txt
+++ b/tests/windows_bugs.txt
@@ -1,4 +1,3 @@
-common_include_dir
 cythonize_script
 cythonize_script_excludes
 cythonize_script_package


### PR DESCRIPTION
This assures identical code generation on Windows and Posix. C/C++ compilers should be ok with it also on Windows.