### PR TITLE
CI: Bump scientific-python/upload-nightly-action from 0.5.0 to 0.6.1

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload wheels to scientific-python-nightly-wheels
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.CYTHON_NIGHTLY_UPLOAD_TOKEN }}


### PR DESCRIPTION
* [`scientific-python/upload-nightly-action` `0.6.x`](https://github.com/scientific-python/upload-nightly-action/releases/tag/0.6.1) adopts [`pixi`](https://pixi.sh/) as the environment and lock file management tool, which both makes maintenance easier and allows for the `scientific-python/upload-nightly-action` to support both Linux and macOS runners.

  There is no change to the `scientific-python/upload-nightly-action` GitHub action API.

* This PR is being opened to keep all projects (known to be) using the action on the same minor version series.