### PR TITLE
Avoid Py_UNICODE deprecation warning for arrayarray

### DIFF
--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -51,7 +51,10 @@ struct arrayobject {
         unsigned short *as_ushorts;
         // Don't use Py_UNICODE ourselves in the union. This avoids deprecation warnings 
         // for anyone who uses array.array but doesn't use this field.
-        Py_DEPRECATED(3.13) wchar_t *as_pyunicodes;
+        #if PY_VERSION_HEX >= 0x030d0000
+        Py_DEPRECATED(3.13) 
+        #endif
+            wchar_t *as_pyunicodes;
         void *as_voidptr;
     } data;
     Py_ssize_t allocated;

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -49,7 +49,9 @@ struct arrayobject {
         long long *as_longlongs;
         short *as_shorts;
         unsigned short *as_ushorts;
-        Py_UNICODE *as_pyunicodes;
+        // Don't use Py_UNICODE ourselves in the union. This avoids deprecation warnings 
+        // for anyone who uses array.array but doesn't use this field.
+        Py_DEPRECATED(3.13) wchar_t *as_pyunicodes;
         void *as_voidptr;
     } data;
     Py_ssize_t allocated;


### PR DESCRIPTION
Change the helper union for arrayarray so that users who don't use as_pyunicodes don't get a deprecation warning. However, add our own deprecation warning for anyone that does use it.

Fixes #6607