### PR TITLE
[3.0.x] Fix & on 0 produced by int.from_bytes on Python 3.10 (GH-6481)

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1281,15 +1281,6 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, long intval, 
         PY_LONG_LONG ll{{ival}}, llx;
 #endif
         {{endif}}
-        {{if c_op == '&'}}
-        // special case for &-ing arbitrarily large numbers with known single digit operands
-        if ((intval & PyLong_MASK) == intval) {
-            // Calling PyLong_CompactValue() requires the PyLong value to be compact, we only need the last digit.
-            long last_digit = (long) __Pyx_PyLong_Digits({{pyval}})[0];
-            long result = intval & (likely(__Pyx_PyLong_IsPos({{pyval}})) ? last_digit : (PyLong_MASK - last_digit + 1));
-            return PyLong_FromLong(result);
-        }
-        {{endif}}
         // special cases for 0: + - * % / // | ^ & >> <<
         if (unlikely(__Pyx_PyLong_IsZero({{pyval}}))) {
             {{if order == 'CObj' and c_op in '%/'}}
@@ -1312,6 +1303,15 @@ static {{c_ret_type}} {{cfunc_name}}(PyObject *op1, PyObject *op2, long intval, 
             return __Pyx_NewRef(op1);
             {{endif}}
         }
+        {{if c_op == '&'}}
+        // special case for &-ing arbitrarily large numbers with known single digit operands
+        if ((intval & PyLong_MASK) == intval) {
+            // Calling PyLong_CompactValue() requires the PyLong value to be compact, we only need the last digit.
+            long last_digit = (long) __Pyx_PyLong_Digits({{pyval}})[0];
+            long result = intval & (likely(__Pyx_PyLong_IsPos({{pyval}})) ? last_digit : (PyLong_MASK - last_digit + 1));
+            return PyLong_FromLong(result);
+        }
+        {{endif}}
         // handle most common case first to avoid indirect branch and optimise branch prediction
         if (likely(__Pyx_PyLong_IsCompact({{pyval}}))) {
             {{ival}} = __Pyx_PyLong_CompactValue({{pyval}});

--- a/tests/run/pyintop.pyx
+++ b/tests/run/pyintop.pyx
@@ -86,6 +86,20 @@ def and_int(obj2):
     return obj1
 
 
+@cython.test_fail_if_path_exists('//IntBinopNode')
+def and_int2(obj2):
+    # On Python 3.10 and earlier, from_bytes produces a non-canonical
+    # 0 that caused trouble when &ing with a constant.
+    """
+    >>> and_int2(1337)
+    57
+    >>> and_int2(int.from_bytes(b'\\x00', 'big'))
+    0
+    """
+    obj1 = obj2 & 0xff
+    return obj1
+
+
 @cython.test_assert_path_exists('//IntBinopNode')
 def lshift_obj(obj2, obj3):
     """

--- a/tests/run/pyintop.pyx
+++ b/tests/run/pyintop.pyx
@@ -92,8 +92,10 @@ def and_int2(obj2):
     # On Python 3.10 and earlier, from_bytes produces a non-canonical
     # 0 that caused trouble when &ing with a constant.
     """
-    >>> and_int2(1337) if sys.version_info[0] >= 3 else 57
+    >>> and_int2(1337)
     57
+    >>> and_int2(0)
+    0
     >>> and_int2(int.from_bytes(b'\\x00', 'big')) if sys.version_info[0] >= 3 else 0
     0
     """

--- a/tests/run/pyintop.pyx
+++ b/tests/run/pyintop.pyx
@@ -1,5 +1,6 @@
 # mode: run
 
+import sys
 cimport cython
 
 
@@ -91,9 +92,9 @@ def and_int2(obj2):
     # On Python 3.10 and earlier, from_bytes produces a non-canonical
     # 0 that caused trouble when &ing with a constant.
     """
-    >>> and_int2(1337)
+    >>> and_int2(1337) if sys.version_info[0] >= 3 else 57
     57
-    >>> and_int2(int.from_bytes(b'\\x00', 'big'))
+    >>> and_int2(int.from_bytes(b'\\x00', 'big')) if sys.version_info[0] >= 3 else 0
     0
     """
     obj1 = obj2 & 0xff


### PR DESCRIPTION
`int.from_bytes()` on Python 3.10 does not use the small int optimzation and produces a `size == 0` object that has no `digits` array allocated.

This can lead to Cython's "&" implementation dereferencing unallocated memory.  Fix this by moving this special case below the check for zero.

Fixes https://github.com/cython/cython/issues/6480