### PR TITLE
Add `get_file_handle()` to `FileSourceDescriptor`

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -365,7 +365,7 @@ class Context:
         # Parse the given source file and return a parse tree.
         num_errors = Errors.get_errors_count()
         try:
-            with source_desc.get_file_handle() as f:
+            with source_desc.get_file_object() as f:
                 from . import Parsing
                 s = PyrexScanner(f, source_desc, source_encoding = f.encoding,
                                  scope = scope, context = self)

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -2277,7 +2277,7 @@ def p_include_statement(s: PyrexScanner, ctx):
         if include_file_path:
             s.included_files.append(include_file_name)
             source_desc = FileSourceDescriptor(include_file_path)
-            with source_desc.get_file_handle() as f:
+            with source_desc.get_file_object() as f:
                 s2 = PyrexScanner(f, source_desc, s, source_encoding=f.encoding, parse_comments=s.parse_comments)
                 tree = p_statement_list(s2, ctx)
             return tree

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -216,7 +216,7 @@ class FileSourceDescriptor(SourceDescriptor):
         except KeyError:
             pass
 
-        with self.get_file_handle(encoding=encoding, error_handling=error_handling) as f:
+        with self.get_file_object(encoding=encoding, error_handling=error_handling) as f:
             lines = f.readlines()
 
         if key in self._lines:
@@ -227,7 +227,7 @@ class FileSourceDescriptor(SourceDescriptor):
             self._lines[key] = None
         return lines
 
-    def get_file_handle(self, encoding=None, error_handling=None):
+    def get_file_object(self, encoding=None, error_handling=None):
         return Utils.open_source_file(self.filename, encoding, error_handling)
 
     def get_description(self):


### PR DESCRIPTION
This PR unifies reading of source code to single method of `FileSourceDescriptor`. Except reducing code duplicity, the main motivation of this PR is #6531 more precisely allowing templating .pxd files (see https://github.com/cython/cython/pull/6531/files#r1865042221)