### PR TITLE
Avoid globally allocated mview locks in freethreading

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -27,6 +27,7 @@ cdef extern from "<string.h>":
 
 cdef extern from *:
     bint __PYX_CYTHON_ATOMICS_ENABLED()
+    bint __PYX_GET_CYTHON_COMPILING_IN_CPYTHON_FREETHREADING()
     int PyObject_GetBuffer(object, Py_buffer *, int) except -1
     void PyBuffer_Release(Py_buffer *)
 
@@ -349,7 +350,9 @@ cdef class memoryview:
 
         if not __PYX_CYTHON_ATOMICS_ENABLED():
             global __pyx_memoryview_thread_locks_used
-            if __pyx_memoryview_thread_locks_used < {{THREAD_LOCKS_PREALLOCATED}}:
+            if (__pyx_memoryview_thread_locks_used < {{THREAD_LOCKS_PREALLOCATED}} and
+                    # preallocated locks cannot be made thread-safe in freethreading
+                    not __PYX_GET_CYTHON_COMPILING_IN_CPYTHON_FREETHREADING()):
                 self.lock = __pyx_memoryview_thread_locks[__pyx_memoryview_thread_locks_used]
                 __pyx_memoryview_thread_locks_used += 1
             if self.lock is NULL:
@@ -376,7 +379,7 @@ cdef class memoryview:
         cdef int i
         global __pyx_memoryview_thread_locks_used
         if self.lock != NULL:
-            for i in range(__pyx_memoryview_thread_locks_used):
+            for i in range(0 if __PYX_GET_CYTHON_COMPILING_IN_CPYTHON_FREETHREADING() else __pyx_memoryview_thread_locks_used):
                 if __pyx_memoryview_thread_locks[i] is self.lock:
                     __pyx_memoryview_thread_locks_used -= 1
                     if i != __pyx_memoryview_thread_locks_used:

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -27,6 +27,7 @@ typedef struct {
 // using CYTHON_ATOMICS as a cdef extern bint in the Cython memoryview code
 // interacts badly with "import *". Therefore, define a helper function-like macro
 #define __PYX_CYTHON_ATOMICS_ENABLED() CYTHON_ATOMICS
+#define __PYX_GET_CYTHON_COMPILING_IN_CPYTHON_FREETHREADING() CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
 
 #define __pyx_atomic_int_type int
 #define __pyx_nonatomic_int_type int

--- a/tests/compile/fused_redeclare_T3111.pyx
+++ b/tests/compile/fused_redeclare_T3111.pyx
@@ -27,10 +27,10 @@ _WARNINGS = """
 36:4: 'cpdef_cname_method' redeclared
 
 # from MemoryView.pyx
-958:29: Ambiguous exception value, same as default return value: 0
-958:29: Ambiguous exception value, same as default return value: 0
-999:46: Ambiguous exception value, same as default return value: 0
-999:46: Ambiguous exception value, same as default return value: 0
-1089:29: Ambiguous exception value, same as default return value: 0
-1089:29: Ambiguous exception value, same as default return value: 0
+961:29: Ambiguous exception value, same as default return value: 0
+961:29: Ambiguous exception value, same as default return value: 0
+1002:46: Ambiguous exception value, same as default return value: 0
+1002:46: Ambiguous exception value, same as default return value: 0
+1092:29: Ambiguous exception value, same as default return value: 0
+1092:29: Ambiguous exception value, same as default return value: 0
 """


### PR DESCRIPTION
It's very difficult to make them thread-safe. Although practically almost everyone will be using the atomic path anyway.