### PR TITLE
Make generators thread safe

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1660,33 +1660,33 @@ static char __Pyx_Coroutine_test_and_set_is_running(__pyx_CoroutineObject *gen) 
     // 2. They aren't *ultra* high performance, and so critical sections (locking) is appropriate
     //    instead of atomics.
     char result;
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_BEGIN_CRITICAL_SECTION(gen);
     #endif
     result = gen->is_running;
     gen->is_running = 1;
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_END_CRITICAL_SECTION();
     #endif
     return result;
 }
 static void __Pyx_Coroutine_unset_is_running(__pyx_CoroutineObject *gen) {
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_BEGIN_CRITICAL_SECTION(gen);
     #endif
     assert(gen->is_running);
     gen->is_running = 0;
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_END_CRITICAL_SECTION();
     #endif
 }
 CYTHON_UNUSED static char __Pyx_Coroutine_get_is_running(__pyx_CoroutineObject *gen) {
     char result;
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_BEGIN_CRITICAL_SECTION(gen);
     #endif
     result = gen->is_running;
-    #if PY_VERSION_HEX >= 0x030d0000
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
     Py_END_CRITICAL_SECTION();
     #endif
     return result;

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -444,7 +444,7 @@ typedef struct __pyx_CoroutineObject {
     uint64_t $monitoring_version_cname;
 #endif
     int resume_label;
-    // using T_BOOL for property below requires char value
+    // is_running is the main thread-safety mechanism for coroutines, so treat it carefully
     char is_running;
 } __pyx_CoroutineObject;
 
@@ -488,6 +488,9 @@ static PyObject *__Pyx_Coroutine_Throw(PyObject *gen, PyObject *args); /*proto*/
 static int __Pyx_PyGen__FetchStopIterationValue(PyThreadState *tstate, PyObject **pvalue); /*proto*/
 static CYTHON_INLINE void __Pyx_Coroutine_ResetFrameBackpointer(__Pyx_ExcInfoStruct *exc_state); /*proto*/
 
+static char __Pyx_Coroutine_test_and_set_is_running(__pyx_CoroutineObject *gen);
+static void __Pyx_Coroutine_unset_is_running(__pyx_CoroutineObject *gen);
+CYTHON_UNUSED static char __Pyx_Coroutine_get_is_running(__pyx_CoroutineObject *gen);
 
 //////////////////// Coroutine.proto ////////////////////
 
@@ -758,7 +761,7 @@ __Pyx_PySendResult __Pyx_Coroutine_SendEx(__pyx_CoroutineObject *self, PyObject 
     __Pyx_ExcInfoStruct *exc_state;
     PyObject *retval;
 
-    assert(!self->is_running);
+    assert(__Pyx_Coroutine_get_is_running(self));  // Callers should ensure is_running
 
     if (unlikely(self->resume_label == -1)) {
         __Pyx_Coroutine_AlreadyTerminatedError((PyObject*)self, value, closing);
@@ -845,9 +848,7 @@ __Pyx_PySendResult __Pyx_Coroutine_SendEx(__pyx_CoroutineObject *self, PyObject 
     }
 #endif
 
-    self->is_running = 1;
     retval = self->body(self, tstate, value);
-    self->is_running = 0;
 
 #if CYTHON_USE_EXC_INFO_STACK
     // See  https://bugs.python.org/issue25612
@@ -977,6 +978,7 @@ static CYTHON_INLINE __Pyx_PySendResult
 __Pyx_Coroutine_FinishDelegation(__pyx_CoroutineObject *gen, PyObject** retval) {
     __Pyx_PySendResult result;
     PyObject *val = NULL;
+    assert(__Pyx_Coroutine_get_is_running(gen));
     __Pyx_Coroutine_Undelegate(gen);
     __Pyx_PyGen__FetchStopIterationValue(__Pyx_PyThreadState_Current, &val);
     // val == NULL on failure => pass on exception
@@ -990,10 +992,9 @@ static __Pyx_PySendResult
 __Pyx_Coroutine_SendToDelegate(__pyx_CoroutineObject *gen, __Pyx_pyiter_sendfunc gen_am_send, PyObject *value, PyObject **retval) {
     PyObject *ret = NULL;
     __Pyx_PySendResult result;
+    assert(__Pyx_Coroutine_get_is_running(gen));
     // we assume that gen->yieldfrom cannot change as long as 'gen->is_running' is set => no safety INCREF()
-    gen->is_running = 1;
     result = gen_am_send(gen->yieldfrom, value, &ret);
-    gen->is_running = 0;
     if (result == PYGEN_NEXT) {
         assert (ret != NULL);
         *retval = ret;
@@ -1016,7 +1017,7 @@ static __Pyx_PySendResult
 __Pyx_Coroutine_AmSend(PyObject *self, PyObject *value, PyObject **retval) {
     __Pyx_PySendResult result;
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject*) self;
-    if (unlikely(gen->is_running)) {
+    if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen))) {
         *retval = __Pyx_Coroutine_AlreadyRunningError(gen);
         return PYGEN_ERROR;
     }
@@ -1028,7 +1029,6 @@ __Pyx_Coroutine_AmSend(PyObject *self, PyObject *value, PyObject **retval) {
     if (gen->yieldfrom) {
         PyObject *yf = gen->yieldfrom;
         PyObject *ret;
-        gen->is_running = 1;
       #if !CYTHON_USE_AM_SEND
         // Py3.10 puts "am_send" into "gen->yieldfrom_am_send" instead of using these special cases.
         // See "__Pyx_Coroutine_Set_Owned_Yield_From()" above.
@@ -1065,8 +1065,8 @@ __Pyx_Coroutine_AmSend(PyObject *self, PyObject *value, PyObject **retval) {
             #endif
                 ret = __Pyx_PyObject_CallMethod1(yf, PYIDENT("send"), value);
         }
-        gen->is_running = 0;
         if (likely(ret)) {
+            __Pyx_Coroutine_unset_is_running(gen);
             *retval = ret;
             return PYGEN_NEXT;
         }
@@ -1074,6 +1074,7 @@ __Pyx_Coroutine_AmSend(PyObject *self, PyObject *value, PyObject **retval) {
     } else {
         result = __Pyx_Coroutine_SendEx(gen, value, retval, 0);
     }
+    __Pyx_Coroutine_unset_is_running(gen);
     return result;
 }
 
@@ -1082,6 +1083,8 @@ __Pyx_Coroutine_AmSend(PyObject *self, PyObject *value, PyObject **retval) {
 static int __Pyx_Coroutine_CloseIter(__pyx_CoroutineObject *gen, PyObject *yf) {
     __Pyx_PySendResult result;
     PyObject *retval = NULL;
+
+    assert(__Pyx_Coroutine_get_is_running(gen));
 
     #ifdef __Pyx_Generator_USED
     if (__Pyx_Generator_CheckExact(yf)) {
@@ -1111,7 +1114,6 @@ static int __Pyx_Coroutine_CloseIter(__pyx_CoroutineObject *gen, PyObject *yf) {
     {
         PyObject *meth;
         result = PYGEN_RETURN;
-        gen->is_running = 1;
         meth = __Pyx_PyObject_GetAttrStrNoError(yf, PYIDENT("close"));
         if (unlikely(!meth)) {
             if (unlikely(PyErr_Occurred())) {
@@ -1124,7 +1126,6 @@ static int __Pyx_Coroutine_CloseIter(__pyx_CoroutineObject *gen, PyObject *yf) {
                 result = PYGEN_ERROR;
             }
         }
-        gen->is_running = 0;
     }
     Py_XDECREF(retval);
     return result == PYGEN_ERROR ? -1 : 0;
@@ -1134,7 +1135,7 @@ static PyObject *__Pyx_Generator_Next(PyObject *self) {
     __Pyx_PySendResult result;
     PyObject *retval = NULL;
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject*) self;
-    if (unlikely(gen->is_running)) {
+    if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen))) {
         return __Pyx_Coroutine_AlreadyRunningError(gen);
     }
     #if CYTHON_USE_AM_SEND
@@ -1146,7 +1147,6 @@ static PyObject *__Pyx_Generator_Next(PyObject *self) {
         PyObject *yf = gen->yieldfrom;
         PyObject *ret;
         // YieldFrom code ensures that yf is an iterator
-        gen->is_running = 1;
         #ifdef __Pyx_Generator_USED
         if (__Pyx_Generator_CheckExact(yf)) {
             ret = __Pyx_Generator_Next(yf);
@@ -1165,14 +1165,15 @@ static PyObject *__Pyx_Generator_Next(PyObject *self) {
         } else
         #endif
             ret = __Pyx_PyIter_Next_Plain(yf);
-        gen->is_running = 0;
         if (likely(ret)) {
+            __Pyx_Coroutine_unset_is_running(gen);
             return ret;
         }
         result = __Pyx_Coroutine_FinishDelegation(gen, &retval);
     } else {
         result = __Pyx_Coroutine_SendEx(gen, Py_None, &retval, 0);
     }
+    __Pyx_Coroutine_unset_is_running(gen);
 
     return __Pyx_Coroutine_MethodReturnFromResult(self, result, retval);
 }
@@ -1195,7 +1196,7 @@ __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
     PyObject *yf = gen->yieldfrom;
     int err = 0;
 
-    if (unlikely(gen->is_running)) {
+    if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen))) {
         *retval = __Pyx_Coroutine_AlreadyRunningError(gen);
         return PYGEN_ERROR;
     }
@@ -1213,6 +1214,7 @@ __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
         // WARNING: *retval == NULL !
         __Pyx_PyThreadState_declare
         __Pyx_PyThreadState_assign
+        __Pyx_Coroutine_unset_is_running(gen);
         if (!__Pyx_PyErr_Occurred()) {
             return PYGEN_RETURN;
         } else if (likely(__Pyx_PyErr_ExceptionMatches2(PyExc_GeneratorExit, PyExc_StopIteration))) {
@@ -1221,6 +1223,7 @@ __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
         }
         return PYGEN_ERROR;
     } else if (likely(result == PYGEN_RETURN && *retval == Py_None)) {
+        __Pyx_Coroutine_unset_is_running(gen);
         return PYGEN_RETURN;
     } else {
         const char *msg;
@@ -1239,6 +1242,7 @@ __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
             msg = "generator ignored GeneratorExit";
         }
         PyErr_SetString(PyExc_RuntimeError, msg);
+        __Pyx_Coroutine_unset_is_running(gen);
         return PYGEN_ERROR;
     }
 }
@@ -1248,7 +1252,7 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject *) self;
     PyObject *yf = gen->yieldfrom;
 
-    if (unlikely(gen->is_running))
+    if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen)))
         return __Pyx_Coroutine_AlreadyRunningError(gen);
 
     if (yf) {
@@ -1266,7 +1270,6 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
                 goto propagate_exception;
             goto throw_here;
         }
