### PR TITLE
Fix an issue with fused dispatch on freethreading

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -657,10 +657,11 @@ class FusedCFuncDefNode(StatListNode):
         #   sees a half filled-in sigindex
         pyx_code.put_chunk(
             """
-                if not _fused_sigindex[0]:
-                    fused_sigindex_contents = {}
+                fused_sigindex = <dict> _fused_sigindex_ref[0]
+                if fused_sigindex is None:
+                    fused_sigindex = {}
                     for sig in <dict> signatures:
-                        sigindex_node = <dict> fused_sigindex_contents
+                        sigindex_node = fused_sigindex
                         *sig_series, last_type = sig.strip('()').split('|')
                         for sig_type in sig_series:
                             if sig_type not in sigindex_node:
@@ -668,7 +669,7 @@ class FusedCFuncDefNode(StatListNode):
                             else:
                                 sigindex_node = <dict> sigindex_node[sig_type]
                         sigindex_node[last_type] = sig
-                    _fused_sigindex[0] = fused_sigindex_contents
+                    _fused_sigindex_ref[0] = fused_sigindex
             """
         )
 
@@ -708,7 +709,7 @@ class FusedCFuncDefNode(StatListNode):
 
         pyx_code.put_chunk(
             """
-                def __pyx_fused_cpdef(signatures, args, kwargs, defaults, _fused_sigindex=[None]):
+                def __pyx_fused_cpdef(signatures, args, kwargs, defaults, _fused_sigindex_ref=[None]):
                     # FIXME: use a typed signature - currently fails badly because
                     #        default arguments inherit the types we specify here!
 
@@ -787,7 +788,7 @@ class FusedCFuncDefNode(StatListNode):
         pyx_code.put_chunk(
             """
                 sigindex_matches = []
-                sigindex_candidates = [_fused_sigindex[0]]
+                sigindex_candidates = [fused_sigindex]
 
                 for dst_type in dest_sig:
                     found_matches = []

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -643,11 +643,24 @@ class FusedCFuncDefNode(StatListNode):
         Generate Cython code for constructing a persistent nested dictionary index of
         fused type specialization signatures.
         """
+        # Note on thread-safety:
+        # Filling in _fused_sigindex should only happen once. However, in a multi-threaded
+        # environment it's possible that multiple threads can all start to fill it in
+        # independently (especially on freehtreading builds).
+        # Therefore:
+        # * _fused_sigindex is a list of length 1 where the first element is either None,
+        #   or a dictionary of signatures to lookup.
+        # * We rely on being able to get/set list elements atomically (which is true on
+        #   freethreading and regular Python).
+        # * It doesn't really matter if multiple threads start generating their own version
+        #   of this - the contents will end up the same. The main point is that no thread
+        #   sees a half filled-in sigindex
         pyx_code.put_chunk(
             """
-                if not _fused_sigindex:
+                if not _fused_sigindex[0]:
+                    fused_sigindex_contents = {}
                     for sig in <dict> signatures:
-                        sigindex_node = <dict> _fused_sigindex
+                        sigindex_node = <dict> fused_sigindex_contents
                         *sig_series, last_type = sig.strip('()').split('|')
                         for sig_type in sig_series:
                             if sig_type not in sigindex_node:
@@ -655,6 +668,7 @@ class FusedCFuncDefNode(StatListNode):
                             else:
                                 sigindex_node = <dict> sigindex_node[sig_type]
                         sigindex_node[last_type] = sig
+                    _fused_sigindex[0] = fused_sigindex_contents
             """
         )
 
@@ -694,7 +708,7 @@ class FusedCFuncDefNode(StatListNode):
 
         pyx_code.put_chunk(
             """
-                def __pyx_fused_cpdef(signatures, args, kwargs, defaults, _fused_sigindex={}):
+                def __pyx_fused_cpdef(signatures, args, kwargs, defaults, _fused_sigindex=[None]):
                     # FIXME: use a typed signature - currently fails badly because
                     #        default arguments inherit the types we specify here!
 
@@ -773,7 +787,7 @@ class FusedCFuncDefNode(StatListNode):
         pyx_code.put_chunk(
             """
                 sigindex_matches = []
-                sigindex_candidates = [_fused_sigindex]
+                sigindex_candidates = [_fused_sigindex[0]]
 
                 for dst_type in dest_sig:
                     found_matches = []

--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -644,11 +644,11 @@ class FusedCFuncDefNode(StatListNode):
         fused type specialization signatures.
         """
         # Note on thread-safety:
-        # Filling in _fused_sigindex should only happen once. However, in a multi-threaded
+        # Filling in "fused_sigindex" should only happen once. However, in a multi-threaded
         # environment it's possible that multiple threads can all start to fill it in
         # independently (especially on freehtreading builds).
         # Therefore:
-        # * _fused_sigindex is a list of length 1 where the first element is either None,
+        # * "_fused_sigindex_ref" is a list of length 1 where the first element is either None,
         #   or a dictionary of signatures to lookup.
         # * We rely on being able to get/set list elements atomically (which is true on
         #   freethreading and regular Python).

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -461,3 +461,53 @@ cdef class HasBound:
     func = bind_me[float]
 
     func_fused = bind_me
+
+
+
+ctypedef fused IntOrFloat1:
+    int
+    float
+
+ctypedef fused IntOrFloat2:
+    int
+    float
+
+ctypedef fused IntOrFloat3:
+    int
+    float
+
+def really_simple_fused_function(IntOrFloat1 a, IntOrFloat2 b, IntOrFloat3 c):
+    # Don't use this function for anything except the thread safety stress test.
+    # The first call should be from that.
+    return (a + 1) * 2 + (b*c)
+
+def run_really_simple_fused_function(start_barrier, n_iters, failed_list):
+    # Maximize the chance of failure by waiting until all threads are ready to start
+    args = [ n if n % 2 else float(n) for n in range(n_iters) ]
+    try:
+        start_barrier.wait()
+        for a in args:
+            really_simple_fused_function(a, a, a)
+    except:
+        failed_list.append(True)
+
+
+def stress_test_thread_safety(n_threads):
+    """
+    >>> stress_test_thread_safety(20)
+    """
+    from threading import Barrier, Thread
+    start_barrier = Barrier(n_threads)
+
+    failed_list = []
+
+    threads = [
+        Thread(
+            target=run_really_simple_fused_function,
+            args=[start_barrier, 30, failed_list]
+        ) for _ in range(n_threads) ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failed_list, len(failed_list)


### PR DESCRIPTION
The main issue was that it was possible for other threads to see _fused_sigindex in a partially initialized state.

Hopefully fixes #6506

I've added a stress-test. This fails (intermittently) without the fix and doesn't seem to fail with the fix. But I obviously doesn't prove all is good