### PR TITLE
Use PyxCodeWriter features in dataclasses

### DIFF
--- a/Cython/Compiler/Code.pxd
+++ b/Cython/Compiler/Code.pxd
@@ -138,6 +138,3 @@ cdef class PyxCodeWriter:
     cdef Py_ssize_t level
     cdef Py_ssize_t original_level
     cdef dict _insertion_points
-
-    @cython.final
-    cdef int _putln(self, line) except -1

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -3086,22 +3086,23 @@ class PyxCodeWriter:
         return result
 
     def putln(self, line, context=None):
-        context = context or self.context
-        if context:
+        if context is None:
+            if self.context is not None:
+                context = self.context
+        if context is not None:
             line = sub_tempita(line, context)
-        self._putln(line)
-
-    def _putln(self, line):
-        self.buffer.write(f"{self.level * '    '}{line}\n")
+        # Avoid indenting empty lines.
+        self.buffer.write(f"{self.level * '    '}{line}\n" if line else "\n")
 
     def put_chunk(self, chunk, context=None):
-        context = context or self.context
-        if context:
+        if context is None:
+            if self.context is not None:
+                context = self.context
+        if context is not None:
             chunk = sub_tempita(chunk, context)
 
-        chunk = textwrap.dedent(chunk)
-        for line in chunk.splitlines():
-            self._putln(line)
+        chunk = _indent_chunk(chunk, self.level * 4)
+        self.buffer.write(chunk)
 
     def insertion_point(self):
         return type(self)(self.buffer.insertion_point(), self.level, self.context)
@@ -3117,6 +3118,66 @@ class PyxCodeWriter:
 
     def __getitem__(self, name):
         return self._insertion_points[name]
+
+
+@cython.final
+@cython.ccall
+def _indent_chunk(chunk: str, indentation_length: cython.int) -> str:
+    """Normalise leading space to the intended indentation and strip empty lines.
+    """
+    assert '\t' not in chunk
+    lines = chunk.splitlines(keepends=True)
+    if not lines:
+        return chunk
+    last_line = lines[-1].rstrip(' ')
+    if last_line:
+        lines[-1] = last_line
+    else:
+        del lines[-1]
+        if not lines:
+            return '\n'
+
+    # Count minimal (non-empty) indentation and strip empty lines.
+    min_indentation: cython.int = len(chunk) + 1
+    line_indentation: cython.int
+    line: str
+    i: cython.int
+    for i, line in enumerate(lines):
+        line_indentation = _count_indentation(line)
+        if line_indentation + 1 == len(line):
+            lines[i] = '\n'
+        elif line_indentation < min_indentation:
+            min_indentation = line_indentation
+
+    if min_indentation > len(chunk):
+        # All empty lines.
+        min_indentation = 0
+
+    if min_indentation < indentation_length:
+        add_indent = ' ' * (indentation_length - min_indentation)
+        lines = [
+            add_indent + line if line != '\n' else '\n'
+            for line in lines
+        ]
+    elif min_indentation > indentation_length:
+        start: cython.int = min_indentation - indentation_length
+        lines = [
+            line[start:] if line != '\n' else '\n'
+            for line in lines
+        ]
+
+    return ''.join(lines)
+
+
+@cython.exceptval(-1)
+@cython.cfunc
+def _count_indentation(s: str) -> cython.int:
+    i: cython.int = 0
+    ch: cython.Py_UCS4
+    for i, ch in enumerate(s):
+        if ch != ' ':
+            break
+    return i
 
 
 class ClosureTempAllocator:

--- a/Cython/Compiler/Dataclass.py
+++ b/Cython/Compiler/Dataclass.py
@@ -112,9 +112,8 @@ class TemplateCode:
     def add_code_line(self, code_line):
         self.writer.putln(code_line)
 
-    def add_code_lines(self, code_lines):
-        for line in code_lines:
-            self.writer.putln(line)
+    def add_code_chunk(self, code_chunk):
+        self.writer.put_chunk(code_chunk)
 
     def reset(self):
         # don't attempt to reset placeholders - it really doesn't matter if
@@ -124,8 +123,14 @@ class TemplateCode:
     def empty(self):
         return self.writer.empty()
 
