### PR TITLE
Dict_GetItem thread safety

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -123,12 +123,16 @@ bad:
     {
         // For the limited API we just defer to the actual builtin
         // (after setting up globals and locals) - there's too much we can't do otherwise
-        PyObject *builtins, *exec;
+        PyObject *builtins, *exec, *exec_str;
         builtins = PyEval_GetBuiltins();
         if (!builtins) return NULL;
-        exec = PyDict_GetItemString(builtins, "exec");
+        PyObject *exec_str = PyUnicode_FromStringAndSize("exec", 4);
+        if (!exec_str) return NULL;
+        exec = PyObject_GetItem(exec_str);
+        Py_DECREF(exec_str);
         if (!exec) return NULL;
         result = PyObject_CallFunctionObjArgs(exec, o, globals, locals, NULL);
+        Py_DECREF(exec);
         return result;
     }
 #endif

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -128,7 +128,7 @@ bad:
         if (!builtins) return NULL;
         PyObject *exec_str = PyUnicode_FromStringAndSize("exec", 4);
         if (!exec_str) return NULL;
-        exec = PyObject_GetItem(exec_str);
+        exec = PyObject_GetItem(builtins, exec_str);
         Py_DECREF(exec_str);
         if (!exec) return NULL;
         result = PyObject_CallFunctionObjArgs(exec, o, globals, locals, NULL);

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -126,7 +126,7 @@ bad:
         PyObject *builtins, *exec, *exec_str;
         builtins = PyEval_GetBuiltins();
         if (!builtins) return NULL;
