### PR TITLE
Enable free-threaded wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ requires = ["setuptools", "wheel"]
 [tool.cibuildwheel]
 build-verbosity = 2
 skip = ["pp*", "cp36*", "cp37*"]
+# Enable free-threaded support
+enable = ["cpython-freethreading"]
 # test-command = "make test"
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools", "wheel"]
 build-verbosity = 2
 skip = ["pp*", "cp36*", "cp37*"]
 # Enable free-threaded support
-enable = ["cpython-freethreading"]
+free-threaded-support = true
 # test-command = "make test"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Would y'all consider doing wheel builds for free-threaded Python?   Various projects are starting to test free-threaded builds, and because they will be using free-threaded Python, they will also benefit from a matching wheel.   I believe this is the correct incantation for CIbuildwheel.