-    def indenter(self):
-        return self.writer.indenter()
+    def indent(self):
+        self.writer.indent()
+
+    def dedent(self):
+        self.writer.dedent()
+
+    def indenter(self, block_opener_line):
+        return self.writer.indenter(block_opener_line)
 
     def new_placeholder(self, field_names, value):
         name = self._new_placeholder_name(field_names)
@@ -139,7 +144,7 @@ class TemplateCode:
 
     def _new_placeholder_name(self, field_names):
         while True:
-            name = "DATACLASS_PLACEHOLDER_%d" % self._placeholder_count
+            name = f"DATACLASS_PLACEHOLDER_{self._placeholder_count:d}"
             if (name not in self.placeholders
                     and name not in field_names):
                 # make sure name isn't already used and doesn't
@@ -399,6 +404,7 @@ def generate_init_code(code, init, node, fields, kw_only):
 
     function_start_point = code.insertion_point()
     code = code.insertion_point()
+    code.indent()
 
     # create a temp to get _HAS_DEFAULT_FACTORY
     dataclass_module = make_dataclasses_module_callnode(node.pos)
@@ -414,7 +420,7 @@ def generate_init_code(code, init, node, fields, kw_only):
     for name, field in fields.items():
         entry = node.scope.lookup(name)
         if entry.annotation:
-            annotation = ": %s" % entry.annotation.string.value
+            annotation = f": {entry.annotation.string.value}"
         else:
             annotation = ""
         assignment = ''
@@ -425,7 +431,7 @@ def generate_init_code(code, init, node, fields, kw_only):
                 ph_name = default_factory_placeholder
             else:
                 ph_name = code.new_placeholder(fields, field.default)  # 'default' should be a node
-            assignment = " = %s" % ph_name
+            assignment = f" = {ph_name}"
         elif seen_default and not kw_only and field.init.value:
             error(entry.pos, ("non-default argument '%s' follows default argument "
                               "in dataclass __init__") % name)
@@ -433,39 +439,39 @@ def generate_init_code(code, init, node, fields, kw_only):
             return
 
         if field.init.value:
-            args.append("%s%s%s" % (name, annotation, assignment))
+            args.append(f"{name}{annotation}{assignment}")
 
         if field.is_initvar:
             continue
         elif field.default_factory is MISSING:
             if field.init.value:
-                code.add_code_line("    %s.%s = %s" % (selfname, name, name))
+                code.add_code_line(f"{selfname}.{name} = {name}")
             elif assignment:
                 # not an argument to the function, but is still initialized
-                code.add_code_line("    %s.%s%s" % (selfname, name, assignment))
+                code.add_code_line(f"{selfname}.{name}{assignment}")
         else:
             ph_name = code.new_placeholder(fields, field.default_factory)
             if field.init.value:
                 # close to:
                 # def __init__(self, name=_PLACEHOLDER_VALUE):
                 #     self.name = name_default_factory() if name is _PLACEHOLDER_VALUE else name
-                code.add_code_line("    %s.%s = %s() if %s is %s else %s" % (
-                    selfname, name, ph_name, name, default_factory_placeholder, name))
+                code.add_code_line(
+                    f"{selfname}.{name} = {ph_name}() if {name} is {default_factory_placeholder} else {name}"
+                )
             else:
                 # still need to use the default factory to initialize
-                code.add_code_line("    %s.%s = %s()" % (
-                    selfname, name, ph_name))
+                code.add_code_line(f"{selfname}.{name} = {ph_name}()")
 
     if node.scope.lookup("__post_init__"):
         post_init_vars = ", ".join(name for name, field in fields.items()
                                    if field.is_initvar)
-        code.add_code_line("    %s.__post_init__(%s)" % (selfname, post_init_vars))
+        code.add_code_line(f"{selfname}.__post_init__({post_init_vars})")
 
     if code.empty():
-        code.add_code_line("    pass")
+        code.add_code_line("pass")
 
     args = ", ".join(args)
-    function_start_point.add_code_line("def __init__(%s):" % args)
+    function_start_point.add_code_line(f"def __init__({args}):")
 
 
 def generate_match_args(code, match_args, node, fields, global_kw_only):
