### PR TITLE
Add headers for "abs" in Limited API

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -111,13 +111,17 @@ class BuiltinProperty:
 builtin_function_table = [
     # name,        args,   return,  C API func,           py equiv = "*"
     BuiltinFunction('abs',        "d",    "d",     "fabs",
-                    is_strict_signature=True, nogil=True),
+                    is_strict_signature=True, nogil=True,
+                    utility_code=UtilityCode.load("IncludeStdlibH", "ModuleSetupCode.c")),
     BuiltinFunction('abs',        "f",    "f",     "fabsf",
-                    is_strict_signature=True, nogil=True),
+                    is_strict_signature=True, nogil=True,
+                    utility_code=UtilityCode.load("IncludeStdlibH", "ModuleSetupCode.c")),
     BuiltinFunction('abs',        "i",    "i",     "abs",
-                    is_strict_signature=True, nogil=True),
+                    is_strict_signature=True, nogil=True,
+                    utility_code=UtilityCode.load("IncludeStdlibH", "ModuleSetupCode.c")),
     BuiltinFunction('abs',        "l",    "l",     "labs",
-                    is_strict_signature=True, nogil=True),
+                    is_strict_signature=True, nogil=True,
+                    utility_code=UtilityCode.load("IncludeStdlibH", "ModuleSetupCode.c")),
     BuiltinFunction('abs',        None,    None,   "__Pyx_abs_longlong",
                 utility_code = UtilityCode.load("abs_longlong", "Builtins.c"),
                 func_type = PyrexTypes.CFuncType(

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -229,6 +229,12 @@ static PyObject* __Pyx_Intern(PyObject* s) {
 
 //////////////////// abs_longlong.proto ////////////////////
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#include <cstdlib>
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#include <stdlib.h>
+#endif
+
 static CYTHON_INLINE PY_LONG_LONG __Pyx_abs_longlong(PY_LONG_LONG x) {
 #if defined (__cplusplus) && __cplusplus >= 201103L
     return std::abs(x);


### PR DESCRIPTION
Because Python.h provides less in the Limited API, we need to provide the headers ourselves.