### PR TITLE
Enable Limited API in srctree tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2002,7 +2002,10 @@ class EndToEndTest(unittest.TestCase):
         new_path = self.cython_syspath
         if old_path:
             new_path = new_path + os.pathsep + self.workdir + os.pathsep + old_path
-        env = dict(os.environ, PYTHONPATH=new_path, PYTHONIOENCODING='utf8')
+        env_cflags = list(CFLAGS) + [f'"-D{macro}={definition}"' for macro, definition in CDEFS]
+        env_cflags = " ".join(env_cflags)
+        env = dict(os.environ, PYTHONPATH=new_path, PYTHONIOENCODING='utf8',
+                   CFLAGS=env_cflags)
         cmd = []
         out = []
         err = []

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -45,6 +45,7 @@ reimport_failure
 line_profile_test
 cdef_multiple_inheritance_errors
 cline_in_traceback
+module_init_error
 
 # Possibly only on early versions of Python?
 fused_def

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -40,6 +40,11 @@ run[.]ufunc
 slice2b
 verbatiminclude
 test_coroutines_pep492
+coverage
+reimport_failure
+line_profile_test
+cdef_multiple_inheritance_errors
+cline_in_traceback
 
 # Possibly only on early versions of Python?
 fused_def
@@ -100,6 +105,8 @@ special_methods_T561
 run[.]slice_ptr
 running_with_gil
 run[.]with_gil
+cimport_from_pyx
+array_cimport
 
 # example in docs that use features unavailable in the limited API
 # (and it's a decision for the docs writers rather than a limitation
@@ -113,6 +120,7 @@ wrapping_CPlusPlus.python_to_cpp
 
 # Tests explicitly use internals
 compile[.]pylong
+extern_varobject_extensions
 
 # Inherit builtin type: PEP697
 bytearraymethods
@@ -123,6 +131,10 @@ r_hordijk1
 trashcan
 unbound_special_methods
 unicode_formatting
+
+# Needs multi-phase import
+# (but is there a reason why we're not doing this in the Limited API anyway?)
+unicode_imports
 
 # Py_UNICODE
 builtin_ord

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -30,6 +30,7 @@ run[.]extra_walrus
 run[.]nonecheck
 run[.]locals
 run[.]parallel
+run[.]pure_pxd
 run[.]pyarray
 run[.]sequential_parallel
 run[.]special_methods_T561

--- a/tests/run/abitests.srctree
+++ b/tests/run/abitests.srctree
@@ -3,6 +3,7 @@
 # simulate getting the environment wrong in the Python headers (which
 # is potentially a more dramatic problem).
 
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 PYTHON test.py
 

--- a/tests/run/freethreading_compatible.srctree
+++ b/tests/run/freethreading_compatible.srctree
@@ -1,4 +1,5 @@
 UNSET PYTHON_GIL
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import default; default.test()"
 PYTHON -c "import compatible; compatible.test()"

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -6,6 +6,7 @@
 # known and working. It should be dropped once the limited API is
 # better tested
 
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 PYTHON run.py limited_single_phase
 PYTHON run.py limited_single_phase_modstate

--- a/tests/run/reimport_from_subinterpreter.srctree
+++ b/tests/run/reimport_from_subinterpreter.srctree
@@ -1,6 +1,7 @@
 # mode: run
 # tag: pep489, subinterpreter
 
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import subtest; subtest.run_main()"
 PYTHON -c "import subtest; subtest.run_sub()"

--- a/tests/run/subinterpreters.srctree
+++ b/tests/run/subinterpreters.srctree
@@ -1,3 +1,4 @@
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 
 # single-phase uses Python's mechanisms so should be reliable

--- a/tests/run/subinterpreters_threading_stress_test.srctree
+++ b/tests/run/subinterpreters_threading_stress_test.srctree
@@ -1,3 +1,4 @@
+UNSET CFLAGS
 PYTHON setup.py build_ext --inplace
 PYTHON main.py
 


### PR DESCRIPTION
by passing the cflags into the environment.

I'm expecting to have to turn this off for some tests (e.g. the isolated limited api ones, where it's being explicitly controlled in the test) and to have to disable some other tests where it'll fail.