### PR TITLE
Update shebang

### DIFF
--- a/Cython/Debugger/libpython.py
+++ b/Cython/Debugger/libpython.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # NOTE: Most of this file is taken from the Python source distribution
 # It can be found under Tools/gdb/libpython.py. It is shipped with Cython


### PR DESCRIPTION
Shebang was hardcoded to `/usr/bin/python` which will fail on many modern OSes.