### PR TITLE
Move some static globals to module state

### DIFF
--- a/Cython/Compiler/Code.pxd
+++ b/Cython/Compiler/Code.pxd
@@ -18,6 +18,7 @@ cdef class UtilityCode(UtilityCodeBase):
     cdef public dict _cache
     cdef public list specialize_list
     cdef public object file
+    cdef public tuple _parts_tuple
 
     cpdef none_or_sub(self, s, context)
     # TODO - Signature not compatible with previous declaration

--- a/Cython/Compiler/Code.pxd
+++ b/Cython/Compiler/Code.pxd
@@ -13,6 +13,7 @@ cdef class UtilityCode(UtilityCodeBase):
     cdef public object init
     cdef public object cleanup
     cdef public object proto_block
+    cdef public object module_state_decls
     cdef public object requires
     cdef public dict _cache
     cdef public list specialize_list

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -644,11 +644,11 @@ class UtilityCode(UtilityCodeBase):
         self.name = name
         self.file = file
 
-    def _parts_tuple(self):
-        return tuple(getattr(self, part, None) for part in self.code_parts)
+        # cached for use in hash and eq
+        self._parts_tuple = tuple(getattr(self, part, None) for part in self.code_parts)
 
     def __hash__(self):
-        return hash(self._parts_tuple())
+        return hash(self._parts_tuple)
 
     def __eq__(self, other):
         if self is other:
@@ -657,7 +657,7 @@ class UtilityCode(UtilityCodeBase):
         if self_type is not other_type and not (isinstance(other, self_type) or isinstance(self, other_type)):
             return False
 
-        return self._parts_tuple() == other._parts_tuple()
+        return self._parts_tuple == other._parts_tuple
 
     def none_or_sub(self, s, context):
         """
@@ -1863,10 +1863,10 @@ class GlobalState:
             if utf16_array:
                 # Narrow and wide representations differ
                 decls_writer.putln("#ifdef Py_UNICODE_WIDE")
-            decls_writer.putln("static const Py_UNICODE %s[] = { %s };" % (cname, utf32_array))
+            decls_writer.putln("static Py_UNICODE %s[] = { %s };" % (cname, utf32_array))
             if utf16_array:
                 decls_writer.putln("#else")
-                decls_writer.putln("static const Py_UNICODE %s[] = { %s };" % (cname, utf16_array))
+                decls_writer.putln("static Py_UNICODE %s[] = { %s };" % (cname, utf16_array))
                 decls_writer.putln("#endif")
 
         if not py_strings:

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -449,7 +449,7 @@ class UtilityCodeBase:
             (r'^%(C)s{5,30}\s*(?P<name>(?:\w|\.)+)\s*%(C)s{5,30}|'
              r'^%(C)s+@(?P<tag>\w+)\s*:\s*(?P<value>(?:\w|[.:])+)') %
             {'C': comment}).match
-        match_type = re.compile(r'(.+)[.](proto(?:[.]\S+)?|impl|init|cleanup)$').match
+        match_type = re.compile(r'(.+)[.](proto(?:[.]\S+)?|impl|init|cleanup|module_state_decls)$').match
 
         all_lines = read_utilities_hook(path)
 
@@ -626,14 +626,17 @@ class UtilityCode(UtilityCodeBase):
     file            filename of the utility code file this utility was loaded
                     from (or None)
     """
+    code_parts = ["proto", "impl", "init", "cleanup", "module_state_decls"]
 
