### PR TITLE
When tracing C return values, allow the Python coercion to fail

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -3114,6 +3114,9 @@ class CCodeWriter:
             retvalue_cname = return_type.as_pyobject(retvalue_cname)
         elif return_type.is_void:
             retvalue_cname = 'Py_None'
+        elif return_type.is_string:
+            # We don't know if the C string is 0-terminated, but we cannot convert if it's not.
+            retvalue_cname = 'Py_None'
         elif return_type.to_py_function:
             trace_func = "__Pyx_TraceReturnCValue"
             extra_arg = f", {return_type.to_py_function}"

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -209,14 +209,20 @@
           if (CYTHON_TRACE_NOGIL) {                                                          \
               PyGILState_STATE state = PyGILState_Ensure();                                  \
               PyObject *pyvalue = convert_function(cresult);                                 \
-              if (unlikely(!pyvalue)) goto_error;                                            \
+              if (unlikely(!pyvalue)) {                                                      \
+                  PyErr_Clear();                                                             \
+                  pyvalue = Py_None; Py_INCREF(Py_None);                                     \
+              }                                                                              \
               ret = PyMonitoring_FirePyReturnEvent(&$monitoring_states_cname[__Pyx_Monitoring_PY_RETURN], $frame_code_cname, offset, pyvalue); \
               Py_DECREF(pyvalue);                                                            \
               PyGILState_Release(state);                                                     \
           }                                                                                  \
       } else {                                                                               \
           PyObject *pyvalue = convert_function(cresult);                                     \
-          if (unlikely(!pyvalue)) goto_error;                                                \
+          if (unlikely(!pyvalue)) {                                                          \
+              PyErr_Clear();                                                                 \
+              pyvalue = Py_None; Py_INCREF(Py_None);                                         \
+          }                                                                                  \
           ret = PyMonitoring_FirePyReturnEvent(&$monitoring_states_cname[__Pyx_Monitoring_PY_RETURN], $frame_code_cname, offset, pyvalue); \
           Py_DECREF(pyvalue);                                                                \
       }                                                                                      \


### PR DESCRIPTION
The value might not be valid.
Also avoid the coercion for char* since the value might not be 0-terminated.

Closes https://github.com/cython/cython/issues/6503