### PR TITLE
"Fix" common_include_dir on Py3.14

### DIFF
--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -29,7 +29,8 @@ nthreads = 0
 if not (hasattr(sys, 'pypy_version_info') or
         (hasattr(sys, 'implementation') and sys.implementation.name == 'graalpython') or
         sys.platform == 'win32' or
-        is_mac_os):
+        is_mac_os or
+        sys.version_info > (3, 14)):
     try:
         import multiprocessing
         multiprocessing.Pool(2).close()


### PR DESCRIPTION
I have no idea why this works.