### PR TITLE
Implement cython.critical_section

### DIFF
--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -176,6 +176,9 @@ parallel_lineno = pyrex_prefix + "parallel_lineno"
 parallel_clineno = pyrex_prefix + "parallel_clineno"
 parallel_why = pyrex_prefix + "parallel_why"
 
+# Python itself used _Py_cs so loosely follow that convention
+critical_section_variable = pyrex_prefix + "cs"
+
 exc_vars = (exc_type_name, exc_value_name, exc_tb_name)
 
 api_name        = pyrex_prefix + "capi__"

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8975,7 +8975,7 @@ class CriticalSectionStatNode(TryFinallyStatNode):
         collector.visitchildren(body)
         if not collector.yields:
             return
-        
+
         from . import ExprNodes
         self.state_temp = ExprNodes.TempNode(pos, self.var_type)
 
@@ -9004,7 +9004,7 @@ class CriticalSectionStatNode(TryFinallyStatNode):
                     "Arguments to cython.critical_section must be Python objects."
                 )
         return super().analyse_expressions(env)
-    
+
     def generate_execution_code(self, code):
         code.mark_pos(self.pos)
         code.begin_block()
@@ -9035,11 +9035,11 @@ class CriticalSectionStatNode(TryFinallyStatNode):
 
     def nogil_check(self, env):
         error(self.pos, "Critical sections require the GIL")
-        
+
 
 class CriticalSectionExitNode(StatNode):
     child_attrs = []
