### PR TITLE
Pick a few small fixes out of #6226

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14114,7 +14114,7 @@ class CastNode(CoercionNode):
         return self.arg.result_as(self.type)
 
     def generate_result_code(self, code):
-        self.arg.generate_result_code(code)
+        pass
 
 
 class PyTypeTestNode(CoercionNode):

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2787,7 +2787,8 @@ class CalculateQualifiedNamesTransform(EnvTransform):
         lhs = ExprNodes.NameNode(
             node.pos,
             name=EncodedString(name),
-            entry=entry)
+            entry=entry,
+            is_target=True)
         rhs = ExprNodes.UnicodeNode(node.pos, value=value)
         node.body.stats.insert(0, Nodes.SingleAssignmentNode(
             node.pos,
@@ -3000,6 +3001,7 @@ class ExpandInplaceOperators(EnvTransform):
                                      operand2 = rhs,
                                      inplace=True)
         # Manually analyse types for new node.
+        lhs.is_target = True
         lhs = lhs.analyse_target_types(env)
         dup.analyse_types(env)  # FIXME: no need to reanalyse the copy, right?
         binop.analyse_operation(env)


### PR DESCRIPTION
So that they don't get lost based on being part of a larger change that may not be our proposed behaviour.

A couple of `is_target` set on the lhs of generated assignments that are generated too late to pick it up in analysis.

Skip `self.arg.generate_result_code` because it already gets called indirectly via `ExprNode.generate_evaluation_code` -> `ExprNode.generate_subexpr_evaluation_code`.