-        gen->is_running = 1;
         if (0
         #ifdef __Pyx_Generator_USED
             || __Pyx_Generator_CheckExact(yf)
@@ -1285,11 +1288,10 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
             if (unlikely(!meth)) {
                 Py_DECREF(yf);
                 if (unlikely(PyErr_Occurred())) {
-                    gen->is_running = 0;
+                    __Pyx_Coroutine_unset_is_running(gen);
                     return NULL;
                 }
                 __Pyx_Coroutine_Undelegate(gen);
-                gen->is_running = 0;
                 goto throw_here;
             }
             if (likely(args)) {
@@ -1301,12 +1303,14 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
             }
             Py_DECREF(meth);
         }
-        gen->is_running = 0;
         Py_DECREF(yf);
-        if (ret)
+        if (ret) {
+            __Pyx_Coroutine_unset_is_running(gen);
             return ret;
+        }
 
         result = __Pyx_Coroutine_FinishDelegation(gen, &ret);
+        __Pyx_Coroutine_unset_is_running(gen);
         return __Pyx_Coroutine_MethodReturnFromResult(self, result, ret);
     }
 throw_here:
@@ -1316,6 +1320,7 @@ propagate_exception:
     {
         PyObject *retval = NULL;
         __Pyx_PySendResult result = __Pyx_Coroutine_SendEx(gen, NULL, &retval, 0);
+        __Pyx_Coroutine_unset_is_running(gen);
         return __Pyx_Coroutine_MethodReturnFromResult(self, result, retval);
     }
 }
