### PR TITLE
Give cdef functions the same position and first line number as def and @cfunc functions

### DIFF
--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2528,25 +2528,26 @@ def p_IF_statement(s: PyrexScanner, ctx):
 @cython.cfunc
 def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = False):
     cdef_flag: cython.bint = ctx.cdef_flag
+    pos = s.position()
     decorators = None
     if s.sy == 'ctypedef':
         if ctx.level not in ('module', 'module_pxd'):
             s.error("ctypedef statement not allowed here")
         #if ctx.api:
-        #    error(s.position(), "'api' not allowed with 'ctypedef'")
+        #    error(pos, "'api' not allowed with 'ctypedef'")
         return p_ctypedef_statement(s, ctx)
     elif s.sy == 'DEF':
         # We used to dep-warn about this but removed the warning again since
         # we don't have a good answer yet for all use cases.
         if s.context.compiler_directives.get("warn.deprecated.DEF", False):
-            warning(s.position(),
+            warning(pos,
                     "The 'DEF' statement  will be removed in a future Cython version. "
                     "Consider using global variables, constants, and in-place literals instead. "
                     "See https://github.com/cython/cython/issues/4310", level=1)
         return p_DEF_statement(s)
     elif s.sy == 'IF':
         if s.context.compiler_directives.get("warn.deprecated.IF", True):
-            warning(s.position(),
+            warning(pos,
                     "The 'IF' statement is deprecated and will be removed in a future Cython version. "
                     "Consider using runtime conditions or C macros instead. "
                     "See https://github.com/cython/cython/issues/4310", level=1)
@@ -2577,7 +2578,7 @@ def p_statement(s: PyrexScanner, ctx, first_statement: cython.bint = False):
         if ctx.level not in ('module', 'module_pxd', 'function', 'c_class', 'c_class_pxd'):
             s.error('cdef statement not allowed here')
         s.level = ctx.level
-        node = p_cdef_statement(s, ctx(overridable=overridable))
+        node = p_cdef_statement(s, pos, ctx(overridable=overridable))
         if decorators is not None:
             tup = (Nodes.CFuncDefNode, Nodes.CVarDefNode, Nodes.CClassDefNode)
             if ctx.allow_struct_enum_decorator:
@@ -3461,8 +3462,7 @@ def p_api(s: PyrexScanner) -> cython.bint:
 
 
 @cython.cfunc
-def p_cdef_statement(s: PyrexScanner, ctx):
-    pos = s.position()
+def p_cdef_statement(s: PyrexScanner, pos, ctx):
     ctx.visibility = p_visibility(s, ctx.visibility)
     ctx.api = ctx.api or p_api(s)
     if ctx.api:
@@ -4301,20 +4301,21 @@ def p_cpp_class_definition(s: PyrexScanner, pos,  ctx):
 
 @cython.cfunc
 def p_cpp_class_attribute(s: PyrexScanner, ctx):
+    pos = s.position()
     decorators = None
     if s.sy == '@':
         decorators = p_decorators(s)
     if s.systring == 'cppclass':
-        return p_cpp_class_definition(s, s.position(), ctx)
+        return p_cpp_class_definition(s, pos, ctx)
     elif s.systring == 'ctypedef':
         return p_ctypedef_statement(s, ctx)
     elif s.sy == 'IDENT' and s.systring in struct_enum_union:
         if s.systring != 'enum':
-            return p_cpp_class_definition(s, s.position(), ctx)
+            return p_cpp_class_definition(s, pos, ctx)
         else:
-            return p_struct_enum(s, s.position(), ctx)
+            return p_struct_enum(s, pos, ctx)
     else:
-        node = p_c_func_or_var_declaration(s, s.position(), ctx)
+        node = p_c_func_or_var_declaration(s, pos, ctx)
         if decorators is not None:
             tup = Nodes.CFuncDefNode, Nodes.CVarDefNode, Nodes.CClassDefNode
             if ctx.allow_struct_enum_decorator:

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -24,7 +24,7 @@ def foo(dtype_t[:] a, dtype_t_out[:, :] b):
 _WARNINGS = """
 # cpdef redeclaration bug, from TestCythonScope.pyx
 25:4: 'cpdef_method' redeclared
-36:4: 'cpdef_cname_method' redeclared
+35:4: 'cpdef_cname_method' redeclared
 
 # from MemoryView.pyx
 958:29: Ambiguous exception value, same as default return value: 0

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -23,8 +23,8 @@ def foo(dtype_t[:] a, dtype_t_out[:, :] b):
 # unrelated to this test.
 _WARNINGS = """
 # cpdef redeclaration bug, from TestCythonScope.pyx
-25:10: 'cpdef_method' redeclared
-36:10: 'cpdef_cname_method' redeclared
+25:4: 'cpdef_method' redeclared
+36:4: 'cpdef_cname_method' redeclared
 
 # from MemoryView.pyx
 958:29: Ambiguous exception value, same as default return value: 0

--- a/tests/errors/cdefspecial.pyx
+++ b/tests/errors/cdefspecial.pyx
@@ -7,7 +7,8 @@ cdef class Test:
     cdef __len__(self):
         pass
 
+
 _ERRORS = u"""
-4:9: Special methods must be declared with 'def', not 'cdef'
-7:9: Special methods must be declared with 'def', not 'cdef'
+4:4: Special methods must be declared with 'def', not 'cdef'
+7:4: Special methods must be declared with 'def', not 'cdef'
 """

--- a/tests/errors/cmethbasematch.pyx
+++ b/tests/errors/cmethbasematch.pyx
@@ -35,11 +35,11 @@ cdef class NarrowerReturn(Base):
 
 
 _ERRORS = u"""
-8: 9: Signature not compatible with previous declaration
-4: 9: Previous declaration is here
+8: 4: Signature not compatible with previous declaration
+4: 4: Previous declaration is here
 # TODO(robertwb): Re-enable these errors.
-#18:8: Compatible but non-identical C method 'f' not redeclared in definition part of extension type 'MissingRedeclaration'
-#2:9: Previous declaration is here
-#23:8: Compatible but non-identical C method 'f' not redeclared in definition part of extension type 'BadRedeclaration'
-#2:9: Previous declaration is here
+#18:4: Compatible but non-identical C method 'f' not redeclared in definition part of extension type 'MissingRedeclaration'
+#2:4: Previous declaration is here
+#23:4: Compatible but non-identical C method 'f' not redeclared in definition part of extension type 'BadRedeclaration'
+#2:4: Previous declaration is here
 """

--- a/tests/errors/const_decl_errors.pyx
+++ b/tests/errors/const_decl_errors.pyx
@@ -41,9 +41,10 @@ cdef const_ok(const int *b, const int *c):
     y, z = b, c
     z = y = b
 
+
 _ERRORS = """
 3:5: Const/volatile base type cannot be a Python object
-8:5: Assignment to const 'x'
+8:0: Assignment to const 'x'
 15:4: Assignment to const 'a'
 16:4: Assignment to const 'c'
 17:5: Assignment to const dereference
@@ -56,7 +57,7 @@ _ERRORS = """
 """
 
 _WARNINGS = """
-31:9: Assigning to 'int *' from 'const int *' discards const qualifier
+31:4: Assigning to 'int *' from 'const int *' discards const qualifier
 34:11: Assigning to 'int *' from 'const int *' discards const qualifier
 34:14: Assigning to 'int *' from 'const int *' discards const qualifier
 35:12: Assigning to 'int *' from 'const int *' discards const qualifier

--- a/tests/errors/cpdef_syntax.pyx
+++ b/tests/errors/cpdef_syntax.pyx
@@ -3,8 +3,9 @@
 cpdef nogil: pass
 cpdef nogil class test: pass
 
+
 _ERRORS = u"""
-3: 6: cdef blocks cannot be declared cpdef
-4: 6: cdef blocks cannot be declared cpdef
+3: 0: cdef blocks cannot be declared cpdef
+4: 0: cdef blocks cannot be declared cpdef
 4:12: Expected ':', found 'class'
 """

--- a/tests/errors/cpdef_vars.pyx
+++ b/tests/errors/cpdef_vars.pyx
@@ -17,8 +17,8 @@ def func():
 
 
 _ERRORS = """
-3:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
-4:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
-7:10: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
-15:10: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
+3:0: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
+4:0: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
+7:4: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
+15:4: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
 """

--- a/tests/errors/cpp_enum_redeclare.pyx
+++ b/tests/errors/cpp_enum_redeclare.pyx
@@ -7,7 +7,8 @@ cdef enum class Spam:
 cdef enum class Spam:
     b
 
+
 _ERRORS="""
-7:5: 'Spam' redeclared
-4:5: Previous declaration is here
+7:0: 'Spam' redeclared
+4:0: Previous declaration is here
 """

--- a/tests/errors/cppexc_non_extern.pyx
+++ b/tests/errors/cppexc_non_extern.pyx
@@ -13,10 +13,11 @@ cdef test_func1(self) except +handle_exception:
 cdef test_func2(self) except +:
     pass
 
+
 _ERRORS = """
-9:5: Only extern functions can throw C++ exceptions.
+9:0: Only extern functions can throw C++ exceptions.
 """
 
 _WARNINGS = """
-13:5: Only extern functions can throw C++ exceptions.
+13:0: Only extern functions can throw C++ exceptions.
 """

--- a/tests/errors/dataclass_e1.pyx
+++ b/tests/errors/dataclass_e1.pyx
@@ -13,10 +13,10 @@ cdef class C:
 
 
 _ERRORS = """
-6:0: Arguments passed to cython.dataclasses.dataclass must be True or False
-6:0: Cannot overwrite attribute __hash__ in class C
-6:0: cython.dataclasses.dataclass() got an unexpected keyword argument 'shouldnt_be_here'
-6:0: cython.dataclasses.dataclass takes no positional arguments
+5:0: Arguments passed to cython.dataclasses.dataclass must be True or False
+5:0: Cannot overwrite attribute __hash__ in class C
+5:0: cython.dataclasses.dataclass() got an unexpected keyword argument 'shouldnt_be_here'
+5:0: cython.dataclasses.dataclass takes no positional arguments
 7:14: mutable default <class 'list'> for field a is not allowed: use default_factory
 8:37: cannot specify both default and default_factory
 9:4: non-default argument 'c' follows default argument in dataclass __init__

--- a/tests/errors/dataclass_e1.pyx
+++ b/tests/errors/dataclass_e1.pyx
@@ -11,11 +11,12 @@ cdef class C:
     def __hash__(self):
         pass
 
+
 _ERRORS = """
-6:5: Arguments passed to cython.dataclasses.dataclass must be True or False
-6:5: Cannot overwrite attribute __hash__ in class C
-6:5: cython.dataclasses.dataclass() got an unexpected keyword argument 'shouldnt_be_here'
-6:5: cython.dataclasses.dataclass takes no positional arguments
+6:0: Arguments passed to cython.dataclasses.dataclass must be True or False
+6:0: Cannot overwrite attribute __hash__ in class C
+6:0: cython.dataclasses.dataclass() got an unexpected keyword argument 'shouldnt_be_here'
+6:0: cython.dataclasses.dataclass takes no positional arguments
 7:14: mutable default <class 'list'> for field a is not allowed: use default_factory
 8:37: cannot specify both default and default_factory
 9:4: non-default argument 'c' follows default argument in dataclass __init__

--- a/tests/errors/dataclass_w1.pyx
+++ b/tests/errors/dataclass_w1.pyx
@@ -8,6 +8,7 @@ from cython.dataclasses cimport dataclass
 cdef class DC(SomeBase):
     a: str = ""
 
+
 _WARNINGS = """
-8:5: Cannot reliably handle Cython dataclasses with base types in external modules since it is not possible to tell what fields they have
+7:0: Cannot reliably handle Cython dataclasses with base types in external modules since it is not possible to tell what fields they have
 """

--- a/tests/errors/e_cdef_closure.pyx
+++ b/tests/errors/e_cdef_closure.pyx
@@ -4,6 +4,7 @@ cpdef cpdef_yield():
     def inner():
         pass
 
+
 _ERRORS = u"""
-3:6: closures inside cpdef functions not yet supported
+3:0: closures inside cpdef functions not yet supported
 """

--- a/tests/errors/e_cdefemptysue.pyx
+++ b/tests/errors/e_cdefemptysue.pyx
@@ -18,11 +18,11 @@ cdef enum flat_ham: pass
 
 
 _ERRORS = u"""
-3:5: Empty struct or union definition not allowed outside a 'cdef extern from' block
+3:0: Empty struct or union definition not allowed outside a 'cdef extern from' block
 6:0: Empty struct or union definition not allowed outside a 'cdef extern from' block
-9:5: Empty enum definition not allowed outside a 'cdef extern from' block
+9:0: Empty enum definition not allowed outside a 'cdef extern from' block
 
-13:5: Empty struct or union definition not allowed outside a 'cdef extern from' block
+13:0: Empty struct or union definition not allowed outside a 'cdef extern from' block
 15:0: Empty struct or union definition not allowed outside a 'cdef extern from' block
-17:5: Empty enum definition not allowed outside a 'cdef extern from' block
+17:0: Empty enum definition not allowed outside a 'cdef extern from' block
 """

--- a/tests/errors/e_cpp_only_features.pyx
+++ b/tests/errors/e_cpp_only_features.pyx
@@ -18,11 +18,12 @@ def use_del():
     cdef A *p = &a
     del p
 
+
 _ERRORS = """
-4:9: Using 'cppclass' while Cython is not in c++ mode
+4:4: Using 'cppclass' while Cython is not in c++ mode
 8:10: typeid operator only allowed in c++
 8:23: typeid operator only allowed in c++
-10:5: Using 'cppclass' while Cython is not in c++ mode
+10:0: Using 'cppclass' while Cython is not in c++ mode
 14:16: Operation only allowed in c++
 19:4: Operation only allowed in c++
 """

--- a/tests/errors/e_ctypedefornot.pyx
+++ b/tests/errors/e_ctypedefornot.pyx
@@ -13,7 +13,8 @@ cdef struct Blarg
 cdef Foo f
 cdef Blarg b
 
+
 _ERRORS = u"""
 5:0: 'Foo' previously declared using 'cdef'
-11:5: 'Blarg' previously declared using 'ctypedef'
+11:0: 'Blarg' previously declared using 'ctypedef'
 """

--- a/tests/errors/e_exttype_freelist.pyx
+++ b/tests/errors/e_exttype_freelist.pyx
@@ -20,5 +20,5 @@ cdef class ExtSubTypeFail(ExtType):
 
 
 _ERRORS = """
-18:5: freelists cannot be used on subtypes, only the base class can manage them
+17:0: freelists cannot be used on subtypes, only the base class can manage them
 """

--- a/tests/errors/e_exttype_total_ordering.pyx
+++ b/tests/errors/e_exttype_total_ordering.pyx
@@ -156,23 +156,23 @@ cdef class ExtEqNe:
 
 
 _WARNINGS = """
-10:5: total_ordering directive used, but no comparison and equality methods defined
-14:5: total_ordering directive used, but no equality method defined
-19:5: total_ordering directive used, but no equality method defined
-24:5: total_ordering directive used, but no equality method defined
-32:5: total_ordering directive used, but no equality method defined
-37:5: total_ordering directive used, but no equality method defined
-45:5: total_ordering directive used, but no equality method defined
-53:5: total_ordering directive used, but no equality method defined
-64:5: total_ordering directive used, but no equality method defined
-69:5: total_ordering directive used, but no equality method defined
-77:5: total_ordering directive used, but no equality method defined
-85:5: total_ordering directive used, but no equality method defined
-96:5: total_ordering directive used, but no equality method defined
-104:5: total_ordering directive used, but no equality method defined
-115:5: total_ordering directive used, but no equality method defined
-126:5: total_ordering directive used, but no equality method defined
-140:5: total_ordering directive used, but no comparison methods defined
-145:5: total_ordering directive used, but no comparison methods defined
-150:5: total_ordering directive used, but no comparison methods defined
+10:0: total_ordering directive used, but no comparison and equality methods defined
+14:0: total_ordering directive used, but no equality method defined
+19:0: total_ordering directive used, but no equality method defined
+24:0: total_ordering directive used, but no equality method defined
+32:0: total_ordering directive used, but no equality method defined
+37:0: total_ordering directive used, but no equality method defined
+45:0: total_ordering directive used, but no equality method defined
+53:0: total_ordering directive used, but no equality method defined
+64:0: total_ordering directive used, but no equality method defined
+69:0: total_ordering directive used, but no equality method defined
+77:0: total_ordering directive used, but no equality method defined
+85:0: total_ordering directive used, but no equality method defined
+96:0: total_ordering directive used, but no equality method defined
+104:0: total_ordering directive used, but no equality method defined
+115:0: total_ordering directive used, but no equality method defined
+126:0: total_ordering directive used, but no equality method defined
+140:0: total_ordering directive used, but no comparison methods defined
+145:0: total_ordering directive used, but no comparison methods defined
+150:0: total_ordering directive used, but no comparison methods defined
 """

--- a/tests/errors/e_exttype_total_ordering.pyx
+++ b/tests/errors/e_exttype_total_ordering.pyx
@@ -156,23 +156,23 @@ cdef class ExtEqNe:
 
 
 _WARNINGS = """
-10:0: total_ordering directive used, but no comparison and equality methods defined
-14:0: total_ordering directive used, but no equality method defined
-19:0: total_ordering directive used, but no equality method defined
-24:0: total_ordering directive used, but no equality method defined
-32:0: total_ordering directive used, but no equality method defined
-37:0: total_ordering directive used, but no equality method defined
-45:0: total_ordering directive used, but no equality method defined
-53:0: total_ordering directive used, but no equality method defined
-64:0: total_ordering directive used, but no equality method defined
-69:0: total_ordering directive used, but no equality method defined
-77:0: total_ordering directive used, but no equality method defined
-85:0: total_ordering directive used, but no equality method defined
-96:0: total_ordering directive used, but no equality method defined
-104:0: total_ordering directive used, but no equality method defined
-115:0: total_ordering directive used, but no equality method defined
-126:0: total_ordering directive used, but no equality method defined
-140:0: total_ordering directive used, but no comparison methods defined
-145:0: total_ordering directive used, but no comparison methods defined
-150:0: total_ordering directive used, but no comparison methods defined
+9:0: total_ordering directive used, but no comparison and equality methods defined
+13:0: total_ordering directive used, but no equality method defined
+18:0: total_ordering directive used, but no equality method defined
+23:0: total_ordering directive used, but no equality method defined
+31:0: total_ordering directive used, but no equality method defined
+36:0: total_ordering directive used, but no equality method defined
+44:0: total_ordering directive used, but no equality method defined
+52:0: total_ordering directive used, but no equality method defined
+63:0: total_ordering directive used, but no equality method defined
+68:0: total_ordering directive used, but no equality method defined
+76:0: total_ordering directive used, but no equality method defined
+84:0: total_ordering directive used, but no equality method defined
+95:0: total_ordering directive used, but no equality method defined
+103:0: total_ordering directive used, but no equality method defined
+114:0: total_ordering directive used, but no equality method defined
+125:0: total_ordering directive used, but no equality method defined
+139:0: total_ordering directive used, but no comparison methods defined
+144:0: total_ordering directive used, but no comparison methods defined
+149:0: total_ordering directive used, but no comparison methods defined
 """

--- a/tests/errors/e_func_in_pxd.pyx
+++ b/tests/errors/e_func_in_pxd.pyx
@@ -2,8 +2,9 @@
 
 cimport e_func_in_pxd_support
 
+
 _ERRORS = u"""
-1:5: function definition in pxd file must be declared 'cdef inline'
-4:5: inline function definition in pxd file cannot be 'public'
-7:5: inline function definition in pxd file cannot be 'api'
+1:0: function definition in pxd file must be declared 'cdef inline'
+4:0: inline function definition in pxd file cannot be 'public'
+7:0: inline function definition in pxd file cannot be 'api'
 """

--- a/tests/errors/e_nogilcmeth.pyx
+++ b/tests/errors/e_nogilcmeth.pyx
@@ -1,10 +1,11 @@
 # mode: error
 
 cdef class C:
-	cdef void f(self) nogil:
-		pass
+    cdef void f(self) nogil:
+        pass
+
 
 _ERRORS = u"""
 2:12: Previous declaration is here
-4: 6: Signature not compatible with previous declaration
+4: 4: Signature not compatible with previous declaration
 """

--- a/tests/errors/e_public_cdef_private_types.pyx
+++ b/tests/errors/e_public_cdef_private_types.pyx
@@ -36,8 +36,8 @@ cdef opt_func(x = None):
 _ERRORS = u"""
 e_public_cdef_private_types.pyx:8:22: Function declared public or api may not have private types
 e_public_cdef_private_types.pyx:11:19: Function declared public or api may not have private types
-e_public_cdef_private_types.pyx:14:5: Function declared public or api may not have private types
-e_public_cdef_private_types.pyx:17:5: Function declared public or api may not have private types
+e_public_cdef_private_types.pyx:14:0: Function declared public or api may not have private types
+e_public_cdef_private_types.pyx:17:0: Function declared public or api may not have private types
 e_public_cdef_private_types.pyx:20:24: Function with optional arguments may not be declared public or api
 e_public_cdef_private_types.pyx:23:21: Function with optional arguments may not be declared public or api
 """

--- a/tests/errors/e_undefexttype.pyx
+++ b/tests/errors/e_undefexttype.pyx
@@ -2,7 +2,9 @@
 
 cdef class Spam
 cdef extern class external.Eggs
+
+
 _ERRORS = u"""
-3:5: C class 'Spam' is declared but not defined
-4:5: C class 'Eggs' is declared but not defined
+3:0: C class 'Spam' is declared but not defined
+4:0: C class 'Eggs' is declared but not defined
 """

--- a/tests/errors/final_methods.pyx
+++ b/tests/errors/final_methods.pyx
@@ -16,7 +16,8 @@ cdef class SubType(BaseClass):
     cdef cdef_method(self):
         pass
 
+
 _ERRORS = """
-11:10: Only final types can have final Python (def/cpdef) methods
-16:9: Overriding final methods is not allowed
+10:4: Only final types can have final Python (def/cpdef) methods
+16:4: Overriding final methods is not allowed
 """

--- a/tests/errors/fused_types.pyx
+++ b/tests/errors/fused_types.pyx
@@ -95,6 +95,7 @@ cdef cython.integral func_with_fused_extension(fused3 foo):
 
 func_with_fused_extension(5)
 
+
 _ERRORS = u"""
 11:15: fused_type does not take keyword arguments
 16:33: Type specified multiple times
@@ -106,20 +107,20 @@ _ERRORS = u"""
 30:16: Call with wrong number of arguments (expected 2, got 3)
 37:6: Invalid base type for memoryview slice: int *
 40:0: Fused lambdas not allowed
-43:5: Fused types not allowed here
+43:0: Fused types not allowed here
 43:21: cdef variable 'x' declared after it is used
-46:9: Fused types not allowed here
+46:4: Fused types not allowed here
 61:0: Invalid use of fused types, type cannot be specialized
 61:29: ambiguous overloaded method
 # Possibly duplicates the errors more often than we want
-79:5: Return type is a fused type that cannot be determined from the function arguments
-82:6: Return type is a fused type that cannot be determined from the function arguments
+79:0: Return type is a fused type that cannot be determined from the function arguments
+82:0: Return type is a fused type that cannot be determined from the function arguments
 86:4: 'z' cannot be specialized since its type is not a fused argument to this function
 86:4: 'z' cannot be specialized since its type is not a fused argument to this function
 86:4: 'z' cannot be specialized since its type is not a fused argument to this function
 87:16: Type cannot be specialized since it is not a fused argument to this function
 87:16: Type cannot be specialized since it is not a fused argument to this function
 87:16: Type cannot be specialized since it is not a fused argument to this function
-93:5: Return type is a fused type that cannot be determined from the function arguments
+93:0: Return type is a fused type that cannot be determined from the function arguments
 96:0: Invalid use of fused types, type cannot be specialized
 """

--- a/tests/errors/missing_self_in_cpdef_method_T156.pyx
+++ b/tests/errors/missing_self_in_cpdef_method_T156.pyx
@@ -5,6 +5,7 @@ cdef class B:
     cpdef b():
         pass
 
+
 _ERRORS = u"""
-5:10: C method has no self argument
+5:4: C method has no self argument
 """

--- a/tests/errors/missing_self_in_cpdef_method_T165.pyx
+++ b/tests/errors/missing_self_in_cpdef_method_T165.pyx
@@ -5,6 +5,7 @@ cdef class A:
     cpdef a(int not_self):
         pass
 
+
 _ERRORS = u"""
-5:10: Self argument (int) of C method 'a' does not match parent type (A)
+5:4: Self argument (int) of C method 'a' does not match parent type (A)
 """

--- a/tests/errors/nogil.pyx
+++ b/tests/errors/nogil.pyx
@@ -108,11 +108,11 @@ cdef int[:] main() nogil:
 
 
 _ERRORS = u"""
-4:5: Function with Python return type cannot be declared nogil
-7:5: Function declared nogil has Python locals or temporaries
+4:0: Function with Python return type cannot be declared nogil
+7:0: Function declared nogil has Python locals or temporaries
 9:4: Assignment of Python object not allowed without gil
 12:5: Discarding owned Python object not allowed without gil
-14:5: Function with Python return type cannot be declared nogil
+14:0: Function with Python return type cannot be declared nogil
 18:5: Calling gil-requiring function not allowed without gil
 27:9: Calling gil-requiring function not allowed without gil
 29:8: Assignment of Python object not allowed without gil

--- a/tests/errors/nogilcmeth.pyx
+++ b/tests/errors/nogilcmeth.pyx
@@ -6,5 +6,5 @@ cdef class C:
 
 _ERRORS = u"""
 2:15: Previous declaration is here
-4:9: Signature not compatible with previous declaration
+4:4: Signature not compatible with previous declaration
 """

--- a/tests/errors/pure_cclass_without_body.py
+++ b/tests/errors/pure_cclass_without_body.py
@@ -4,5 +4,5 @@ class Test(object):
     pass
 
 _ERRORS = u"""
-3:5: C class 'Test' is declared but not defined
+3:0: C class 'Test' is declared but not defined
 """

--- a/tests/errors/pxd_cdef_class_declaration_T286.pyx
+++ b/tests/errors/pxd_cdef_class_declaration_T286.pyx
@@ -5,5 +5,5 @@ cdef class A:
     pass
 
 _ERRORS = u"""
-1:5: C class 'A' is declared but not defined
+1:0: C class 'A' is declared but not defined
 """

--- a/tests/errors/pxd_signature_mismatch.pyx
+++ b/tests/errors/pxd_signature_mismatch.pyx
@@ -56,13 +56,13 @@ cdef int narrower_exception_check_optimised(int x, int y) except *:
 
 
 _ERRORS = """
-30:5: Function signature does not match previous declaration
-33:5: Function signature does not match previous declaration
-36:5: Function signature does not match previous declaration
-39:5: Function signature does not match previous declaration
-42:5: Function signature does not match previous declaration
-45:5: Function signature does not match previous declaration
-48:5: Function signature does not match previous declaration
-51:5: Function signature does not match previous declaration
-54:5: Function signature does not match previous declaration
+30:0: Function signature does not match previous declaration
+33:0: Function signature does not match previous declaration
+36:0: Function signature does not match previous declaration
+39:0: Function signature does not match previous declaration
+42:0: Function signature does not match previous declaration
+45:0: Function signature does not match previous declaration
+48:0: Function signature does not match previous declaration
+51:0: Function signature does not match previous declaration
+54:0: Function signature does not match previous declaration
 """

--- a/tests/errors/redeclaration_of_var_by_cfunc_T600.pyx
+++ b/tests/errors/redeclaration_of_var_by_cfunc_T600.pyx
@@ -9,6 +9,6 @@ cdef class Bar:
 
 
 _ERRORS = """
-7:9: '_operands' redeclared
+7:4: '_operands' redeclared
 5:14: Previous declaration is here
 """

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -434,7 +434,7 @@ _WARNINGS = """
 64:44: Found C type name 'long' in a Python annotation. Did you mean to use 'cython.long'?
 64:44: Unknown type declaration 'long' in annotation, ignoring
 # BUG:
-64:6: 'pytypes_cpdef' redeclared
+64:0: 'pytypes_cpdef' redeclared
 165:0: 'struct_io' redeclared
 200:0: 'struct_convert' redeclared
 219:0: 'exception_default' redeclared

--- a/tests/run/cpp_class_redef.pyx
+++ b/tests/run/cpp_class_redef.pyx
@@ -24,5 +24,5 @@ def test_Foo(n):
 
 
 _WARNINGS = """
-5:5: 'Foo' already defined  (ignoring second definition)
+5:0: 'Foo' already defined  (ignoring second definition)
 """

--- a/tests/run/legacy_implicit_noexcept.pyx
+++ b/tests/run/legacy_implicit_noexcept.pyx
@@ -146,10 +146,11 @@ def test_pure_noexcept():
 cdef extern int extern_fun()
 cdef extern int extern_fun_fun(int (*f)(int))
 
+
 _WARNINGS = """
-12:5: Unraisable exception in function 'legacy_implicit_noexcept.func_implicit'.
+12:0: Unraisable exception in function 'legacy_implicit_noexcept.func_implicit'.
 12:22: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
-15:5: Unraisable exception in function 'legacy_implicit_noexcept.func_noexcept'.
+15:0: Unraisable exception in function 'legacy_implicit_noexcept.func_noexcept'.
 27:28: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
 45:0: Implicit noexcept declaration is deprecated. Function declaration should contain 'noexcept' keyword.
 45:0: Unraisable exception in function 'legacy_implicit_noexcept.func_pure_implicit'.

--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -219,18 +219,18 @@ _PERFORMANCE_HINTS = """
 5:18: No exception value declared for 'f_in_pxd1' in pxd file.
 6:18: No exception value declared for 'f_in_pxd2' in pxd file.
 20:9: Exception check after calling 'f' will always require the GIL to be acquired.
-24:5: Exception check on 'f' will always require the GIL to be acquired.
-34:5: Exception check on 'release_gil_in_nogil' will always require the GIL to be acquired.
-39:6: Exception check on 'release_gil_in_nogil2' will always require the GIL to be acquired.
+24:0: Exception check on 'f' will always require the GIL to be acquired.
+34:0: Exception check on 'release_gil_in_nogil' will always require the GIL to be acquired.
+39:0: Exception check on 'release_gil_in_nogil2' will always require the GIL to be acquired.
 49:28: Exception check after calling 'release_gil_in_nogil' will always require the GIL to be acquired.
 51:29: Exception check after calling 'release_gil_in_nogil2' will always require the GIL to be acquired.
-55:5: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired.
-59:6: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired.
+55:0: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired.
+59:0: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired.
 68:24: Exception check after calling 'get_gil_in_nogil' will always require the GIL to be acquired.
 70:25: Exception check after calling 'get_gil_in_nogil2' will always require the GIL to be acquired.
-133:5: Exception check on 'copy_array_exception' will always require the GIL to be acquired.
+133:0: Exception check on 'copy_array_exception' will always require the GIL to be acquired.
 184:28: Exception check after calling 'copy_array_exception' will always require the GIL to be acquired.
-187:5: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
+187:0: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
 195:30: Exception check after calling 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
 198:36: Exception check after calling 'voidexceptnogil_in_other_pxd' will always require the GIL to be acquired.
 """


### PR DESCRIPTION
I.e. the one of the outermost (first) decorator, not necessarily the function signature line.
This affects both the error reporting (column before instead of after a `cdef`, for example) as well as line numbers in profiling/tracing.

Closes https://github.com/cython/cython/issues/6366
