### PR TITLE
Allow some of cpython to be cimported in limited API

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3890,7 +3890,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         sizeof_objstruct = objstruct = type.objstruct_cname if type.typedef_flag else f"struct {type.objstruct_cname}"
         module_name = type.module_name
         type_name = type.name
-        if module_name not in ('__builtin__', 'builtins'):
+        is_builtin = module_name in ('__builtin__', 'builtins')
+        if not is_builtin:
             module_name = f'"{module_name}"'
         elif type_name in Code.ctypedef_builtins_map:
             # Fast path for special builtins, don't actually import
@@ -3913,6 +3914,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         typeptr_cname = type.typeptr_cname
         if not is_api:
             typeptr_cname = code.name_in_main_c_code_module_state(typeptr_cname)
+
+        if is_builtin:
+            # Don't check the sizes of builtin types in the Limited API.
+            # They're almost invariably defined as opaque typedefs.
+            code.putln("#if !CYTHON_COMPILING_IN_LIMITED_API")
         code.put(
             f"{typeptr_cname} = __Pyx_ImportType_{Naming.cyversion}("
             f"{module}, {module_name}, {type.name.as_c_string_literal()},"
@@ -3922,8 +3928,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if sizeof_objstruct != objstruct:
             code.putln("")  # start in new line
             code.putln("#if defined(PYPY_VERSION_NUM) && PYPY_VERSION_NUM < 0x050B0000")
-            code.putln(f'sizeof({objstruct}), {alignment_func}({objstruct}),')
-            code.putln("#elif CYTHON_COMPILING_IN_LIMITED_API")
             code.putln(f'sizeof({objstruct}), {alignment_func}({objstruct}),')
             code.putln("#else")
             code.putln(f'sizeof({sizeof_objstruct}), {alignment_func}({sizeof_objstruct}),')
@@ -3942,6 +3946,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.put(f'__Pyx_ImportType_CheckSize_{check_size.title()}_{Naming.cyversion});')
 
         code.putln(f' if (!{typeptr_cname}) {error_code}')
+        if is_builtin:
+            code.putln("#else  // CYTHON_COMPILING_IN_LIMITED_API")
+            # silence some warnings
+            code.putln(f"CYTHON_UNUSED_VAR(__Pyx_ImportType_{Naming.cyversion});")
+            code.putln(f"if ((0)) {error_code}")
+            code.putln("#endif  // !CYTHON_COMPILING_IN_LIMITED_API")
 
     def generate_type_ready_code(self, entry, code):
         Nodes.CClassDefNode.generate_type_ready_code(entry, code)

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -49,11 +49,11 @@
 
 cdef extern from *:
     """
-    #if CYTHON_COMPILING_IN_PYPY
+    #if CYTHON_COMPILING_IN_PYPY || CYTHON_COMPILING_IN_LIMITED_API
     #ifdef _MSC_VER
-    #pragma message ("This module uses CPython specific internals of 'array.array', which are not available in PyPy.")
+    #pragma message ("This module uses CPython specific internals of 'array.array', which are not available in PyPy or the limited API.")
     #else
-    #warning This module uses CPython specific internals of 'array.array', which are not available in PyPy.
+    #warning This module uses CPython specific internals of 'array.array', which are not available in PyPy or the limited API.
     #endif
     #endif
     """

--- a/Cython/Includes/cpython/datetime.pxd
+++ b/Cython/Includes/cpython/datetime.pxd
@@ -1,6 +1,17 @@
 from cpython.object cimport PyObject
 from cpython.version cimport PY_VERSION_HEX
 
+cdef extern from *:
+    """
+    #if CYTHON_COMPILING_IN_LIMITED_API
+    #ifdef _MSC_VER
+    #pragma message ("This module uses CPython specific internals of 'datetime.datetime', which are not available in the limited API.")
+    #else
+    #warning This module uses CPython specific internals of 'datetime.datetime', which are not available in the limited API.
+    #endif
+    #endif
+    """
+
 cdef extern from "Python.h":
     ctypedef struct PyTypeObject:
         pass

--- a/Cython/Includes/cpython/longintrepr.pxd
+++ b/Cython/Includes/cpython/longintrepr.pxd
@@ -1,13 +1,8 @@
-# Internals of the "long" type (Python 2) or "int" type (Python 3).
+# Internals of the "int" type.
 
 cdef extern from "Python.h":
-    """
-    #if PY_MAJOR_VERSION < 3
-     #include "longintrepr.h"
-    #endif
-    """
     ctypedef unsigned int digit
-    ctypedef int sdigit  # Python >= 2.7 only
+    ctypedef int sdigit
 
     ctypedef class __builtin__.py_long [object PyLongObject]:
         cdef digit* ob_digit

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -91,6 +91,15 @@ assert limited.float_equals(decimal.Decimal("1.5"))
 
 import cython
 
+# Cimporting from cpython imports a range of types with their internals exposed.
+# These can't necessarily be used in the limited API but simply cimporting them
+# shouldn't break compilation.
+# Although at this stage cimporting the full cpython import is still broken.
+cimport cpython.bool
+cimport cpython.descr
+cimport cpython.longintrepr
+cimport cpython.type
+
 @cython.binding(False)
 def fib(int n):
     cdef int a, b


### PR DESCRIPTION
Just a cherry-pick of the non-contentious bits of #5871.

Essentially all types are opaque and not size checked.

A few modules that heavily use internals that'll be impossible to replace have warnings added.

Unfortunately `cimport cpython` itself is still broken (due to bool and contextvar)