### PR TITLE
Libcpp vector reordering

### DIFF
--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -129,6 +129,7 @@ cdef extern from "<vector>" namespace "std" nogil:
         # vector& operator=(const vector&)
         void assign[InputIt](InputIt, InputIt) except +
         void assign(size_type, const T&)
+        allocator_type get_allocator()
 
         # iterators
         iterator begin()
@@ -172,9 +173,14 @@ cdef extern from "<vector>" namespace "std" nogil:
 
         iterator emplace(const_iterator, ...) except +  # C++11
         iterator insert(iterator, const T&) except +
+        iterator insert(const_iterator, const T&) except +
         iterator insert(iterator, size_type, const T&) except +
+        iterator insert(const_iterator, size_type, const T&) except +
         iterator insert[InputIt](iterator, InputIt, InputIt) except +
+        iterator insert[InputIt](const_iterator, InputIt, InputIt) except +
         iterator erase(iterator) except +
+        const_iterator erase(const_iterator) except +  # C++11
         iterator erase(iterator, iterator) except +
+        iterator erase(const_iterator, const_iterator) except +  # C++11
         void swap(vector&)
         void clear()

--- a/Cython/Includes/libcpp/vector.pxd
+++ b/Cython/Includes/libcpp/vector.pxd
@@ -9,6 +9,13 @@ cdef extern from "<vector>" namespace "std" nogil:
         ctypedef size_t size_type
         ctypedef ptrdiff_t difference_type
 
+        bint operator==(const vector&, const vector&)
+        bint operator!=(const vector&, const vector&)
+        bint operator<(const vector&, const vector&)
+        bint operator>(const vector&, const vector&)
+        bint operator<=(const vector&, const vector&)
+        bint operator>=(const vector&, const vector&)
+
         cppclass const_iterator
         cppclass iterator:
             iterator() except +
@@ -112,57 +119,62 @@ cdef extern from "<vector>" namespace "std" nogil:
             bint operator>=(reverse_iterator)
             bint operator>=(const_reverse_iterator)
 
-        vector() except +
-        vector(const vector&) except +
-        vector(size_type) except +
-        vector(size_type, const T&) except +
+        # 22.3.11.2, construct/copy/destroy
+        vector() except +  # (1)
+        vector(size_type) except +  # (3)
+        vector(size_type, const T&) except +  # (4)
         # type (vector&) is needed here so that Cython can compile templated definition
-        vector& vector[InputIt](InputIt, InputIt) except +
-        T& operator[](size_type)
-        #vector& operator=(vector&)
-        bint operator==(const vector&, const vector&)
-        bint operator!=(const vector&, const vector&)
-        bint operator<(const vector&, const vector&)
-        bint operator>(const vector&, const vector&)
-        bint operator<=(const vector&, const vector&)
-        bint operator>=(const vector&, const vector&)
-        void assign(size_type, const T&)
+        vector& vector[InputIt](InputIt, InputIt) except +  # (5)
+        vector(const vector&) except +  # (6)
+        # vector& operator=(const vector&)
         void assign[InputIt](InputIt, InputIt) except +
-        T& at(size_type) except +
-        T& back()
+        void assign(size_type, const T&)
+
+        # iterators
         iterator begin()
         const_iterator const_begin "begin"()
-        const_iterator cbegin()
-        size_type capacity()
-        void clear()
-        bint empty()
         iterator end()
         const_iterator const_end "end"()
+        reverse_iterator rbegin()
+        const_reverse_iterator const_rbegin "rbegin"()
+        reverse_iterator rend()
+        const_reverse_iterator const_rend "rend"()
+
+        const_iterator cbegin()
         const_iterator cend()
-        iterator erase(iterator) except +
-        iterator erase(iterator, iterator) except +
+        const_reverse_iterator crbegin()
+        const_reverse_iterator crend()
+
+        # 22.3.11.3, capacity
+        bint empty()
+        size_type size()
+        size_type max_size()
+        size_type capacity()
+        void resize(size_type) except +
+        void resize(size_type, const T&) except +
+        void reserve(size_type) except +
+        void shrink_to_fit() except +  # C++11
+
+        # element access
+        T& operator[](size_type)
+        T& at(size_type) except +
         T& front()
+        T& back()
+
+        # 22.3.11.4, data access - C++11
+        T* data()
+        const T* const_data "data"()
+
+        # 22.3.11.5, modifiers
+        T& emplace_back(...) except +  # C++11
+        void push_back(const T&) except +
+        void pop_back()
+
+        iterator emplace(const_iterator, ...) except +  # C++11
         iterator insert(iterator, const T&) except +
         iterator insert(iterator, size_type, const T&) except +
         iterator insert[InputIt](iterator, InputIt, InputIt) except +
