### PR TITLE
Add PyWeakref_GetRef to cpython.weakref

### DIFF
--- a/Cython/Includes/cpython/weakref.pxd
+++ b/Cython/Includes/cpython/weakref.pxd
@@ -1,5 +1,42 @@
 from .object cimport PyObject
 
+cdef extern from *:
+    # Backport PyWeakref_GetRef to Python < 3.13
+    """
+    #if PY_VERSION_HEX < 0x030d0000
+    static CYTHON_INLINE int __Pyx_PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
+    {
+        PyObject *obj;
+        if (ref != NULL && !PyWeakref_Check(ref)) {
+            *pobj = NULL;
+            PyErr_SetString(PyExc_TypeError, "expected a weakref");
+            return -1;
+        }
+        obj = PyWeakref_GetObject(ref);
+        if (obj == NULL) {
+            // SystemError if ref is NULL
+            *pobj = NULL;
+            return -1;
+        }
+        if (obj == Py_None) {
+            *pobj = NULL;
+            return 0;
+        }
+        *pobj = Py_NewRef(obj);
+        return (*pobj != NULL);
+    }
+    #else
+    #define __Pyx_PyWeakref_GetRef PyWeakref_GetRef
+    #endif
+    """
+    bint PyWeakref_GetRef "__Pyx_PyWeakref_GetRef" (object ref, PyObject** pobj)
+    # Get a strong reference to the referenced object from a weak reference,
+    # ref, into *pobj.
+    # - On success, set *pobj to a new strong reference to the referenced
+    #   object and return 1.
+    # - If the reference is dead, set *pobj to NULL and return 0.
+    # - On error, raise an exception and return -1.
+
 cdef extern from "Python.h":
 
     bint PyWeakref_Check(object ob)
@@ -34,9 +71,13 @@ cdef extern from "Python.h":
     # None, or NULL, this will return NULL and raise TypeError.
 
     PyObject* PyWeakref_GetObject(object ref) except NULL
-    # Return the referenced object from a weak reference, ref.  If the
-    # referent is no longer live, returns None.
+    # Return a borrowed reference to the referenced object from a weak
+    # reference, ref.  If the referent is no longer live, returns None.
+    # Deprecated since Python 3.13, will be removed in version 3.15: Use
+    # PyWeakref_GetRef instead.
 
     PyObject* PyWeakref_GET_OBJECT(object ref)
     # Similar to PyWeakref_GetObject, but implemented as a macro that
     # does no error checking.
+    # Deprecated since Python 3.13, will be removed in version 3.15: Use
+    # PyWeakref_GetRef instead.

--- a/Cython/Includes/cpython/weakref.pxd
+++ b/Cython/Includes/cpython/weakref.pxd
@@ -6,13 +6,7 @@ cdef extern from *:
     #if PY_VERSION_HEX < 0x030d0000
     static CYTHON_INLINE int __Pyx_PyWeakref_GetRef(PyObject *ref, PyObject **pobj)
     {
-        PyObject *obj;
-        if (ref != NULL && !PyWeakref_Check(ref)) {
-            *pobj = NULL;
-            PyErr_SetString(PyExc_TypeError, "expected a weakref");
-            return -1;
-        }
-        obj = PyWeakref_GetObject(ref);
+        PyObject *obj = PyWeakref_GetObject(ref);
         if (obj == NULL) {
             // SystemError if ref is NULL
             *pobj = NULL;
@@ -22,8 +16,9 @@ cdef extern from *:
             *pobj = NULL;
             return 0;
         }
-        *pobj = Py_NewRef(obj);
-        return (*pobj != NULL);
+        Py_INCREF(obj);
+        *pobj = obj;
+        return 1;
     }
     #else
     #define __Pyx_PyWeakref_GetRef PyWeakref_GetRef


### PR DESCRIPTION
Adding this since `PyWeakref_GetObject` has been deprecated since 3.13, `PyWeakref_GetRef` is the recommended replacement and we're already hitting thread safety issues (looks like [this one](https://github.com/pandas-dev/pandas/issues/59057#issuecomment-2474643730) is related to this) with using `PyWeakref_GetObject`, so it needs a replacement.