@@ -521,25 +527,35 @@ def generate_repr_code(code, repr, node, fields):
             break
 
     if needs_recursive_guard:
-        code.add_code_line("__pyx_recursive_repr_guard = __import__('threading').local()")
-        code.add_code_line("__pyx_recursive_repr_guard.running = set()")
-    code.add_code_line("def __repr__(self):")
-    if needs_recursive_guard:
-        code.add_code_line("    key = id(self)")
-        code.add_code_line("    guard_set = self.__pyx_recursive_repr_guard.running")
-        code.add_code_line("    if key in guard_set: return '...'")
-        code.add_code_line("    guard_set.add(key)")
-        code.add_code_line("    try:")
-    strs = ["%s={self.%s!r}" % (name, name)
-            for name, field in fields.items()
-            if field.repr.value and not field.is_initvar]
-    format_string = ", ".join(strs)
+        code.add_code_chunk("""
+            __pyx_recursive_repr_guard = __import__('threading').local()
+            __pyx_recursive_repr_guard.running = set()
+        """)
 
-    code.add_code_line('        name = getattr(type(self), "__qualname__", type(self).__name__)')
-    code.add_code_line("        return f'{name}(%s)'" % format_string)
-    if needs_recursive_guard:
-        code.add_code_line("    finally:")
-        code.add_code_line("        guard_set.remove(key)")
+    with code.indenter("def __repr__(self):"):
+        if needs_recursive_guard:
+            code.add_code_chunk("""
+                key = id(self)
+                guard_set = self.__pyx_recursive_repr_guard.running
+                if key in guard_set: return '...'
+                guard_set.add(key)
+                try:
+            """)
+            code.indent()
+
+        strs = ["%s={self.%s!r}" % (name, name)
+                for name, field in fields.items()
+                if field.repr.value and not field.is_initvar]
+        format_string = ", ".join(strs)
+
+        code.add_code_chunk(f'''
+            name = getattr(type(self), "__qualname__", None) or type(self).__name__
+            return f'{{name}}({format_string})'
+        ''')
+        if needs_recursive_guard:
+            code.dedent()
+            with code.indenter("finally:"):
+                code.add_code_line("guard_set.remove(key)")
 
 
 def generate_cmp_code(code, op, funcname, node, fields):
@@ -548,39 +564,33 @@ def generate_cmp_code(code, op, funcname, node, fields):
 
     names = [name for name, field in fields.items() if (field.compare.value and not field.is_initvar)]
 
-    code.add_code_lines([
-        "def %s(self, other):" % funcname,
-        "    if other.__class__ is not self.__class__:"
-        "        return NotImplemented",
+    with code.indenter(f"def {funcname}(self, other):"):
+        code.add_code_chunk(f"""
+            if other.__class__ is not self.__class__: return NotImplemented
+
+            cdef {node.class_name} other_cast
+            other_cast = <{node.class_name}>other
+        """)
+
+        # The Python implementation of dataclasses.py does a tuple comparison
+        # (roughly):
+        #  return self._attributes_to_tuple() {op} other._attributes_to_tuple()
         #
-        "    cdef %s other_cast" % node.class_name,
-        "    other_cast = <%s>other" % node.class_name,
-    ])
+        # For the Cython implementation a tuple comparison isn't an option because
+        # not all attributes can be converted to Python objects and stored in a tuple
+        #
+        # TODO - better diagnostics of whether the types support comparison before
+        #    generating the code. Plus, do we want to convert C structs to dicts and
+        #    compare them that way (I think not, but it might be in demand)?
+        checks = []
+        op_without_equals = op.replace('=', '')
 
