### PR TITLE
Remove unused memoryview field

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -331,7 +331,8 @@ cdef class memoryview:
 
     cdef object obj
     cdef object _size
-    cdef object _array_interface
+    # This comes before acquisition_count so can't be removed without breaking ABI compatibility
+    cdef void* _unused
     cdef PyThread_type_lock lock
     cdef __pyx_atomic_int_type acquisition_count
     cdef Py_buffer view


### PR DESCRIPTION
I don't think we can remove it without breaking ABI compatibility for people calling functions taking memoryviews in other versions of Cython.

However, `object` will generate reference-counting code so we should avoid that.