-        PyObject *exec_str = PyUnicode_FromStringAndSize("exec", 4);
+        exec_str = PyUnicode_FromStringAndSize("exec", 4);
         if (!exec_str) return NULL;
         exec = PyObject_GetItem(builtins, exec_str);
         Py_DECREF(exec_str);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1819,7 +1819,7 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
 #else
     {
         PyObject *types_module, *method_type=NULL, *func=NULL;
-        PyObject *builtins, *classmethod, *result=NULL;
+        PyObject *builtins, *classmethod, *classmethod_str, *result=NULL;
         types_module = PyImport_ImportModule("types");
         if (!types_module) {
             return NULL;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1834,11 +1834,14 @@ static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
             Py_INCREF(func);
         }
         builtins = PyEval_GetBuiltins(); // borrowed
-        if (!builtins) goto bad;
-        classmethod = PyDict_GetItemString(builtins, "classmethod");
-        // classmethod is borrowed
-        if (!classmethod) goto bad;
+        if (unlikely(!builtins)) goto bad;
+        classmethod_str = PyUnicode_FromString("classmethod");
+        if (unlikely(!classmethod_str)) goto bad;
+        classmethod = PyObject_GetItem(builtins, classmethod_str);
+        Py_DECREF(classmethod_str);
+        if (unlikely(!classmethod)) goto bad;
         result = PyObject_CallFunctionObjArgs(classmethod, func, NULL);
+        Py_DECREF(classmethod);
 
         bad:
         Py_XDECREF(func);

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -788,15 +788,23 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
 #if CYTHON_COMPILING_IN_CPYTHON
     cython_runtime_dict = _PyObject_GetDictPtr(NAMED_CGLOBAL(cython_runtime_cname));
     if (likely(cython_runtime_dict)) {
+#if PY_VERSION_HEX >= 0x030d0000
+        Py_BEGIN_CRITICAL_SECTION(cython_runtime_dict);
+#endif
         __PYX_PY_DICT_LOOKUP_IF_MODIFIED(
             use_cline, *cython_runtime_dict,
             __Pyx_PyDict_GetItemStr(*cython_runtime_dict, PYIDENT("cline_in_traceback")))
+        Py_XINCREF(use_cline);
+#if PY_VERSION_HEX >= 0x030d0000
+        Py_END_CRITICAL_SECTION();
+#endif
     } else
 #endif
     {
       PyObject *use_cline_obj = __Pyx_PyObject_GetAttrStrNoError(NAMED_CGLOBAL(cython_runtime_cname), PYIDENT("cline_in_traceback"));
       if (use_cline_obj) {
         use_cline = PyObject_Not(use_cline_obj) ? Py_False : Py_True;
+        Py_INCREF(use_cline);
         Py_DECREF(use_cline_obj);
       } else {
         PyErr_Clear();
@@ -811,6 +819,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     else if (use_cline == Py_False || (use_cline != Py_True && PyObject_Not(use_cline) != 0)) {
         c_line = 0;
     }
+    Py_XDECREF(use_cline);
     __Pyx_ErrRestoreInState(tstate, ptype, pvalue, ptraceback);
     return c_line;
 }

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -781,6 +781,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line);/*proto*/
 //@requires: ObjectHandling.c::PyObjectGetAttrStrNoError
 //@requires: ObjectHandling.c::PyDictVersioning
 //@requires: PyErrFetchRestore
+//@requires: ModuleSetupCode.c::CriticalSections
 
 #if CYTHON_CLINE_IN_TRACEBACK && CYTHON_CLINE_IN_TRACEBACK_RUNTIME
 static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
@@ -802,16 +803,12 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
 #if CYTHON_COMPILING_IN_CPYTHON
     cython_runtime_dict = _PyObject_GetDictPtr(NAMED_CGLOBAL(cython_runtime_cname));
     if (likely(cython_runtime_dict)) {
-#if PY_VERSION_HEX >= 0x030d0000
-        Py_BEGIN_CRITICAL_SECTION(*cython_runtime_dict);
-#endif
+        __Pyx_BEGIN_CRITICAL_SECTION(*cython_runtime_dict);
         __PYX_PY_DICT_LOOKUP_IF_MODIFIED(
             use_cline, *cython_runtime_dict,
             __Pyx_PyDict_GetItemStr(*cython_runtime_dict, PYIDENT("cline_in_traceback")))
         Py_XINCREF(use_cline);
-#if PY_VERSION_HEX >= 0x030d0000
-        Py_END_CRITICAL_SECTION();
-#endif
+        __Pyx_END_CRITICAL_SECTION();
     } else
 #endif
     {

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -789,7 +789,7 @@ static int __Pyx_CLineForTraceback(PyThreadState *tstate, int c_line) {
     cython_runtime_dict = _PyObject_GetDictPtr(NAMED_CGLOBAL(cython_runtime_cname));
     if (likely(cython_runtime_dict)) {
 #if PY_VERSION_HEX >= 0x030d0000
-        Py_BEGIN_CRITICAL_SECTION(cython_runtime_dict);
+        Py_BEGIN_CRITICAL_SECTION(*cython_runtime_dict);
 #endif
         __PYX_PY_DICT_LOOKUP_IF_MODIFIED(
             use_cline, *cython_runtime_dict,

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -705,7 +705,7 @@ static int __Pyx_ExportVoidPtr(PyObject *name, void *p, const char *sig) {
     PyObject *cobj = 0;
 
 #if PY_VERSION_HEX >= 0x030d0000
-    if (PyDict_GetItemString(NAMED_CGLOBAL(moddict_cname), PYIDENT("$api_name"), &d) == -1) {
+    if (PyDict_GetItemRef(NAMED_CGLOBAL(moddict_cname), PYIDENT("$api_name"), &d) == -1) {
         goto bad;
     }
 #else

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -577,7 +577,12 @@ static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcnam
     d = PyObject_GetAttrString(module, "$api_name");
     if (!d)
         goto bad;
+#if PY_VERSION_HEX >= 0x030d0000
+    PyDict_GetItemStringRef(d, funcname, &cobj);
+#else
     cobj = PyDict_GetItemString(d, funcname);
+    Py_XINCREF(cobj);
+#endif
     if (!cobj) {
         PyErr_Format(PyExc_ImportError,
             "%.200s does not export expected C function %.200s",
@@ -594,9 +599,11 @@ static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcnam
     if (!(*f))
         goto bad;
     Py_DECREF(d);
+    Py_DECREF(cobj);
     return 0;
 bad:
     Py_XDECREF(d);
+    Py_XDECREF(cobj);
     return -1;
 }
 #endif
@@ -654,7 +661,12 @@ static int __Pyx_ImportVoidPtr_$cyversion(PyObject *module, const char *name, vo
     d = PyObject_GetAttrString(module, "$api_name");
     if (!d)
         goto bad;
+#if PY_VERSION_HEX >= 0x030d0000
+    PyDict_GetItemStringRef(d, name, &cobj);
+#else
     cobj = PyDict_GetItemString(d, name);
+    Py_XINCREF(cobj);
+#endif
     if (!cobj) {
         PyErr_Format(PyExc_ImportError,
             "%.200s does not export expected C variable %.200s",
@@ -671,9 +683,11 @@ static int __Pyx_ImportVoidPtr_$cyversion(PyObject *module, const char *name, vo
     if (!(*p))
         goto bad;
     Py_DECREF(d);
+    Py_DECREF(cobj);
     return 0;
 bad:
     Py_XDECREF(d);
+    Py_XDECREF(cobj);
     return -1;
 }
 #endif
@@ -690,8 +704,14 @@ static int __Pyx_ExportVoidPtr(PyObject *name, void *p, const char *sig) {
     PyObject *d;
     PyObject *cobj = 0;
 
+#if PY_VERSION_HEX >= 0x030d0000
+    if (PyDict_GetItemString(NAMED_CGLOBAL(moddict_cname), PYIDENT("$api_name"), &d) == -1) {
+        goto bad;
+    }
+#else
     d = PyDict_GetItem(NAMED_CGLOBAL(moddict_cname), PYIDENT("$api_name"));
     Py_XINCREF(d);
+#endif
     if (!d) {
         d = PyDict_New();
         if (!d)

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1212,7 +1212,7 @@ static CYTHON_INLINE int __Pyx_PyDict_GetItemRef(PyObject *dict, PyObject *key, 
     #define __Pyx_TPFLAGS_HAVE_AM_SEND (0)
 #endif
 
-#if Py_VERSION_HEX >= 0x03090000
+#if PY_VERSION_HEX >= 0x03090000
 #define __Pyx_PyInterpreterState_Get() PyInterpreterState_Get()
 #else
 #define __Pyx_PyInterpreterState_Get() PyThreadState_Get()->interp
@@ -2500,7 +2500,7 @@ static int __Pyx_VersionSanityCheck(void) {
         return -1;
       #endif
     }
-  #endif // Py_VERSION_HEX < 0x03080000
+  #endif // PY_VERSION_HEX < 0x03080000
   #if PY_VERSION_HEX >= 0x030d0000
     if (PyRun_SimpleStringFlags(
       "if "

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -248,6 +248,8 @@ static CYTHON_INLINE PyObject *__Pyx_PyDict_SetDefault(PyObject *d, PyObject *ke
     CYTHON_MAYBE_UNUSED_VAR(is_safe_type);
 #if CYTHON_COMPILING_IN_LIMITED_API
     value = PyObject_CallMethod(d, "setdefault", "OO", key, default_value);
+#elif PY_VERSION_HEX >= 0x030d0000
+    PyDict_SetDefaultRef(d, key, default_value, &value);
 #else
     value = PyDict_SetDefault(d, key, default_value);
     if (unlikely(!value)) return NULL;


### PR DESCRIPTION
A bunch of small thread-safety changes related to PyDict_GetItem and similar avoiding borrowed references.