### PR TITLE
Disable monitoring in parallel/prange

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -9977,6 +9977,11 @@ class ParallelStatNode(StatNode, ParallelNode):
             self.num_threads.generate_disposal_code(code)
             self.num_threads.free_temps(code)
 
+        if c.is_tracing():
+            # Disable sys monitoring in parallel blocks. It isn't thread safe in either
+            # Cython or Python.
+            c.putln("__Pyx_TurnOffSysMonitoringInParallel")
+
         # Firstly, always prefer errors over returning, continue or break
         if self.error_label_used:
             c.putln("const char *%s = NULL; int %s = 0, %s = 0;" % self.parallel_pos_info)

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -95,17 +95,21 @@
   #define __Pyx_TraceDeclarationsFunc \
       PyObject *$frame_code_cname = NULL; \
       PyMonitoringState $monitoring_states_cname[__Pyx_MonitoringEventTypes_CyFunc_count]; \
-      int __pyx_exception_already_reported = 0;
+      int __pyx_exception_already_reported = 0; \
+      const int __pyx_sys_monitoring_disabled_in_parallel = 0;
 
   #define __Pyx_TraceDeclarationsGen \
       PyObject *$frame_code_cname = Py_NewRef($generator_cname->gi_code); \
       PyMonitoringState* $monitoring_states_cname = $generator_cname->$monitoring_states_cname; \
       __pyx_monitoring_version_type $monitoring_version_cname = $generator_cname->$monitoring_version_cname; \
-      int __pyx_exception_already_reported = 0;
+      int __pyx_exception_already_reported = 0; \
+      const int __pyx_sys_monitoring_disabled_in_parallel = 0;
 
-  #define __Pyx_IsTracing(event_id)  (($monitoring_states_cname[event_id]).active)
+  #define __Pyx_IsTracing(event_id)  ((!__pyx_sys_monitoring_disabled_in_parallel) && ($monitoring_states_cname[event_id]).active)
   #define __Pyx_TraceFrameInit(codeobj) \
       if (codeobj) $frame_code_cname = codeobj;
+
+  #define __Pyx_TurnOffSysMonitoringInParallel const int __pyx_sys_monitoring_disabled_in_parallel = 1;
 
   CYTHON_UNUSED static PyCodeObject *__Pyx_createFrameCodeObject(const char *funcname, const char *srcfile, int firstlineno); /*proto*/
   CYTHON_UNUSED static int __Pyx__TraceStartFunc(PyMonitoringState *state_array, PyObject *code_obj, int offset, int skip_event); /*proto*/
@@ -333,6 +337,7 @@
   #define __Pyx_TraceException(offset, reraised, fresh)  {}
   #define __Pyx_TraceExceptionHandled(offset)  {}
   #define __Pyx_TraceExceptionDone()  {}
+  #define __Pyx_TurnOffSysMonitoringInParallel {} // Only needed for freethreading
 
 #if PY_VERSION_HEX >= 0x030b00a2
   #if PY_VERSION_HEX >= 0x030C00b1
@@ -537,6 +542,7 @@
   #define __Pyx_TraceDeclarationsGen
   #define __Pyx_TraceExceptionDone()  {}
   #define __Pyx_TraceFrameInit(codeobj)  {}
+  #define __Pyx_TurnOffSysMonitoringInParallel {}
   #define __Pyx_PyMonitoring_ExitScope(nogil)  {}
   #define __Pyx_TraceException(offset, reraised, fresh)  {}
   #define __Pyx_TraceExceptionUnwind(offset, nogil)  {}

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -96,20 +96,22 @@
       PyObject *$frame_code_cname = NULL; \
       PyMonitoringState $monitoring_states_cname[__Pyx_MonitoringEventTypes_CyFunc_count]; \
       int __pyx_exception_already_reported = 0; \
-      const int __pyx_sys_monitoring_disabled_in_parallel = 0;
+      const int __pyx_sys_monitoring_disabled_in_parallel = 0; CYTHON_UNUSED_VAR(__pyx_sys_monitoring_disabled_in_parallel);
 
   #define __Pyx_TraceDeclarationsGen \
       PyObject *$frame_code_cname = Py_NewRef($generator_cname->gi_code); \
       PyMonitoringState* $monitoring_states_cname = $generator_cname->$monitoring_states_cname; \
       __pyx_monitoring_version_type $monitoring_version_cname = $generator_cname->$monitoring_version_cname; \
       int __pyx_exception_already_reported = 0; \
-      const int __pyx_sys_monitoring_disabled_in_parallel = 0;
+      const int __pyx_sys_monitoring_disabled_in_parallel = 0; CYTHON_UNUSED_VAR(__pyx_sys_monitoring_disabled_in_parallel);
 
   #define __Pyx_IsTracing(event_id)  ((!__pyx_sys_monitoring_disabled_in_parallel) && ($monitoring_states_cname[event_id]).active)
   #define __Pyx_TraceFrameInit(codeobj) \
       if (codeobj) $frame_code_cname = codeobj;
 
-  #define __Pyx_TurnOffSysMonitoringInParallel const int __pyx_sys_monitoring_disabled_in_parallel = 1;
+  #define __Pyx_TurnOffSysMonitoringInParallel \
+    const int __pyx_sys_monitoring_disabled_in_parallel = 1; \
+    CYTHON_UNUSED_VAR(__pyx_sys_monitoring_disabled_in_parallel);
 
   CYTHON_UNUSED static PyCodeObject *__Pyx_createFrameCodeObject(const char *funcname, const char *srcfile, int firstlineno); /*proto*/
   CYTHON_UNUSED static int __Pyx__TraceStartFunc(PyMonitoringState *state_array, PyObject *code_obj, int offset, int skip_event); /*proto*/


### PR DESCRIPTION
The Python implementation doesn't look like it attempts any thread safety. The Cython implementation doesn't currently. This feels like a corner-case where it isn't worth the complication to make it work right, but is worth disabling so that people doing try to use it.