### PR TITLE
Fix `IndexError` when stepping the debugger through unindexed C code

### DIFF
--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -317,7 +317,7 @@ class CythonBase:
         correspondence between the C and Cython code.
         """
         cyfunc = self.get_cython_function(frame)
-        return cyfunc.module.lineno_c2cy.get(self.get_c_lineno(frame), 0)
+        return cyfunc.module.lineno_c2cy.get(self.get_c_lineno(frame), ("<no filename>", 0))
 
     @default_selected_gdb_frame()
     def get_source_desc(self, frame):

--- a/Cython/Debugger/libcython.py
+++ b/Cython/Debugger/libcython.py
@@ -313,7 +313,7 @@ class CythonBase:
     @default_selected_gdb_frame()
     def get_cython_lineno(self, frame):
         """
-        Get the current Cython line number. Returns 0 if there is no
+        Get the current Cython line number. Returns ("<no filename>", 0) if there is no
         correspondence between the C and Cython code.
         """
         cyfunc = self.get_cython_function(frame)


### PR DESCRIPTION
I encountered this bug when [trying to debug Kivy](https://gist.github.com/clayote/6ba9692240e0471859aa212baf94d643). I'm not sure exactly why that line of C code didn't get indexed; that could be another bug. But in any case, the debugger should keep working.