### PR TITLE
Improve code-gen for critical_section error path

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8980,6 +8980,7 @@ class CriticalSectionStatNode(TryFinallyStatNode):
 
     var_type = None
     state_temp = None
+    preserve_exception = False
 
     def __init__(self, pos, /, args, body, **kwds):
         if len(args) > 1:


### PR DESCRIPTION
Since PyCriticalSection_End with never generate exceptions we can save the effort of getting and restoring the exception state while we call it.