### PR TITLE
Fix incorrect code generation for method override

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -529,14 +529,14 @@ class Scope:
                         # Note that we can override an inherited method with a compatible but not exactly equal signature, as in C++.
                         cpp_override_allowed = True
                     if cpp_override_allowed:
+                        entry = copy.copy(alt_entry)
                         # A compatible signature doesn't mean the exact same signature,
                         # so we're taking the new signature for the entry.
-                        alt_entry.type = type
-                        alt_entry.is_inherited = False
+                        entry.type = type
+                        entry.is_inherited = False
                         # Updating the entry attributes which can be modified in the method redefinition.
-                        alt_entry.cname = cname
-                        alt_entry.pos = pos
-                        entry = alt_entry
+                        entry.cname = cname
+                        entry.pos = pos
                     break
             else:
                 cpp_override_allowed = True

--- a/tests/run/static_method_inheritance.pyx
+++ b/tests/run/static_method_inheritance.pyx
@@ -1,0 +1,19 @@
+# mode: run
+
+cdef class A:
+    pass
+
+cdef class B(A):
+    pass
+
+cdef class Foo:
+    @staticmethod
+    cdef A meth():
+        return A()
+
+
+cdef class Bar(Foo):
+    @staticmethod
+    cdef B meth():
+        return B()
+

--- a/tests/run/static_method_inheritance.pyx
+++ b/tests/run/static_method_inheritance.pyx
@@ -1,19 +1,36 @@
 # mode: run
 
 cdef class A:
-    pass
+    @staticmethod
+    def moo():
+        return "moo"
 
 cdef class B(A):
-    pass
+    @staticmethod
+    def moo():
+        return "boo"
 
 cdef class Foo:
     @staticmethod
     cdef A meth():
         return A()
 
-
 cdef class Bar(Foo):
     @staticmethod
     cdef B meth():
         return B()
+
+def call_foo():
+    """
+    >>> call_foo()
+    'moo'
+    """
+    return Foo.meth().moo()
+
+def call_bar():
+    """
+    >>> call_bar()
+    'boo'
+    """
+    return Bar.meth().moo()
 

--- a/tests/run/static_method_inheritance.pyx
+++ b/tests/run/static_method_inheritance.pyx
@@ -3,34 +3,34 @@
 cdef class A:
     @staticmethod
     def moo():
-        return "moo"
+        return "mooA"
 
 cdef class B(A):
     @staticmethod
     def moo():
-        return "boo"
+        return "mooB"
 
-cdef class Foo:
+cdef class GetBaseA:
     @staticmethod
     cdef A meth():
         return A()
 
-cdef class Bar(Foo):
+cdef class GetSubB(GetBaseA):
     @staticmethod
     cdef B meth():
         return B()
 
-def call_foo():
+def call_base():
     """
-    >>> call_foo()
-    'moo'
+    >>> call_base()
+    'mooA'
     """
-    return Foo.meth().moo()
+    return GetBaseA.meth().moo()
 
-def call_bar():
+def call_sub():
     """
-    >>> call_bar()
-    'boo'
+    >>> call_sub()
+    'mooB'
     """
-    return Bar.meth().moo()
+    return GetSubB.meth().moo()
 


### PR DESCRIPTION
#3235 subtly changed the behavior of `declare` to return a reference to an already declared `Entry` in the case of overriding a parent method. 

This caused `cfunc_entries` to have two entries pointing to the same `Entry` object, whereas `cfunc_entries` is expected to have two different `Entry` objects, one for the parent method that is being inherited, and one of the new override from the child class.

This PR fixes this bug by copying `Entry` instead of returning a reference. 

Closes https://github.com/cython/cython/issues/6704