### PR TITLE
Get module-state working on multi-phase init

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3423,7 +3423,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         # which is sometime unreliable during destruction
         # (e.g. during interpreter shutdown).
         # In that case the safest thing is to give up.
+        code.putln("#if CYTHON_USE_MODULE_STATE")
         code.putln(f"if (!__Pyx_State_FindModule(&{Naming.pymoduledef_cname})) return;")
+        code.putln("#endif")
         code.putln(f"{Naming.modulestatevalue_cname} = __Pyx_PyModule_GetState(self);")
 
         if Options.generate_cleanup_code >= 2:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3597,7 +3597,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("#if CYTHON_USE_MODULE_STATE")
         code.putln(f"  sizeof({Naming.modulestatetype_cname}), /* m_size */")
         code.putln("#else")
-        code.putln("  CYTHON_PEP489_MULTI_PHASE_INIT ? 0 :-1, /* m_size */")
+        code.putln("  (CYTHON_PEP489_MULTI_PHASE_INIT) ? 0 : -1, /* m_size */")
         code.putln("#endif")
         code.putln("  %s /* m_methods */," % env.method_table_cname)
         code.putln("#if CYTHON_PEP489_MULTI_PHASE_INIT")

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -52,8 +52,9 @@ typedef struct {
     #define __pyx_atomic_int_type atomic_int
     #define __pyx_atomic_ptr_type atomic_uintptr_t
     #define __pyx_nonatomic_ptr_type uintptr_t
-    #define __pyx_atomic_incr_aligned(value) atomic_fetch_add_explicit(value, 1, memory_order_relaxed)
-    #define __pyx_atomic_decr_aligned(value) atomic_fetch_sub_explicit(value, 1, memory_order_acq_rel)
+    #define __pyx_atomic_incr_relaxed(value) atomic_fetch_add_explicit(value, 1, memory_order_relaxed)
+    #define __pyx_atomic_incr_acq_rel(value) atomic_fetch_add_explicit(value, 1, memory_order_acq_rel)
+    #define __pyx_atomic_decr_acq_rel(value) atomic_fetch_sub_explicit(value, 1, memory_order_acq_rel)
     #define __pyx_atomic_load(value) atomic_load(value)
     #define __pyx_atomic_pointer_load_relaxed(value) atomic_load_explicit(value, memory_order_relaxed)
     #define __pyx_atomic_pointer_load_acquire(value) atomic_load_explicit(value, memory_order_acquire)
@@ -73,8 +74,9 @@ typedef struct {
     #define __pyx_atomic_int_type std::atomic_int
     #define __pyx_atomic_ptr_type std::atomic_uintptr_t
     #define __pyx_nonatomic_ptr_type uintptr_t
-    #define __pyx_atomic_incr_aligned(value) std::atomic_fetch_add_explicit(value, 1, std::memory_order_relaxed)
-    #define __pyx_atomic_decr_aligned(value) std::atomic_fetch_sub_explicit(value, 1, std::memory_order_acq_rel)
+    #define __pyx_atomic_incr_relaxed(value) std::atomic_fetch_add_explicit(value, 1, std::memory_order_relaxed)
+    #define __pyx_atomic_incr_acq_rel(value) std::atomic_fetch_add_explicit(value, 1, std::memory_order_acq_rel)
+    #define __pyx_atomic_decr_acq_rel(value) std::atomic_fetch_sub_explicit(value, 1, std::memory_order_acq_rel)
     #define __pyx_atomic_load(value) std::atomic_load(value)
     #define __pyx_atomic_pointer_load_relaxed(value) std::atomic_load_explicit(value, std::memory_order_relaxed)
     #define __pyx_atomic_pointer_load_acquire(value) std::atomic_load_explicit(value, std::memory_order_acquire)
@@ -90,8 +92,9 @@ typedef struct {
                     (__GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ >= 2))))
     /* gcc >= 4.1.2 */
     #define __pyx_atomic_ptr_type void*
