### PR TITLE
3.0.x critical section backport

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -171,7 +171,8 @@ def copy_inherited_directives(outer_directives, **new_directives):
     # For example, test_assert_path_exists and test_fail_if_path_exists should not be inherited
     #  otherwise they can produce very misleading test failures
     new_directives_out = dict(outer_directives)
-    for name in ('test_assert_path_exists', 'test_fail_if_path_exists', 'test_assert_c_code_has', 'test_fail_if_c_code_has'):
+    for name in ('test_assert_path_exists', 'test_fail_if_path_exists', 'test_assert_c_code_has', 'test_fail_if_c_code_has',
+                 'critical_section'):
         new_directives_out.pop(name, None)
     new_directives_out.update(new_directives)
     return new_directives_out
@@ -366,7 +367,7 @@ directive_scopes = {  # defaults to available everywhere
     'nogil' : ('function', 'with statement'),
     'gil' : ('with statement'),
     'with_gil' : ('function',),
-    'critical_section': ('with statement',),
+    'critical_section': ('function', 'with statement'),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -327,6 +327,7 @@ directive_types = {
     'collection_type': one_of('sequence'),
     'nogil' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'gil' : DEFER_ANALYSIS_OF_ARGUMENTS,
+    'critical_section' : DEFER_ANALYSIS_OF_ARGUMENTS,
     'with_gil' : None,
     'internal' : bool,  # cdef class visibility in the module dict
     'infer_types' : bool,  # values can be True/None/False
@@ -365,6 +366,7 @@ directive_scopes = {  # defaults to available everywhere
     'nogil' : ('function', 'with statement'),
     'gil' : ('with statement'),
     'with_gil' : ('function',),
+    'critical_section': ('with statement',),
     'inline' : ('function',),
     'cfunc' : ('function', 'with statement'),
     'ccall' : ('function', 'with statement'),

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1393,6 +1393,9 @@ class InterpretCompilerDirectives(CythonTransform):
                                 PostParseError(node.pos, "Compiler directive %s accepts one positional argument." % name))
                         node = Nodes.GILStatNode(node.pos, state=name, body=node.body, condition=condition)
                         return self.visit_Node(node)
+                    if name == "critical_section":
+                        # For Cython 3.0.x this is only supported as a no-op
+                        return self.visit_Node(node.body)
                     if self.check_directive_scope(node.pos, name, 'with statement'):
                         directive_dict[name] = value
         if directive_dict:
@@ -3643,13 +3646,17 @@ class GilCheck(VisitorTransform):
         """
         Take care of try/finally statements in nogil code sections.
         """
-        if not self.nogil or isinstance(node, Nodes.GILStatNode):
+        if not self.nogil:
             return self.visit_Node(node)
 
         node.nogil_check = None
         node.is_try_finally_in_nogil = True
         self.visitchildren(node)
         return node
+
+    def visit_CriticalSectionStatNode(self, node):
+        # skip normal "try/finally node" handling
+        return self.visit_Node(node)
 
     def visit_GILExitNode(self, node):
         if not self.current_gilstat_node_knows_gil_state:

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -234,8 +234,12 @@ del _nogil
 
 
 class critical_section:
-    def __init__(self, *args):
-        pass
+    def __init__(self, arg0, arg1=None):
+        # It's ambiguous if this is being used as a decorator or context manager
+        # even with a callable arg.
+        self.arg0 = arg0
+    def __call__(self, *args, **kwds):
+        return self.arg0(*args, **kwds)
     def __enter__(self):
         pass
     def __exit__(self, exc_class, exc, tb):

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -233,6 +233,15 @@ with_gil = _nogil()  # Actually not a context manager, but compilation will give
 del _nogil
 
 
+class critical_section:
+    def __init__(self, *args):
+        pass
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_class, exc, tb):
+        return False
+
+
 # Emulated types
 
 class CythonMetaType(type):

--- a/runtests.py
+++ b/runtests.py
@@ -477,6 +477,7 @@ VER_DEP_MODULES = {
                                            'run.reimport_failure',  # reimports don't do anything in Py2
                                            'run.cpp_stl_cmath_cpp17',
                                            'run.cpp_stl_cmath_cpp20'
+                                           'run.critical_sections'
                                            ]),
     (3,): (operator.ge, lambda x: x in ['run.non_future_division',
                                         'compile.extsetslice',

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -1,0 +1,121 @@
+# mode: run
+
+cimport cython
+
+import threading
+
+# This test is most useful on free-threading builds.
+# It should pass on regular builds just by virtue of
+# the GIL.
+#
+# Cython 3.0.x note - free-threading isn't yet supported
+# so critical_section is a no-op and test is just
+# using the GIL.
+
+def test_single_critical_section(n_threads, n_loops):
+    """
+    >>> test_single_critical_section(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    def worker():
+        nonlocal count
+        barrier.wait()
+        for i in range(n_loops):
+            with cython.critical_section(lock):
+                count += i
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = ((n_loops * (n_loops - 1))/2)*n_threads
+    assert count == expected, (count, expected)
+
+
+def test_double_critical_section(n_loops):
+    """
+    >>> test_double_critical_section(100)
+    """
+    cdef int a = 0
+    cdef int b = 0
+    barrier = threading.Barrier(3)
+    lock_a = object()
+    lock_b = object()
+
+    def a_thread():
+        nonlocal a
+        barrier.wait()
+        for i in range(n_loops):
+            with cython.critical_section(lock_a):
+                a += i
+
+    def b_thread():
+        nonlocal b
+        barrier.wait()
+        for i in range(n_loops):
+            with cython.critical_section(lock_b):
+                b += i
+
+    def ab_thread():
+        nonlocal a, b
+        barrier.wait()
+        for i in range(n_loops):
+            with cython.critical_section(lock_a, lock_b):
+                a += i
+                b += i
+
+    threads = [
+        threading.Thread(target=target)
+        for target in [a_thread, b_thread, ab_thread]
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # Each variable is modified from 2 threads
+    expected = ((n_loops * (n_loops - 1))/2)*2
+    assert a == expected, (a, expected)
+    assert b == expected, (b, expected)
+
+
+def test_critical_section_in_generators(n_threads, n_loops):
+    """
+    >>> test_critical_section_in_generators(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    def gen():
+        nonlocal count
+        barrier.wait()
+        with cython.critical_section(lock):
+            for i in range(n_loops):
+                count += i
+                yield
+
+    def make_and_run_generator():
+        g = gen()
+        for _ in g:
+            pass
+
+    threads = [
+        threading.Thread(target=make_and_run_generator)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = ((n_loops * (n_loops - 1))/2)*n_threads
+    assert count == expected, (count, expected)

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -119,3 +119,97 @@ def test_critical_section_in_generators(n_threads, n_loops):
 
     expected = ((n_loops * (n_loops - 1))/2)*n_threads
     assert count == expected, (count, expected)
+
+
+cdef class CClass:
+    cdef int count
+    def __cinit__(self):
+        self.count = 0
+
+    @cython.critical_section
+    def increment(self, other):
+        self.count += other
+
+    @cython.critical_section
+    def increment_one(self):
+        self.count += 1
+
+    @cython.critical_section
+    cpdef increment_one_cp(self):
+        self.count += 1
+
+    @cython.critical_section
+    cdef increment_one_c(self):
+        self.count += 1
+
+
+def test_class_critical_section_decorator(n_threads, n_loops):
+    """
+    >>> test_class_critical_section_decorator(4, 100)
+    """
+    barrier = threading.Barrier(n_threads)
+
+    instance = CClass()
+
+    def worker():
+        nonlocal instance
+        barrier.wait()
+        for i in range(n_loops):
+            remainder = i % 4
+            if remainder == 0:
+                instance.increment_one()
+            elif remainder == 1:
+                instance.increment(1)
+            elif remainder == 2:
+                instance.increment_one_c()
+            else:
+                instance.increment_one_cp()
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_loops*n_threads
+    assert instance.count == expected, (instance.count, expected)
+
+
+def test_free_function_with_critical_section(n_threads, n_loops):
+    """
+    >>> test_free_function_with_critical_section(4, 100)
+    """
+    cdef int count = 0
+    lock = object()
+    barrier = threading.Barrier(n_threads)
+
+    @cython.test_assert_path_exists("//CriticalSectionStatNode")
+    @cython.critical_section
+    def inner(lock):
+        @cython.test_fail_if_path_exists("//CriticalSectionStatNode")
+        def inner_inner():
+            pass  # Unused - just to test the directive one-level only
+
+
+        nonlocal count
+        count += 1
+
+    def worker():
+        barrier.wait()
+        for i in range(n_loops):
+            inner(lock)
+
+    threads = [
+        threading.Thread(target=worker)
+        for _ in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    expected = n_loops*n_threads
+    assert count == expected, (count, expected)

--- a/tests/run/critical_sections.pyx
+++ b/tests/run/critical_sections.pyx
@@ -186,7 +186,6 @@ def test_free_function_with_critical_section(n_threads, n_loops):
     lock = object()
     barrier = threading.Barrier(n_threads)
 
-    @cython.test_assert_path_exists("//CriticalSectionStatNode")
     @cython.critical_section
     def inner(lock):
         @cython.test_fail_if_path_exists("//CriticalSectionStatNode")


### PR DESCRIPTION
This is intended to let people write thread-safe code supporting
Cython 3.1 while still compiling their regular builds with 3.0.

Since it's a no-op on the regular builds anyway so it's fairly harmless to support it as a no-op here too.