### PR TITLE
Cast non-PyObject return values in __Pyx_TraceReturnValue invocations

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -3099,8 +3099,10 @@ class CCodeWriter:
         extra_arg = ""
         trace_func = "__Pyx_TraceReturnValue"
 
-        if return_type is None or return_type.is_pyobject:
+        if return_type is None:
             pass
+        elif return_type.is_pyobject:
+            retvalue_cname = return_type.as_pyobject(retvalue_cname)
         elif return_type.is_void:
             retvalue_cname = 'Py_None'
         elif return_type.to_py_function:

--- a/tests/compile/profile_exttypereturn.pyx
+++ b/tests/compile/profile_exttypereturn.pyx
@@ -1,0 +1,12 @@
+# mode: compile
+# cython: profile=True
+
+cdef class Foo:
+    ...
+
+cdef Foo _foo():
+    return Foo()
+
+def foo():
+    return _foo()
+


### PR DESCRIPTION
The first argument of `__Pyx_TraceReturnValue` needs to be cast to `PyObject *` if the function returns an extension type.