### PR TITLE
Fix example in fusedtypes

### DIFF
--- a/docs/examples/userguide/fusedtypes/memoryview_indexing.py
+++ b/docs/examples/userguide/fusedtypes/memoryview_indexing.py
@@ -1,0 +1,13 @@
+import numpy as np
+import cython
+
+myarray: cython.int[:, ::1] = np.arange(20, dtype=np.intc).reshape((2, 10))
+
+my_fused_type = cython.fused_type(cython.int[:, ::1], cython.float[:, ::1])
+
+
+
+def func(array: my_fused_type):
+    print("func called:", cython.typeof(array))
+
+func["int[:, ::1]"](myarray)

--- a/docs/examples/userguide/fusedtypes/memoryview_indexing.pyx
+++ b/docs/examples/userguide/fusedtypes/memoryview_indexing.pyx
@@ -1,0 +1,13 @@
+import numpy as np
+import cython
+
+myarray: cython.int[:, ::1] = np.arange(20, dtype=np.intc).reshape((2, 10))
+
+ctypedef fused my_fused_type:
+    int[:, ::1]
+    float[:, ::1]
+
+def func(my_fused_type array):
+    print("func called:", cython.typeof(array))
+
+func["int[:, ::1]"](myarray)

--- a/docs/src/userguide/fusedtypes.rst
+++ b/docs/src/userguide/fusedtypes.rst
@@ -367,27 +367,11 @@ For memoryview indexing from python space we can do the following:
 
     .. group-tab:: Pure Python
 
-        .. code-block:: python
-
-            my_fused_type = cython.fused_type(cython.int[:, ::1], cython.float[:, ::1])
-
-            def func(array: my_fused_type):
-                print("func called:", cython.typeof(array))
-
-            my_fused_type[cython.int[:, ::1]](myarray)
+        .. literalinclude:: ../../examples/userguide/fusedtypes/memoryview_indexing.py
 
     .. group-tab:: Cython
 
-        .. code-block:: cython
-
-            ctypedef fused my_fused_type:
-                int[:, ::1]
-                float[:, ::1]
-
-            def func(my_fused_type array):
-                print("func called:", cython.typeof(array))
-
-            my_fused_type[cython.int[:, ::1]](myarray)
+        .. literalinclude:: ../../examples/userguide/fusedtypes/memoryview_indexing.pyx
 
 The same goes for when using e.g. ``cython.numeric[:, :]``.
 


### PR DESCRIPTION
This fixes #6472.

Superseedes #6474 and #6540.

Co-authored-by: Nick Papior <nickpapior@gmail.com>
