### PR TITLE
Fix inplace assignment on nested attributes without GIL

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2982,7 +2982,7 @@ class ExpandInplaceOperators(EnvTransform):
                 index = LetRefNode(node.index)
                 return ExprNodes.IndexNode(node.pos, base=base, index=index), temps + [index]
             elif node.is_attribute:
-                obj, temps = side_effect_free_reference(node.obj)
+                obj, temps = side_effect_free_reference(node.obj, setting=setting)
                 return ExprNodes.AttributeNode(node.pos, obj=obj, attribute=node.attribute), temps
             elif isinstance(node, ExprNodes.BufferIndexNode):
                 raise ValueError("Don't allow things like attributes of buffer indexing operations")

--- a/tests/compile/inplace_lhs_nested.pyx
+++ b/tests/compile/inplace_lhs_nested.pyx
@@ -1,0 +1,17 @@
+# mode: compile
+
+cdef class A:
+    cdef int b
+
+cdef class C:
+    cdef A _a
+
+
+cdef void set_a(A a) noexcept nogil:
+    a.b |= 1
+
+cdef void set_b(C c) noexcept nogil:
+    c._a.b |= 1
+
+cdef void set_c(C c) noexcept nogil:
+    c._a.b = c._a.b | 1


### PR DESCRIPTION
Fixing what I determine must be a bug. When using "inplace assignment", Cython would emit code to acquire the GIL, although it shouldn't be necessary.

Given two extension types:
```Cython
cdef class A:
    cdef int b

cdef class C:
    cdef A _a
```

We can successfully bitwise-or onto the attribute `b` without GIL:
```Cython
cdef void set_a(A a) noexcept nogil:
    a.b |= 1
# __pyx_v_a->b = (__pyx_v_a->b | 1);
```

But if we nest the structure, we now hit a problem, as this will take `c` as a PyObject and emit code to reference count (requiring GIL).
```Cython
cdef void set_b(C c) noexcept:
    c._a.b |= 1
#  __Pyx_INCREF((PyObject *)__pyx_v_c->_a);
#  __pyx_t_1 = __pyx_v_c->_a;
#  __pyx_t_1->b = (__pyx_t_1->b | 1);
#  __Pyx_DECREF((PyObject *)__pyx_t_1); __pyx_t_1 = 0;
```

Although if we split up the bitwise-or and assignment, we can now perform the same operation without acquiring the GIL:
```Cython
cdef void set_c(C c) noexcept nogil:
    c._a.b = c._a.b | 1
#  __pyx_v_c->_a->b = (__pyx_v_c->_a->b | 1);
```

This PR attempts to fix this issue, and emit the same code for `a.b.c |= 1` as `a.b.c = a.b.c | 1`. I'm not 100% confident in the implementation, so please verify the soundness of this before merging.