### PR TITLE
Fix outdated URL for packaging tutorial

### DIFF
--- a/docs/src/quickstart/build.rst
+++ b/docs/src/quickstart/build.rst
@@ -13,7 +13,7 @@ Cython code must, unlike Python, be compiled. This happens in two stages:
    
 To understand fully the Cython + setuptools build process,
 one may want to read more about
-`distributing Python modules <https://docs.python.org/3/distributing/index.html>`_.
+`distributing Python modules <https://packaging.python.org/en/latest/tutorials/packaging-projects/>`_.
 
 There are several ways to build Cython code:
 


### PR DESCRIPTION
Currently, the user lands at a redirection page:

![image](https://github.com/user-attachments/assets/7af2a3f2-db2f-4bdd-b0ae-768300866abd)

I replaced the URL with the tutorial shown on the right (which is a subdomain of the general guide shown on the left)