-    # The Python implementation of dataclasses.py does a tuple comparison
-    # (roughly):
-    #  return self._attributes_to_tuple() {op} other._attributes_to_tuple()
-    #
-    # For the Cython implementation a tuple comparison isn't an option because
-    # not all attributes can be converted to Python objects and stored in a tuple
-    #
-    # TODO - better diagnostics of whether the types support comparison before
-    #    generating the code. Plus, do we want to convert C structs to dicts and
-    #    compare them that way (I think not, but it might be in demand)?
-    checks = []
-    op_without_equals = op.replace('=', '')
-
-    for name in names:
-        if op != '==':
-            # tuple comparison rules - early elements take precedence
-            code.add_code_line("    if self.%s %s other_cast.%s: return True" % (
-                name, op_without_equals, name))
-        code.add_code_line("    if self.%s != other_cast.%s: return False" % (
-            name, name))
-    if "=" in op:
-        code.add_code_line("    return True")  # "() == ()" is True
-    else:
-        code.add_code_line("    return False")
+        for name in names:
+            if op != '==':
+                # tuple comparison rules - early elements take precedence
+                code.add_code_line(f"if self.{name} {op_without_equals} other_cast.{name}: return True")
+            code.add_code_line(f"if self.{name} != other_cast.{name}: return False")
+        code.add_code_line(f"return {'True' if '=' in op else 'False'}")  # "() == ()" is True
 
 
 def generate_eq_code(code, eq, node, fields):
@@ -672,10 +682,8 @@ def generate_hash_code(code, unsafe_hash, eq, frozen, node, fields):
         hash_tuple_items += ","  # ensure that one arg form is a tuple
 
     # if we're here we want to generate a hash
-    code.add_code_lines([
-        "def __hash__(self):",
-        "    return hash((%s))" % hash_tuple_items,
-    ])
+    with code.indenter("def __hash__(self):"):
+        code.add_code_line(f"return hash(({hash_tuple_items}))")
 
 
 def get_field_type(pos, entry):
