### PR TITLE
Optimise constant f-strings and constant builtin method calls

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -420,6 +420,10 @@ inferred_method_return_types = {
         index='Py_ssize_t',
         count='Py_ssize_t',
     ),
+    'tuple': dict(
+        index='Py_ssize_t',
+        count='Py_ssize_t',
+    ),
     'str': dict(
         capitalize='T',
         casefold='T',
@@ -543,6 +547,158 @@ inferred_method_return_types = {
 
 inferred_method_return_types['bytearray'].update(inferred_method_return_types['bytes'])
 inferred_method_return_types['frozenset'].update(inferred_method_return_types['set'])
+
+
+safe_compile_time_methods = {
+    # We collect only types here that have a literal representation, allowing for constant folding.
+    'complex': {
+        'conjugate',
+    },
+    'int': {
+        'as_integer_ratio',
+        'bit_length',
+        'bit_count',
+        'is_integer',
+        # 'from_bytes',  # classmethod
+        'to_bytes',
+    },
+    'float': {
+        'as_integer_ratio',
+        'is_integer',
+        'hex',
+        # 'fromhex',  # classmethod
+    },
+    'list': {
+        'index',
+        'count',
+    },
+    'tuple': {
+        'index',
+        'count',
+    },
+    'str': {
+        'capitalize',
+        'casefold',
+        'center',
+        'count',
+        'encode',
+        'endswith',
+        'expandtabs',
+        'find',
+        'format_map',
+        'format',
+        'index',
+        'isalnum',
+        'isalpha',
+        'isascii',
+        'isdecimal',
+        'isdigit',
+        'isidentifier',
+        'islower',
+        'isnumeric',
+        'isprintable',
+        'isspace',
+        'istitle',
+        'isupper',
+        'join',
+        'ljust',
+        'lower',
+        'lstrip',
+        # 'maketrans',  # staticmethod
+        'partition',
+        'removeprefix',
+        'removesuffix',
+        'replace',
+        'rfind',
+        'rindex',
+        'rjust',
+        'rpartition',
+        'rsplit',
+        'rstrip',
+        'split',
+        'splitlines',
+        'startswith',
+        'strip',
+        'swapcase',
+        'title',
+        'translate',
+        'upper',
+        'zfill',
+    },
+    'bytes': {
+        'capitalize',
+        'center',
+        'count',
+        'decode',
+        'endswith',
+        'expandtabs'
+        'find',
+        # 'fromhex',  # classmethod
+        'hex',
+        'index',
+        'isalnum',
+        'isalpha',
+        'isascii',
+        'isdigit',
+        'islower',
+        'isspace',
+        'istitle',
+        'isupper',
+        'join',
+        'ljust',
+        'lower',
+        'lstrip',
+        # 'maketrans',  # staticmethod
+        'partition',
+        'removeprefix',
+        'removesuffix',
+        'replace',
+        'rfind',
+        'rindex',
+        'rjust',
+        'rpartition',
+        'rsplit',
+        'rstrip',
+        'split',
+        'splitlines',
+        'startswith',
+        'strip',
+        'swapcase',
+        'title',
+        'translate',
+        'upper',
+        'zfill',
+    },
+    # 'bytearray': {
+    #     # Inherited from 'bytes' below.
+    # },
+    # 'memoryview': {
+    #     'tobytes',
+    #     'hex',
+    #     'tolist',
+    #     'toreadonly',
+    #     'cast',
+    # },
+    'set': {
+        'isdisjoint',
+        'isubset',
+        'issuperset',
+        'union',
+        'intersection',
+        'difference',
+        'symmetric_difference',
+        # 'copy',
+    },
+    # 'frozenset': {
+    #     # Inherited from 'set' below.
+    # },
+    # 'dict': {
+    #     'copy',
+    # },
+}
+
+# safe_compile_time_methods['bytearray'].update(safe_compile_time_methods['bytes'])
+# safe_compile_time_methods['frozenset'].update(safe_compile_time_methods['set'])
 
 
 def find_return_type_of_builtin_method(builtin_type, method_name):

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -555,29 +555,31 @@ safe_compile_time_methods = {
         'conjugate',
     },
     'int': {
-        'as_integer_ratio',
+        # 'as_integer_ratio',  # Py3.8+
         'bit_length',
-        'bit_count',
-        'is_integer',
+        # 'bit_count',  # Py3.10+
+        'conjugate',
         # 'from_bytes',  # classmethod
-        'to_bytes',
+        # 'is_integer',  # Py3.12+
+        # 'to_bytes',  # changed in Py3.11
     },
     'float': {
         'as_integer_ratio',
-        'is_integer',
-        'hex',
+        'conjugate',
         # 'fromhex',  # classmethod
+        'hex',
+        'is_integer',
     },
     'list': {
-        'index',
         'count',
+        'index',
     },
     'tuple': {
-        'index',
         'count',
+        'index',
     },
     'str': {
-        'capitalize',
+        # 'capitalize',  # changed in Py3.8+
         'casefold',
         'center',
         'count',
@@ -606,8 +608,8 @@ safe_compile_time_methods = {
         'lstrip',
         # 'maketrans',  # staticmethod
         'partition',
-        'removeprefix',
-        'removesuffix',
+        # 'removeprefix',  # Py3.9+
+        # 'removesuffix',  # Py3.9+
         'replace',
         'rfind',
         'rindex',
@@ -634,7 +636,7 @@ safe_compile_time_methods = {
         'expandtabs'
         'find',
         # 'fromhex',  # classmethod
-        'hex',
+        # 'hex',  # changed in Py3.8+
         'index',
         'isalnum',
         'isalpha',
@@ -650,8 +652,8 @@ safe_compile_time_methods = {
         'lstrip',
         # 'maketrans',  # staticmethod
         'partition',
-        'removeprefix',
-        'removesuffix',
+        # 'removeprefix',  # Py3.9+
+        # 'removesuffix',  # Py3.9+
         'replace',
         'rfind',
         'rindex',

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6004,8 +6004,7 @@ class SimpleCallNode(CallNode):
                 object_type = self.function.obj.type
                 object_type_name = object_type.name if object_type else type(method.__self__).__name__
 
-                safe_methods = Builtin.safe_compile_time_methods.get(object_type_name)
-                if safe_methods and method_name in safe_methods:
+                if Builtin.is_safe_compile_time_method(object_type_name, method_name):
                     args = [arg.constant_result for arg in self.args]
                     self.constant_result = method(*args)
 
@@ -6918,8 +6917,7 @@ class GeneralCallNode(CallNode):
                 object_type = self.function.obj.type
                 object_type_name = object_type.name if object_type else type(method.__self__).__name__
 
-                safe_methods = Builtin.safe_compile_time_methods.get(object_type_name)
-                if safe_methods and method_name in safe_methods:
+                if Builtin.is_safe_compile_time_method(object_type_name, method_name):
                     args = self.positional_args.constant_result
                     kwargs = self.keyword_args.constant_result
                     self.constant_result = method(*args, **kwargs)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -5998,7 +5998,7 @@ class SimpleCallNode(CallNode):
     def calculate_constant_result(self):
         if self.function.is_attribute and self.function.obj.is_literal:
             method = self.function.constant_result
-            if inspect.isbuiltin(method):
+            if inspect.isbuiltin(method) or inspect.ismethod(method):
                 method_name = method.__name__
                 # Prefer the actual builtin type over internal representations like "EncodedString".
                 object_type = self.function.obj.type
@@ -6912,7 +6912,7 @@ class GeneralCallNode(CallNode):
     def calculate_constant_result(self):
         if self.function.is_attribute and self.function.obj.is_literal:
             method = self.function.constant_result
-            if inspect.isbuiltin(method):
+            if inspect.isbuiltin(method) or inspect.ismethod(method):
                 method_name = method.__name__
                 # Prefer the actual builtin type over internal representations like "EncodedString".
                 object_type = self.function.obj.type

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5211,7 +5211,7 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
                 # Thus, we might want to be more specific and allow only simple Python types.
                 pass
             else:
-                # Other Python objects are not safe as they can change their formatting on each acces.
+                # Other Python objects are not safe as they can change their formatting on each access.
                 continue
 
             if not (fnode_value_node.is_name and fnode_value_node.is_simple()):

--- a/tests/run/constant_folding.py
+++ b/tests/run/constant_folding.py
@@ -505,3 +505,35 @@ def const_in_binop(v):
         return 1
     else:
         return 0
+
+
+@cython.test_fail_if_path_exists(
+    "//JoinedStrNode",
+)
+def const_fstring():
+    """
+    >>> const_fstring()
+    ('123a456', 'a456', '-123b', 'a-45b')
+    """
+    return (
+        f"{123}a{456}",
+        f"a{456}",
+        f"{-123}b",
+        f"a{-45}b",
+    )
+
+
+@cython.test_fail_if_path_exists(
+    "//AddNode",
+)
+def fstring_plus(x: cython.int):
+    """
+    >>> fstring_plus(9)
+    ('9a9xyz', 'xyza9a', 'b9b', 'a9bx9x')
+    """
+    return (
+        f"{x}a{x}" + "xyz",
+        "xyz" + f"a{x}a",
+        f"b{x}b" + "",
+        f"a{x}b" + f"x{x}x",
+    )

--- a/tests/run/fstring.pyx
+++ b/tests/run/fstring.pyx
@@ -615,6 +615,58 @@ def sideeffect(l):
     return list(l)
 
 
+@cython.test_assert_path_exists(
+    "//JoinedStrNode",
+    "//JoinedStrNode/CloneNode",
+)
+def dedup_same(x, int i, float f):
+    """
+    >>> dedup_same('abc', 5, 5.5)
+    'xabci5f5.5xabci5f5.5'
+    """
+    return f"x{x}i{i}f{f}x{x}i{i}f{f}"
+
+
+@cython.test_assert_path_exists(
+    "//JoinedStrNode",
+    "//JoinedStrNode/CloneNode",
+)
+def dedup_same_kind(x, int i, float f):
+    """
+    >>> dedup_same_kind('abc', 5, 5.5)
+    'xabci5f5.5xabci5f5.5'
+    """
+    return f"x{x}i{i}f{f}x{x!s}i{i!s}f{f!s}"
+
+
+@cython.test_fail_if_path_exists(
+    "//JoinedStrNode//CloneNode",
+)
+@cython.test_assert_path_exists(
+    "//JoinedStrNode",
+)
+def dedup_different_format_char(x, int i, float f):
+    """
+    >>> dedup_different_format_char('abc', 5, 5.5)
+    "xabci5f5.5x'abc'i5f5.5"
+    """
+    return f"x{x}i{i}f{f}x{x!r}i{i:d}f{f!a}"
+
+
+@cython.test_fail_if_path_exists(
+    "//JoinedStrNode//CloneNode",
+)
+@cython.test_assert_path_exists(
+    "//JoinedStrNode",
+)
+def dedup_non_simple(x, int i, float f):
+    """
+    >>> dedup_non_simple('abc', 5, 5.5)
+    'xabci6f6.5xabci6f6.5'
+    """
+    return f"x{x+''}i{i+1}f{f+1}x{x}i{i+1}f{f+1}"
+
+
 ########################################
 # await inside f-string
 


### PR DESCRIPTION
I actually started off optimising constant builtin method calls here and ended up doing a lot of additional optimisations for f-strings. Especially the expression deduplication seems a very neat improvement, although there's a tiny risk of diverting from strict Python semantics. It's difficult to run into for users, though.