@@ -1647,6 +1652,47 @@ static __pyx_CoroutineObject *__Pyx__Coroutine_NewInit(
 }
 
 
+static char __Pyx_Coroutine_test_and_set_is_running(__pyx_CoroutineObject *gen) {
+    // Working on the basis that:
+    // 1. is_running is the main thing needed to keep generators thread-safe. They can't be
+    //    run simultaneously from multiple threads so as long as we track this correctly
+    //    then all is good.
+    // 2. They aren't *ultra* high performance, and so critical sections (locking) is appropriate
+    //    instead of atomics.
+    char result;
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_BEGIN_CRITICAL_SECTION(gen);
+    #endif
+    result = gen->is_running;
+    gen->is_running = 1;
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_END_CRITICAL_SECTION();
+    #endif
+    return result;
+}
+static void __Pyx_Coroutine_unset_is_running(__pyx_CoroutineObject *gen) {
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_BEGIN_CRITICAL_SECTION(gen);
+    #endif
+    assert(gen->is_running);
+    gen->is_running = 0;
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_END_CRITICAL_SECTION();
+    #endif
+}
+CYTHON_UNUSED static char __Pyx_Coroutine_get_is_running(__pyx_CoroutineObject *gen) {
+    char result;
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_BEGIN_CRITICAL_SECTION(gen);
+    #endif
+    result = gen->is_running;
+    #if PY_VERSION_HEX >= 0x030d0000
+    Py_END_CRITICAL_SECTION();
+    #endif
+    return result;
+}
+
+
 //////////////////// Coroutine ////////////////////
 //@requires: CoroutineBase
 //@requires: ExtensionTypes.c::CallTypeTraverse
