### PR TITLE
Fix subinterpreters test in 3.14

### DIFF
--- a/tests/run/subinterpreters.srctree
+++ b/tests/run/subinterpreters.srctree
@@ -63,9 +63,11 @@ if sysconfig.get_config_var("Py_GIL_DISABLED"):
 # TODO - in Py3.14 this'll probably be in the standard library
 try:
     from interpreters_backport import interpreters
+    low_level_module = False
 except ImportError:
     # Py3.14?
     import _interpreters as interpreters
+    low_level_module = True
 
 SKIP_FIRST = "skip_first="
 CYTHON_MODULE = "cython_module="
@@ -112,7 +114,15 @@ assert len(cymod.some_global) == 1
 # skip_first is useful because we apply an optimization when all the interpreter ids are small,
 # so it lets us pick this optimization.
 for i in all_interpreters[skip_first:]:
-    i.exec(code_to_exec)
+    if low_level_module:
+        excinfo = interpreters.exec(i, code_to_exec, restrict=True)
+        if excinfo is not None:
+            raise RuntimeError(excinfo)
+    else:
+        i.exec(code_to_exec)
     if close_after_exec:
         # Will probably clean up the module, but we don't actually check this
-        i.close()
+        if low_level_module:
+            interpreters.destroy(i, restrict=True)
+        else:
+            i.close()


### PR DESCRIPTION
The low-level _interpreters module has a slightly different interface - it doesn't have the nice "Interpreter" object but just returns an integer ID