### PR TITLE
Re-enable subinterpreters tests

### DIFF
--- a/tests/run/subinterpreters.srctree
+++ b/tests/run/subinterpreters.srctree
@@ -49,12 +49,13 @@ include "shared.pxi"
 #################### runtest.py #############################
 
 import sys
+import sysconfig
 
 if sys.version_info < (3, 13):
     # No chance of this working I think.
     # (Although there probably is a test that would...)
     exit(0)
-if hasattr(sys, "_is_gil_enabled"):
+if sysconfig.get_config_var("Py_GIL_DISABLED"):
     # _override_multi_interp_extensions_check is banned on free-threading builds
     exit(0)
 

--- a/tests/run/subinterpreters_threading_stress_test.srctree
+++ b/tests/run/subinterpreters_threading_stress_test.srctree
@@ -69,9 +69,10 @@ def f():
 # are started.
 
 import sys
+import sysconfig
 if sys.version_info < (3, 13):
     exit(0)  # test won't work
-if hasattr(sys, "_is_gil_enabled"):
+if sysconfig.get_config_var("Py_GIL_DISABLED"):
     # we aren't allowed to do _imp._override_multi_interp_extensions_check(-1) on freethreading
     exit(0)
 


### PR DESCRIPTION
I was using the wrong test for freethreading Python, and so it was being skipped on all Py3.13+ versions (which wasn't the intent because it's also skipped on anything under Py3.13).