### PR TITLE
Add `std::span` to `libcpp`

### DIFF
--- a/Cython/Includes/libcpp/span.pxd
+++ b/Cython/Includes/libcpp/span.pxd
@@ -1,0 +1,87 @@
+from libcpp.vector cimport vector
+
+cdef extern from "<span>" namespace "std" nogil:
+    # Only Extent = std::dynamic_extent is supported until Cython can also
+    # support integer templates. See https://github.com/cython/cython/pull/426
+    cdef cppclass span[T]:
+        ctypedef T value_type
+        ctypedef size_t size_type
+        ctypedef ptrdiff_t difference_type
+
+        size_t extent
+
+        cppclass iterator:
+            iterator() except +
+            iterator(iterator&) except +
+            T& operator*()
+            iterator operator++()
+            iterator operator--()
+            iterator operator++(int)
+            iterator operator--(int)
+            iterator operator+(size_type)
+            iterator operator-(size_type)
+            difference_type operator-(iterator)
+            difference_type operator-(const_iterator)
+            bint operator==(iterator)
+            bint operator==(const_iterator)
+            bint operator!=(iterator)
+            bint operator!=(const_iterator)
+            bint operator<(iterator)
+            bint operator<(const_iterator)
+            bint operator>(iterator)
+            bint operator>(const_iterator)
+            bint operator<=(iterator)
+            bint operator<=(const_iterator)
+            bint operator>=(iterator)
+            bint operator>=(const_iterator)
+
+        cppclass reverse_iterator:
+            reverse_iterator() except +
+            reverse_iterator(reverse_iterator&) except +
+            T& operator*()
+            reverse_iterator operator++()
+            reverse_iterator operator--()
+            reverse_iterator operator++(int)
+            reverse_iterator operator--(int)
+            reverse_iterator operator+(size_type)
+            reverse_iterator operator-(size_type)
+            difference_type operator-(iterator)
+            difference_type operator-(const_iterator)
+            bint operator==(reverse_iterator)
+            bint operator==(const_reverse_iterator)
+            bint operator!=(reverse_iterator)
+            bint operator!=(const_reverse_iterator)
+            bint operator<(reverse_iterator)
+            bint operator<(const_reverse_iterator)
+            bint operator>(reverse_iterator)
+            bint operator>(const_reverse_iterator)
+            bint operator<=(reverse_iterator)
+            bint operator<=(const_reverse_iterator)
+            bint operator>=(reverse_iterator)
+            bint operator>=(const_reverse_iterator)
+
+        # const_iterator was added in C++23, so leaving it out for now
+
+        span()
+        span(T*, size_type)  # span[It](It, size_type)
+        span(T*, T*)  # span[It, End](It, End)
+        span(vector&)  # span[U, N](array[T, N]& arr)
+        span(span&)
+
+        T& operator[](ssize_t)
+
+        T& back()
+        iterator begin()
+        T* data()
+        bint empty()
+        iterator end()
+        span[T] first(size_type)
+        T& front()
+        span[T] last(size_type)
+        reverse_iterator rbegin()
+        reverse_iterator rend()
+        size_type size()
+        span[T] subspan(size_type)
+        span[T] subspan(size_type, size_type)
+
+    cdef size_t dynamic_extent

