### PR TITLE
Test requirements jupyter->ipython

### DIFF
--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,4 @@
-jupyter
+ipython
 pytest  # needed by IPython/Jupyter integration tests
 line_profiler<4  # currently 4 appears to collect no profiling info
 setuptools<60


### PR DESCRIPTION
(Dependencies of) Jupyter is failing to install on Windows Python 3.8. I don't think we need the full install anyway, so try this instead.