### PR TITLE
Wrap C++ std::future and std::exception_ptr

### DIFF
--- a/Cython/Includes/libcpp/exception.pxd
+++ b/Cython/Includes/libcpp/exception.pxd
@@ -1,0 +1,75 @@
+from libcpp cimport bool
+
+cdef extern from "<exception>" namespace "std" nogil:
+    cdef cppclass exception_ptr:
+        bool operator bool()
+
+    exception_ptr make_exception_ptr[E](E e) noexcept
+    void rethrow_exception(exception_ptr) except +
+    # current_exception skipped because it'll be almost impossible to use from Cython
+
+cdef extern from *:
+    """
+    CYTHON_UNUSED static void __pyx_deallocate_exception_ptr_capsule(PyObject *c) {
+        std::exception_ptr *ptr = static_cast<std::exception_ptr*>(
+            PyCapsule_GetPointer(c, "std::exception_ptr wrapper"));
+        delete ptr;
+        PyErr_Clear();
+    }
+
+    CYTHON_UNUSED static void __pyx_to_exception_ptr() {
+        try {
+            throw;
+        } catch (...) {
+            std::exception_ptr *current = new std::exception_ptr(std::current_exception());
+            PyObject *capsule = PyCapsule_New(
+                static_cast<void*>(current),
+                "std::exception_ptr wrapper",
+                &__pyx_deallocate_exception_ptr_capsule);
+            if (!capsule)
+                delete current;  // otherwise it'll be leaked
+            else
+                PyErr_SetObject(PyExc_Exception, capsule);
+        }
+    }
+
+    CYTHON_UNUSED static std::exception_ptr __pyx_wrapped_exception_ptr_from_exception(PyObject *e) {
+        PyObject *args = NULL, *arg0 = NULL;
+        std::exception_ptr result;
+        Py_ssize_t size;
+#if __PYX_LIMITED_VERSION_HEX < 0x030C0000
+        args = PyObject_GetAttrString(e, "args");
+#else
+        args = PyException_GetArgs(e);
+#endif
+        if (!args)
+            goto done;
+        size = PyTuple_Size(args);
+        if (size == -1)
+            goto done;
+        if (size != 1) {
+            PyErr_SetString(PyExc_ValueError, "exception args were not the expected length of 1");
+            goto done;
+        }
+        arg0 = PyTuple_GetItem(args, 0);
+        if (!arg0)
+            goto done;
+        {
+            std::exception_ptr* wrapped = static_cast<std::exception_ptr*>(
+                PyCapsule_GetPointer(arg0, "std::exception_ptr wrapper"));
+            if (!wrapped) {
+                goto done;
+            }
+            result = *wrapped;
+        }
+
+      done:
+        Py_XDECREF(args);
+        return result;
+    }
+    """
+    # This can be used as `except +exception_ptr_error_handler`.
+    # It raises a generic Exception, with a wrapped exception_ptr as its value.
+    void exception_ptr_error_handler "__pyx_to_exception_ptr"() except *
+    # Extract the exception_ptr from a caught exception
+    exception_ptr wrapped_exception_ptr_from_exception "__pyx_wrapped_exception_ptr_from_exception"(e) except *

