### PR TITLE
Stop suggesting depending on `wheel` in PEP 518 config

### DIFF
--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -140,7 +140,7 @@ creating a :file:`pyproject.toml` file containing, at least:
     :caption: pyproject.toml
 
     [build-system]
-    requires = ["setuptools", "wheel", "Cython"]
+    requires = ["setuptools", "Cython"]
 
 To understand the :file:`setup.py` more fully look at the official `setuptools
 documentation`_. To compile the extension for use in the current directory use:


### PR DESCRIPTION
`wheel` was never necessary, as old `setuptools` is auto-injecting it as a dep for wheel builds (but not sdist). And the modern one vendors it (`wheel` moved into `setuptools` during the PyCon 2024 sprint days). `setuptools`' docs used to mistakenly imply that it was needed but I fixed those docs examples a few years ago. Let's correct this mistake in the Cython docs too.