### PR TITLE
Define buffer typeinfo structs as const

### DIFF
--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -608,7 +608,7 @@ def get_type_information_cname(code, dtype, maxdepth=None):
             assert len(fields) > 0
             types = [get_type_information_cname(code, f.type, maxdepth - 1)
                      for f in fields]
-            typecode.putln("static __Pyx_StructField %s[] = {" % structinfo_name, safe=True)
+            typecode.putln("static const __Pyx_StructField %s[] = {" % structinfo_name, safe=True)
 
             if dtype.is_cv_qualified:
                 # roughly speaking, remove "const" from struct_type
@@ -648,7 +648,7 @@ def get_type_information_cname(code, dtype, maxdepth=None):
         else:
             assert False, dtype
 
-        typeinfo = ('static __Pyx_TypeInfo %s = '
+        typeinfo = ('static const __Pyx_TypeInfo %s = '
                         '{ "%s", %s, sizeof(%s), { %s }, %s, %s, %s, %s };')
         tup = (name, rep, structinfo_name, declcode,
                ', '.join([str(x) for x in arraysizes]) or '0', len(arraysizes),

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -57,7 +57,7 @@ struct __Pyx_StructField_;
 
 typedef struct {
   const char* name; /* for error messages only */
-  struct __Pyx_StructField_* fields;
+  const struct __Pyx_StructField_* fields;
   size_t size;     /* sizeof(type) */
   size_t arraysize[8]; /* length of array in each dimension */
   int ndim;
@@ -67,13 +67,13 @@ typedef struct {
 } __Pyx_TypeInfo;
 
 typedef struct __Pyx_StructField_ {
-  __Pyx_TypeInfo* type;
+  const __Pyx_TypeInfo* type;
   const char* name;
   size_t offset;
 } __Pyx_StructField;
 
 typedef struct {
-  __Pyx_StructField* field;
+  const __Pyx_StructField* field;
   size_t parent_offset;
 } __Pyx_BufFmt_StackElem;
 
@@ -99,7 +99,7 @@ typedef struct {
     __Pyx__GetBufferAndValidate(buf, obj, dtype, flags, nd, cast, stack))
 
 static int  __Pyx__GetBufferAndValidate(Py_buffer* buf, PyObject* obj,
-    __Pyx_TypeInfo* dtype, int flags, int nd, int cast, __Pyx_BufFmt_StackElem* stack);
+  const __Pyx_TypeInfo* dtype, int flags, int nd, int cast, __Pyx_BufFmt_StackElem* stack);
 static void __Pyx_ZeroBuffer(Py_buffer* buf);
 static CYTHON_INLINE void __Pyx_SafeReleaseBuffer(Py_buffer* info);/*proto*/
 
@@ -125,7 +125,7 @@ static void __Pyx_ZeroBuffer(Py_buffer* buf) {
 }
 
 static int __Pyx__GetBufferAndValidate(
-        Py_buffer* buf, PyObject* obj,  __Pyx_TypeInfo* dtype, int flags,
+        Py_buffer* buf, PyObject* obj,  const __Pyx_TypeInfo* dtype, int flags,
         int nd, int cast, __Pyx_BufFmt_StackElem* stack)
 {
   buf->buf = NULL;
@@ -177,7 +177,7 @@ fail:;
 static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const char* ts);
 static void __Pyx_BufFmt_Init(__Pyx_BufFmt_Context* ctx,
                               __Pyx_BufFmt_StackElem* stack,
-                              __Pyx_TypeInfo* type); /*proto*/
+                              const __Pyx_TypeInfo* type); /*proto*/
 
 /////////////// BufferFormatCheck ///////////////
 //@requires: ModuleSetupCode.c::IsLittleEndian
@@ -185,7 +185,7 @@ static void __Pyx_BufFmt_Init(__Pyx_BufFmt_Context* ctx,
 
 static void __Pyx_BufFmt_Init(__Pyx_BufFmt_Context* ctx,
                               __Pyx_BufFmt_StackElem* stack,
-                              __Pyx_TypeInfo* type) {
+                              const __Pyx_TypeInfo* type) {
   stack[0].field = &ctx->root;
   stack[0].parent_offset = 0;
   ctx->root.type = type;
@@ -411,8 +411,8 @@ static void __Pyx_BufFmt_RaiseExpected(__Pyx_BufFmt_Context* ctx) {
                  quote, expected, quote,
                  __Pyx_BufFmt_DescribeTypeChar(ctx->enc_type, ctx->is_complex));
   } else {
-    __Pyx_StructField* field = ctx->head->field;
-    __Pyx_StructField* parent = (ctx->head - 1)->field;
+    const __Pyx_StructField* field = ctx->head->field;
+    const __Pyx_StructField* parent = (ctx->head - 1)->field;
     PyErr_Format(PyExc_ValueError,
                  "Buffer dtype mismatch, expected '%s' but got %s in '%s.%s'",
                  field->type->name, __Pyx_BufFmt_DescribeTypeChar(ctx->enc_type, ctx->is_complex),
@@ -458,8 +458,8 @@ static int __Pyx_BufFmt_ProcessTypeChunk(__Pyx_BufFmt_Context* ctx) {
 
   group = __Pyx_BufFmt_TypeCharToGroup(ctx->enc_type, ctx->is_complex);
   do {
-    __Pyx_StructField* field = ctx->head->field;
-    __Pyx_TypeInfo* type = field->type;
+    const __Pyx_StructField* field = ctx->head->field;
+    const __Pyx_TypeInfo* type = field->type;
 
     if (ctx->enc_packmode == '@' || ctx->enc_packmode == '^') {
       size = __Pyx_BufFmt_TypeCharToNativeSize(ctx->enc_type, ctx->is_complex);
@@ -753,14 +753,14 @@ static const char* __Pyx_BufFmt_CheckString(__Pyx_BufFmt_Context* ctx, const cha
 }
 
 /////////////// TypeInfoCompare.proto ///////////////
-static int __pyx_typeinfo_cmp(__Pyx_TypeInfo *a, __Pyx_TypeInfo *b);
+static int __pyx_typeinfo_cmp(const __Pyx_TypeInfo *a, const __Pyx_TypeInfo *b);
 
 /////////////// TypeInfoCompare ///////////////
 //@requires: BufferFormatStructs
 
 // See if two dtypes are equal
 static int
-__pyx_typeinfo_cmp(__Pyx_TypeInfo *a, __Pyx_TypeInfo *b)
+__pyx_typeinfo_cmp(const __Pyx_TypeInfo *a, const __Pyx_TypeInfo *b)
 {
     int i;
 
@@ -800,8 +800,8 @@ __pyx_typeinfo_cmp(__Pyx_TypeInfo *a, __Pyx_TypeInfo *b)
 
             /* compare */
             for (i = 0; a->fields[i].type && b->fields[i].type; i++) {
-                __Pyx_StructField *field_a = a->fields + i;
-                __Pyx_StructField *field_b = b->fields + i;
+                const __Pyx_StructField *field_a = a->fields + i;
+                const __Pyx_StructField *field_b = b->fields + i;
 
                 if (field_a->offset != field_b->offset ||
                     !__pyx_typeinfo_cmp(field_a->type, field_b->type))
@@ -821,14 +821,14 @@ __pyx_typeinfo_cmp(__Pyx_TypeInfo *a, __Pyx_TypeInfo *b)
 struct __pyx_typeinfo_string {
     char string[3];
 };
-static struct __pyx_typeinfo_string __Pyx_TypeInfoToFormat(__Pyx_TypeInfo *type);
+static struct __pyx_typeinfo_string __Pyx_TypeInfoToFormat(const __Pyx_TypeInfo *type);
 
 /////////////// TypeInfoToFormat ///////////////
 //@requires: BufferFormatStructs
 
 // See also MemoryView.pyx:BufferFormatFromTypeInfo
 
-static struct __pyx_typeinfo_string __Pyx_TypeInfoToFormat(__Pyx_TypeInfo *type) {
+static struct __pyx_typeinfo_string __Pyx_TypeInfoToFormat(const __Pyx_TypeInfo *type) {
     struct __pyx_typeinfo_string result = { {0} };
     char *buf = (char *) result.string;
     size_t size = type->size;

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -44,7 +44,7 @@ cdef extern from *:
     cdef struct __pyx_memoryview "__pyx_memoryview_obj":
         Py_buffer view
         PyObject *obj
-        __Pyx_TypeInfo *typeinfo
+        const __Pyx_TypeInfo *typeinfo
 
     ctypedef struct {{memviewslice_name}}:
         __pyx_memoryview *memview
@@ -337,7 +337,7 @@ cdef class memoryview:
     cdef Py_buffer view
     cdef int flags
     cdef bint dtype_is_object
-    cdef __Pyx_TypeInfo *typeinfo
+    cdef const __Pyx_TypeInfo *typeinfo
 
     def __cinit__(memoryview self, object obj, int flags, bint dtype_is_object=False):
         self.obj = obj
@@ -654,7 +654,7 @@ cdef class memoryview:
 
 
 @cname('__pyx_memoryview_new')
-cdef memoryview_cwrapper(object o, int flags, bint dtype_is_object, __Pyx_TypeInfo *typeinfo):
+cdef memoryview_cwrapper(object o, int flags, bint dtype_is_object, const __Pyx_TypeInfo *typeinfo):
     cdef memoryview result = memoryview(o, flags, dtype_is_object)
     result.typeinfo = typeinfo
     return result
@@ -1419,7 +1419,7 @@ cdef extern from *:
 
     ctypedef struct __Pyx_TypeInfo:
         char* name
-        __Pyx_StructField* fields
+        const __Pyx_StructField* fields
         size_t size
         size_t arraysize[8]
         int ndim
@@ -1428,12 +1428,12 @@ cdef extern from *:
         int flags
 
     ctypedef struct __Pyx_StructField:
-        __Pyx_TypeInfo* type
+        const __Pyx_TypeInfo* type
         char* name
         size_t offset
 
     ctypedef struct __Pyx_BufFmt_StackElem:
-        __Pyx_StructField* field
+        const __Pyx_StructField* field
         size_t parent_offset
 
     #ctypedef struct __Pyx_BufFmt_Context:
@@ -1443,12 +1443,12 @@ cdef extern from *:
     struct __pyx_typeinfo_string:
         char string[3]
 
-    __pyx_typeinfo_string __Pyx_TypeInfoToFormat(__Pyx_TypeInfo *)
+    __pyx_typeinfo_string __Pyx_TypeInfoToFormat(const __Pyx_TypeInfo *)
 
 
 @cname('__pyx_format_from_typeinfo')
-cdef bytes format_from_typeinfo(__Pyx_TypeInfo *type):
-    cdef __Pyx_StructField *field
+cdef bytes format_from_typeinfo(const __Pyx_TypeInfo *type):
+    cdef const __Pyx_StructField *field
     cdef __pyx_typeinfo_string fmt
     cdef bytes part, result
     cdef Py_ssize_t i

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -253,7 +253,7 @@ static int __Pyx_ValidateAndInit_memviewslice(
                 int c_or_f_flag,
                 int buf_flags,
                 int ndim,
-                __Pyx_TypeInfo *dtype,
+                const __Pyx_TypeInfo *dtype,
                 __Pyx_BufFmt_StackElem stack[],
                 __Pyx_memviewslice *memviewslice,
                 PyObject *original_obj);
@@ -386,7 +386,7 @@ static int __Pyx_ValidateAndInit_memviewslice(
                 int c_or_f_flag,
                 int buf_flags,
                 int ndim,
-                __Pyx_TypeInfo *dtype,
+                const __Pyx_TypeInfo *dtype,
                 __Pyx_BufFmt_StackElem stack[],
                 __Pyx_memviewslice *memviewslice,
                 PyObject *original_obj)


### PR DESCRIPTION
They aren't modified, so const will hopefully help the compiler out a little (and prevent them from being modified in future)