@@ -837,11 +845,11 @@ def _set_up_dataclass_fields(node, fields, dataclass_module):
                 key=ExprNodes.IdentifierStringNode(node.pos, value=EncodedString(name)),
                 value=dc_field_call))
         dc_fields_namevalue_assignments.append(
-            dedent("""\
-                __dataclass_fields__[{0!r}].name = {0!r}
-                __dataclass_fields__[{0!r}].type = {1}
-                __dataclass_fields__[{0!r}]._field_type = {2}
-            """).format(name, type_placeholder_name, field_type_placeholder_name))
+            dedent(f"""\
+                __dataclass_fields__[{name!r}].name = {name!r}
+                __dataclass_fields__[{name!r}].type = {type_placeholder_name}
+                __dataclass_fields__[{name!r}]._field_type = {field_type_placeholder_name}
+            """))
 
     dataclass_fields_assignment = \
         Nodes.SingleAssignmentNode(node.pos,

--- a/Cython/Compiler/Tests/TestCode.py
+++ b/Cython/Compiler/Tests/TestCode.py
@@ -1,0 +1,86 @@
+import textwrap
+from unittest import TestCase
+
+from ..Code import _indent_chunk
+
+class TestIndent(TestCase):
+    def _test_indentations(self, chunk, expected):
+        for indentation in range(16):
+            expected_indented = textwrap.indent(expected, ' ' * indentation)
+            for line in expected_indented.splitlines():
+                # Validate before the comparison that empty lines got stripped also by textwrap.indent().
+                self.assertTrue(line == '' or line.strip(), repr(line))
+
+            with self.subTest(indentation=indentation):
+                result = _indent_chunk(chunk, indentation_length=indentation)
+                self.assertEqual(expected_indented, result)
+
+    def test_indent_empty(self):
+        self._test_indentations('', '')
+
+    def test_indent_empty_lines(self):
+        self._test_indentations('\n', '\n')
+        self._test_indentations('\n'*2, '\n'*2)
+        self._test_indentations('\n'*3, '\n'*3)
+        self._test_indentations(' \n'*2, '\n'*2)
+        self._test_indentations('\n  \n \n    \n', '\n'*4)
+
+    def test_indent_one_line(self):
+        self._test_indentations('abc', 'abc')
+
+    def test_indent_chunk(self):
+        chunk = """
+            x = 1
+            if x == 2:
+                print("False")
+            else:
+                print("True")
+        """
+        expected = """
+x = 1
+if x == 2:
+    print("False")
+else:
+    print("True")
+"""
+        self._test_indentations(chunk, expected)
+
+    def test_indent_empty_line(self):
+        chunk = """
+            x = 1
+
+            if x == 2:
+                print("False")
+            else:
+                print("True")
+        """
+        expected = """
+x = 1
+
+if x == 2:
+    print("False")
+else:
+    print("True")
+"""
+        self._test_indentations(chunk, expected)
+
+    def test_indent_empty_line_unclean(self):
+        lines = """
+            x = 1
+
+            if x == 2:
+                print("False")
+            else:
+                print("True")
+        """.splitlines(keepends=True)
+        lines[2] = '            \n'
+        chunk = ''.join(lines)
+        expected = """
+x = 1
+
+if x == 2:
+    print("False")
+else:
+    print("True")
+"""
+        self._test_indentations(chunk, expected)

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -548,30 +548,38 @@ static CYTHON_INLINE Py_UCS4 __Pyx_PyUnicode_AsPy_UCS4(PyObject*);
 
 /////////////// UnicodeAsUCS4 ///////////////
 
-static CYTHON_INLINE Py_UCS4 __Pyx_PyUnicode_AsPy_UCS4(PyObject* x) {
-    Py_ssize_t length = __Pyx_PyUnicode_GET_LENGTH(x);
-    if (likely(length == 1)) {
-        return __Pyx_PyUnicode_READ_CHAR(x, 0);
-    } else if (likely(length >= 0)) {
+static void __Pyx_PyUnicode_AsPy_UCS4_error(Py_ssize_t length) {
+    if (likely(length >= 0)) {
         // "length == -1" indicates an error already.
         PyErr_Format(PyExc_ValueError,
                      "only single character unicode strings can be converted to Py_UCS4, "
                      "got length %" CYTHON_FORMAT_SSIZE_T "d", length);
     }
-    return (Py_UCS4)-1;
+}
+
+static CYTHON_INLINE Py_UCS4 __Pyx_PyUnicode_AsPy_UCS4(PyObject* x) {
+    Py_ssize_t length = __Pyx_PyUnicode_GET_LENGTH(x);
+    if (unlikely(length != 1)) {
+        __Pyx_PyUnicode_AsPy_UCS4_error(length);
+        return (Py_UCS4)-1;
+    }
+    return __Pyx_PyUnicode_READ_CHAR(x, 0);
 }
 
 
 /////////////// ObjectAsUCS4.proto ///////////////
 //@requires: UnicodeAsUCS4
 
-#define __Pyx_PyObject_AsPy_UCS4(x) \
-    (likely(PyUnicode_Check(x)) ? __Pyx_PyUnicode_AsPy_UCS4(x) : __Pyx__PyObject_AsPy_UCS4(x))
 static Py_UCS4 __Pyx__PyObject_AsPy_UCS4(PyObject*);
+
+static CYTHON_INLINE Py_UCS4 __Pyx_PyObject_AsPy_UCS4(PyObject *x) {
+    return (likely(PyUnicode_Check(x)) ? __Pyx_PyUnicode_AsPy_UCS4(x) : __Pyx__PyObject_AsPy_UCS4(x));
+}
+
 
 /////////////// ObjectAsUCS4 ///////////////
 
-static Py_UCS4 __Pyx__PyObject_AsPy_UCS4_raise_error(long ival) {
+static void __Pyx__PyObject_AsPy_UCS4_raise_error(long ival) {
    if (ival < 0) {
        if (!PyErr_Occurred())
            PyErr_SetString(PyExc_OverflowError,
@@ -580,14 +588,14 @@ static Py_UCS4 __Pyx__PyObject_AsPy_UCS4_raise_error(long ival) {
        PyErr_SetString(PyExc_OverflowError,
                        "value too large to convert to Py_UCS4");
    }
-   return (Py_UCS4)-1;
 }
 
 static Py_UCS4 __Pyx__PyObject_AsPy_UCS4(PyObject* x) {
    long ival;
    ival = __Pyx_PyLong_As_long(x);
    if (unlikely(!__Pyx_is_valid_index(ival, 1114111 + 1))) {
-       return __Pyx__PyObject_AsPy_UCS4_raise_error(ival);
+       __Pyx__PyObject_AsPy_UCS4_raise_error(ival);
+       return (Py_UCS4)-1;
    }
    return (Py_UCS4)ival;
 }


### PR DESCRIPTION
The `PyxCodeWriter` knows about code indentation, so we don't need to take care of the indentation in the code strings.

The first two changes in this PR are taken from https://github.com/cython/cython/pull/6358