### PR TITLE
Add a directive to control thread-safe indexing

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -251,6 +251,9 @@ _directive_defaults = {
     'warn.deprecated.IF': True,
     'show_performance_hints': True,
 
+# thread safety (mostly only applies to freethreading)
+    'thread_safety.container_access': True,
+
 # optimizations
     'optimize.inline_defnode_calls': True,
     'optimize.unpack_method_calls': True,  # increases code size when True

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -277,17 +277,17 @@ static CYTHON_INLINE int __Pyx_PyBytes_Equals(PyObject* s1, PyObject* s2, int eq
 
 //////////////////// GetItemIntByteArray.proto ////////////////////
 
-#define __Pyx_GetItemInt_ByteArray(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_GetItemInt_ByteArray(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck, thread_safety) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
-    __Pyx_GetItemInt_ByteArray_Fast(o, (Py_ssize_t)i, wraparound, boundscheck) : \
+    __Pyx_GetItemInt_ByteArray_Fast(o, (Py_ssize_t)i, wraparound, boundscheck, thread_safety) : \
     (PyErr_SetString(PyExc_IndexError, "bytearray index out of range"), -1))
 
 static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i,
-                                                         int wraparound, int boundscheck);
+                                                         int wraparound, int boundscheck, int thread_safety);
 
 //////////////////// GetItemIntByteArray ////////////////////
 
-static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i,
+static CYTHON_INLINE int __Pyx__GetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i,
                                                          int wraparound, int boundscheck) {
     Py_ssize_t length;
     if (wraparound | boundscheck) {
@@ -317,20 +317,36 @@ static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ss
     }
 }
 
+static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i,
+                                                         int wraparound, int boundscheck, CYTHON_NCP_UNUSED int thread_safety) {
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+    // We can't really trust that the size doesn't change from under us.
+    // Note that, as of Dec-2024, this is better than what CPython does.
+    if (thread_safety && (wraparound || boundscheck)) {
+        int result;
+        Py_BEGIN_CRITICAL_SECTION(string);
+        result = __Pyx__GetItemInt_ByteArray_Fast(string, i, wraparound, boundscheck);
+        Py_END_CRITICAL_SECTION();
+        return result;
+    } else
+#endif
+    return __Pyx__GetItemInt_ByteArray_Fast(string, i, wraparound, boundscheck);
+}
+
 
 //////////////////// SetItemIntByteArray.proto ////////////////////
 
-#define __Pyx_SetItemInt_ByteArray(o, i, v, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_SetItemInt_ByteArray(o, i, v, type, is_signed, to_py_func, is_list, wraparound, boundscheck, thread_safety) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
-    __Pyx_SetItemInt_ByteArray_Fast(o, (Py_ssize_t)i, v, wraparound, boundscheck) : \
+    __Pyx_SetItemInt_ByteArray_Fast(o, (Py_ssize_t)i, v, wraparound, boundscheck, thread_safety) : \
     (PyErr_SetString(PyExc_IndexError, "bytearray index out of range"), -1))
 
 static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i, unsigned char v,
-                                                         int wraparound, int boundscheck);
+                                                         int wraparound, int boundscheck, int thread_safety);
 
 //////////////////// SetItemIntByteArray ////////////////////
 
-static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i, unsigned char v,
+static CYTHON_INLINE int __Pyx__SetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i, unsigned char v,
                                                          int wraparound, int boundscheck) {
     Py_ssize_t length;
     if (wraparound | boundscheck) {
@@ -364,10 +380,26 @@ static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ss
     }
 }
 
+static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i, unsigned char v,
+                                                         int wraparound, int boundscheck, CYTHON_NCP_UNUSED int thread_safety) {
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+    // We can't really trust that the size doesn't change from under us.
+    // Note that, as of Dec-2024, this is better than what CPython does.
+    if (thread_safety && (wraparound || boundscheck)) {
+        int result;
+        Py_BEGIN_CRITICAL_SECTION(string);
+        result = __Pyx__SetItemInt_ByteArray_Fast(string, i, v, wraparound, boundscheck);
+        Py_END_CRITICAL_SECTION();
+        return result;
+    } else
+#endif
+    return __Pyx__SetItemInt_ByteArray_Fast(string, i, v, wraparound, boundscheck);
+}
+
 
 //////////////////// GetItemIntUnicode.proto ////////////////////
 
-#define __Pyx_GetItemInt_Unicode(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_GetItemInt_Unicode(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck, thread_safety) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
     __Pyx_GetItemInt_Unicode_Fast(o, (Py_ssize_t)i, wraparound, boundscheck) : \
     (PyErr_SetString(PyExc_IndexError, "string index out of range"), (Py_UCS4)-1))

--- a/docs/src/userguide/freethreading.rst
+++ b/docs/src/userguide/freethreading.rst
@@ -51,6 +51,15 @@ extension modules claim to support it then you can either:
 
 These options are mainly useful for testing.
 
+Directives for controlling Thread-safety
+========================================
+
+Cython has :ref:`a selection of compiler directives<thread_safety>` to lets you
+enable and disable thread-safety in its code generation.  These mostly just ensure
+that Python reference-counting can't be corrupted by accessing data from different
+threads (and thus that Python does not crash).  On their own, they typically do not
+provide a useful level of thread-safety.
+
 Tools for Thread-safety
 =======================
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1050,6 +1050,20 @@ Cython code.  Here is the list of currently supported directives:
     cause Cython 3.0 to have the same semantics as Cython 0.x. This directive was solely added
     to help migrate legacy code written before Cython 3. It will be removed in a future release.
 
+.. _thread_safety:
+
+Thread-safety
+-------------
+
+The following directives control thread-safety in free-threading builds of Python.
+They should make little to no difference in regular builds.
+
+``thread_safety.container_access`` (True / False), *default=True*
+    Controls whether indexing into mutable containers (like ``list`` and ``bytearray``)
+    is thread-safe.  In free-threading builds setting this to ``True`` has the effect
+    of re-enabling ``boundscheck`` when using these containers.  Disable this
+    directive only when you know the container will not be being accessed from another
+    thread.
 
 .. _configurable_optimisations:
 

--- a/tests/compile/c_directives.pyx
+++ b/tests/compile/c_directives.pyx
@@ -41,3 +41,7 @@ from cython cimport warn as my_warn
 @my_warn(undeclared=True)
 def j():
     pass
+
+@cy.thread_safety.container_access(False):
+def k(list l):
+    l[2] = l[1]


### PR DESCRIPTION
It's on by default, but can be used to turn off thread-safe indexing in free-threading builds (which is useful because without it turning off boundscheck is effectively useless).

My intention is to add more of these directives in future.