### PR TITLE
Fix logic for c_safe_identifier to extension types

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2473,7 +2473,7 @@ class CClassScope(ClassScope):
                         % name)
             if not cname:
                 cname = name
-                if not (self.parent_type.is_external or self.parent_type.entry.api or 
+                if not (self.parent_type.is_external or self.parent_type.entry.api or
                         self.parent_type.entry.visibility == "public"):
                     cname = c_safe_identifier(cname)
                 cname = punycodify_name(cname, Naming.unicode_structmember_prefix)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2473,7 +2473,8 @@ class CClassScope(ClassScope):
                         % name)
             if not cname:
                 cname = name
-                if visibility == 'private':
+                if not (self.parent_type.is_external or self.parent_type.entry.api or 
+                        self.parent_type.entry.visibility == "public"):
                     cname = c_safe_identifier(cname)
                 cname = punycodify_name(cname, Naming.unicode_structmember_prefix)
             entry = self.declare(name, cname, type, pos, visibility)

--- a/tests/run/cclass_attr.pyx
+++ b/tests/run/cclass_attr.pyx
@@ -1,0 +1,16 @@
+# mode: run
+
+cdef class CReserved:
+    """
+    >>> cr = CReserved()
+    >>> cr.default
+    1
+    >>> cr.void
+    2
+    """
+    cdef readonly int default
+    cdef public int void
+
+    def __init__(self):
+        self.default = 1
+        self.void = 2


### PR DESCRIPTION
"visibility" in this case means "visibility to Python". It's where the class comes from that matters to whether we mangle the name.

It's slightly debatable what we should be doing for api or public classes, but it's probably reasonable to treat them as the user's responsibility to get them right.

Fixes #6678