### PR TITLE
Use `memoryview` type in `cpython.memoryview`

### DIFF
--- a/Cython/Includes/cpython/memoryview.pxd
+++ b/Cython/Includes/cpython/memoryview.pxd
@@ -6,27 +6,27 @@ cdef extern from "Python.h":
     # A memoryview object exposes the C level buffer interface as a Python
     # object which can then be passed around like any other object
 
-    object PyMemoryView_FromObject(object obj)
+    memoryview PyMemoryView_FromObject(object obj)
     # Return value: New reference.
     # Create a memoryview object from an object that provides the buffer
     # interface. If obj supports writable buffer exports, the memoryview object
     # will be read/write, otherwise it may be either read-only or read/write at
     # the discretion of the exporter.
 
-    object PyMemoryView_FromMemory(char *mem, Py_ssize_t size, int flags)
+    memoryview PyMemoryView_FromMemory(char *mem, Py_ssize_t size, int flags)
     # Return value: New reference.
     # Create a memoryview object using mem as the underlying buffer. flags can
     # be one of PyBUF_READ or PyBUF_WRITE.
     # New in version 3.3.
 
-    object PyMemoryView_FromBuffer(Py_buffer *view)
+    memoryview PyMemoryView_FromBuffer(Py_buffer *view)
     # Return value: New reference.
     # Create a memoryview object wrapping the given buffer structure view. For
     # simple byte buffers, PyMemoryView_FromMemory() is the preferred function.
 
-    object PyMemoryView_GetContiguous(object obj,
-                                      int buffertype,
-                                      char order)
+    memoryview PyMemoryView_GetContiguous(object obj,
+                                          int buffertype,
+                                          char order)
     # Return value: New reference.
     # Create a memoryview object to a contiguous chunk of memory (in either ‘C’
     # or ‘F’ortran order) from an object that defines the buffer interface. If


### PR DESCRIPTION
Convert these from `object` to `memoryview`. This will allow these to return the `memoryview` typed object and thus bypass additional checks and benefit from associated optimizations.

Left alone the input arguments of...:
* `PyMemoryView_Check`
* `PyMemoryView_GET_BUFFER`
* `PyMemoryView_GET_BASE`

The first one should handle any type.

The latter two say the don't check type currently. So presumably we don't want to add our own checks on top of those.

That said, perhaps there is a better way to accomplish what the latter two functions offer through `memoryview` attributes?