### PR TITLE
Enable Limited API run tests (e-o)

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1962,10 +1962,10 @@ static CYTHON_INLINE PyObject *__Pyx_CallUnboundCMethod2(__Pyx_CachedCFunction *
 #endif
 
 static PyObject* __Pyx__CallUnboundCMethod2(__Pyx_CachedCFunction* cfunc, PyObject* self, PyObject* arg1, PyObject* arg2){
-    PyObject *result = NULL;
     if (unlikely(!cfunc->func && !cfunc->method) && unlikely(__Pyx_TryUnpackUnboundCMethod(cfunc) < 0)) return NULL;
 #if CYTHON_COMPILING_IN_CPYTHON
     if (cfunc->func && (cfunc->flag & METH_VARARGS)) {
+        PyObject *result = NULL;
         PyObject *args = PyTuple_New(2);
         if (unlikely(!args)) return NULL;
         Py_INCREF(arg1);

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -38,8 +38,10 @@ run[.]nogil
 run[.]no_gc
 run[.]numpy
 line_trace
+
 # Possibly only on early versions of Python?
 fused_def
+legacy_implicit_noexcept
 
 # Something to do with complex
 view_count

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -38,6 +38,7 @@ run[.]nogil
 run[.]no_gc
 run[.]numpy
 line_trace
+longintrepr
 
 # Possibly only on early versions of Python?
 fused_def

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -43,6 +43,7 @@ longintrepr
 # Possibly only on early versions of Python?
 fused_def
 legacy_implicit_noexcept
+method_module_name_T422
 
 # Something to do with complex
 view_count

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -38,6 +38,8 @@ run[.]nogil
 run[.]no_gc
 run[.]numpy
 line_trace
+# Possibly only on early versions of Python?
+fused_def
 
 # Something to do with complex
 view_count

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -37,7 +37,7 @@ importfrom
 run[.]nogil
 run[.]no_gc
 run[.]numpy
-linetrace
+line_trace
 
 # Something to do with complex
 view_count

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -24,10 +24,24 @@ run[.]any
 async_iter_pep492
 async_def
 run[.]all
+embedsignatures_python
+embedsignatures_clinic
+extern_builtins_T258
+ext_attribute_cache
+fastcall
+run[.]generators$
+run[.]generators_py
+generator_frame_cycle
+# probably just an exact error message
+importfrom
+run[.]nogil
+run[.]no_gc
+run[.]numpy
 
 # Something to do with complex
 view_count
 matrix_with_buffer
+fused_types
 
 # cimport cpython
 extension_type_memoryview
@@ -57,6 +71,9 @@ annotation_typing
 datetime_cimport
 datetime_pxd
 datetime_members
+run[.]exttype
+exceptionrefcount
+isinstance
 
 # example in docs that use features unavailable in the limited API
 # (and it's a decision for the docs writers rather than a limitation
@@ -74,14 +91,19 @@ compile[.]pylong
 # Inherit builtin type: PEP697
 bytearraymethods
 cdef_subclass_builtin
+ext_auto_richcmp
 
 # Py_UNICODE
 builtin_ord
+for_in_string
+fstring
+run[.]inop
+run[.]notinop
 
 # Segfault
 cfunc_convert
 duplicate_keyword_in_call
 
 # Excluded for now - to be enabled incrementally
-run[.][^abcd]
+run[.][^a-o]
 buffers[.]

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -37,6 +37,7 @@ importfrom
 run[.]nogil
 run[.]no_gc
 run[.]numpy
+linetrace
 
 # Something to do with complex
 view_count

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -26,6 +26,8 @@ compile.ctuple_unused_T3543
 run[.]cdef_class_dataclass
 run[.]cyfunction_defaults
 run[.]embedsignatures
+run[.]extra_walrus
+run[.]nonecheck
 
 # generic filters
 buffer

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -28,6 +28,7 @@ run[.]cyfunction_defaults
 run[.]embedsignatures
 run[.]extra_walrus
 run[.]nonecheck
+run[.]locals
 
 # generic filters
 buffer

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -25,6 +25,7 @@ compile.ctuple_unused_T3543
 
 run[.]cdef_class_dataclass
 run[.]cyfunction_defaults
+run[.]embedsignatures
 
 # generic filters
 buffer

--- a/tests/run/exectest.pyx
+++ b/tests/run/exectest.pyx
@@ -133,9 +133,9 @@ def test_compile(d):
 
 def exec_invalid_type(x):
     """
-    >>> exec_invalid_type(42)
+    >>> exec_invalid_type(42)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: exec: arg 1 must be string, bytes or code object, got int
+    TypeError: exec... arg 1 must be... string, bytes or code object...
     """
     exec x in {}
 


### PR DESCRIPTION
Enables a bunch more limited API run tests, silence one unused variable warning, fix one test.