### PR TITLE
Enable remaining Limited API run tests

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -565,10 +565,6 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
 #if CYTHON_COMPILING_IN_LIMITED_API
     {"__module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
-#if __PYX_LIMITED_VERSION_HEX < 0x03090000
-    // Python messes up module by overwriting it and this gives us a way to fix it up
-    {"__cy_module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
-#endif
 #endif
     {0, 0, 0, 0, 0}
 };
@@ -1223,20 +1219,6 @@ static int __pyx_CyFunction_init(PyObject *module) {
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
 #if CYTHON_USE_TYPE_SPECS
     mstate->__pyx_CyFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_CyFunctionType_spec, NULL);
-#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x03090000
-    // Fixup __module__ attribute if necessary.
-    // This is worth a hacky workaround because it makes functions pickleable
-    if (mstate->__pyx_CyFunctionType) {
-        PyObject *cymodule = PyObject_GetAttrString((PyObject*)mstate->__pyx_CyFunctionType, "__cy_module__");
-        if (cymodule) {
-            int set_result = PyObject_SetAttrString((PyObject*)mstate->__pyx_CyFunctionType, "__module__", cymodule);
-            Py_DECREF(cymodule);
-            if (set_result < 0) PyErr_Clear();
-        } else {
-            PyErr_Clear();
-        }
-    }
-#endif
 #else
     mstate->__pyx_CyFunctionType = __Pyx_FetchCommonType(&__pyx_CyFunctionType_type);
 #endif
@@ -1773,20 +1755,6 @@ static int __pyx_FusedFunction_init(PyObject *module) {
     }
     mstate->__pyx_FusedFunctionType = __Pyx_FetchCommonTypeFromSpec(module, &__pyx_FusedFunctionType_spec, bases);
     Py_DECREF(bases);
-#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x03090000
-    // Fixup __module__ attribute if necessary.
-    // This is worth a hacky workaround because it makes functions pickleable
-    if (mstate->__pyx_CyFunctionType) {
-        PyObject *cymodule = PyObject_GetAttrString((PyObject*)mstate->__pyx_FusedFunctionType, "__cy_module__");
-        if (cymodule) {
-            int set_result = PyObject_SetAttrString((PyObject*)mstate->__pyx_FusedFunctionType, "__module__", cymodule);
-            Py_DECREF(cymodule);
-            if (set_result < 0) PyErr_Clear();
-        } else {
-            PyErr_Clear();
-        }
-    }
-#endif
 #else
     // Set base from __Pyx_FetchCommonTypeFromSpec, in case it's different from the local static value.
     __pyx_FusedFunctionType_type.tp_base = mstate->__pyx_CyFunctionType;

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2776,11 +2776,33 @@ static PyObject *__Pyx_PyMethod_New(PyObject *func, PyObject *self, PyObject *ty
 #endif
 
 ///////////// PyMethodNew2Arg.proto /////////////
+//@requires: CachedMethodType
 
 // TODO: remove
 // Another wrapping of PyMethod_New that matches the Python3 signature
+#if CYTHON_COMPILING_IN_LIMITED_API
+static PyObject *__Pyx_PyMethod_New2Arg(PyObject *func, PyObject *self); /* proto */
+#else
 #define __Pyx_PyMethod_New2Arg PyMethod_New
+#endif
 
+///////////// PyMethodNew2Arg /////////////
+//@requires: CachedMethodType
+
+#if CYTHON_COMPILING_IN_LIMITED_API
+static PyObject *__Pyx_PyMethod_New2Arg(PyObject *func, PyObject *self) {
+    PyObject *result;
+    #if __PYX_LIMITED_VERSION_HEX >= 0x030C0000
+    {
+        PyObject *args[] = {func, self};
+        result = PyObject_Vectorcall(CGLOBAL(__Pyx_CachedMethodType), args, 2, NULL);
+    }
+    #else
+    result = PyObject_CallFunctionObjArgs(CGLOBAL(__Pyx_CachedMethodType), func, self, NULL);
+    #endif
+    return result;
+}
+#endif
 
 /////////////// UnicodeConcatInPlace.proto ////////////////
 

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -153,6 +153,7 @@ unicode_indexing
 weakfail
 reduce_pickle
 test_dataclasses
+test_genericclass_exttype
 test_class_getitem_errors_2
 yield_from_pep380
 

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -51,6 +51,8 @@ tss
 run[.]tryfinally
 running_with_gil
 run[.]with_gil
+sys_monitoring
+sequential_parallel
 
 # Possibly only on early versions of Python?
 fused_def
@@ -143,6 +145,7 @@ unicode_indexing
 # Only on specific versions
 # (TODO) be more specific here
 weakfail
+reduce_pickle
 
 # Excluded for now - to be enabled incrementally
 buffers[.]

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -53,6 +53,9 @@ running_with_gil
 run[.]with_gil
 sys_monitoring
 sequential_parallel
+special_method_docstrings
+run[.]ufunc
+slice2b
 
 # Possibly only on early versions of Python?
 fused_def
@@ -108,6 +111,8 @@ r_pythonapi
 refcount_in_meth
 time_pxd
 run[.]type_inference
+special_methods_T561
+run[.]slice_ptr
 
 # example in docs that use features unavailable in the limited API
 # (and it's a decision for the docs writers rather than a limitation
@@ -146,6 +151,7 @@ unicode_indexing
 # (TODO) be more specific here
 weakfail
 reduce_pickle
+test_dataclasses
 
 # Excluded for now - to be enabled incrementally
 buffers[.]

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -39,6 +39,18 @@ run[.]no_gc
 run[.]numpy
 line_trace
 longintrepr
+pstats_profile_test
+py35_pep492_interop
+py_ucs4_type
+pep442_tp_finalize
+test_asyncgen
+tracebacks
+test_grammar
+tuple_constants
+tss
+run[.]tryfinally
+running_with_gil
+run[.]with_gil
 
 # Possibly only on early versions of Python?
 fused_def
@@ -49,6 +61,8 @@ method_module_name_T422
 view_count
 matrix_with_buffer
 fused_types
+pycapsule
+r_extcomplex2
 
 # cimport cpython
 extension_type_memoryview
@@ -81,6 +95,17 @@ datetime_members
 run[.]exttype
 exceptionrefcount
 isinstance
+pycontextvar
+run[.]pytype
+run[.]pyarray
+pyclass_scope_T671
+pyclass_special_methods
+run[.]parallel
+pep448_extended_unpacking
+r_pythonapi
+refcount_in_meth
+time_pxd
+run[.]type_inference
 
 # example in docs that use features unavailable in the limited API
 # (and it's a decision for the docs writers rather than a limitation
@@ -99,6 +124,11 @@ compile[.]pylong
 bytearraymethods
 cdef_subclass_builtin
 ext_auto_richcmp
+pylistsubtype
+r_hordijk1
+trashcan
+unbound_special_methods
+unicode_formatting
 
 # Py_UNICODE
 builtin_ord
@@ -106,11 +136,13 @@ for_in_string
 fstring
 run[.]inop
 run[.]notinop
+py_unicode_strings
+py_unicode_type
+unicode_indexing
 
-# Segfault
-cfunc_convert
-duplicate_keyword_in_call
+# Only on specific versions
+# (TODO) be more specific here
+weakfail
 
 # Excluded for now - to be enabled incrementally
-run[.][^a-o]
 buffers[.]

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -56,6 +56,7 @@ sequential_parallel
 special_method_docstrings
 run[.]ufunc
 slice2b
+verbatiminclude
 
 # Possibly only on early versions of Python?
 fused_def
@@ -152,6 +153,8 @@ unicode_indexing
 weakfail
 reduce_pickle
 test_dataclasses
+test_class_getitem_errors_2
+yield_from_pep380
 
 # Excluded for now - to be enabled incrementally
 buffers[.]

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -32,6 +32,7 @@ run[.]locals
 run[.]parallel
 run[.]pyarray
 run[.]sequential_parallel
+run[.]special_methods_T561
 
 # generic filters
 buffer

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -31,6 +31,7 @@ run[.]nonecheck
 run[.]locals
 run[.]parallel
 run[.]pyarray
+run[.]sequential_parallel
 
 # generic filters
 buffer

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -29,6 +29,8 @@ run[.]embedsignatures
 run[.]extra_walrus
 run[.]nonecheck
 run[.]locals
+run[.]parallel
+run[.]pyarray
 
 # generic filters
 buffer


### PR DESCRIPTION
Again, fixing very little - just disabling tests.

~One notable fix is `__module__` for cyfunction - this messes up pickling so seems fairly useful to get right.~ (Removed - it breaks other things)