### PR TITLE
Make access fused access to ndarray thread safe

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -930,7 +930,8 @@ static CYTHON_INLINE PyObject* __Pyx__ImportNumPyArrayTypeIfAvailable(void) {
         PyMutex_Lock(&ndarray_mutex);
         // Now we've got the lock and know that no-one else is modifying it, check again
         // that it hasn't already been set.
-        if (!__pyx_atomic_pointer_load_acquire(&CGLOBAL(__pyx_numpy_ndarray))) {
+        result = __pyx_atomic_pointer_load_acquire(&CGLOBAL(__pyx_numpy_ndarray));
+        if (!result) {
             result = __Pyx__ImportNumPyArray();
             __pyx_atomic_pointer_exchange(&CGLOBAL(__pyx_numpy_ndarray), result);
         }

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -871,15 +871,31 @@ other_failure:
     return -1;
 }
 
+/////////////// ImportNumPyArray.module_state_decls //////////////
+//@requires: MemoryView_C.c::Atomics
+
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && CYTHON_ATOMICS
+__pyx_atomic_ptr_type __pyx_numpy_ndarray;
+#else
+// If freethreading but not atomics, then this is guarded by ndarray_mutex
+// in __Pyx__ImportNumPyArrayTypeIfAvailable
+PyObject *__pyx_numpy_ndarray;
+#endif
 
 /////////////// ImportNumPyArray.proto ///////////////
-
-static PyObject *__pyx_numpy_ndarray = NULL;
 
 static PyObject* __Pyx_ImportNumPyArrayTypeIfAvailable(void); /*proto*/
 
 /////////////// ImportNumPyArray.cleanup ///////////////
-Py_CLEAR(__pyx_numpy_ndarray);
+
+// I'm not actually worried about thread-safety in the cleanup function.
+// The CYTHON_ATOMICS code is only for the type-casting.
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && CYTHON_ATOMICS
+Py_XDECREF((PyObject*)__pyx_atomic_pointer_load_acquire(&CGLOBAL(__pyx_numpy_ndarray)));
+__pyx_atomic_pointer_exchange(&CGLOBAL(__pyx_numpy_ndarray), NULL);
+#else
+Py_CLEAR(CGLOBAL(__pyx_numpy_ndarray));
+#endif
 
 /////////////// ImportNumPyArray ///////////////
 //@requires: ImportExport.c::Import
@@ -903,10 +919,41 @@ static PyObject* __Pyx__ImportNumPyArray(void) {
     return ndarray_object;
 }
 
-static CYTHON_INLINE PyObject* __Pyx_ImportNumPyArrayTypeIfAvailable(void) {
-    if (unlikely(!__pyx_numpy_ndarray)) {
-        __pyx_numpy_ndarray = __Pyx__ImportNumPyArray();
+// Returns a borrowed reference, and encapsulates all thread safety stuff needed
+static CYTHON_INLINE PyObject* __Pyx__ImportNumPyArrayTypeIfAvailable(void) {
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+    static PyMutex ndarray_mutex = {0};
+#endif
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && CYTHON_ATOMICS
+    PyObject *result = (PyObject*)__pyx_atomic_pointer_load_relaxed(&CGLOBAL(__pyx_numpy_ndarray));
+    if (unlikely(!result)) {
+        PyMutex_Lock(&ndarray_mutex);
+        // Now we've got the lock and know that no-one else is modifying it, check again
+        // that it hasn't already been set.
+        if (!__pyx_atomic_pointer_load_acquire(&CGLOBAL(__pyx_numpy_ndarray))) {
+            result = __Pyx__ImportNumPyArray();
+            __pyx_atomic_pointer_exchange(&CGLOBAL(__pyx_numpy_ndarray), result);
+        }
+        PyMutex_Unlock(&ndarray_mutex);
     }
-    Py_INCREF(__pyx_numpy_ndarray);
-    return __pyx_numpy_ndarray;
+    return result;
+#else
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING // but not atomics
+    PyMutex_Lock(&ndarray_mutex);
+#endif
+    if (unlikely(!CGLOBAL(__pyx_numpy_ndarray)))
+    {
+        CGLOBAL(__pyx_numpy_ndarray) = __Pyx__ImportNumPyArray();
+    }
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING // but not atomics
+    PyMutex_Unlock(&ndarray_mutex);
+#endif
+    return CGLOBAL(__pyx_numpy_ndarray);
+#endif
+}
+
+static CYTHON_INLINE PyObject* __Pyx_ImportNumPyArrayTypeIfAvailable(void) {
+    PyObject *result = __Pyx__ImportNumPyArrayTypeIfAvailable();
+    Py_INCREF(result);
+    return result;
 }


### PR DESCRIPTION
1. Put the ndarray object onto the module state rather than a static global. This would be necessary in a multi-interpreter environment.
2. On freethreading builds, access this via atomics (for read) and a lock (for write). This can be fairly simple because it's only written once.

Part of #6506 (but I don't think this is the major problem).