-    
+
     def __deepcopy__(self, memo):
         # I have no idea how GILExitNode manages to deepcopy but still
         # have an initialized state_temp. However, here we just avoid

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -352,6 +352,7 @@ directive_types = {
     'collection_type': one_of('sequence'),
     'nogil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'gil' : DEFER_ANALYSIS_OF_ARGUMENTS,
+    'critical_section' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'with_gil' : None,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
@@ -391,6 +392,7 @@ directive_scopes = {  # defaults to available everywhere
     'nogil' : ('function', 'with statement'),
     'gil' : ('with statement'),
     'with_gil' : ('function',),
+    'critical_section': ('with statement'),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -392,7 +392,7 @@ directive_scopes = {  # defaults to available everywhere
     'nogil' : ('function', 'with statement'),
     'gil' : ('with statement'),
     'with_gil' : ('function',),
-    'critical_section': ('with statement'),
+    'critical_section': ('with statement',),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3767,15 +3767,17 @@ class GilCheck(VisitorTransform):
         """
         Take care of try/finally statements in nogil code sections.
         """
-        if (not self.nogil or
-                isinstance(node, Nodes.GILStatNode) or
-                isinstance(node, Nodes.CriticalSectionStatNode)):
+        if not self.nogil:
             return self.visit_Node(node)
 
         node.nogil_check = None
         node.is_try_finally_in_nogil = True
         self.visitchildren(node)
         return node
+
+    def visit_CriticalSectionStatNode(self, node):
+        # skip normal "try/finally node" handling
+        return self.visit_Node(node)
 
     def visit_GILExitNode(self, node):
         if not self.current_gilstat_node_knows_gil_state:

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1424,7 +1424,7 @@ class InterpretCompilerDirectives(CythonTransform):
                                 PostParseError(node.pos, "Compiler directive %s accepts one positional argument." % name))
                         node = Nodes.GILStatNode(node.pos, state=name, body=node.body, condition=condition)
                         return self.visit_Node(node)
-                    if name == "critical_section":
+                    elif name == "critical_section":
                         args, kwds = value
                         if len(args) < 1 or len(args) > 2 or kwds:
                             self.context.nonfatal_error(

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4870,6 +4870,12 @@ c_gilstate_type = CEnumType("PyGILState_STATE", "PyGILState_STATE", True)
 c_threadstate_type = CStructOrUnionType("PyThreadState", "struct", None, 1, "PyThreadState")
 c_threadstate_ptr_type = CPtrType(c_threadstate_type)
 
+# Critical section
+c_py_critical_section_type = CStructOrUnionType(
+    "__Pyx_PyCriticalSection", "struct", None, 1, "__Pyx_PyCriticalSection")
+c_py_critical_section2_type = CStructOrUnionType(
+    "__Pyx_PyCriticalSection2", "struct", None, 1, "__Pyx_PyCriticalSection2")
+
 # PEP-539 "Py_tss_t" type
 c_pytss_t_type = CPyTSSTType()
 

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -227,6 +227,15 @@ with_gil = _nogil()  # Actually not a context manager, but compilation will give
 del _nogil
 
 
+class critical_section:
+    def __init__(self, *args):
+        pass
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_class, exc, tb):
+        return exc_class is None
+
+
 # Emulated types
 
 class CythonMetaType(type):

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -233,7 +233,7 @@ class critical_section:
     def __enter__(self):
         pass
     def __exit__(self, exc_class, exc, tb):
-        return exc_class is None
+        return False
 
 
 # Emulated types

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2986,3 +2986,22 @@ static int __Pyx_State_RemoveModule(CYTHON_UNUSED void* dummy) {
 }
 
 #endif
+
+/////////////////////// CriticalSections.proto /////////////////////
+//@proto_block: utility_code_proto_before_types
+
+#if !CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+#define __Pyx_PyCriticalSection void*
+#define __Pyx_PyCriticalSection2 void*
+#define __Pyx_PyCriticalSection_Begin1(cs, arg) (void)cs
+#define __Pyx_PyCriticalSection_Begin2(cs, arg) (void)cs
+#define __Pyx_PyCriticalSection_End1(cs)
+#define __Pyx_PyCriticalSection_End2(cs)
+#else
+#define __Pyx_PyCriticalSection PyCriticalSection
+#define __Pyx_PyCriticalSection2 PyCriticalSection2
+#define __Pyx_PyCriticalSection_Begin1 PyCriticalSection_Begin
+#define __Pyx_PyCriticalSection_Begin2 PyCriticalSection2_Begin
+#define __Pyx_PyCriticalSection_End1 PyCriticalSection_End
+#define __Pyx_PyCriticalSection_End2 PyCriticalSection2_End
+#endif

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2994,7 +2994,7 @@ static int __Pyx_State_RemoveModule(CYTHON_UNUSED void* dummy) {
 #define __Pyx_PyCriticalSection void*
 #define __Pyx_PyCriticalSection2 void*
 #define __Pyx_PyCriticalSection_Begin1(cs, arg) (void)cs
-#define __Pyx_PyCriticalSection_Begin2(cs, arg) (void)cs
+#define __Pyx_PyCriticalSection_Begin2(cs, arg1, arg2) (void)cs
 #define __Pyx_PyCriticalSection_End1(cs)
 #define __Pyx_PyCriticalSection_End2(cs)
 #else

--- a/docs/src/userguide/freethreading.rst
+++ b/docs/src/userguide/freethreading.rst
@@ -77,8 +77,8 @@ a useful thing to do).
 
 We suggest reading the Python documentation to understand how critical sections work.
 
-* You can guarantee that the lock will be held when executing code within the 
-  critical section, however you can not guarantee that the lock will be executed
+* It is guaranteed that the lock will be held when executing code within the 
+  critical section. However, there is no guarantee that the code block will be executed
   in one atomic action.  This is very similar to the guarantee provided by
   a ``with gil`` block.
 * Operations on another Python object may end up temporarily releasing the

--- a/docs/src/userguide/freethreading.rst
+++ b/docs/src/userguide/freethreading.rst
@@ -51,6 +51,42 @@ extension modules claim to support it then you can either:
 
 These options are mainly useful for testing.
 
+Tools for Thread-safety
+=======================
+
+Cython is gradually adding tools to help you write thread-safe code. These are
+described here.
+
+Critical Sections
+-----------------
+
+`Critical Sections <https://docs.python.org/3.13/c-api/init.html#python-critical-section-api>`_
+are a feature provided by Python to generate a local lock based on some Python object.
+Cython allows you to use critical sections with a convenient
+syntax::
+
+    o = object()
+    ...
+    with cython.critical_section(o):
+      ...
+      
+Critical sections can take one or two Python objects as arguments.  You are required to
+hold the GIL on entry to a critical section (you can release the GIL inside the critical
+section but that also temporarily releases the critical section so is unlikely to be
+a useful thing to do).
+
+We suggest reading the Python documentation to understand how critical sections work.
+
+* You can guarantee that the lock will be held when executing code within the 
+  critical section, however you can not guarantee that the lock will be executed
+  in one atomic action.  This is very similar to the guarantee provided by
+  a ``with gil`` block.
+* Operations on another Python object may end up temporarily releasing the
+  critical section in favour of a critical section based on that object.
+
+On non-freethreading builds ``cython.critical_section`` does nothing - you get the
+same guarantees simply from the fact you hold the GIL.
+
 Pitfalls
 ========
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -990,7 +990,7 @@ Cython code.  Here is the list of currently supported directives:
 ``c_string_type`` (bytes / str / unicode), *default=bytes*
     Globally set the type of an implicit coercion from char* or std::string.
 
-``c_string_encoding`` (ascii, default, utf-8, etc.), *default=""`
+``c_string_encoding`` (ascii, default, utf-8, etc.), *default=""*
     Globally set the encoding to use when implicitly coercing char* or std:string
     to a unicode object.  Coercion from a unicode object to C type is only allowed
     when set to ``ascii`` or ``default``, the latter being utf-8 in Python 3 and

--- a/tests/errors/critical_sections.pyx
+++ b/tests/errors/critical_sections.pyx
@@ -22,8 +22,8 @@ _ERRORS = """
 7:9: critical_section directive accepts one or two positional arguments
 9:9: critical_section directive accepts one or two positional arguments
 11:9: critical_section directive accepts one or two positional arguments
-13:9: Arguments to cython.critical_section must be Python objects.
-15:9: Arguments to cython.critical_section must be Python objects.
+13:33: Arguments to cython.critical_section must be Python objects.
+15:33: Arguments to cython.critical_section must be Python objects.
 18:13: Critical sections require the GIL
 # slightly extraneous, but no real harm
 18:37: Creating temporary Python reference not allowed without gil

--- a/tests/errors/critical_sections.pyx
+++ b/tests/errors/critical_sections.pyx
@@ -1,0 +1,30 @@
+# mode: error
+
+cimport cython
+
+def f():
+    o = object()
+    with cython.critical_section():  # no arguments
+        pass
+    with cython.critical_section(o, o, o):  # Too many arguments (also the same argument, but we don't check for that)
+        pass
+    with cython.critical_section(please_ensure_thread_safety=True):  # While this keyword argument would be nice, it doesn't exist
+        pass
+    with cython.critical_section(1):  # C argument type
+        pass
+    with cython.critical_section(<void*>o):  # silly, but again, a C argument
+        pass
+    with nogil:
+        with cython.critical_section(o):  # critical sections require the GIL
+            pass
+
+_ERRORS = """
+7:9: critical_section directive accepts one or two positional arguments
+9:9: critical_section directive accepts one or two positional arguments
+11:9: critical_section directive accepts one or two positional arguments
+13:9: Arguments to cython.critical_section must be Python objects.
+15:9: Arguments to cython.critical_section must be Python objects.
+18:13: Critical sections require the GIL
+# slightly extraneous, but no real harm
+18:37: Creating temporary Python reference not allowed without gil
+"""

--- a/tests/errors/critical_sections.pyx
+++ b/tests/errors/critical_sections.pyx
@@ -18,6 +18,7 @@ def f():
         with cython.critical_section(o):  # critical sections require the GIL
             pass
 
+
 _ERRORS = """
 7:9: critical_section directive accepts one or two positional arguments
 9:9: critical_section directive accepts one or two positional arguments

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -1,0 +1,121 @@
+# mode: run
+
+cimport cython
+
+import threading
+
+# This test is most useful on free-threading builds.
+# It should pass on regular builds just by virtue of
+# the GIL.
+
+def test_single_critical_section(n_threads, n_loops):
+    """
+    >>> test_single_critical_section(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    def worker():
+        nonlocal count
+        barrier.wait()
+        for i in range(n_loops):
+            with cython.critical_section(lock):
+                count += i
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = ((n_loops * (n_loops - 1))/2)*n_threads
+    assert count == expected, (count, expected)
+
+def test_double_critical_section(n_loops):
+    """
+    >>> test_double_critical_section(100)
+    """
+    cdef int a = 2
+    cdef int b = 3
+    barrier = threading.Barrier(3)
+    finished_event = threading.Event()
+    failed = threading.Event()
+    lock_a = object()
+    lock_b = object()
+
+    def reader1():
+        barrier.wait()
+        while not finished_event.is_set():
+            for _ in range(10):
+                with cython.critical_section(lock_a):
+                    if not (a==2 or a==3):
+                        failed.set()
+
+    def reader2():
+        barrier.wait()
+        while not finished_event.is_set():
+            for _ in range(10):
+                with cython.critical_section(lock_b):
+                    if not (b==2 or b==3):
+                        failed.set()
+
+    def swapper():
+        nonlocal a, b
+        barrier.wait()
+        for _ in range(n_loops):
+            with cython.critical_section(lock_a, lock_b):
+                old_a = a
+                old_b = b
+                a = 1000
+                b = 2000
+                a = old_b
+                b = old_a
+        finished_event.set()
+    t1 = threading.Thread(target=reader1)
+    t2 = threading.Thread(target=reader2)
+    t3 = threading.Thread(target=swapper)
+    t1.start()
+    t2.start()
+    t3.start()
+    t1.join()
+    t2.join()
+    t3.join()
+
+    assert not failed.is_set()
+
+def test_critical_section_in_generators(n_threads, n_loops):
+    """
+    >>> test_critical_section_in_generators(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    def gen():
+        nonlocal count
+        barrier.wait()
+        with cython.critical_section(lock):
+            for i in range(n_loops):
+                count += i
+                yield
+
+    def make_and_run_generator():
+        g = gen()
+        for _ in g:
+            pass
+
+    threads = [
+        threading.Thread(target=make_and_run_generator)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = ((n_loops * (n_loops - 1))/2)*n_threads
+    assert count == expected, (count, expected)

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -35,57 +35,53 @@ def test_single_critical_section(n_threads, n_loops):
     expected = ((n_loops * (n_loops - 1))/2)*n_threads
     assert count == expected, (count, expected)
 
+
 def test_double_critical_section(n_loops):
     """
     >>> test_double_critical_section(100)
     """
-    cdef int a = 2
-    cdef int b = 3
+    cdef int a = 0
+    cdef int b = 0
     barrier = threading.Barrier(3)
-    finished_event = threading.Event()
-    failed = threading.Event()
     lock_a = object()
     lock_b = object()
 
-    def reader1():
+    def a_thread():
+        nonlocal a
         barrier.wait()
-        while not finished_event.is_set():
-            for _ in range(10):
-                with cython.critical_section(lock_a):
-                    if not (a==2 or a==3):
-                        failed.set()
+        for i in range(n_loops):
+            with cython.critical_section(lock_a):
+                a += i
 
-    def reader2():
+    def b_thread():
+        nonlocal b
         barrier.wait()
-        while not finished_event.is_set():
-            for _ in range(10):
-                with cython.critical_section(lock_b):
-                    if not (b==2 or b==3):
-                        failed.set()
+        for i in range(n_loops):
+            with cython.critical_section(lock_b):
+                b += i
 
-    def swapper():
+    def ab_thread():
         nonlocal a, b
         barrier.wait()
-        for _ in range(n_loops):
+        for i in range(n_loops):
             with cython.critical_section(lock_a, lock_b):
-                old_a = a
-                old_b = b
-                a = 1000
-                b = 2000
-                a = old_b
-                b = old_a
-        finished_event.set()
-    t1 = threading.Thread(target=reader1)
-    t2 = threading.Thread(target=reader2)
-    t3 = threading.Thread(target=swapper)
-    t1.start()
-    t2.start()
-    t3.start()
-    t1.join()
-    t2.join()
-    t3.join()
+                a += i
+                b += i
 
-    assert not failed.is_set()
+    threads = [
+        threading.Thread(target=target)
+        for target in [a_thread, b_thread, ab_thread]
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # Each variable is modified from 2 threads
+    expected = ((n_loops * (n_loops - 1))/2)*2
+    assert a == expected, (a, expected)
+    assert b == expected, (b, expected)
+
 
 def test_critical_section_in_generators(n_threads, n_loops):
     """


### PR DESCRIPTION
This just provides a nice interface for the freethreading Python's critical section feature, so that users can attempt to do their own locking.

Implementation is heavily based on `with gil`/`with nogil` blocks however I haven't attempted to directly share it via inheritance.