--- a/Cython/Includes/libcpp/future.pxd
+++ b/Cython/Includes/libcpp/future.pxd
@@ -1,0 +1,103 @@
+from libcpp cimport bool
+from libcpp.exception cimport exception_ptr
+
+cdef extern from "<future>":
+    pass  # include first
+
+cdef extern from *:
+    """
+    static void __Pyx_CppExn2PyErr();
+    CYTHON_UNUSED static void __pyx_future_error_handler() {
+        try {
+            throw;
+        } catch (const std::future_error &e) {
+            PyObject *args = Py_BuildValue(
+                "sis",
+                "std::future_error",
+                e.code().value(),
+                e.what()
+            );
+            if (!args) return;
+            Py_INCREF(PyExc_RuntimeError);
+            // It'd be nice to raise something more specific, but I can't easily do that
+            // so I've tried to at least make them identifiable by the arguments.
+            PyErr_Restore(PyExc_RuntimeError, args, NULL);
+        } catch (...) {
+            // Forward to the normal Cython exception conversion;
+            __Pyx_CppExn2PyErr();
+        }
+    }
+    """
+    void __pyx_future_error_handler() except+
+
+cdef extern from "<future>" namespace "std" nogil:
+    cdef enum class future_status:
+        ready
+        timeout
+        deferred
+
+    cdef cppclass future[T]:
+        future() noexcept
+        future(future& other) noexcept  # slighly mistyped move constructor
+
+        future& operator=(future& other) noexcept  # slightly mistyped move assignment
+
+        shared_future[T] share() noexcept
+
+        # Not strictly right when T is a reference or void
+        T get() except +__pyx_future_error_handler
+
+        bool valid() noexcept
+
+        void wait() except+
+        # For wait_for and wait_until we don't have chrono yet
+        future_status wait_for(...) except+
+        future_status wait_until(...) except+
+
+    cdef cppclass shared_future[T]:
+        shared_future() noexcept
+        shared_future(const shared_future& other) noexcept  # noexcept only from c++17 strictly
+        shared_future(future[T]& other) noexcept  # slightly mistyped move
+
+        shared_future& operator=(const shared_future& other) noexcept  # noexcept only from c++17 strictly
+        shared_future& operator=(future& other) noexcept  # slightly mistyped move
+
+        # Not strictly right when T is a reference or void
+        const T& get() except +__pyx_future_error_handler
+
+        bool valid() noexcept
+
+        void wait() except+
+        # For wait_for and wait_until we don't have chrono yet
+        future_status wait_for(...) except+
+        future_status wait_until(...) except+
+
+    cdef cppclass promise[T]:
+        promise() noexcept
+        # don't expose the allocator version
+        promise(promise& other) noexcept  # slightly mistyped move
+
+        promise& operator=(promise& other) noexcept  # slightly mistyped move
+
+        void swap(promise& other) noexcept
+
+        future[T] get_future() except+
+
+        # Note that the set_* functions all have specialized error handling.
+        # A std::future_error will be converted to a RuntimeError with 3 arguments.
+        # The first argument is the string "std::future_error",
+        # the second is the error code as an int for comparison with future_errc,
+        # and the third is the message.
+        void set_value(T value) except +__pyx_future_error_handler
+        void set_value() except +__pyx_future_error_handler  # only for void specialization
+        void set_value_at_thread_exit(T value) except +__pyx_future_error_handler
+        void set_value_at_thread_exit() except +__pyx_future_error_handler  # only for void specialization
+
+        void set_exception(exception_ptr p) except +__pyx_future_error_handler
+        void set_exception_at_thread_exit(exception_ptr p) except +__pyx_future_error_handler
+
+    cdef enum class future_errc:
+        broken_promise
+        future_already_retrieved
+        promise_already_satisfied
+        no_state

--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -545,6 +545,19 @@ listed in the table above. The code for this standard exception handler can be
 found `here
 <https://github.com/cython/cython/blob/master/Cython/Utility/CppSupport.cpp>`__.
 
+If you want to use `std::exception_ptr` then you can ``cimport`` it from
+``libcpp.exception``.  That provides a special exception handler
+``exception_ptr_error_handler`` allowing you to declare a function: ::
+
+    cdef extern from "some_header":
+        void some_function() except +exception_ptr_error_handler
+
+The exception raised from ``some_function`` will always be an ``Exception``
+and the underlying ``std::exception_ptr`` can be retrieved with
+``wrapped_exception_ptr_from_exception``.  This is a slightly niche use,
+but ``std::exception_ptr`` is a useful way to safely store arbitrary C++
+exceptions for later.
+
 There is also the special form::
 
     cdef int raise_py_or_cpp() except +*

