### PR TITLE
Fixes for cdef subclass of int/float/complex user defined types

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5482,10 +5482,10 @@ class CClassDefNode(ClassDefNode):
             base_type = base.analyse_as_type(env)
 
             # If we accidentally picked the C type of the same name, use the Python rather than the C variant.
-            if base_type in (PyrexTypes.c_int_type, PyrexTypes.c_long_type, PyrexTypes.c_float_type):
+            if base_type in (PyrexTypes.c_int_type, PyrexTypes.c_float_type):
                 base_type = env.lookup(base_type.sign_and_name()).type
             elif base_type is PyrexTypes.c_double_complex_type:
-                base_type = Builtin.builtin_scope.lookup('complex').type
+                base_type = env.lookup('complex').type
 
             if base_type is None:
                 error(base.pos, "First base of '%s' is not an extension type" % self.class_name)

--- a/tests/run/cdef_subclass_userdef.pyx
+++ b/tests/run/cdef_subclass_userdef.pyx
@@ -1,31 +1,26 @@
 # mode: run
 
-"""
+__doc__ = f"""
 >>> int
-<class 'int'>
+<class '{__name__}.int'>
 >>> issubclass(Int, int)
 True
+
 >>> float
-<class 'float'>
+<class '{__name__}.float'>
 >>> issubclass(Float, float)
 True
+
 >>> complex
-<class 'complex'>
+<class '{__name__}.complex'>
 >>> issubclass(Complex, complex)
 True
-
->>> issubclass(List, list)
-True
->>> issubclass(Set, set)
-True
->>> issubclass(Dict, dict)
-True
 """
+
+cdef class int: pass
+cdef class float: pass
+cdef class complex: pass
 
 cdef class Int(int): pass
 cdef class Float(float): pass
 cdef class Complex(complex): pass
-
-cdef class List(list): pass
-cdef class Set(set): pass
-cdef class Dict(dict): pass


### PR DESCRIPTION
* Lookup complex type in current scope.
* Remove special handling for `c_long_type` as `long` is Python 2.

@scoder's objections https://github.com/cython/cython/commit/a2120861a9c3f87b246c9ade4bed68b84ce95dba#r145771848 to my changes in #6346 proved very accurate. Indeed, I trusted type analysis too much. As per Stefan's request, I'm PRing the fix.

The following type-analysis code doesn't not do the right thing. If the scope is a C context (which it is in a cdef class?), I believe it goes too quickly to check whether the name can be parsed as int/float/complex basic C type, rather than looking first in the scope to see if name is already user defined.

```python
# Cython/Compiler/ExprNodes.py
class NameNode(AtomicExprNode):
    ...
    def analyse_as_type(self, env):
        type = None
        if self.cython_attribute:
            type = PyrexTypes.parse_basic_type(self.cython_attribute)
        elif env.in_c_type_context: # <-- HERE is the problem
            type = PyrexTypes.parse_basic_type(self.name)
        if type:
            return type
    ...
```
In any case, after the changes in this PR things will work as expected when subclassing a builtin vs user-defined  `complex` type, but maybe the type analysis issue may bite in other scenarios.
Unfortunately, I do not consider myself expert enough in type analysis as to even suggest a fix, much less provide an implementation.