--- a/tests/run/cpp_stl_span.pyx
+++ b/tests/run/cpp_stl_span.pyx
@@ -1,0 +1,163 @@
+# mode: run
+# tag: cpp, cpp20, span
+
+# cython: language_level=3
+
+from cython.operator cimport dereference as deref
+from cython.operator cimport preincrement as inc
+
+from libcpp.span cimport dynamic_extent, span
+from libcpp.utility cimport move
+from libcpp.vector cimport vector
+
+def test_span_construction_iterator_count(vals):
+    """
+    >>> test_span_construction_iterator_count([0, 1, 2, 3])
+    [0, 1, 2, 3]
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec.data(), vec.size())
+    return [val for val in s]
+
+def test_span_construction_iterator_iterator(vals):
+    """
+    >>> test_span_construction_iterator_iterator([0, 1, 2, 3])
+    [0, 1, 2, 3]
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec.data(), vec.data() + vec.size())
+    return [val for val in s]
+
+def test_span_construction_range(vals):
+    """
+    >>> test_span_construction_range([0, 1, 2, 3])
+    [0, 1, 2, 3]
+    """
+    # construct the vector
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec)
+    return [val for val in s]
+
+def test_span_data(vals):
+    """
+    >>> test_span_data([0, 1, 2, 3])
+    True
+    >>> test_span_data([1.25])
+    True
+    """
+    cdef vector[double] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[double] s = span[double](vec.data(), vec.size())
+    return vec.data() == s.data()
+
+def test_span_empty(vals):
+    """
+    >>> test_span_empty([])
+    True
+    >>> test_span_empty([0, 1])
+    False
+    """
+    cdef vector[double] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[double] s = span[double](vec.data(), vec.size())
+    return s.empty()
+
+def test_span_extent():
+    """
+    >>> test_span_extent()
+    True
+    """
+    cdef span[int] s = span[int]()
+    return s.extent == dynamic_extent
+
+def test_span_first_last(vals, n):
+    """
+    >>> test_span_first_last([0, 1, 2, 3], 2)
+    ([0, 1], [2, 3])
+    >>> test_span_first_last([0, 1, 2, 3], 0)
+    ([], [])
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec)
+    return [val for val in s.first(n)], [val for val in s.last(n)]
+
+
+def test_span_front_back(vals):
+    """
+    >>> test_span_front_back([0, 1, 2, 3])
+    (0.0, 3.0)
+    >>> test_span_front_back([1.25])
+    (1.25, 1.25)
+    """
+    cdef vector[double] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[double] s = span[double](vec)
+    return s.front(), s.back()
+
+def test_span_index(vals):
+    """
+    >>> test_span_index([0, 1, 2, 3])
+    (0.0, 3.0)
+    >>> test_span_index([1.25])
+    (1.25, 1.25)
+    """
+    cdef vector[double] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[double] s = span[double](vec)
+    return s[0], s[s.size() - 1]
+
+def test_span_reverse_iteration(vals):
+    """
+    >>> test_span_reverse_iteration([1, 2, 4, 8])
+    8
+    4
+    2
+    1
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec)
+
+    it = s.rbegin()
+    while it != s.rend():
+        print(deref(it))
+        inc(it)
+
+def test_span_subspan(vals, offset):
+    """
+    >>> test_span_subspan([1, 2, 4, 8], 2)
+    [4, 8]
+    >>> test_span_subspan([1, 2, 4, 8], 1)
+    [2, 4, 8]
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec)
+    return [val for val in s.subspan(offset)]
+
+def test_span_subspan_count(vals, offset, count):
+    """
+    >>> test_span_subspan_count([1, 2, 4, 8], 2, 1)
+    [4]
+    >>> test_span_subspan_count([1, 2, 4, 8], 1, 2)
+    [2, 4]
+    """
+    cdef vector[int] vec
+    for v in vals:
+        vec.push_back(v)
+    cdef span[int] s = span[int](vec)
+    return [val for val in s.subspan(offset, count)]


### PR DESCRIPTION
We've been using a [locally included](https://github.com/dwavesystems/dwave-optimization/blob/b8d10fcdbbd9e2123e177a527b2c29f3de5dfb29/dwave/optimization/libcpp/__init__.pxd#L15-L55) version of `std::span` in one of our projects for a while now. But I thought it might be useful for others.

I have only included C++20 features for now, but I would be happy to also add C++23 methods/overloads if that's desired.

I believe that templated constructors are not currently supported, so I added a few aliases for convenience. Happy to remove them if it's preferred to be more strict. Or add templated versions if I am mistaken.