-        size_type max_size()
-        void pop_back()
-        void push_back(const T&) except +
-        reverse_iterator rbegin()
-        const_reverse_iterator const_rbegin "rbegin"()
-        const_reverse_iterator crbegin()
-        reverse_iterator rend()
-        const_reverse_iterator const_rend "rend"()
-        const_reverse_iterator crend()
-        void reserve(size_type) except +
-        void resize(size_type) except +
-        void resize(size_type, const T&) except +
-        size_type size()
+        iterator erase(iterator) except +
+        iterator erase(iterator, iterator) except +
         void swap(vector&)
-
-        # C++11 methods
-        T* data()
-        const T* const_data "data"()
-        void shrink_to_fit() except +
-        iterator emplace(const_iterator, ...) except +
-        T& emplace_back(...) except +
+        void clear()

--- a/tests/run/cpp_stl_cpp11.pyx
+++ b/tests/run/cpp_stl_cpp11.pyx
@@ -28,23 +28,6 @@ def test_reference_wrapper():
     return "pass"
 
 
-def test_vector_functionality():
-    """
-    >>> test_vector_functionality()
-    'pass'
-    """
-    cdef:
-        vector[int] int_vector = vector[int]()
-        int* data
-        const int* const_data
-    int_vector.push_back(77)
-    data = int_vector.data()
-    const_data = int_vector.const_data()
-    assert data[0] == 77
-    assert const_data[0] == 77
-    return "pass"
-
-
 def test_queue_functionality():
     """
     >>> test_queue_functionality()

--- a/tests/run/cpp_stl_vector.pyx
+++ b/tests/run/cpp_stl_vector.pyx
@@ -60,11 +60,15 @@ def test_modifiers():
     cdef ivector v1 = ivector(3)
     cdef ivector v2 = ivector(3)
     v2.insert(v2.end(), 1)
+    v2.insert(v2.cend(), 1)
     v2.insert(v2.end(), v1.begin(), v1.end())
+    v2.insert(v2.cend(), v1.cbegin(), v1.cend())
     v1.clear()
     v2.pop_back()
     v2.erase(v2.begin())
+    v2.erase(v2.cbegin())
     v2.erase(v2.begin(), v2.end())
+    v2.erase(v2.cbegin(), v2.cend())
     return v1.size(), v2.size()
 
 def test_swap(ivector v1, ivector v2):

--- a/tests/run/cpp_stl_vector_cpp11.pyx
+++ b/tests/run/cpp_stl_vector_cpp11.pyx
@@ -8,6 +8,20 @@ from libcpp.vector cimport vector
 
 ctypedef vector[int] ivector
 
+def test_vector_data():
+    """
+    >>> test_vector_data()
+    (77, 77)
+    """
+    cdef:
+        int* data
+        const int* const_data
+    int_vector = ivector()
+    int_vector.push_back(77)
+    data = int_vector.data()
+    const_data = int_vector.const_data()
+    return data[0], const_data[0]
+
 def test_vector_emplace():
     """
     >>> test_vector_emplace()


### PR DESCRIPTION
This is a follow-up to #489:

This time, I split it in two commits - one that does purely reordering and labeling, and the second one with follow-up changes.

To check the first commit, I have sorted master-version of `vector.pxd` and my version of `vector.pxd`, while removing the comments and indentation. The following diff comes out:

```diff
libcpp % diff -Naur vector-orig.pxd vector-new.pxd
--- vector-orig.pxd     2025-01-24 17:12:28.927578349 +0100
+++ vector-new.pxd      2025-01-24 17:15:15.482622670 +0100
@@ -102,7 +102,7 @@
 difference_type operator-(iterator)
 difference_type operator-(iterator)
 iterator begin()
-iterator emplace(const_iterator, ...) except +
+iterator emplace(const_iterator, ...) except + # C++11
 iterator end()
 iterator erase(iterator) except +
 iterator erase(iterator, iterator) except +
@@ -134,17 +134,17 @@
 size_type size()
 T& at(size_type) except +
 T& back()
-T& emplace_back(...) except +
+T& emplace_back(...) except + # C++11
 T& front()
 T& operator*()
 T& operator*()
 T& operator[](size_type)
 T* data()
-vector& vector[InputIt](InputIt, InputIt) except +
-vector() except +
-vector(const vector&) except +
-vector(size_type) except +
-vector(size_type, const T&) except +
+vector& vector[InputIt](InputIt, InputIt) except +  # (5)
+vector() except +  # (1)
+vector(const vector&) except +  # (6)
+vector(size_type) except +  # (3)
+vector(size_type, const T&) except +  # (4)
 void assign(size_type, const T&)
 void assign[InputIt](InputIt, InputIt) except +
 void clear()
@@ -153,5 +153,5 @@
 void reserve(size_type) except +
 void resize(size_type) except +
 void resize(size_type, const T&) except +
-void shrink_to_fit() except +
+void shrink_to_fit() except + # C++11
 void swap(vector&)
```

The second commit adds `const_iterator` versions of modifiers as discussed in #489.

The re-ordering was done according to the draft for the C++ 2020 edition (N4849 - https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/n4849.pdf).

The test is moved to have all vector tests in one place.