-    #define __pyx_atomic_incr_aligned(value) __sync_fetch_and_add(value, 1)
-    #define __pyx_atomic_decr_aligned(value) __sync_fetch_and_sub(value, 1)
+    #define __pyx_atomic_incr_relaxed(value) __sync_fetch_and_add(value, 1)
+    #define __pyx_atomic_incr_acq_rel(value) __sync_fetch_and_add(value, 1)
+    #define __pyx_atomic_decr_acq_rel(value) __sync_fetch_and_sub(value, 1)
     // the legacy gcc sync builtins don't seem to have plain "load" or "store".
     #define __pyx_atomic_load(value) __sync_fetch_and_add(value, 0)
     #define __pyx_atomic_pointer_load_relaxed(value) __sync_fetch_and_add(value, 0)
@@ -110,8 +113,9 @@ typedef struct {
     #undef __pyx_nonatomic_int_type
     #define __pyx_nonatomic_int_type long
     #pragma intrinsic (_InterlockedExchangeAdd)
-    #define __pyx_atomic_incr_aligned(value) _InterlockedExchangeAdd(value, 1)
-    #define __pyx_atomic_decr_aligned(value) _InterlockedExchangeAdd(value, -1)
+    #define __pyx_atomic_incr_relaxed(value) _InterlockedExchangeAdd(value, 1)
+    #define __pyx_atomic_incr_acq_rel(value) _InterlockedExchangeAdd(value, 1)
+    #define __pyx_atomic_decr_acq_rel(value) _InterlockedExchangeAdd(value, -1)
     #define __pyx_atomic_load(value) _InterlockedExchangeAdd(value, 0)
     // Microsoft says that simple reads are guaranteed to be atomic.
     // https://learn.microsoft.com/en-gb/windows/win32/sync/interlocked-variable-access?redirectedfrom=MSDN
@@ -135,9 +139,9 @@ typedef struct {
 
 #if CYTHON_ATOMICS
     #define __pyx_add_acquisition_count(memview) \
-             __pyx_atomic_incr_aligned(__pyx_get_slice_count_pointer(memview))
+             __pyx_atomic_incr_relaxed(__pyx_get_slice_count_pointer(memview))
     #define __pyx_sub_acquisition_count(memview) \
-            __pyx_atomic_decr_aligned(__pyx_get_slice_count_pointer(memview))
+            __pyx_atomic_decr_acq_rel(__pyx_get_slice_count_pointer(memview))
 #else
     #define __pyx_add_acquisition_count(memview) \
             __pyx_add_acquisition_count_locked(__pyx_get_slice_count_pointer(memview), memview->lock)

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -106,7 +106,7 @@ typedef struct {
     #include <intrin.h>
     #undef __pyx_atomic_int_type
     #define __pyx_atomic_int_type long
-    #define __pyx_atomic_ptr_type void*;
+    #define __pyx_atomic_ptr_type void*
     #undef __pyx_nonatomic_int_type
     #define __pyx_nonatomic_int_type long
     #pragma intrinsic (_InterlockedExchangeAdd)

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -122,7 +122,7 @@ typedef struct {
     // The volatile cast is what CPython does.
     #define __pyx_atomic_pointer_load_relaxed(value) *(void * volatile *)value
     // compare/exchange is probably overkill nonsense, but plain "load" intrinsics are hard to get.
-    #define __pyx_atomic_pointer_load_acquire(value) _InterlockedCompareExchangePointer_acq(value, 0, 0)
+    #define __pyx_atomic_pointer_load_acquire(value) _InterlockedCompareExchangePointer(value, 0, 0)
     #define __pyx_atomic_pointer_exchange(value, new_value) _InterlockedExchangePointer(value, (__pyx_atomic_ptr_type)new_value)
 
     #ifdef __PYX_DEBUG_ATOMICS

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2690,7 +2690,7 @@ static PyObject *__Pyx_State_FindModule(CYTHON_UNUSED void* dummy) {
         data = (__Pyx_ModuleStateLookupData*)__pyx_atomic_pointer_load_relaxed(&__Pyx_ModuleStateLookup_data);
         __Pyx_ModuleStateLookup_Unlock();
     }
-  read_finished:
+  read_finished:;
 
 #else
     __Pyx_ModuleStateLookupData* data = __Pyx_ModuleStateLookup_data;

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2562,7 +2562,7 @@ static pthread_rwlock_t __Pyx_ModuleStateLookup_mutex = PTHREAD_RWLOCK_INITIALIZ
 #define __Pyx_ModuleStateLookup_UnlockForWrite() pthread_rwlock_unlock(&__Pyx_ModuleStateLookup_mutex)
 #elif (CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE==1 && defined(_WIN32)) || \
     CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE==4
-#include <synchapi.h>  // windows
+#include <Windows.h>  // synchapi.h on its own doesn't work
 static SRWLock __Pyx_ModuleStateLookup_mutex = SRWLOCK_INIT;
 #define __Pyx_ModuleStateLookup_LockForRead() AcquireSRWLockExclusive(&__Pyx_ModuleStateLookup_mutex)
 #define __Pyx_ModuleStateLookup_UnlockForRead() pthread_rwlock_unlock(&__Pyx_ModuleStateLookup_mutex)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1207,6 +1207,12 @@ static CYTHON_INLINE int __Pyx_PyDict_GetItemRef(PyObject *dict, PyObject *key, 
     #define __Pyx_TPFLAGS_HAVE_AM_SEND (0)
 #endif
 
+#if Py_VERSION_HEX >= 0x03090000
+#define __Pyx_PyInterpreterState_Get() PyInterpreterState_Get()
+#else
+#define __Pyx_PyInterpreterState_Get() PyThreadState_Get()->interp
+#endif
+
 
 /////////////// CythonABIVersion.proto ///////////////
 //@proto_block: module_declarations
@@ -2651,7 +2657,7 @@ static __Pyx_InterpreterIdAndModule* __Pyx_State_FindModuleStateLookupTableLower
 }
 
 static PyObject *__Pyx_State_FindModule(CYTHON_UNUSED void* dummy) {
-    int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
+    int64_t interpreter_id = PyInterpreterState_GetID(__Pyx_PyInterpreterState_Get());
     if (interpreter_id == -1) return NULL;
 
     // There's one "already imported" check that'll hit this
@@ -2726,7 +2732,7 @@ static void __Pyx_State_ConvertFromReallySmall() {
 }
 
 static int __Pyx_State_AddModule(PyObject* module, CYTHON_UNUSED void* dummy) {
-    int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
+    int64_t interpreter_id = PyInterpreterState_GetID(__Pyx_PyInterpreterState_Get());
     if (interpreter_id == -1) return -1;
 
     __Pyx_ModuleStateLookup_LockForWrite();
@@ -2790,7 +2796,7 @@ static int __Pyx_State_AddModule(PyObject* module, CYTHON_UNUSED void* dummy) {
 }
 
 static int __Pyx_State_RemoveModule(CYTHON_UNUSED void* dummy) {
-    int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
+    int64_t interpreter_id = PyInterpreterState_GetID(__Pyx_PyInterpreterState_Get());
     if (interpreter_id == -1) return -1;
 
     __Pyx_ModuleStateLookup_LockForWrite();

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2563,7 +2563,7 @@ static pthread_rwlock_t __Pyx_ModuleStateLookup_mutex = PTHREAD_RWLOCK_INITIALIZ
 #elif (CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE==1 && defined(_WIN32)) || \
     CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE==4
 #include <Windows.h>  // synchapi.h on its own doesn't work
-static SRWLock __Pyx_ModuleStateLookup_mutex = SRWLOCK_INIT;
+static SRWLOCK __Pyx_ModuleStateLookup_mutex = SRWLOCK_INIT;
 #define __Pyx_ModuleStateLookup_LockForRead() AcquireSRWLockExclusive(&__Pyx_ModuleStateLookup_mutex)
 #define __Pyx_ModuleStateLookup_UnlockForRead() pthread_rwlock_unlock(&__Pyx_ModuleStateLookup_mutex)
 #define __Pyx_ModuleStateLookup_LockForWrite() AcquireSRWLockExclusive(&__Pyx_ModuleStateLookup_mutex)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2650,7 +2650,7 @@ static __Pyx_InterpreterIdAndModule* __Pyx_State_FindModuleStateLookupTableLower
     return begin;
 }
 
-static PyObject *__Pyx_State_FindModule(void*) {
+static PyObject *__Pyx_State_FindModule(CYTHON_UNUSED void* dummy) {
     int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
     if (interpreter_id == -1) return NULL;
 
@@ -2725,7 +2725,7 @@ static void __Pyx_State_ConvertFromReallySmall() {
     __Pyx_ModuleStateLookup_really_small = 0;
 }
 
-static int __Pyx_State_AddModule(PyObject* module, void*) {
+static int __Pyx_State_AddModule(PyObject* module, CYTHON_UNUSED void* dummy) {
     int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
     if (interpreter_id == -1) return -1;
 
@@ -2789,7 +2789,7 @@ static int __Pyx_State_AddModule(PyObject* module, void*) {
     return 0;
 }
 
-static int __Pyx_State_RemoveModule(void*) {
+static int __Pyx_State_RemoveModule(CYTHON_UNUSED void* dummy) {
     int64_t interpreter_id = PyInterpreterState_GetID(PyInterpreterState_Get());
     if (interpreter_id == -1) return -1;
 

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2613,7 +2613,7 @@ typedef struct {
 } __Pyx_ModuleStateLookupData;
 
 #define __PYX_MODULE_STATE_LOOKUP_SMALL_SIZE 32
-// Really small means "the maximum interpreter ID ever seen is smaller than
+// "Really small" above means "the maximum interpreter ID ever seen is smaller than
 // __PYX_MODULE_STATE_LOOKUP_SMALL_SIZE and thus they're stored in an array
 // where the index corresponds to interpreter ID, and __Pyx_ModuleStateLookup_count
 // is the size of the array.
@@ -2643,7 +2643,7 @@ static __Pyx_InterpreterIdAndModule* __Pyx_State_FindModuleStateLookupTableLower
         return begin;
     }
 
-    while ((end-begin) > __PYX_MODULE_STATE_LOOKUP_SMALL_SIZE) {
+    while ((end - begin) > __PYX_MODULE_STATE_LOOKUP_SMALL_SIZE) {
         __Pyx_InterpreterIdAndModule* halfway = begin + (end - begin)/2;
         if (halfway->id == interpreterId) {
             return halfway;
@@ -2656,7 +2656,7 @@ static __Pyx_InterpreterIdAndModule* __Pyx_State_FindModuleStateLookupTableLower
     }
 
     // Assume that for small ranges, it's quicker to do a linear search
-    for (; begin<end; ++begin) {
+    for (; begin < end; ++begin) {
         if (begin->id >= interpreterId) return begin;
     }
     return begin;
@@ -2725,7 +2725,7 @@ static PyObject *__Pyx_State_FindModule(CYTHON_UNUSED void* dummy) {
 #if CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE
 void __Pyx_ModuleStateLookup_wait_until_no_readers(void) {
     // Wait for any readers will working on the old data. Spin-lock is
-    // fine because readers should be much faster that memory allocation.
+    // fine because readers should be much faster than memory allocation.
     while (__pyx_atomic_load(&__Pyx_ModuleStateLookup_read_counter) != 0);
 }
 #else

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -98,6 +98,9 @@ if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
     # Install packages one by one, allowing failures due to missing recent wheels.
     cat test-requirements-312.txt | while read package; do python -m pip install --pre --only-binary ":all:" "$package" || true; done
   fi
+  if [[ $PYTHON_VERSION == "3.13"* ]]; then
+    python -m pip install --pre -r test-requirements-313.txt || exit 1
+  fi
 else
   python -m pip install -U pip "setuptools<60" wheel || exit 1
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1220,7 +1220,7 @@ most important to least important:
     Stores module data on a struct associated with the module object rather than as
     C global variables.  The advantage is that it should be possible to import the
     same module more than once (e.g. in different sub-interpreters).  At the moment
-    this is experimental and not all data has been moved.  Specifically ``cdef``
+    this is experimental and not all data has been moved.  Specifically, ``cdef``
     globals have not been moved.
 
 ``CYTHON_USE_TYPE_SPECS``

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1220,9 +1220,8 @@ most important to least important:
     Stores module data on a struct associated with the module object rather than as
     C global variables.  The advantage is that it should be possible to import the
     same module more than once (e.g. in different sub-interpreters).  At the moment
-    this is experimental and not all data has been moved.  It also requires that
-    ``CYTHON_PEP489_MULTI_PHASE_INIT`` is off - we plan to remove this limitation
-    in the future.
+    this is experimental and not all data has been moved.  Specifically ``cdef``
+    globals have not been moved.
 
 ``CYTHON_USE_TYPE_SPECS``
     Defines ``cdef classes`` as `"heap types" <https://docs.python.org/3/c-api/typeobj.html#heap-types>`_
@@ -1337,3 +1336,11 @@ hidden by default since most users will be uninterested in changing them.
             [``gc.get_referents()``](https://docs.python.org/3/library/gc.html#gc.get_referents).
             By default, Cython avoids GC traversing these objects because they can never participate
             in reference cycles, and thus would uselessly waste time during garbage collection runs.
+            
+        ``CYTHON_MODULE_STATE_LOOKUP_THREAD_SAFE``
+            Makes module state lookup thread-safe (when ``CYTHON_USE_MODULE_STATE`` and
+            ``CYTHON_PEP489_MULTI_PHASE_INIT`` are both enabled).  This is on by default
+            where it would be helpful, however it can be disabled if you are sure that
+            one interpreter will not be importing your module at the same time as another
+            is using it.  Values greater than 1 can be used to select a specific implementation
+            for debugging purposes.

--- a/test-requirements-313.txt
+++ b/test-requirements-313.txt
@@ -1,0 +1,1 @@
+interpreters-pep-734

--- a/tests/run/subinterpreters.srctree
+++ b/tests/run/subinterpreters.srctree
@@ -49,13 +49,14 @@ include "shared.pxi"
 #################### runtest.py #############################
 
 import sys
-# TODO - in Py3.14 this'll probably be in the standard library
-from interpreters_backport import interpreters
 
 if sys.version_info < (3, 13):
     # No chance of this working I think.
     # (Although there probably is a test that would...)
     exit(0)
+
+# TODO - in Py3.14 this'll probably be in the standard library
+from interpreters_backport import interpreters
 
 SKIP_FIRST = "skip_first="
 CYTHON_MODULE = "cython_module="

--- a/tests/run/subinterpreters.srctree
+++ b/tests/run/subinterpreters.srctree
@@ -1,0 +1,108 @@
+PYTHON setup.py build_ext --inplace
+
+# single-phase uses Python's mechanisms so should be reliable
+PYTHON runtest.py 20 cython_module=with_singlephase
+
+# multi-phase uses our mechanisms so is work more thorough
+# testing
+PYTHON runtest.py 20
+PYTHON runtest.py 20 close_after_exec
+# less than 32 interpreters, but interpreter ID will go over 32 (32 being the optimization cut-off)
+PYTHON runtest.py 20 skip_first=20
+PYTHON runtest.py 20 randomize_order
+PYTHON runtest.py 40
+PYTHON runtest.py 40 start_at_back
+PYTHON runtest.py 40 start_at_back close_after_exec
+PYTHON runtest.py 40 randomize_order
+
+##################### setup.py ################################
+
+from setuptools import setup
+from Cython.Build import cythonize
+
+setup(
+    ext_modules = cythonize(
+        [ "with_multiphase.pyx", "with_singlephase.pyx" ]
+    )
+)
+
+##################### shared.pxi #############################
+
+import _interpreters
+
+some_global = []
+def append_to_global():
+    some_global.append(f"hello from interpreter {_interpreters.get_current()}")
+    
+#################### with_multiphase.pyx ####################
+
+# distutils: extra_compile_args = -DCYTHON_USE_MODULE_STATE=1
+
+include "shared.pxi"
+
+#################### with_singlephase.pyx ####################
+
+# distutils: extra_compile_args = -DCYTHON_USE_MODULE_STATE=1 -DCYTHON_PEP489_MULTI_PHASE_INIT=0
+
+include "shared.pxi"
+    
+#################### runtest.py #############################
+
+import sys
+# TODO - in Py3.14 this'll probably be in the standard library
+from interpreters_backport import interpreters
+
+if sys.version_info < (3, 13):
+    # No chance of this working I think.
+    # (Although there probably is a test that would...)
+    exit(0)
+
+SKIP_FIRST = "skip_first="
+CYTHON_MODULE = "cython_module="
+
+number_of_interpreters = int(sys.argv[1])
+start_at_back = False
+close_after_exec = False
+skip_first = 0
+randomize_order = False
+cython_module = "with_multiphase"
+for arg in sys.argv[2:]:
+    if arg == "start_at_back":
+        start_at_back = True
+    elif arg == "close_after_exec":
+        close_after_exec = True
+    elif arg == "randomize_order":
+        randomize_order = True
+    elif arg.startswith(SKIP_FIRST):
+        skip_first = int(arg[len(SKIP_FIRST):])
+    elif arg.startswith(CYTHON_MODULE):
+        cython_module = arg[len(CYTHON_MODULE):]
+    else:
+        print(f"Unrecognised argument {arg}", arg)
+        exit(1)
+
+all_interpreters = [ interpreters.create() for i in range(number_of_interpreters+skip_first) ]
+if start_at_back:
+    all_interpreters = list(reversed(all_interpreters))
+if randomize_order:
+    import random
+    random.shuffle(all_interpreters)
+
+code_to_exec = f"""
+import _imp
+# TODO - eventually we'll properly allow this, at least for multi-phase
+_imp._override_multi_interp_extensions_check(-1)
+
+import {cython_module} as cymod
+cymod.append_to_global()
+# will fail if accidentally shared
+assert len(cymod.some_global) == 1
+"""
+    
+# skip_first is useful because we apply an optimization when all the interpreter ids are small,
+# so it lets us pick this optimization.
+for i in all_interpreters[skip_first:]:
+    i.exec(code_to_exec)
+    if close_after_exec:
+        # Will probably clean up the module, but we don't actually check this
+        i.close()

--- a/tests/run/subinterpreters_threading_stress_test.srctree
+++ b/tests/run/subinterpreters_threading_stress_test.srctree
@@ -1,0 +1,99 @@
+PYTHON setup.py build_ext --inplace
+PYTHON main.py
+
+##################### setup.py ###################
+
+import sys
+from setuptools import setup
+from Cython.Build import cythonize
+
+if sys.version_info < (3, 13):
+    exit(0)
+
+setup(
+    ext_modules = cythonize(
+        [ "cy_module.pyx" ]
+    )
+)
+
+#################### cy_module.pyx ##################
+
+# distutils: extra_compile_args = -DCYTHON_USE_MODULE_STATE=1
+
+cdef extern from *:
+    # actually returns a borrowed PyObject*
+    void* __Pyx_State_FindModule(void*)
+
+def run(start_next_queue, stop_queue):
+    # queues appear to be the only synchonization primitive we're
+    # allowed. So use it to control stopping the test
+    cdef void *initial = <void*>__Pyx_State_FindModule(NULL)
+    cdef void *current=NULL
+    while stop_queue.empty():
+        # wait until we're running properly and then allow the
+        # next interpreter to start
+        if start_next_queue is not None:
+            start_next_queue.put(None)
+            start_next_queue = None
+        for i in range(1000):
+            current = <void*>__Pyx_State_FindModule(NULL)
+            # if the current module pointer ever changes, then the state
+            # has got corrupted somewhere along the way
+            assert current == initial, f"{<long>current} {<long>initial}"
+
+
+################## callable.py ###################
+
+# Note - free globals are evaluated in the interpreter's "__main__" module
+# (which we prepare)
+
+def f():
+    import _imp
+    # TODO - eventually we'll properly allow this, at least for multi-phase
+    _imp._override_multi_interp_extensions_check(-1)
+    
+    start_next_queue.get(20.0)
+    started_queue.put(None)
+    import cy_module
+    cy_module.run(start_next_queue, stop_queue)
+            
+################## main.py ######################
+
+import sys
+if sys.version_info < (3, 13):
+    exit(0)  # test won't work
+
+# TODO - in Py3.14 this'll probably be in the standard library
+from interpreters_backport import interpreters
+
+# create a bunch of interpreters
+num_interpreters = 5
+all_interpreters = [ interpreters.create() for _ in range(num_interpreters) ]
+
+# set up the queues used for inter-interpreter communication
+stop_queue = interpreters.create_queue()
+started_queue = interpreters.create_queue()
+start_next_queue = interpreters.create_queue()
+start_next_queue.put(None)
+
+for i in all_interpreters:
+    # I don't think this exec should be needed, but as of Nov 2024 it is.
+    i.exec("from interpreters_backport.interpreters import queues")
+    i.prepare_main(
+        stop_queue=stop_queue,
+        started_queue=started_queue,
+        start_next_queue=start_next_queue)
+
+import callable
+
+threads = [ i.call_in_thread(callable.f) for i in all_interpreters ]
+
+# wait until we know all interpreters have started
+for _ in range(num_interpreters):
+    started_queue.get(20.0)
+
+# signal for the interpreters to stop.
+stop_queue.put(None)
+
+for t in threads:
+    t.join()

--- a/tests/run/subinterpreters_threading_stress_test.srctree
+++ b/tests/run/subinterpreters_threading_stress_test.srctree
@@ -25,7 +25,7 @@ cdef extern from *:
     void* __Pyx_State_FindModule(void*)
 
 def run(start_next_queue, stop_queue):
-    # queues appear to be the only synchonization primitive we're
+    # queues appear to be the only synchronization primitive we're
     # allowed. So use it to control stopping the test
     cdef void *initial = <void*>__Pyx_State_FindModule(NULL)
     cdef void *current=NULL
@@ -52,12 +52,21 @@ def f():
     # TODO - eventually we'll properly allow this, at least for multi-phase
     _imp._override_multi_interp_extensions_check(-1)
     
+    # wait for previous interpreter to reach its read-loop before proceeding
+    # with this one.
     start_next_queue.get(20.0)
     started_queue.put(None)
     import cy_module
     cy_module.run(start_next_queue, stop_queue)
             
 ################## main.py ######################
+
+# What we're doing here is running isolated sub-interpreters
+# (each with their own individual GIL) in parallel with the
+# intention of spotting thread-safety issues in __Pyx_State_FindModule.
+# Each loaded module repeatedly calls __Pyx_State_FindModule
+# expecting the same result each time. At the same time new interpreters
+# are started.
 
 import sys
 if sys.version_info < (3, 13):
@@ -70,9 +79,14 @@ from interpreters_backport import interpreters
 num_interpreters = 5
 all_interpreters = [ interpreters.create() for _ in range(num_interpreters) ]
 
-# set up the queues used for inter-interpreter communication
+# set up the queues used for inter-interpreter communication.
+# non-empty stop_queue is used to signal that the test is over and all interpreters should stop.
 stop_queue = interpreters.create_queue()
+# started_queue allows the main interpreter to count how many sub-interpreters have started.
+# Each sub-interpreter pushes to it once.
 started_queue = interpreters.create_queue()
+# start_next_queue allows each sub-interpreter to wait for the previous interpreter to start
+# its main loop before proceeding. Each sub-interpreter reads once from it then writes once to it.
 start_next_queue = interpreters.create_queue()
 start_next_queue.put(None)
 


### PR DESCRIPTION
Essentially I've reimplemented the PyState_GetModule function to provide a base-line fallback which will work (at least while the GIL is held). Long-term I think we want to use the proper mechanisms for isolating modules to get the state from the class or the functions. However this achieves a base level of functionality.

I've used binary-search in a list of thread ids. This is probably needlessly inefficient (since practically the thread ids are low sequential integers). However it should at least be fairly general.