### PR TITLE
Add filename prefix remapping

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -74,6 +74,12 @@ class SetAnnotateCoverageAction(Action):
         namespace.annotate = True
         namespace.annotate_coverage_xml = values
 
+class SetPrefixMapAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        mappings = getattr(namespace, self.dest, {})
+        k, v = values.split("=", 1)
+        mappings[k] = v
+        setattr(namespace, self.dest, mappings)
 
 def create_cython_argparser():
     description = "Cython (https://cython.org/) is a compiler for code written in the "\
@@ -157,6 +163,7 @@ def create_cython_argparser():
                            'deduced from the import path if source file is in '
                            'a package, or equals the filename otherwise.')
     parser.add_argument('-M', '--depfile', action='store_true', help='produce depfiles for the sources')
+    parser.add_argument("--prefix-map", action=SetPrefixMapAction, help='Map build paths in generated files', metavar="OLDPATH=NEWPATH")
     parser.add_argument('sources', nargs='*', default=[])
 
     # TODO: add help

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -796,4 +796,5 @@ default_options = dict(
     create_extension=None,
     np_pythran=False,
     legacy_implicit_noexcept=None,
+    prefix_map={},
 )

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2106,6 +2106,7 @@ def p_include_statement(s, ctx):
             s.included_files.append(include_file_name)
             with Utils.open_source_file(include_file_path) as f:
                 source_desc = FileSourceDescriptor(include_file_path)
+                print(f"TODO Cannot use prefix map on {include_file_path}")
                 s2 = PyrexScanner(f, source_desc, s, source_encoding=f.encoding, parse_comments=s.parse_comments)
                 tree = p_statement_list(s2, ctx)
             return tree

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -195,7 +195,7 @@ class FileSourceDescriptor(SourceDescriptor):
     optional name argument and will be passed back when asking for
     the position()-tuple.
     """
-    def __init__(self, filename, path_description=None):
+    def __init__(self, filename, path_description=None, prefix_map={}):
         filename = Utils.decode_filename(filename)
         self.path_description = path_description or filename
         self.filename = filename
@@ -205,6 +205,7 @@ class FileSourceDescriptor(SourceDescriptor):
         self.set_file_type_from_name(filename)
         self._cmp_name = filename
         self._lines = {}
+        self.prefix_map = prefix_map
 
     def get_lines(self, encoding=None, error_handling=None):
         # we cache the lines only the second time this is called, in
@@ -243,7 +244,11 @@ class FileSourceDescriptor(SourceDescriptor):
         return path
 
     def get_filenametable_entry(self):
-        return self.file_path
+        entry = self.file_path
+        for old in self.prefix_map:
+            if entry.startswith(old):
+                entry = entry.replace(old, self.prefix_map[old], 1)
+        return entry
 
     def __eq__(self, other):
         return isinstance(other, FileSourceDescriptor) and self.filename == other.filename


### PR DESCRIPTION
This adds prefix remapping to FileSourceDescriptor.get_filenametable_entry which is useful to remove build paths from the generated files by mapping them to a constant location.

Very much a WIP, at least one path where there's no mapping available and it needs documentation. But I'd like to get more feedback from the cython maintainers about the direction.

Closes #5949.