### PR TITLE
Better fix for common_include_dir

### DIFF
--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -22,7 +22,7 @@ from distutils.core import setup
 
 if __name__ == "__main__":
     setup(
-    ext_modules = cythonize("*.pyx", common_utility_include_dir='common', nthreads=2),
+        ext_modules = cythonize("*.pyx", common_utility_include_dir='common', nthreads=2),
     )
 
 ######## a.pyx ########

--- a/tests/build/common_include_dir.srctree
+++ b/tests/build/common_include_dir.srctree
@@ -20,26 +20,10 @@ import os
 
 from distutils.core import setup
 
-# MacOS seems to crash with nthreads>0
-is_mac_os = sys.platform == "darwin"
-
-# Test concurrent safety if multiprocessing is available.
-# (In particular, CI providers like Travis and Github Actions do not support spawning processes from tests.)
-nthreads = 0
-if not (hasattr(sys, 'pypy_version_info') or
-        (hasattr(sys, 'implementation') and sys.implementation.name == 'graalpython') or
-        sys.platform == 'win32' or
-        is_mac_os):
-    try:
-        import multiprocessing
-        multiprocessing.Pool(2).close()
-        nthreads = 2
-    except (ImportError, OSError):
-        pass
-
-setup(
-  ext_modules = cythonize("*.pyx", common_utility_include_dir='common', nthreads=nthreads),
-)
+if __name__ == "__main__":
+    setup(
+    ext_modules = cythonize("*.pyx", common_utility_include_dir='common', nthreads=2),
+    )
 
 ######## a.pyx ########
 


### PR DESCRIPTION
For anything but fork, multiprocessing need the main script to be wrapped in `if __name__ == "__main__":`

Supercedes #6668 (assuming to works universally)