### PR TITLE
Add type-inference to prange target

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1046,7 +1046,21 @@ class ControlFlowAnalysis(CythonTransform):
             # Python strings, etc., while correctly falling back to an
             # object type when the base type cannot be handled.
 
-            self.mark_assignment(target, node.item, rhs_scope=node.iterator.expr_scope)
+            self.mark_assignment(target, node.item)
+
+    def mark_parallel_forloop_assignment(self, node):
+        target = node.target
+        for arg in node.args[:2]:
+            self.mark_assignment(target, arg)
+        if len(node.args) > 2:
+            self.mark_assignment(target, self.constant_folder(
+                ExprNodes.binop_node(node.pos,
+                                        '+',
+                                        node.args[0],
+                                        node.args[2])))
+        if not node.args:
+            # Almost certainly an error
+            self.mark_assignment(target)
 
     def visit_AsyncForStatNode(self, node):
         return self.visit_ForInStatNode(node)
@@ -1065,8 +1079,10 @@ class ControlFlowAnalysis(CythonTransform):
         elif isinstance(node, Nodes.AsyncForStatNode):
             # not entirely correct, but good enough for now
             self.mark_assignment(node.target, node.item)
-        else:  # Parallel
-            self.mark_assignment(node.target)
+        elif isinstance(node, Nodes.ParallelRangeNode):  # Parallel
+            self.mark_parallel_forloop_assignment(node)
+        else:
+            assert False, type(node)
 
         # Body block
         if isinstance(node, Nodes.ParallelRangeNode):

--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1046,7 +1046,7 @@ class ControlFlowAnalysis(CythonTransform):
             # Python strings, etc., while correctly falling back to an
             # object type when the base type cannot be handled.
 
-            self.mark_assignment(target, node.item)
+            self.mark_assignment(target, node.item, rhs_scope=node.iterator.expr_scope)
 
     def mark_parallel_forloop_assignment(self, node):
         target = node.target

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -863,3 +863,28 @@ def test_prange_call_exception_checked_function():
             assert buf[i] == i
     finally:
         free(buf)
+
+def test_prange_type_inference_1(short end):
+    """
+    >>> test_prange_type_inference_1(1)
+    """
+    for i in prange(end, nogil=True):
+        pass
+    assert cython.typeof(i) == "short", cython.typeof(i)
+
+def test_prange_type_inference_2(long start, short end):
+    """
+    >>> test_prange_type_inference_2(-100, 5)
+    """
+    for i in prange(start, end, nogil=True):
+        pass
+    assert cython.typeof(i) == "long", cython.typeof(i)
+
+def test_prange_type_inference_3(short start, short end, short step):
+    """
+    >>> test_prange_type_inference_3(-100, 5, 2)
+    """
+    for i in prange(start, end, step, nogil=True):
+        pass
+    # Addition in "step" makes it expand the type to "int"
+    assert cython.typeof(i) == "int", cython.typeof(i)


### PR DESCRIPTION
So that it behaves like a regular for-loop does (rather than always being inferred to object). Just because the absence of this feature is a bit of a pain for prange.