### PR TITLE
Don't include pycore_lock.h

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2852,8 +2852,6 @@ class CCodeWriter:
         self.putln("__Pyx_PyGILState_Release(%s);" % variable)
 
     def put_acquire_freethreading_lock(self):
-        self.globalstate.use_utility_code(
-            UtilityCode.load_cached("AccessPyMutexForFreeThreading", "ModuleSetupCode.c"))
         self.putln("#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING")
         self.putln(f"PyMutex_Lock(&{Naming.parallel_freethreading_mutex});")
         self.putln("#endif")

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2477,16 +2477,6 @@ static int __Pyx_VersionSanityCheck(void) {
     return 0;
 }
 
-/////////////////////////// AccessPyMutexForFreeThreading.proto ////////////
-
-#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
-// TODO - this is likely to get exposed properly at some point
-#ifndef Py_BUILD_CORE
-#define Py_BUILD_CORE 1
-#endif
-#include "internal/pycore_lock.h"
-#endif
-
 ////////////////////////// SharedInFreeThreading.proto //////////////////
 
 #if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING


### PR DESCRIPTION
The PyMutex functions were previously in a private pycore_lock.h header. Since Python 3.13.0b3, `PyMutex_Lock` and `PyMutex_Unlock` are now available when including `Python.h`.

Fixes #6391