### PR TITLE
Disallow cpp_locals and boolean binary operators

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14754,6 +14754,12 @@ class CppOptionalTempCoercion(CoercionNode):
     def generate_result_code(self, code):
         pass
 
+    def generate_bool_evaluation_code(self, *args, **kwds):
+        # This is enough of a corner-case that it probably isn't worth
+        # the corner-case of supporting it right now.
+        error(self.pos, "Using C++ classes in boolean binary operators with "
+                "the 'cpp_locals' directive is not currently supported.")
+
     def _make_move_result_rhs(self, result, optional=False):
         # this wouldn't normally get moved (because it isn't a temp), but force it to be because it
         # is a thin wrapper around a temp

--- a/tests/run/cpp_operators.pyx
+++ b/tests/run/cpp_operators.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: cpp, werror
+# tag: cpp, werror, no-cpp-locals
 
 from __future__ import division
 


### PR DESCRIPTION
It looks very difficult to handle correctly, so I'm not sure it's worth the complication. A clean error message is better than a compiler crash.

One part of #6370