@@ -1883,7 +1929,6 @@ static PyMethodDef __pyx_Coroutine_methods[] = {
 };
 
 static PyMemberDef __pyx_Coroutine_memberlist[] = {
-    {"cr_running", T_BOOL, offsetof(__pyx_CoroutineObject, is_running), READONLY, NULL},
     {"cr_await", T_OBJECT, offsetof(__pyx_CoroutineObject, yieldfrom), READONLY,
      PyDoc_STR("object being awaited, or None")},
     {"cr_code", T_OBJECT, offsetof(__pyx_CoroutineObject, gi_code), READONLY, NULL},
@@ -1901,6 +1946,8 @@ static PyGetSetDef __pyx_Coroutine_getsets[] = {
      PyDoc_STR("qualified name of the coroutine"), 0},
     {"cr_frame", (getter)__Pyx_Coroutine_get_frame, NULL,
      PyDoc_STR("Frame of the coroutine"), 0},
+    // getter rather than member for thread safety. 
+    {"cr_running", (getter)__Pyx_Coroutine_get_is_running, NULL, NULL},
     {0, 0, 0, 0, 0}
 };
 
@@ -2340,7 +2387,11 @@ static int __pyx_Generator_init(PyObject *module) {
 static PyObject *__Pyx_Generator_GetInlinedResult(PyObject *self) {
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject*) self;
     PyObject *retval = NULL;
+    if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen))) {
+        return __Pyx_Coroutine_AlreadyRunningError(gen);
+    }
     __Pyx_PySendResult result = __Pyx_Coroutine_SendEx(gen, Py_None, &retval, 0);
+    __Pyx_Coroutine_unset_is_running(gen);
     (void) result;
     assert (result == PYGEN_RETURN || result == PYGEN_ERROR);
     assert ((result == PYGEN_RETURN && retval != NULL) || (result == PYGEN_ERROR && retval == NULL));

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1193,13 +1193,14 @@ static __Pyx_PySendResult
 __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject *) self;
     __Pyx_PySendResult result;
-    PyObject *yf = gen->yieldfrom;
+    PyObject *yf;
     int err = 0;
 
     if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen))) {
         *retval = __Pyx_Coroutine_AlreadyRunningError(gen);
         return PYGEN_ERROR;
     }
