### PR TITLE
Avoid spurious noexcept warnings

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3126,6 +3126,11 @@ class DefNode(FuncDefNode):
             if scope is None:
                 scope = cfunc.scope
             cfunc_type = cfunc.type
+            if cfunc_type.exception_check:
+                # this ensures `legacy_implicit_noexcept` does not trigger
+                # as it would result in a mismatch
+                # (declaration with except, definition with implicit noexcept)
+                has_explicit_exc_clause = True
             if len(self.args) != len(cfunc_type.args) or cfunc_type.has_varargs:
                 error(self.pos, "wrong number of arguments")
                 error(cfunc.pos, "previous declaration here")

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3126,7 +3126,6 @@ class DefNode(FuncDefNode):
             if scope is None:
                 scope = cfunc.scope
             cfunc_type = cfunc.type
-            has_explicit_exc_clause=True
             if len(self.args) != len(cfunc_type.args) or cfunc_type.has_varargs:
                 error(self.pos, "wrong number of arguments")
                 error(cfunc.pos, "previous declaration here")

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -717,10 +717,8 @@ class CFuncDeclaratorNode(CDeclaratorNode):
                 and not self.has_explicit_exc_clause
                 and self.exception_check
                 and visibility != 'extern'):
-            # If function is already declared from pxd, the exception_check has already correct value.
-            if not (self.declared_name() in env.entries and not in_pxd):
-                self.exception_check = False
             # implicit noexcept, with a warning
+            self.exception_check = False
             warning(self.pos,
                     "Implicit noexcept declaration is deprecated."
                     " Function declaration should contain 'noexcept' keyword.",
@@ -3128,6 +3126,7 @@ class DefNode(FuncDefNode):
             if scope is None:
                 scope = cfunc.scope
             cfunc_type = cfunc.type
+            has_explicit_exc_clause=True
             if len(self.args) != len(cfunc_type.args) or cfunc_type.has_varargs:
                 error(self.pos, "wrong number of arguments")
                 error(cfunc.pos, "previous declaration here")

--- a/tests/errors/w_noexcept.pxd
+++ b/tests/errors/w_noexcept.pxd
@@ -1,0 +1,2 @@
+cdef object test_return_object_noexcept_in_pxd(x) noexcept
+cdef object test_return_object_in_pxd(x)

--- a/tests/errors/w_noexcept.pyx
+++ b/tests/errors/w_noexcept.pyx
@@ -10,6 +10,12 @@ ctypedef fused double_or_object:
 cdef object test_return_object_noexcept(x) noexcept: # Err
     return x
 
+cdef object test_return_object_noexcept_in_pxd(x) noexcept: # Err
+    return x
+
+cdef object test_return_object_in_pxd(x): # OK
+    return x
+
 cdef str test_return_str_noexcept() noexcept: # Err
     return 'a'
 
@@ -70,9 +76,13 @@ def test_pure_return_fused_noexcept(x: double_or_object) -> double_or_object: # 
 
 _ERRORS = """
 10:39: noexcept clause is ignored for function returning Python object
-13:33: noexcept clause is ignored for function returning Python object
-16:18: noexcept clause is ignored for function returning Python object
-38:0: noexcept clause is ignored for function returning Python object
-43:0: noexcept clause is ignored for function returning Python object
-48:0: noexcept clause is ignored for function returning Python object
+13:46: noexcept clause is ignored for function returning Python object
+19:33: noexcept clause is ignored for function returning Python object
+22:18: noexcept clause is ignored for function returning Python object
+44:0: noexcept clause is ignored for function returning Python object
+49:0: noexcept clause is ignored for function returning Python object
+54:0: noexcept clause is ignored for function returning Python object
+
+# from pxd
+1:46: noexcept clause is ignored for function returning Python object
 """

--- a/tests/errors/w_noexcept_pure.pxd
+++ b/tests/errors/w_noexcept_pure.pxd
@@ -1,0 +1,7 @@
+cdef object test_return_object_noexcept_in_pxd(x) noexcept
+cdef object test_return_object_in_pxd(x)
+
+cdef extern from *:
+    cdef object extern_return_object() # Ok
+
+    cdef object extern_noexcept() noexcept # Ok

--- a/tests/errors/w_noexcept_pure.py
+++ b/tests/errors/w_noexcept_pure.py
@@ -1,0 +1,48 @@
+# mode: error
+# tag: werror
+
+import cython
+
+@cython.cfunc
+@cython.exceptval(check=False)
+def test_return_object_noexcept(x) -> object: # Err
+    return x
+
+# declared in pxd as noexcept and cdef
+def test_return_object_noexcept_in_pxd(x): # Err
+    return x
+
+# declared in pxd as cdef
+def test_return_object_in_pxd(x): # OK
+    return x
+
+@cython.cfunc
+@cython.exceptval(check=False)
+def test_return_str_noexcept() -> str: # Err
+    return 'a'
+
+@cython.cfunc
+@cython.exceptval(check=False)
+def test_noexcept():  # Err
+    pass
+
+@cython.cfunc
+def test_implicit_noexcept(): # Ok
+    pass
+
+@cython.cfunc
+def test_return_object(x) -> object: # Ok
+    return x
+
+@cython.cfunc
+def test_return_str() -> str: # Ok
+    return 'a'
+
+_ERRORS = """
+6:0: noexcept clause is ignored for function returning Python object
+19:0: noexcept clause is ignored for function returning Python object
+24:0: noexcept clause is ignored for function returning Python object
+
+# from pxd
+1:46: noexcept clause is ignored for function returning Python object
+"""

--- a/tests/run/legacy_implicit_noexcept_build.srctree
+++ b/tests/run/legacy_implicit_noexcept_build.srctree
@@ -179,6 +179,10 @@ try: aa.r3(True)
 except ValueError: assert False, "ValueError not raised"
 else:              pass
 
+######## bar.pxd ########
+cdef int func_noexcept_declared_in_pxd() noexcept
+cdef int func_implicit_declared_in_pxd()
+
 ######## bar.pyx ########
 
 cdef int func_noexcept() noexcept:
@@ -187,11 +191,20 @@ cdef int func_noexcept() noexcept:
 cdef int func_implicit():
     raise RuntimeError()
 
+cdef int func_noexcept_declared_in_pxd():
+    raise RuntimeError()
+
+cdef int func_implicit_declared_in_pxd():
+    raise RuntimeError()
+
 cdef int func_return_value() except -1:
     raise RuntimeError()
 
 func_noexcept()
 func_implicit()
+
+func_noexcept_declared_in_pxd()
+func_implicit_declared_in_pxd()
 
 try:
     func_return_value()


### PR DESCRIPTION
This re-adds #6343, removes one line which seems to be the source of the spurious warnings, and add a bunch of tests to make sure we don't get the spurious warnings.

Goes into 3.0.x

Fixes https://github.com/cython/cython/issues/6428