### PR TITLE
Fix definition in pyx not overriding declaration in pxd

### DIFF
--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -579,14 +579,15 @@ class Scope:
             entry = Entry(name, cname, type, pos = pos)
             entry.in_cinclude = self.in_cinclude
             entry.create_wrapper = create_wrapper
-            if name:
-                entry.qualified_name = self.qualify_name(name)
-                if not shadow:
-                    if name in entries and self.is_cpp() and type.is_cfunction and not entries[name].is_cmethod:
-                        # Which means: function or cppclass method is already present
-                        entries[name].overloaded_alternatives.append(entry)
-                    else:
-                        entries[name] = entry
+
+        if name:
+            entry.qualified_name = self.qualify_name(name)
+            if not shadow:
+                if name in entries and self.is_cpp() and type.is_cfunction and not entries[name].is_cmethod:
+                    # Which means: function or cppclass method is already present
+                    entries[name].overloaded_alternatives.append(entry)
+                else:
+                    entries[name] = entry
 
         if type.is_memoryviewslice:
             entry.init = type.default_value

--- a/tests/run/static_method_inheritance.pxd
+++ b/tests/run/static_method_inheritance.pxd
@@ -1,0 +1,14 @@
+cdef class A:
+    pass
+
+cdef class B(A):
+    pass
+
+cdef class GetBaseA:
+    @staticmethod
+    cdef A meth()
+
+cdef class GetSubB(GetBaseA):
+    @staticmethod
+    cdef B meth()
+


### PR DESCRIPTION
If a static method is declared in a `.pxd` file, we're not overriding `self.entries[name]`
with the definition in the `.pyx` file.

The difference in behavior with 3.0.x was changed by #3235.

This issue surfaces as there being two distinct entries in `cfunc_entries`, causing the one
declared by the `.pxd` to surface this error when checking that the `.pyx` implements all
methods declared in the `.pxd`:

```
=== Got: ===
13:15: C method 'meth' is declared but not defined
```