+    yf = gen->yieldfrom;
 
     if (yf) {
         Py_INCREF(yf);
@@ -1250,11 +1251,12 @@ __Pyx_Coroutine_Close(PyObject *self, PyObject **retval) {
 static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject *val, PyObject *tb,
                                         PyObject *args, int close_on_genexit) {
     __pyx_CoroutineObject *gen = (__pyx_CoroutineObject *) self;
-    PyObject *yf = gen->yieldfrom;
+    PyObject *yf;
 
     if (unlikely(__Pyx_Coroutine_test_and_set_is_running(gen)))
         return __Pyx_Coroutine_AlreadyRunningError(gen);
 
+    yf = gen->yieldfrom;
     if (yf) {
         __Pyx_PySendResult result;
         PyObject *ret;

--- a/tests/run/generator_thread_safety.pyx
+++ b/tests/run/generator_thread_safety.pyx
@@ -152,9 +152,9 @@ def test_value_into_generator(n_threads, n_loops):
 class MyError(Exception):
     pass
 
-def test_value_into_generator(n_threads, n_loops):
+def test_throw_into_generator(n_threads, n_loops):
     """
-    >>> test_value_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
     """
     barrier = threading.Barrier(n_threads)
     done = threading.Event()

--- a/tests/run/generator_thread_safety.pyx
+++ b/tests/run/generator_thread_safety.pyx
@@ -1,0 +1,196 @@
+# mode: run
+
+from __future__ import print_function
+
+import threading
+import sys
+
+def make_thread_func(barrier, failed, done, body):
+    def thread_func():
+        barrier.wait()
+        while not done.is_set() and not failed.is_set():
+            # Acceptable things to happen:
+            # 1. We successfully get the next value.
+            # 2. The iteration has finished completely.
+            # 3. The generator is already executing in another thread
+            # Unacceptable things to happen:
+            # 1. The generator runs in multiple threads, giving a miscount
+            # 2. Any other exception
+            try:
+                body()
+            except StopIteration:
+                pass  # OK
+            except ValueError as e:
+                if "already executing" not in e.args[0]:
+                    failed.set()
+                    raise  # otherwise OK
+            except BaseException as e:
+                failed.set()
+                raise
+    return thread_func
+
+def test_simple_generator(n_threads, n_loops):
+    """
+    >>> test_simple_generator(4, 500)
+    """
+    barrier = threading.Barrier(n_threads)
+    done = threading.Event()
+    failed = threading.Event()
+    count = 0
+
+    def gen():
+        nonlocal count
+        try:
+            for i in range(n_loops):
+                count += 1
+                yield
+        finally:
+            done.set()
+
+    g = gen()
+
+    threads = [ 
+        threading.Thread(
+            target=make_thread_func(
+                barrier=barrier,
+                failed=failed,
+                done=done,
+                body=lambda: next(g)
+            )
+        ) for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failed.is_set()
+    assert count == n_loops, (count, n_loops)
+
+def test_yield_from_generator(n_threads, n_loops):
+    """
+    >>> test_yield_from_generator(4, 500)
+    """
+    barrier = threading.Barrier(n_threads)
+    done = threading.Event()
+    failed = threading.Event()
+    count = 0
+
+    def gen():
+        nonlocal count
+        try:
+            for i in range(n_loops):
+                count += 1
+                yield
+        finally:
+            done.set()
+
+    def gen2(other):
+        yield from other
+
+    g = gen2(gen())
+
+    threads = [ 
+        threading.Thread(
+            target=make_thread_func(
+                barrier=barrier,
+                failed=failed,
+                done=done,
+                body=lambda: next(g)
+            )
+        ) for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failed.is_set()
+    assert count == n_loops, (count, n_loops)
+
+def test_value_into_generator(n_threads, n_loops):
+    """
+    >>> test_value_into_generator(4, 500)
+    """
+    barrier = threading.Barrier(n_threads)
+    done = threading.Event()
+    failed = threading.Event()
+    count = 0
+
+    def gen():
+        nonlocal count
+        try:
+            for i in range(n_loops):
+                count += 1
+                value = yield count
+                assert value == "hello"
+        finally:
+            done.set()
+
+    g = gen()
+    next(g)
+
+    def body():
+        out = g.send("hello")
+        assert isinstance(out, int), out
+
+    threads = [ 
+        threading.Thread(
+            target=make_thread_func(
+                barrier=barrier,
+                failed=failed,
+                done=done,
+                body=body
+            )
+        ) for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failed.is_set()
+    assert count == n_loops, (count, n_loops)
+
+class MyError(Exception):
+    pass
+
+def test_value_into_generator(n_threads, n_loops):
+    """
+    >>> test_value_into_generator(4, 500)
+    """
+    barrier = threading.Barrier(n_threads)
+    done = threading.Event()
+    failed = threading.Event()
+    count = 0
+
+    def gen():
+        nonlocal count
+        try:
+            for i in range(n_loops):
+                count += 1
+                try:
+                    yield
+                except MyError:
+                    pass  # good
+                else:
+                    assert False, "We're supposed to get an exception!"
+        finally:
+            done.set()
+
+    g = gen()
+    next(g)
+
+    threads = [ 
+        threading.Thread(
+            target=make_thread_func(
+                barrier=barrier,
+                failed=failed,
+                done=done,
+                body=lambda: g.throw(MyError())
+            )
+        ) for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failed.is_set()
+    assert count == n_loops, (count, n_loops)

--- a/tests/run/generator_thread_safety.pyx
+++ b/tests/run/generator_thread_safety.pyx
@@ -32,6 +32,11 @@ def make_thread_func(barrier, failed, done, body):
 def test_simple_generator(n_threads, n_loops):
     """
     >>> test_simple_generator(4, 500)
+    >>> test_simple_generator(4, 500)
+    >>> test_simple_generator(4, 500)
+    >>> test_simple_generator(4, 500)
+    >>> test_simple_generator(4, 500)
+    >>> test_simple_generator(4, 500)
     """
     barrier = threading.Barrier(n_threads)
     done = threading.Event()
@@ -68,6 +73,11 @@ def test_simple_generator(n_threads, n_loops):
 
 def test_yield_from_generator(n_threads, n_loops):
     """
+    >>> test_yield_from_generator(4, 500)
+    >>> test_yield_from_generator(4, 500)
+    >>> test_yield_from_generator(4, 500)
+    >>> test_yield_from_generator(4, 500)
+    >>> test_yield_from_generator(4, 500)
     >>> test_yield_from_generator(4, 500)
     """
     barrier = threading.Barrier(n_threads)
@@ -108,6 +118,11 @@ def test_yield_from_generator(n_threads, n_loops):
 
 def test_value_into_generator(n_threads, n_loops):
     """
+    >>> test_value_into_generator(4, 500)
+    >>> test_value_into_generator(4, 500)
+    >>> test_value_into_generator(4, 500)
+    >>> test_value_into_generator(4, 500)
+    >>> test_value_into_generator(4, 500)
     >>> test_value_into_generator(4, 500)
     """
     barrier = threading.Barrier(n_threads)
@@ -155,6 +170,13 @@ class MyError(Exception):
 def test_throw_into_generator(n_threads, n_loops):
     """
     >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
+    >>> test_throw_into_generator(4, 500)
     """
     barrier = threading.Barrier(n_threads)
     done = threading.Event()
@@ -178,13 +200,23 @@ def test_throw_into_generator(n_threads, n_loops):
     g = gen()
     next(g)
 
+    def body():
+        try:
+            g.throw(MyError())
+        except MyError:
+            if not done.is_set():
+                raise
+            # For an exhausted generator the correct behaviour is to rethrow
+            # the error that was passed to it, so swallow the exception in this case. 
+            pass
+
     threads = [ 
         threading.Thread(
             target=make_thread_func(
                 barrier=barrier,
                 failed=failed,
                 done=done,
-                body=lambda: g.throw(MyError())
+                body=body
             )
         ) for _ in range(n_threads)
     ]


### PR DESCRIPTION
Mostly for free-threading build but somewhere applicable anyway.

Improve thread safety of generators. The main mechanism to enforce that was `is_running` so ensure that this is read and set pseudo-atomically. This mostly means moving it a little further out in the implementation (which is probably a good thing anyway).

Add some tests to try to stress-test the implementation at bit. They definitely fail without the changes.