--- a/tests/run/cpp_exception_ptr.pyx
+++ b/tests/run/cpp_exception_ptr.pyx
@@ -1,0 +1,53 @@
+# mode: run
+# tag: cpp, cpp11
+
+from libcpp.exception cimport (
+    exception_ptr,
+    exception_ptr_error_handler,
+    make_exception_ptr,
+    rethrow_exception,
+    wrapped_exception_ptr_from_exception,
+)
+
+cdef extern from *:
+    """
+    void raise_runtime_error() {
+        throw std::runtime_error("hello");
+    }
+    """
+    void raise_runtime_error() except +exception_ptr_error_handler
+
+cdef extern from "<stdexcept>" namespace "std" nogil:
+    cdef cppclass runtime_error:
+        runtime_error(const char* s)
+
+def test_custom_error_handler():
+    """
+    >>> test_custom_error_handler()
+    """
+    cdef exception_ptr eptr
+    try:
+        raise_runtime_error()
+    except Exception as e:
+        eptr = wrapped_exception_ptr_from_exception(e)
+        assert eptr
+        try:
+            rethrow_exception(eptr)
+        except RuntimeError as re:  # normal Cython error conversion
+            assert re.args[0] == "hello"
+        else:
+            assert False
+    else:
+        assert False
+
+def test_make_directly():
+    """
+    >>> test_make_directly()
+    """
+    eptr = make_exception_ptr(runtime_error("I'm an error"))
+    try:
+        rethrow_exception(eptr)
+    except RuntimeError as re:
+        assert re.args[0] == "I'm an error"
+    else:
+        assert False

--- a/tests/run/cpp_future.pyx
+++ b/tests/run/cpp_future.pyx
@@ -1,0 +1,98 @@
+# mode: run
+# tag: cpp, cpp11
+
+from libcpp cimport future
+from libcpp.exception cimport make_exception_ptr
+
+cdef extern from "<stdexcept>" namespace "std" nogil:
+    cdef cppclass runtime_error:
+        runtime_error(const char*)
+
+cdef extern from "<chrono>" namespace "std::chrono" nogil:
+    cdef cppclass milliseconds:
+        milliseconds(int v)
+
+def test_basic_usage():
+    """
+    >>> test_basic_usage()
+    """
+    cdef future.promise[int] p = future.promise[int]()
+    f = p.get_future()
+    assert f.valid()
+
+    p.set_value(5)
+    f.wait()  # shouldn't actually do anything
+    assert f.get() == 5
+
+def test_basic_usage_void():
+    """
+    >>> test_basic_usage_void()
+    """
+    cdef future.promise[void] p = future.promise[void]()
+    f = p.get_future()
+    assert f.valid()
+
+    p.set_value()
+    f.wait()  # shouldn't actually do anything
+    f.get()
+
+def test_set_exception(msg):
+    """
+    >>> test_set_exception(b"error message")
+    Traceback (most recent call last):
+    ...
+    RuntimeError: error message
+    """
+    cdef future.promise[int] p = future.promise[int]()
+    f = p.get_future()
+
+    p.set_exception(make_exception_ptr(runtime_error(msg)))
+    f.get()
+
+
+def test_shared():
+    """
+    >>> test_shared()
+    """
+    cdef future.promise[int] p = future.promise[int]()
+    f = p.get_future().share()
+
+    p.set_value(5)
+    assert f.get() == 5
+
+def test_shared_void():
+    """
+    >>> test_shared()
+    """
+    cdef future.promise[void] p = future.promise[void]()
+    f = p.get_future().share()
+
+    p.set_value()
+    f.get()
+
+
+def test_custom_error_handling():
+    """
+    >>> test_custom_error_handling()
+    std::future_error
+    True
+    """
+    cdef future.promise[void] p = future.promise[void]()
+
+    p.set_value()
+    try:
+        p.set_value()
+    except RuntimeError as e:
+        print(e.args[0])
+        print(e.args[1] == future.future_errc.promise_already_satisfied)
+
+def test_timeout():
+    """
+    >>> test_timeout()
+    """
+    cdef future.promise[void] p = future.promise[void]()
+    f = p.get_future()
+
+    assert f.wait_for(milliseconds(1)) == future.future_status.timeout
+    p.set_value()
+    assert f.wait_for(milliseconds(1)) == future.future_status.ready


### PR DESCRIPTION
Mainly in the interests of providing std::future to people who want to use C++ threading tools.

`std::exception_ptr` was just because it's useful to work with `std::future` but I have occasionally found them useful in C++ code generally.