### PR TITLE
Use vectorcall when calling known builtin/ext types

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6817,7 +6817,6 @@ class PyMethodCallNode(CallNode):
             return has_explicit_kwargs or not has_kwargs
         return True
 
-
     @staticmethod
     def can_be_used_for_function(function):
         """
@@ -6825,15 +6824,13 @@ class PyMethodCallNode(CallNode):
         into a PyMethodCallNode
         """
         may_be_a_method = True
-        if function.type is Builtin.type_type:
-            may_be_a_method = False
-        elif function.is_attribute:
+        if function.is_attribute:
             if function.entry and function.entry.type.is_cfunction:
                 # optimised builtin method
                 may_be_a_method = False
         elif function.is_name:
             entry = function.entry
-            if entry.is_builtin or entry.type.is_cfunction:
+            if entry.type.is_cfunction:
                 may_be_a_method = False
             elif entry.cf_assignments:
                 # local functions/classes are definitely not methods

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5032,7 +5032,7 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
         return (
             node.is_temp and
             function_type.is_pyobject and
-            not function_type is Builtin.type_type and
+            function_type is not Builtin.type_type and
             not (entry and entry.is_builtin) and
             self.current_directives.get(
                 "optimize.unpack_method_calls_in_pyinit"

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5021,16 +5021,24 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
 
     def _check_optimize_method_calls(self, node):
         function = node.function
+        function_type = function.type
+        entry = function.entry if function.is_name or function.is_attribute else None
         env = self.current_env()
         in_global_scope = (
             env.is_module_scope or
             env.is_c_class_scope or
             (env.is_py_class_scope and env.outer_scope.is_module_scope)
         )
-        return (node.is_temp and function.type.is_pyobject and self.current_directives.get(
+        return (
+            node.is_temp and
+            function_type.is_pyobject and
+            not function_type is Builtin.type_type and
+            not (entry and entry.is_builtin) and
+            self.current_directives.get(
                 "optimize.unpack_method_calls_in_pyinit"
                 if not self.in_loop and in_global_scope
-                else "optimize.unpack_method_calls"))
+                else "optimize.unpack_method_calls")
+        )
 
     def visit_SimpleCallNode(self, node):
         """

--- a/tests/errors/tree_assert.pyx
+++ b/tests/errors/tree_assert.pyx
@@ -2,10 +2,14 @@
 
 cimport cython
 
-@cython.test_fail_if_path_exists("//SimpleCallNode",
-                                 "//NameNode")
-@cython.test_assert_path_exists("//ComprehensionNode",
-                                "//ComprehensionNode//FuncDefNode")
+@cython.test_fail_if_path_exists(
+    "//PyMethodCallNode",
+    "//NameNode",
+)
+@cython.test_assert_path_exists(
+    "//ComprehensionNode",
+    "//ComprehensionNode//FuncDefNode",
+)
 def test():
     object()
 
@@ -13,6 +17,6 @@ def test():
 _ERRORS = u"""
 5:0: Expected path '//ComprehensionNode' not found in result tree
 5:0: Expected path '//ComprehensionNode//FuncDefNode' not found in result tree
-10:4: Unexpected path '//NameNode' found in result tree
-10:10: Unexpected path '//SimpleCallNode' found in result tree
+14:4: Unexpected path '//NameNode' found in result tree
+14:10: Unexpected path '//PyMethodCallNode' found in result tree
 """

--- a/tests/run/all.pyx
+++ b/tests/run/all.pyx
@@ -12,8 +12,13 @@ cdef class VerboseGetItem(object):
 
 cimport cython
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+@cython.test_assert_path_exists(
+    "//PyMethodCallNode",
+)
+@cython.test_fail_if_path_exists(
+    "//ForInStatNode",
+    "//SimpleCallNode",
+)
 def all_item(x):
     """
     >>> all_item([1,1,1,1,1])
@@ -58,11 +63,12 @@ def all_item(x):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def all_in_simple_gen(seq):
     """
@@ -92,11 +98,12 @@ def all_in_simple_gen(seq):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def all_in_simple_gen_scope(seq):
     """
@@ -129,11 +136,12 @@ def all_in_simple_gen_scope(seq):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def all_in_conditional_gen(seq):
     """
@@ -171,11 +179,12 @@ upper_ustring = mixed_ustring.upper()
 
 @cython.test_assert_path_exists(
     '//PythonCapiCallNode',
-    '//ForFromStatNode'
+    '//ForFromStatNode',
 )
 @cython.test_fail_if_path_exists(
     '//SimpleCallNode',
-    '//ForInStatNode'
+    "//PyMethodCallNode",
+    '//ForInStatNode',
 )
 def all_lower_case_characters(unicode ustring):
     """
@@ -192,10 +201,11 @@ def all_lower_case_characters(unicode ustring):
 @cython.test_assert_path_exists(
     "//ForInStatNode",
     "//InlinedGeneratorExpressionNode",
-    "//InlinedGeneratorExpressionNode//IfStatNode"
+    "//InlinedGeneratorExpressionNode//IfStatNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
+    "//PyMethodCallNode",
     "//YieldExprNode",
 #    "//IfStatNode//CoerceToBooleanNode"
 )
@@ -229,10 +239,11 @@ def all_in_typed_gen(seq):
 @cython.test_assert_path_exists(
     "//ForInStatNode",
     "//InlinedGeneratorExpressionNode",
-    "//InlinedGeneratorExpressionNode//IfStatNode"
+    "//InlinedGeneratorExpressionNode//IfStatNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
+    "//PyMethodCallNode",
     "//YieldExprNode",
 #    "//IfStatNode//CoerceToBooleanNode"
 )

--- a/tests/run/any.pyx
+++ b/tests/run/any.pyx
@@ -10,8 +10,14 @@ cdef class VerboseGetItem(object):
 
 cimport cython
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//ForInStatNode")
+
+@cython.test_assert_path_exists(
+    "//PyMethodCallNode",
+)
+@cython.test_fail_if_path_exists(
+    "//ForInStatNode",
+    "//SimpleCallNode",
+)
 def any_item(x):
     """
     >>> any_item([0,0,1,0,0])
@@ -54,11 +60,12 @@ def any_item(x):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def any_in_simple_gen(seq):
     """
@@ -86,11 +93,12 @@ def any_in_simple_gen(seq):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def any_in_simple_gen_scope(seq):
     """
@@ -121,11 +129,12 @@ def any_in_simple_gen_scope(seq):
 
 @cython.test_assert_path_exists(
     "//ForInStatNode",
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def any_in_conditional_gen(seq):
     """
@@ -161,11 +170,12 @@ upper_ustring = mixed_ustring.upper()
 @cython.test_assert_path_exists(
     '//PythonCapiCallNode',
     '//ForFromStatNode',
-    "//InlinedGeneratorExpressionNode"
+    "//InlinedGeneratorExpressionNode",
 )
 @cython.test_fail_if_path_exists(
     '//SimpleCallNode',
-    '//ForInStatNode'
+    "//PyMethodCallNode",
+    '//ForInStatNode',
 )
 def any_lower_case_characters(unicode ustring):
     """
@@ -182,10 +192,11 @@ def any_lower_case_characters(unicode ustring):
 @cython.test_assert_path_exists(
     "//ForInStatNode",
     "//InlinedGeneratorExpressionNode",
-    "//InlinedGeneratorExpressionNode//IfStatNode"
+    "//InlinedGeneratorExpressionNode//IfStatNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
+    "//PyMethodCallNode",
     "//YieldExprNode",
 #    "//IfStatNode//CoerceToBooleanNode"
 )
@@ -217,11 +228,12 @@ def any_in_typed_gen(seq):
 @cython.test_assert_path_exists(
     "//ForInStatNode",
     "//InlinedGeneratorExpressionNode",
-    "//InlinedGeneratorExpressionNode//IfStatNode"
+    "//InlinedGeneratorExpressionNode//IfStatNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
-    "//YieldExprNode"
+    "//PyMethodCallNode",
+    "//YieldExprNode",
 )
 def any_in_gen_builtin_name(seq):
     """
@@ -250,10 +262,11 @@ def any_in_gen_builtin_name(seq):
 @cython.test_assert_path_exists(
     "//ForInStatNode",
     "//InlinedGeneratorExpressionNode",
-    "//InlinedGeneratorExpressionNode//IfStatNode"
+    "//InlinedGeneratorExpressionNode//IfStatNode",
 )
 @cython.test_fail_if_path_exists(
     "//SimpleCallNode",
+    "//PyMethodCallNode",
     "//YieldExprNode",
 #    "//IfStatNode//CoerceToBooleanNode"
 )

--- a/tests/run/builtin_sorted.pyx
+++ b/tests/run/builtin_sorted.pyx
@@ -36,7 +36,13 @@ def sorted_arg(x):
     return sorted(x)
 
 
-@cython.test_assert_path_exists("//GeneralCallNode")
+@cython.test_assert_path_exists(
+    "//PyMethodCallNode",
+)
+@cython.test_fail_if_path_exists(
+    "//GeneralCallNode",
+    "//SimpleCallNode",
+)
 def sorted_arg_with_key(x):
     """
     >>> a = [3, 2, 1]

--- a/tests/run/isinstance.pyx
+++ b/tests/run/isinstance.pyx
@@ -9,9 +9,14 @@ cdef class A:
 a_as_obj = A
 
 
-@cython.test_assert_path_exists('//SimpleCallNode//SimpleCallNode')
-@cython.test_fail_if_path_exists('//SimpleCallNode//PythonCapiCallNode',
-                                 '//PythonCapiCallNode//SimpleCallNode')
+@cython.test_assert_path_exists(
+    '//SimpleCallNode',
+    '//PyMethodCallNode',
+    '//SimpleCallNode//PyMethodCallNode',
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+)
 def test_non_optimised():
     """
     >>> test_non_optimised()
@@ -23,21 +28,25 @@ def test_non_optimised():
     return True
 
 
-@cython.test_assert_path_exists('//PythonCapiCallNode',
-                                '//PythonCapiCallNode//SimpleCallNode',
-                                '//PythonCapiFunctionNode[@cname = "PyType_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyLong_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyFloat_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyBytes_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyUnicode_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyTuple_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyList_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyDict_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PySet_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PySlice_Check"]',
-                                '//PythonCapiFunctionNode[@cname = "PyComplex_Check"]')
-@cython.test_fail_if_path_exists('//SimpleCallNode//SimpleCallNode',
-                                 '//SimpleCallNode//PythonCapiCallNode')
+@cython.test_assert_path_exists(
+    '//PythonCapiCallNode',
+    '//PyMethodCallNode',
+    '//PythonCapiCallNode//PyMethodCallNode',
+    '//PythonCapiFunctionNode[@cname = "PyType_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyLong_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyFloat_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyBytes_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyUnicode_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyTuple_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyList_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyDict_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PySet_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PySlice_Check"]',
+    '//PythonCapiFunctionNode[@cname = "PyComplex_Check"]',
+)
+@cython.test_fail_if_path_exists(
+    '//SimpleCallNode',
+)
 def test_optimised():
     """
     >>> test_optimised()


### PR DESCRIPTION
Recent CPython versions added vectorcall support for `type` and builtin types, allowing faster object creation and calls to `__init__` etc.

See https://github.com/cython/cython/issues/6710