### PR TITLE
Thread safety option for generated code

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -3,11 +3,6 @@
 #
 
 
-import os
-
-from .. import Utils
-
-
 class ShouldBeFromDirective:
 
     known_directives = []
@@ -251,6 +246,9 @@ _directive_defaults = {
     'warn.deprecated.IF': True,
     'show_performance_hints': True,
 
+# thread safety (mostly only applies to freethreading)
+    'thread_safety.generated_functions': False,
+
 # optimizations
     'optimize.inline_defnode_calls': True,
     'optimize.unpack_method_calls': True,  # increases code size when True
@@ -353,6 +351,7 @@ directive_types = {
     'nogil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'gil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'critical_section' : DEFER_ANALYSIS_OF_ARGUMENTS,
+    '_dummy_context' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'with_gil' : None,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
@@ -393,6 +392,7 @@ directive_scopes = {  # defaults to available everywhere
     'gil' : ('with statement'),
     'with_gil' : ('function',),
     'critical_section': ('with statement',),
+    '_dummy_context': ('with statement',),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -100,6 +100,9 @@ class _EmptyDecoratorAndManager:
 class _Optimization:
     pass
 
+class _ThreadSafety:
+    pass
+
 cclass = ccall = cfunc = _EmptyDecoratorAndManager()
 
 annotation_typing = returns = wraparound = boundscheck = initializedcheck = \
@@ -118,10 +121,13 @@ exceptval = lambda _=None, check=True: _EmptyDecoratorAndManager()
 
 overflowcheck = lambda _: _EmptyDecoratorAndManager()
 optimize = _Optimization()
+thread_safety = _ThreadSafety()
 
 
 embedsignature.format = overflowcheck.fold = optimize.use_switch = \
     optimize.unpack_method_calls = lambda arg: _EmptyDecoratorAndManager()
+
+thread_safety.generated_functions = lambda arg: _EmptyDecoratorAndManager()
 
 final = internal = type_version_tag = no_gc_clear = no_gc = total_ordering = \
     ufunc = _empty_decorator

--- a/Cython/Tests/TestShadow.py
+++ b/Cython/Tests/TestShadow.py
@@ -27,7 +27,7 @@ class TestShadow(unittest.TestCase):
                 # used from the cython module
                 continue
 
-            if not hasattr(Shadow, directive):
+            if not directive.startswith('_') and not hasattr(Shadow, directive):
                 missing_directives.append(full_directive)
             elif rest:
                 directive_value = getattr(Shadow, directive)

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1050,6 +1050,26 @@ Cython code.  Here is the list of currently supported directives:
     cause Cython 3.0 to have the same semantics as Cython 0.x. This directive was solely added
     to help migrate legacy code written before Cython 3. It will be removed in a future release.
 
+.. _thread_safety:
+
+Thread-safety
+-------------
+
+The following directives control thread-safety in free-threading builds of Python.
+They should make little to no difference in regular builds.
+
+``thread_safety.generated_functions`` (True / False), *default=False*
+    Controls whether Cython-generated functions are thread-safe by default.
+    This includes properties on extension types (e.g. ``cdef public int x`` or
+    ``cdef readonly int x``), the auto-generated pickle functions of
+    extension types, and functions of ``cython.dataclasses.dataclass`` class.
+    The thread-safety here is achieve by adding ``with cython.critical_section(self[, other]):``
+    where ``self`` is the instance of the extension type and ``other`` is the second argument
+    for dataclass comparison functions only.  Therefore, if you are writing
+    your own code interacting with the underlying data then you should use the same
+    lock.  Remember that critical sections can be interrupted so this is mostly
+    a no-crash guarrantee - the auto-generated pickle function won't necessary be
+    an atomic snapshot for example.
 
 .. _configurable_optimisations:
 

--- a/tests/run/threadsafe_generated.pyx
+++ b/tests/run/threadsafe_generated.pyx
@@ -1,0 +1,92 @@
+# mode: run
+
+# cython: thread_safety.generated_functions = True
+
+cimport cython
+
+import threading
+import pickle
+
+cdef class C:
+    cdef public object o
+    cdef readonly int i
+
+def test_properties(n_writers, n_readers):
+    """
+    >>> test_properties(2, 2)
+    """
+
+    # Mostly just a "do the references get messed up?" stress test
+    c = C()
+    o1 = object()
+    o2 = object()
+    cdef object c_obj = c
+    cdef object two = eval("2")  # obfuscate from Cython a bit
+    
+    barrier = threading.Barrier(n_writers+n_readers)
+    done = threading.Event()
+
+    def writer():
+        barrier.wait()
+        while not done.is_set():
+            c_obj.o = o1
+            # Test documented interaction of locking with threadsafe properties
+            with cython.critical_section(c):
+                c.i += 1
+                c.i *= <int>two
+                if c.i > 1000:
+                    c.i = 0
+            c_obj.o = o2
+    
+    def reader():
+        barrier.wait()
+        for _ in range(5000):
+            p = pickle.dumps(c_obj)
+            o = c_obj.o
+            assert c_obj.i % 2 == 0
+
+    readers = [ threading.Thread(target=reader) for _ in range(n_readers) ]
+    writers = [ threading.Thread(target=writer) for _ in range(n_writers) ]
+
+    for thread in readers+writers:
+        thread.start()
+    for thread in readers:
+        thread.join()
+    done.set()
+    for thread in writers:
+        thread.join()
+
+@cython.dataclasses.dataclass(order=True)
+cdef class DC:
+    x: object
+    y: object
+
+def test_dataclasses():
+    """
+    >>> test_dataclasses()
+    """
+    cdef object dc1 = DC(x=1.0, y=1.0)
+    cdef object dc2 = DC(x=2.0, y=2.0)
+
+    barrier = threading.Barrier(2)
+    done = threading.Event()
+
+    def writer():
+        barrier.wait()
+        while not done.is_set():
+            # only one writer thread so no raace between read and writer
+            dc1.__init__(x=dc1.x+0.1, y=dc1.y+0.1)
+            dc2.__init__(x=dc2.x+0.1, y=dc2.y+0.1)
+
+    def reader():
+        barrier.wait()
+        for _ in range(5000):
+            assert dc1 < dc2
+
+    t1 = threading.Thread(target=reader)
+    t2 = threading.Thread(target=writer)
+    t1.start()
+    t2.start()
+    t1.join()
+    done.set()
+    t2.join()


### PR DESCRIPTION
This adds a `thread_safety.generated_functions` directive which wraps properties/pickle/dataclasses functions inside a suitable critical section, so that they can't corrupt the interpreter state.

I'm slightly undecided if this should be off or on by default. I'm leaning towards "on by default" on the basis that these functions mostly define the interaction with Python code (which is expected to be non-crashing, and which many of our users will consider their external interface) and also because this isn't the highest performance path. It's off by default for now though.

Follows the directive naming scheme for for #6587