### PR TITLE
Add a missing "const" in memoryview code

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -80,7 +80,7 @@ cdef extern from *:
     ctypedef int __pyx_atomic_int_type
     {{memviewslice_name}} slice_copy_contig "__pyx_memoryview_copy_new_contig"(
                                  {{memviewslice_name}} *from_mvs,
-                                 char *mode, int ndim,
+                                 const char *mode, int ndim,
                                  size_t sizeof_dtype, int contig_flag,
                                  bint dtype_is_object) except * nogil
     bint slice_is_contig "__pyx_memviewslice_is_contig" (


### PR DESCRIPTION
It's generating a compiler warning and an unnecessary cast in Cython code.