### PR TITLE
Add Python 3.13 info to the `classifiers` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ def run_build():
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Programming Language :: C",


### PR DESCRIPTION
Fix https://github.com/cython/cython/issues/6364