### PR TITLE
loosen errmsg regex for PyPy

### DIFF
--- a/tests/run/defnode_err_val.pyx
+++ b/tests/run/defnode_err_val.pyx
@@ -10,6 +10,6 @@ def test_errval():
     >>> test_errval()
     Traceback (most recent call last):
     ...
-    TypeError: Argument 'a' has incorrect type (expected...TestErrVal, got int)
+    TypeError: Argument 'a' has incorrect type (expected ...TestErrVal, got int)
     """
     TestErrVal(123)

--- a/tests/run/defnode_err_val.pyx
+++ b/tests/run/defnode_err_val.pyx
@@ -7,9 +7,9 @@ cdef class TestErrVal(object):
 
 def test_errval():
     """
-    >>> test_errval()
+    >>> test_errval() # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    TypeError: Argument 'a' has incorrect type (expected ...TestErrVal, got int)
+    TypeError: Argument 'a' has incorrect type (expected...TestErrVal, got int)
     """
     TestErrVal(123)

--- a/tests/run/defnode_err_val.pyx
+++ b/tests/run/defnode_err_val.pyx
@@ -10,6 +10,6 @@ def test_errval():
     >>> test_errval()
     Traceback (most recent call last):
     ...
-    TypeError: Argument 'a' has incorrect type (expected defnode_err_val.TestErrVal, got int)
+    TypeError: Argument 'a' has incorrect type (expected...TestErrVal, got int)
     """
     TestErrVal(123)


### PR DESCRIPTION
Similar to #6592. The error message on PyPy3.11 does not include the module name, which I don't think is an error but an implementation detail.