### PR TITLE
Improve Bazel `pyx_library()`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,13 +21,6 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
-py_binary(
-    name = "cythonize",
-    srcs = ["cythonize.py"],
-    visibility = ["//visibility:public"],
-    deps = ["cython_lib"],
-)
-
 # May not be named "cython", since that conflicts with Cython/ on OSX
 py_binary(
     name = "cython_binary",

--- a/Tools/rules.bzl
+++ b/Tools/rules.bzl
@@ -21,11 +21,30 @@ cimports using the package layout.
 
 def pyx_library(
         name,
-        deps = [],
+        cc_deps = [],
+        py_deps = [],
         srcs = [],
-        cython_directives = [],
-        cython_options = [],
+        copts = None,
+        defines = None,
         **kwargs):
+    """Compiles a group of .pyx / .pxd / .py files.
+
+    First runs Cython to create .cpp files for each input .pyx or .py + .pxd
+    pair. Then builds a shared object for each, passing "cc_deps" to each cc_binary
+    rule (includes Python headers by default). Finally, creates a py_library rule
+    with the shared objects and any pure Python "srcs", with py_deps as its
+    dependencies; the shared objects can be imported like normal Python files.
+
+    Args:
+      name: Name for the rule.
+      cc_deps: C/C++ dependencies of the Cython (e.g. Numpy headers).
+      py_deps: Pure Python dependencies of the final library.
+      srcs: .py, .pyx, or .pxd files to either compile or pass through.
+      copts: List of copts to pass to cc rules.
+      defines: List of defines to pass to cc rules.
+      **kwargs: Extra keyword arguments passed to the py_library.
+    """
+
     # First filter out files that should be run compiled vs. passed through.
     py_srcs = []
     pyx_srcs = []
@@ -39,33 +58,45 @@ def pyx_library(
         else:
             pxd_srcs.append(src)
         if src.endswith("__init__.py"):
-            # TODO(robertwb): Infer __init__.py files/package root?
             pxd_srcs.append(src)
 
-    # Invoke cythonize to produce the shared object libraries.
-    outs = [src.split(".")[0] + ".so" for src in pyx_srcs]
-    extra_flags = " ".join(["-X '%s=%s'" % x for x in cython_directives] +
-                           ["-s '%s=%s'" % x for x in cython_options])
+    # Invoke cython to produce the shared object libraries.
+    for filename in pyx_srcs:
+        native.genrule(
+            name = filename + "_cython_translation",
+            srcs = [filename],
+            outs = [filename.split(".")[0] + ".cpp"],
+            # Optionally use PYTHON_BIN_PATH on Linux platforms so that python 3
+            # works. Windows has issues with cython_binary so skip PYTHON_BIN_PATH.
+            cmd = "PYTHONHASHSEED=0 $(execpath %s) --cplus $(SRCS) --output-file $(OUTS)" % Label("//:cython_binary"),
+            testonly = kwargs.get("testonly"),
+            tools = [Label("//:cython_binary")] + pxd_srcs,
+        )
 
-    # TODO(robertwb): It might be better to only generate the C files,
-    # letting cc_library (or similar) handle the rest, but there isn't yet
-    # support compiling Python C extensions from bazel.
-    native.genrule(
-        name = name + "_cythonize",
-        srcs = pyx_srcs,
-        outs = outs,
-        cmd = "PYTHONHASHSEED=0 $(location @cython//:cythonize) -k -i %s $(SRCS)" % extra_flags +
-              # Rename outputs to expected location.
-              # TODO(robertwb): Add an option to cythonize itself to do this.
-              """ && python -c 'import os, sys; n = len(sys.argv); [os.rename(src.split(".")[0] + ".so", dst) for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:])]' $(SRCS) $(OUTS)""",
-        tools = ["@cython//:cythonize"] + pxd_srcs,
-    )
+    shared_objects = []
+    for src in pyx_srcs:
+        stem = src.split(".")[0]
+        shared_object_name = stem + ".so"
+        native.cc_binary(
+            name = shared_object_name,
+            srcs = [stem + ".cpp"],
+            deps = cc_deps + [
+                "@rules_python//python/cc:current_py_cc_headers",
+                "@rules_python//python/cc:current_py_cc_libs",
+            ],
+            defines = defines,
+            linkshared = 1,
+            testonly = kwargs.get("testonly"),
+            copts = copts,
+        )
+        shared_objects.append(shared_object_name)
 
     # Now create a py_library with these shared objects as data.
+    data = shared_objects + kwargs.pop("data", [])
     native.py_library(
         name = name,
         srcs = py_srcs,
-        deps = deps,
-        data = outs + pyx_srcs + pxd_srcs,
+        deps = py_deps,
+        data = data,
         **kwargs
     )

--- a/Tools/rules.bzl
+++ b/Tools/rules.bzl
@@ -19,6 +19,9 @@ The __init__.py file must be in your srcs list so that Cython can resolve
 cimports using the package layout.
 """
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_python//python:defs.bzl", "py_library")
+
 def pyx_library(
         name,
         cc_deps = [],
@@ -77,7 +80,7 @@ def pyx_library(
     for src in pyx_srcs:
         stem = src.split(".")[0]
         shared_object_name = stem + ".so"
-        native.cc_binary(
+        cc_binary(
             name = shared_object_name,
             srcs = [stem + ".cpp"],
             deps = cc_deps + [
@@ -93,7 +96,7 @@ def pyx_library(
 
     # Now create a py_library with these shared objects as data.
     data = shared_objects + kwargs.pop("data", [])
-    native.py_library(
+    py_library(
         name = name,
         srcs = py_srcs,
         deps = py_deps,

--- a/Tools/rules.bzl
+++ b/Tools/rules.bzl
@@ -21,31 +21,32 @@ cimports using the package layout.
 
 def pyx_library(
         name,
-        deps=[],
-        srcs=[],
-        cython_directives=[],
-        cython_options=[],
+        deps = [],
+        srcs = [],
+        cython_directives = [],
+        cython_options = [],
         **kwargs):
     # First filter out files that should be run compiled vs. passed through.
     py_srcs = []
     pyx_srcs = []
     pxd_srcs = []
     for src in srcs:
-        if src.endswith('.pyx') or (src.endswith('.py')
-                                    and src[:-3] + '.pxd' in srcs):
+        if src.endswith(".pyx") or (src.endswith(".py") and
+                                    src[:-3] + ".pxd" in srcs):
             pyx_srcs.append(src)
-        elif src.endswith('.py'):
+        elif src.endswith(".py"):
             py_srcs.append(src)
         else:
             pxd_srcs.append(src)
-        if src.endswith('__init__.py'):
+        if src.endswith("__init__.py"):
             # TODO(robertwb): Infer __init__.py files/package root?
             pxd_srcs.append(src)
 
     # Invoke cythonize to produce the shared object libraries.
-    outs = [src.split('.')[0] + '.so' for src in pyx_srcs]
+    outs = [src.split(".")[0] + ".so" for src in pyx_srcs]
     extra_flags = " ".join(["-X '%s=%s'" % x for x in cython_directives] +
                            ["-s '%s=%s'" % x for x in cython_options])
+
     # TODO(robertwb): It might be better to only generate the C files,
     # letting cc_library (or similar) handle the rest, but there isn't yet
     # support compiling Python C extensions from bazel.
@@ -53,18 +54,18 @@ def pyx_library(
         name = name + "_cythonize",
         srcs = pyx_srcs,
         outs = outs,
-        cmd = "PYTHONHASHSEED=0 $(location @cython//:cythonize) -k -i %s $(SRCS)" % extra_flags
+        cmd = "PYTHONHASHSEED=0 $(location @cython//:cythonize) -k -i %s $(SRCS)" % extra_flags +
               # Rename outputs to expected location.
               # TODO(robertwb): Add an option to cythonize itself to do this.
-              + """ && python -c 'import os, sys; n = len(sys.argv); [os.rename(src.split(".")[0] + ".so", dst) for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:])]' $(SRCS) $(OUTS)""",
+              """ && python -c 'import os, sys; n = len(sys.argv); [os.rename(src.split(".")[0] + ".so", dst) for src, dst in zip(sys.argv[1:], sys.argv[1+n//2:])]' $(SRCS) $(OUTS)""",
         tools = ["@cython//:cythonize"] + pxd_srcs,
     )
 
     # Now create a py_library with these shared objects as data.
     native.py_library(
-        name=name,
-        srcs=py_srcs,
-        deps=deps,
-        data=outs + pyx_srcs + pxd_srcs,
+        name = name,
+        srcs = py_srcs,
+        deps = deps,
+        data = outs + pyx_srcs + pxd_srcs,
         **kwargs
     )


### PR DESCRIPTION
- Format `rules.bzl`
- Use `cc_binary` instead of `cytonize.py` to compile generated CC code
- Use rules libraries instead of deprecated native ones
