### PR TITLE
Fix cpp_locals code generation with unused expressions

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3810,6 +3810,11 @@ class CoerceCppTemps(EnvTransform, SkipDeclarations):
 
         return node
 
+    def visit_ExprStatNode(self, node):
+        # Deliberately skip `expr` in ExprStatNode - we don't need to access it.
+        self.visitchildren(node.expr)
+        return node
+
 
 class TransformBuiltinMethods(EnvTransform):
     """


### PR DESCRIPTION
One of the issues from #6370.

Fixes erroneous generation of "(void)((*None));"