### PR TITLE
Stop Cython compiling itself in freethreaded builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,21 @@ cython_coverage = check_option('cython-coverage')
 cython_with_refnanny = check_option('cython-with-refnanny')
 
 compile_cython_itself = not check_option('no-cython-compile')
+
+if compile_cython_itself and sysconfig.get_config_var("Py_GIL_DISABLED"):
+    # On freethreaded builds there's good reasons not to compile Cython by default.
+    # Mainly that it doesn't currently declare as compatible with the limited API
+    # (because little effort has been spent making it thread-safe) and thus
+    # importing a compiled version of Cython will throw the interpreter back
+    # to using the GIL.
+    # This will adversely affect users of pyximport or jupyter.
+    # Therefore, we let users explicitly force Cython to be compiled on freethreaded
+    # builds but don't do it by default.
+    compile_cython_itself = (
+        check_option('cython-compile') or
+        check_option('cython-compile-all') or
+        check_option('cython-compile-minimal'))
+
 if compile_cython_itself:
     cython_compile_more = check_option('cython-compile-all')
     cython_compile_minimal = check_option('cython-compile-minimal')


### PR DESCRIPTION
Provide a mechanism where users can force it to if they want, but turn it off by default.

---------------------------

As discussed in the comments of #6653, I think this is something that shouldn't be enabled for most people. I don't want to stop anyone who wants to, but making it off by default will stop pip doing it by mistake.