### PR TITLE
Add critical_section decorator

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -170,7 +170,8 @@ def copy_inherited_directives(outer_directives, **new_directives):
     # For example, test_assert_path_exists and test_fail_if_path_exists should not be inherited
     #  otherwise they can produce very misleading test failures
     new_directives_out = dict(outer_directives)
-    for name in ('test_assert_path_exists', 'test_fail_if_path_exists', 'test_assert_c_code_has', 'test_fail_if_c_code_has'):
+    for name in ('test_assert_path_exists', 'test_fail_if_path_exists', 'test_assert_c_code_has', 'test_fail_if_c_code_has',
+                 'critical_section'):
         new_directives_out.pop(name, None)
     new_directives_out.update(new_directives)
     return new_directives_out
@@ -392,7 +393,7 @@ directive_scopes = {  # defaults to available everywhere
     'nogil' : ('function', 'with statement'),
     'gil' : ('with statement'),
     'with_gil' : ('function',),
-    'critical_section': ('with statement',),
+    'critical_section': ('function', 'with statement'),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3049,6 +3049,7 @@ class AdjustDefByDirectives(CythonTransform, SkipDeclarations):
     @cython.ccall
     @cython.inline
     @cython.nogil
+    @cython.critical_section
     """
     # list of directives that cause conversion to cclass
     converts_to_cclass = ('cclass', 'total_ordering', 'dataclasses.dataclass')
@@ -3107,6 +3108,20 @@ class AdjustDefByDirectives(CythonTransform, SkipDeclarations):
             error(node.pos, "Python functions cannot be declared 'nogil'")
         if with_gil:
             error(node.pos, "Python functions cannot be declared 'with_gil'")
+        self.visit_FuncDefNode(node)
+        return node
+
+    def visit_FuncDefNode(self, node):
+        if "critical_section" in self.directives:
+            value = self.directives["critical_section"]
+            if value is not None:
+                error(node.pos, "critical_section decorator does not take arguments")
+            new_body = Nodes.CriticalSectionStatNode(
+                node.pos,
+                args=[ExprNodes.FirstArgumentForCriticalSectionNode(node.pos, func_node=node)],
+                body=node.body
+            )
+            node.body = new_body
         self.visitchildren(node)
         return node
 

--- a/docs/src/userguide/freethreading.rst
+++ b/docs/src/userguide/freethreading.rst
@@ -87,6 +87,24 @@ We suggest reading the Python documentation to understand how critical sections 
 On non-freethreading builds ``cython.critical_section`` does nothing - you get the
 same guarantees simply from the fact you hold the GIL.
 
+As an alternative syntax, ``cython.critical_section`` can be used as a decorator
+or a function taking at least one argument.  In this case the critical section
+lasts the duration of the function and locks on the first argument::
+
+    @cython.cclass
+    class C:
+        @cython.critical_section
+        def func(self, *args):
+            ...
+
+        # equivalent to:
+        def func(self, *args):
+            with cython.critical_section(self):
+                ...
+
+Our expectation is that this will be most useful for locking on the ``self`` argument
+of methods in C classes.
+
 Pitfalls
 ========
 

--- a/tests/errors/critical_sections.pyx
+++ b/tests/errors/critical_sections.pyx
@@ -18,6 +18,30 @@ def f():
         with cython.critical_section(o):  # critical sections require the GIL
             pass
 
+@cython.critical_section
+def crit_sec_func():
+    pass
+
+@cython.critical_section
+def crit_sec_func2(*args):
+    pass
+
+@cython.critical_section
+def crit_sec_func3(**kwds):
+    pass
+
+@cython.critical_section(True)  # should not have arguments
+def crit_sec_func4(arg):
+    pass
+
+@cython.critical_section
+def has_int_arg(int arg):
+    pass
+
+@cython.critical_section
+cdef void some_nogil_function(a) noexcept nogil:
+    pass
+
 
 _ERRORS = """
 7:9: critical_section directive accepts one or two positional arguments
@@ -26,6 +50,14 @@ _ERRORS = """
 13:33: Arguments to cython.critical_section must be Python objects.
 15:33: Arguments to cython.critical_section must be Python objects.
 18:13: Critical sections require the GIL
+21:0: critical_section directive can only be applied to a function with one or more positional arguments
+25:0: critical_section directive can only be applied to a function with one or more positional arguments
+29:0: critical_section directive can only be applied to a function with one or more positional arguments
+33:0: critical_section decorator does not take arguments
+37:0: Arguments to cython.critical_section must be Python objects.
+41:0: Critical sections require the GIL
+
 # slightly extraneous, but no real harm
 18:37: Creating temporary Python reference not allowed without gil
+41:0: Creating temporary Python reference not allowed without gil
 """

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -115,3 +115,97 @@ def test_critical_section_in_generators(n_threads, n_loops):
 
     expected = ((n_loops * (n_loops - 1))/2)*n_threads
     assert count == expected, (count, expected)
+
+
+cdef class CClass:
+    cdef int count
+    def __cinit__(self):
+        self.count = 0
+
+    @cython.critical_section
+    def increment(self, other):
+        self.count += other
+
+    @cython.critical_section
+    def increment_one(self):
+        self.count += 1
+
+    @cython.critical_section
+    cpdef increment_one_cp(self):
+        self.count += 1
+
+    @cython.critical_section
+    cdef increment_one_c(self):
+        self.count += 1
+
+
+def test_class_critical_section_decorator(n_threads, n_loops):
+    """
+    >>> test_class_critical_section_decorator(4, 100)
+    """
+    barrier = threading.Barrier(n_threads)
+
+    instance = CClass()
+
+    def worker():
+        nonlocal instance
+        barrier.wait()
+        for i in range(n_loops):
+            remainder = i % 4
+            if remainder == 0:
+                instance.increment_one()
+            elif remainder == 1:
+                instance.increment(1)
+            elif remainder == 2:
+                instance.increment_one_c()
+            else:
+                instance.increment_one_cp()
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_loops*n_threads
+    assert instance.count == expected, (instance.count, expected)
+
+
+def test_free_function_with_critical_section(n_threads, n_loops):
+    """
+    >>> test_free_function_with_critical_section(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    @cython.test_assert_path_exists("//CriticalSectionStatNode")
+    @cython.critical_section
+    def inner(lock):
+        @cython.test_fail_if_path_exists("//CriticalSectionStatNode")
+        def inner_inner():
+            pass  # Unused - just to test the directive one-level only
+
+
+        nonlocal count
+        count += 1
+
+    def worker():
+        barrier.wait()
+        for i in range(n_loops):
+            inner(lock)
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_loops*n_threads
+    assert count == expected, (count, expected)


### PR DESCRIPTION
Allows critical_section to be applied as a function decorator, to put the entire function body in a with critical_section block (using the first argument as the lock).

This is just a useful bit of syntax (I hope) - it doesn't do anything that you can't already do with the with statement.

It's inspired by a somewhat similar feature in Python's argument clinic (see e.g. https://github.com/python/cpython/blob/3f6a618e49b1c8c12a7bc0c26e846735e108dc97/Modules/_queuemodule.c#L284) which seems like a useful tool there so I thought I'd copy it.