-    def __init__(self, proto=None, impl=None, init=None, cleanup=None, requires=None,
+    def __init__(self, proto=None, impl=None, init=None, cleanup=None,
+                 module_state_decls=None, requires=None,
                  proto_block='utility_code_proto', name=None, file=None):
         # proto_block: Which code block to dump prototype in. See GlobalState.
         self.proto = proto
         self.impl = impl
         self.init = init
         self.cleanup = cleanup
+        self.module_state_decls = module_state_decls
         self.requires = requires
         self._cache = {}
         self.specialize_list = []
@@ -641,8 +644,11 @@ class UtilityCode(UtilityCodeBase):
         self.name = name
         self.file = file
 
+    def _parts_tuple(self):
+        return tuple(getattr(self, part, None) for part in self.code_parts)
+
     def __hash__(self):
-        return hash((self.proto, self.impl))
+        return hash(self._parts_tuple())
 
     def __eq__(self, other):
         if self is other:
@@ -651,11 +657,7 @@ class UtilityCode(UtilityCodeBase):
         if self_type is not other_type and not (isinstance(other, self_type) or isinstance(self, other_type)):
             return False
 
-        self_init = getattr(self, 'init', None)
-        other_init = getattr(other, 'init', None)
-        self_proto = getattr(self, 'proto', None)
-        other_proto = getattr(other, 'proto', None)
-        return (self_init, self_proto, self.impl) == (other_init, other_proto, other.impl)
+        return self._parts_tuple() == other._parts_tuple()
 
     def none_or_sub(self, s, context):
         """
@@ -686,6 +688,7 @@ class UtilityCode(UtilityCodeBase):
                 self.none_or_sub(self.impl, data),
                 self.none_or_sub(self.init, data),
                 self.none_or_sub(self.cleanup, data),
+                self.none_or_sub(self.module_state_decls, data),
                 requires,
                 self.proto_block,
                 name,
@@ -733,6 +736,8 @@ class UtilityCode(UtilityCodeBase):
             self._put_code_section(output['utility_code_def'], output, 'impl')
         if self.cleanup and Options.generate_cleanup_code:
             self._put_code_section(output['cleanup_globals'], output, 'cleanup')
+        if self.module_state_decls:
+            self._put_code_section(output['module_state_contents'], output, 'module_state_decls')
 
         if self.init:
             self._put_init_code_section(output)
@@ -816,7 +821,9 @@ def _inject_unbound_method(output, matchobj):
     type_cname = '&%s' % type_cname
     args = [arg.strip() for arg in args[1:].split(',')] if args else []
     assert len(args) < 3, f"CALL_UNBOUND_METHOD() does not support {len(args):d} call arguments"
-    return output.cached_unbound_method_call_code(obj_cname, type_cname, method_name, args)
+    return output.cached_unbound_method_call_code(
+        f"{Naming.modulestateglobal_cname}->",
+        obj_cname, type_cname, method_name, args)
 
 
 @add_macro_processor(
@@ -1364,6 +1371,8 @@ class GlobalState:
         'decls',
         'late_includes',
         'module_state',
+        'module_state_contents',  # can be used to inject declarations into the modulestate struct
+        'module_state_end',
         'constant_name_defines',
         'module_state_clear',
         'module_state_traverse',
@@ -1697,14 +1706,15 @@ class GlobalState:
                 'umethod', '%s_%s' % (type_cname, method_name))
         return cname
 
-    def cached_unbound_method_call_code(self, obj_cname, type_cname, method_name, arg_cnames):
+    def cached_unbound_method_call_code(self, modulestate_cname, obj_cname, type_cname, method_name, arg_cnames):
         # admittedly, not the best place to put this method, but it is reused by UtilityCode and ExprNodes ...
         utility_code_name = "CallUnboundCMethod%d" % len(arg_cnames)
         self.use_utility_code(UtilityCode.load_cached(utility_code_name, "ObjectHandling.c"))
         cache_cname = self.get_cached_unbound_method(type_cname, method_name)
         args = [obj_cname] + arg_cnames
-        return "__Pyx_%s(&%s, %s)" % (
+        return "__Pyx_%s(&%s%s, %s)" % (
             utility_code_name,
+            modulestate_cname,
             cache_cname,
             ', '.join(args),
         )
@@ -1798,25 +1808,26 @@ class GlobalState:
         if not self.cached_cmethods:
             return
 
-        decl = self.parts['decls']
+        decl = self.parts['module_state']
         init = self.parts['init_constants']
         cnames = []
         for (type_cname, method_name), cname in sorted(self.cached_cmethods.items()):
             cnames.append(cname)
             method_name_cname = self.get_interned_identifier(StringEncoding.EncodedString(method_name)).cname
-            decl.putln('static __Pyx_CachedCFunction %s = {0, 0, 0, 0, 0};' % (
+            decl.putln('__Pyx_CachedCFunction %s;' % (
                 cname))
             # split type reference storage as it might not be static
             init.putln('%s.type = (PyObject*)%s;' % (
-                cname, type_cname))
+                init.name_in_main_c_code_module_state(cname), type_cname))
             # method name string isn't static in limited api
             init.putln(
-                f'{cname}.method_name = &{init.name_in_main_c_code_module_state(method_name_cname)};')
+                f'{init.name_in_main_c_code_module_state(cname)}.method_name = '
+                f'&{init.name_in_main_c_code_module_state(method_name_cname)};')
 
         if Options.generate_cleanup_code:
             cleanup = self.parts['cleanup_globals']
             for cname in cnames:
-                cleanup.putln("Py_CLEAR(%s.method);" % cname)
+                cleanup.putln(f"Py_CLEAR({init.name_in_main_c_code_module_state(cname)}.method);")
 
     def generate_string_constants(self):
         c_consts = [(len(c.cname), c.cname, c) for c in self.string_const_index.values()]
@@ -1852,10 +1863,10 @@ class GlobalState:
             if utf16_array:
                 # Narrow and wide representations differ
                 decls_writer.putln("#ifdef Py_UNICODE_WIDE")
-            decls_writer.putln("static Py_UNICODE %s[] = { %s };" % (cname, utf32_array))
+            decls_writer.putln("static const Py_UNICODE %s[] = { %s };" % (cname, utf32_array))
             if utf16_array:
                 decls_writer.putln("#else")
-                decls_writer.putln("static Py_UNICODE %s[] = { %s };" % (cname, utf16_array))
+                decls_writer.putln("static const Py_UNICODE %s[] = { %s };" % (cname, utf16_array))
                 decls_writer.putln("#endif")
 
         if not py_strings:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6924,6 +6924,7 @@ class CachedBuiltinMethodCallNode(CallNode):
         obj_cname = self.obj.py_result()
         args = [arg.py_result() for arg in self.args]
         call_code = code.globalstate.cached_unbound_method_call_code(
+            code.name_in_module_state(""),
             obj_cname, type_cname, self.method_name, args)
         code.putln("%s = %s; %s" % (
             self.result(), call_code,

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -130,7 +130,7 @@ static CYTHON_INLINE int __Pyx__IsSameCyOrCFunctionNoMethod(PyObject *func, void
 }
 
 static CYTHON_INLINE int __Pyx__IsSameCyOrCFunction(PyObject *func, void *cfunc) {
-    if ((PyObject*)Py_TYPE(func) == __Pyx_CachedMethodType) {
+    if ((PyObject*)Py_TYPE(func) == CGLOBAL(__Pyx_CachedMethodType)) {
         int result;
         PyObject *newFunc = PyObject_GetAttr(func, PYIDENT("__func__"));
         if (unlikely(!newFunc)) {

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1225,7 +1225,21 @@ static CYTHON_INLINE int __Pyx_PyDict_GetItemRef(PyObject *dict, PyObject *key, 
     #define __PYX_MONITORING_ABI_SUFFIX
 #endif
 
-#define CYTHON_ABI  __PYX_ABI_VERSION __PYX_LIMITED_ABI_SUFFIX __PYX_MONITORING_ABI_SUFFIX
+#if CYTHON_USE_TP_FINALIZE
+    #define __PYX_TP_FINALIZE_ABI_SUFFIX
+#else
+    // affects destruction of async generator/coroutines
+    #define __PYX_TP_FINALIZE_ABI_SUFFIX "nofinalize"
+#endif
+
+#if CYTHON_USE_FREELISTS || !defined(__Pyx_AsyncGen_USED)
+    #define __PYX_FREELISTS_ABI_SUFFIX
+#else
+    // affects allocation/deallocation of async generator objects.
+    #define __PYX_FREELISTS_ABI_SUFFIX "nofreelists"
+#endif
+
+#define CYTHON_ABI  __PYX_ABI_VERSION __PYX_LIMITED_ABI_SUFFIX __PYX_MONITORING_ABI_SUFFIX __PYX_TP_FINALIZE_ABI_SUFFIX __PYX_FREELISTS_ABI_SUFFIX
 
 #define __PYX_ABI_MODULE_NAME "_cython_" CYTHON_ABI
 #define __PYX_TYPE_MODULE_PREFIX __PYX_ABI_MODULE_NAME "."

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -380,7 +380,8 @@
     #define CYTHON_USE_DICT_VERSIONS 0
   #elif !defined(CYTHON_USE_DICT_VERSIONS)
     // Python 3.12a5 deprecated "ma_version_tag"
-    #define CYTHON_USE_DICT_VERSIONS  (PY_VERSION_HEX < 0x030C00A5)
+    // and we use static variables with dict versions so it's incompatible with module state
+    #define CYTHON_USE_DICT_VERSIONS  (PY_VERSION_HEX < 0x030C00A5 && !CYTHON_USE_MODULE_STATE)
   #endif
   #ifndef CYTHON_USE_EXC_INFO_STACK
     #define CYTHON_USE_EXC_INFO_STACK 1

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -184,6 +184,12 @@ static CYTHON_INLINE PyObject *__Pyx_PyIter_Next_Plain(PyObject *iterator);
 static PyObject *__Pyx_GetBuiltinNext_LimitedAPI(void);
 #endif
 
+/////////////// IterNextPlain.module_state_decls ///////////////
+
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
+PyObject *__Pyx_GetBuiltinNext_LimitedAPI_cache = NULL;
+#endif
+
 /////////////// IterNextPlain ///////////////
 //@requires: GetBuiltinName
 
@@ -193,10 +199,10 @@ static PyObject *__Pyx_GetBuiltinNext_LimitedAPI(void);
 
 #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
 static PyObject *__Pyx_GetBuiltinNext_LimitedAPI(void) {
-    static PyObject *next = NULL;
-    if (unlikely(!next)) next = __Pyx_GetBuiltinName(PYIDENT("next"));
+    if (unlikely(!CGLOBAL(__Pyx_GetBuiltinNext_LimitedAPI_cache)))
+        CGLOBAL(__Pyx_GetBuiltinNext_LimitedAPI_cache) = __Pyx_GetBuiltinName(PYIDENT("next"));
     // Returns the globally owned reference, not a new reference!
-    return next;
+    return CGLOBAL(__Pyx_GetBuiltinNext_LimitedAPI_cache);
 }
 #endif
 
@@ -2710,10 +2716,10 @@ static CYTHON_INLINE int __Pyx_object_dict_version_matches(PyObject* obj, PY_UIN
 }
 #endif
 
-////////////// CachedMethodType.proto //////////////
+////////////// CachedMethodType.module_state_decls ////////////
 
 #if CYTHON_COMPILING_IN_LIMITED_API
-static PyObject *__Pyx_CachedMethodType = NULL;
+PyObject *__Pyx_CachedMethodType;
 #endif
 
 ////////////// CachedMethodType.init //////////////
@@ -2723,7 +2729,7 @@ static PyObject *__Pyx_CachedMethodType = NULL;
     PyObject *typesModule=NULL;
     typesModule = PyImport_ImportModule("types");
     if (typesModule) {
-        __Pyx_CachedMethodType = PyObject_GetAttrString(typesModule, "MethodType");
+        CGLOBAL(__Pyx_CachedMethodType) = PyObject_GetAttrString(typesModule, "MethodType");
         Py_DECREF(typesModule);
     }
 } // error handling follows
@@ -2732,7 +2738,7 @@ static PyObject *__Pyx_CachedMethodType = NULL;
 /////////////// CachedMethodType.cleanup ////////////////
 
 #if CYTHON_COMPILING_IN_LIMITED_API
-Py_CLEAR(__Pyx_CachedMethodType);
+Py_CLEAR(CGLOBAL(__Pyx_CachedMethodType));
 #endif
 
 /////////////// PyMethodNew.proto ///////////////

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -187,7 +187,7 @@ static PyObject *__Pyx_GetBuiltinNext_LimitedAPI(void);
 /////////////// IterNextPlain.module_state_decls ///////////////
 
 #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
-PyObject *__Pyx_GetBuiltinNext_LimitedAPI_cache = NULL;
+PyObject *__Pyx_GetBuiltinNext_LimitedAPI_cache;
 #endif
 
 /////////////// IterNextPlain ///////////////
@@ -2742,6 +2742,10 @@ Py_CLEAR(CGLOBAL(__Pyx_CachedMethodType));
 #endif
 
 /////////////// PyMethodNew.proto ///////////////
+
+static PyObject *__Pyx_PyMethod_New(PyObject *func, PyObject *self, PyObject *typ); /* proto */
+
+/////////////// PyMethodNew ///////////////
 //@requires: CachedMethodType
 
 #if CYTHON_COMPILING_IN_LIMITED_API
@@ -2753,10 +2757,10 @@ static PyObject *__Pyx_PyMethod_New(PyObject *func, PyObject *self, PyObject *ty
     #if __PYX_LIMITED_VERSION_HEX >= 0x030C0000
     {
         PyObject *args[] = {func, self};
-        result = PyObject_Vectorcall(__Pyx_CachedMethodType, args, 2, NULL);
+        result = PyObject_Vectorcall(CGLOBAL(__Pyx_CachedMethodType), args, 2, NULL);
     }
     #else
-    result = PyObject_CallFunctionObjArgs(__Pyx_CachedMethodType, func, self, NULL);
+    result = PyObject_CallFunctionObjArgs(CGLOBAL(__Pyx_CachedMethodType), func, self, NULL);
     #endif
     return result;
 }

--- a/Cython/Utility/Printing.c
+++ b/Cython/Utility/Printing.c
@@ -1,26 +1,26 @@
 ////////////////////// Print.proto //////////////////////
-//@substitute: naming
 
 static int __Pyx_Print(PyObject*, PyObject *, int); /*proto*/
-static PyObject* $print_function = 0;
-static PyObject* $print_function_kwargs = 0;
+
+////////////////////// Print.module_state_decls /////////////
+//@substitute: naming
+PyObject* $print_function;
+PyObject* $print_function_kwargs;
 
 ////////////////////// Print.cleanup //////////////////////
-//@substitute: naming
 
-Py_CLEAR($print_function);
-Py_CLEAR($print_function_kwargs);
+Py_CLEAR(NAMED_CGLOBAL(print_function));
+Py_CLEAR(NAMED_CGLOBAL(print_function_kwargs));
 
 ////////////////////// Print //////////////////////
-//@substitute: naming
 
 static int __Pyx_Print(PyObject* stream, PyObject *arg_tuple, int newline) {
     PyObject* kwargs = 0;
     PyObject* result = 0;
     PyObject* end_string;
-    if (unlikely(!$print_function)) {
-        $print_function = PyObject_GetAttr(NAMED_CGLOBAL(builtins_cname), PYIDENT("print"));
-        if (!$print_function)
+    if (unlikely(!NAMED_CGLOBAL(print_function))) {
+        NAMED_CGLOBAL(print_function) = PyObject_GetAttr(NAMED_CGLOBAL(builtins_cname), PYIDENT("print"));
+        if (!NAMED_CGLOBAL(print_function))
             return -1;
     }
     if (stream) {
@@ -40,30 +40,30 @@ static int __Pyx_Print(PyObject* stream, PyObject *arg_tuple, int newline) {
             Py_DECREF(end_string);
         }
     } else if (!newline) {
-        if (unlikely(!$print_function_kwargs)) {
-            $print_function_kwargs = PyDict_New();
-            if (unlikely(!$print_function_kwargs))
+        if (unlikely(!NAMED_CGLOBAL(print_function_kwargs))) {
+            NAMED_CGLOBAL(print_function_kwargs) = PyDict_New();
+            if (unlikely(!NAMED_CGLOBAL(print_function_kwargs)))
                 return -1;
             end_string = PyUnicode_FromStringAndSize(" ", 1);
             if (unlikely(!end_string))
                 return -1;
-            if (PyDict_SetItem($print_function_kwargs, PYIDENT("end"), end_string) < 0) {
+            if (PyDict_SetItem(NAMED_CGLOBAL(print_function_kwargs), PYIDENT("end"), end_string) < 0) {
                 Py_DECREF(end_string);
                 return -1;
             }
             Py_DECREF(end_string);
         }
-        kwargs = $print_function_kwargs;
+        kwargs = NAMED_CGLOBAL(print_function_kwargs);
     }
-    result = PyObject_Call($print_function, arg_tuple, kwargs);
-    if (unlikely(kwargs) && (kwargs != $print_function_kwargs))
+    result = PyObject_Call(NAMED_CGLOBAL(print_function), arg_tuple, kwargs);
+    if (unlikely(kwargs) && (kwargs != NAMED_CGLOBAL(print_function_kwargs)))
         Py_DECREF(kwargs);
     if (!result)
         return -1;
     Py_DECREF(result);
     return 0;
 bad:
-    if (kwargs != $print_function_kwargs)
+    if (kwargs != NAMED_CGLOBAL(print_function_kwargs))
         Py_XDECREF(kwargs);
     return -1;
 }


### PR DESCRIPTION
A lot of the things we currently store as static globals really belong in module state (at least if they are to work in multiple interpreters in future). Here this includes freelists, async types, and various cached objects.

Do this partly by adding a new utility code section that can be used to inject declarations into the module state.

Additionally make async freelists obey CYTHON_USE_FREELISTS (since they're not thread safe in freethreading).

(Probably isn't completely comprehensive yet)