### PR TITLE
Enable a few more Limited API tests

### DIFF
--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -126,5 +126,9 @@ py_unicode_strings
 py_unicode_type
 unicode_indexing
 
+# Works on DW's computer, fails on CI on Python3.11 only with exactly the same versions
+# (might be due to shared ABI possibly?)
+yield_from_pep380
+
 # Excluded for now - to be enabled incrementally
 buffers[.]

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -20,8 +20,6 @@ ext_attribute_cache
 fastcall
 run[.]generators_py
 generator_frame_cycle
-# probably just an exact error message
-importfrom
 run[.]no_gc
 run[.]numpy
 line_trace
@@ -32,7 +30,6 @@ py_ucs4_type
 pep442_tp_finalize
 test_asyncgen
 tracebacks
-tuple_constants
 tss
 sys_monitoring
 special_method_docstrings
@@ -40,11 +37,6 @@ run[.]ufunc
 slice2b
 verbatiminclude
 test_coroutines_pep492
-
-# Possibly only on early versions of Python?
-fused_def
-legacy_implicit_noexcept
-method_module_name_T422
 
 # Something to do with complex
 view_count
@@ -133,15 +125,6 @@ run[.]notinop
 py_unicode_strings
 py_unicode_type
 unicode_indexing
-
-# Only on specific versions
-# (TODO) be more specific here
-weakfail
-reduce_pickle
-test_dataclasses
-test_genericclass_exttype
-test_class_getitem_errors_2
-yield_from_pep380
 
 # Excluded for now - to be enabled incrementally
 buffers[.]

--- a/tests/limited_api_bugs_38.txt
+++ b/tests/limited_api_bugs_38.txt
@@ -1,3 +1,14 @@
 # __dict__ doesn't work on cdef classes
 run[.]cdef_multiple_inheritance$
 test_grammar
+
+# To do with missing attributes when initializing types
+weakfail
+reduce_pickle
+test_dataclasses
+method_module_name_T422
+
+test_genericclass_exttype
+yield_from_pep380
+fused_def
+legacy_implicit_noexcept

--- a/tests/run/importfrom.pyx
+++ b/tests/run/importfrom.pyx
@@ -1,5 +1,9 @@
 from distutils import cmd, core, version
 
+cdef extern from *:
+    cdef enum:
+        CYTHON_COMPILING_IN_LIMITED_API
+
 def import1():
     """
     >>> import1() == (cmd, core, version)
@@ -68,7 +72,7 @@ def typed_imports():
     try:
         from sys import version_info as maxunicode
     except TypeError, e:
-        if getattr(sys, "pypy_version_info", None):
+        if getattr(sys, "pypy_version_info", None) or CYTHON_COMPILING_IN_LIMITED_API:
             # translate message
             if e.args[0].startswith("int() argument must be"):
                 e = "an integer is required"


### PR DESCRIPTION
Mainly just version-specific ones that fail on Python 3.8.