### PR TITLE
Fix iteration over cpp input ranges

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3316,14 +3316,14 @@ class CppIteratorNode(ExprNode):
 
         # end call isn't cached to support containers that allow adding while iterating
         # (much as this is usually a bad idea)
-        code.putln("; %s%s != %s%s%s(); ++%s%s" % (
-                        self.extra_dereference,
-                        self.result(),
-                        self.cpp_sequence_cname or self.sequence.result(),
-                        self.cpp_attribute_op,
-                        end_name,
-                        self.extra_dereference,
-                        self.result()))
+        code.put("; %s%s != %s%s%s(); ++%s%s" % (
+            self.extra_dereference,
+            self.result(),
+            self.cpp_sequence_cname or self.sequence.result(),
+            self.cpp_attribute_op,
+            end_name,
+            self.extra_dereference,
+            self.result()))
 
     def generate_iter_next_result_code(self, result_name, code):
         code.putln("%s = *%s%s;" % (

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3312,10 +3312,9 @@ class CppIteratorNode(ExprNode):
                     begin_name))
 
     def generate_for_loop_header(self, code):
-        _, end_name = self.get_iterator_func_names()
-
         # end call isn't cached to support containers that allow adding while iterating
         # (much as this is usually a bad idea)
+        _, end_name = self.get_iterator_func_names()
         code.put("; %s%s != %s%s%s(); ++%s%s" % (
             self.extra_dereference,
             self.result(),

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3417,7 +3417,7 @@ class AsyncIteratorNode(ScopedExprNode):
     type = py_object_type
     is_temp = 1
     has_local_scope = False
-    has_custom_for_loop = True
+    has_custom_for_loop = False
 
     def infer_type(self, env):
         return py_object_type

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7707,7 +7707,8 @@ class _ForInStatNode(LoopNode, StatNode):
         code.mark_pos(self.pos)
         old_loop_labels = code.new_loop_labels()
         self.iterator.generate_evaluation_code(code)
-        code.putln("for (;;) {")
+        if not self.iterator.has_custom_for_loop:
+            code.putln("for (;;) {")
         self.item.generate_evaluation_code(code)
         self.target.generate_assignment_code(self.item, code)
         code.write_trace_line(self.pos)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7707,8 +7707,9 @@ class _ForInStatNode(LoopNode, StatNode):
         code.mark_pos(self.pos)
         old_loop_labels = code.new_loop_labels()
         self.iterator.generate_evaluation_code(code)
-        if not self.iterator.has_custom_for_loop:
-            code.putln("for (;;) {")
+        code.put("for (")
+        self.iterator.generate_for_loop_header(code)
+        code.put(") {")
         self.item.generate_evaluation_code(code)
         self.target.generate_assignment_code(self.item, code)
         code.write_trace_line(self.pos)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7709,7 +7709,7 @@ class _ForInStatNode(LoopNode, StatNode):
         self.iterator.generate_evaluation_code(code)
         code.put("for (")
         self.iterator.generate_for_loop_header(code)
-        code.put(") {")
+        code.putln(") {")
         self.item.generate_evaluation_code(code)
         self.target.generate_assignment_code(self.item, code)
         code.write_trace_line(self.pos)


### PR DESCRIPTION
Hello wonderful people!

This PR resolves #6578.
This change allows CppIteratorNode to insert it's own 'for' statement that uses standard C for loop capabilities.

```
from libcpp.vector cimport vector

cpdef test():
    cdef vector[int] v
    for i in v:
        print(i)
```

Before:
```
  __pyx_t_1 = __pyx_v_v.begin();
                      /*              <- CppIteratorNode.generate_result_code (6, 13) */
  for (;;) {
                        /*              -> NextNode.generate_result_code (6, 13) */
    if (!(__pyx_t_1 != __pyx_v_v.end())) break;
    __pyx_t_2 = *__pyx_t_1;
    ++__pyx_t_1;
                        /*              <- NextNode.generate_result_code (6, 13) */
    __pyx_v_i = __pyx_t_2;
```

After:
```
  __pyx_t_1 = __pyx_v_v.begin();
                      /*              <- CppIteratorNode.generate_result_code (6, 13) */
  for (                    /*          -> CppIteratorNode.generate_for_loop_header (6, 13) */
; __pyx_t_1 != __pyx_v_v.end(); ++__pyx_t_1                    /*          <- CppIteratorNode.generate_for_loop_header (6, 13) */
  ) {
                        /*              -> NextNode.generate_result_code (6, 13) */
    __pyx_t_2 = *__pyx_t_1;
                        /*              <- NextNode.generate_result_code (6, 13) */
    __pyx_v_i = __pyx_t_2;

```
