### PR TITLE
Update freethreading check in tests

### DIFF
--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -14,11 +14,11 @@ PYTHON run.py limited_multi_phase
 
 ##################### setup.py ################################
 
-import sys
+import sysconfig
 from setuptools import setup
 from Cython.Build import cythonize
 
-if hasattr(sys, "_is_gil_enabled"):
+if sysconfig.get_config_var("Py_GIL_DISABLED"):
     print("Skipping isolated_limited_api tests on free-threading build")
     exit(0)  # At least for 3.13, freethreading and limited API don't mix
 
@@ -38,8 +38,9 @@ import decimal
 
 import weakref
 import sys
+import sysconfig
 
-if hasattr(sys, "_is_gil_enabled"):
+if sysconfig.get_config_var("Py_GIL_DISABLED"):
     print("Skipping isolated_limited_api tests on free-threading build")
     exit(0)  # At least for 3.13, freethreading and limited API don't mix
 

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -11,6 +11,7 @@ from libc.stdio cimport puts
 
 import os
 import sys
+import sysconfig
 
 try:
     from builtins import next # Py3k
@@ -21,7 +22,7 @@ except ImportError:
 def skip_in_freethreading(f):
     # defined in parallel.pyx
     if "OPENMP_PARALLEL" in globals():
-        if hasattr(sys, "_is_gil_enabled"):
+        if sysconfig.get_config_var("Py_GIL_DISABLED"):
             return None
     return f
 


### PR DESCRIPTION
The existing one excluded any Py3.13+ build while this is the one that's documented.