### PR TITLE
Update definition of critical_section in Shadow

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -229,13 +229,20 @@ with_gil = _nogil()  # Actually not a context manager, but compilation will give
 del _nogil
 
 
-class critical_section:
-    def __init__(self, *args):
-        pass
+class _critical_section:
+    def __init__(self, arg0):
+        # It's ambiguous if this is being used as a decorator or context manager
+        # even with a callable arg.
+        self.arg0 = arg0
+    def __call__(self, *args, **kwds):
+        return self.arg0(*args, **kwds)
     def __enter__(self):
         pass
     def __exit__(self, exc_class, exc, tb):
         return False
+    
+def critical_section(arg0, arg1=None):
+    return _critical_section(arg0)
 
 
 # Emulated types

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -240,7 +240,6 @@ class _critical_section:
         pass
     def __exit__(self, exc_class, exc, tb):
         return False
-    
 def critical_section(arg0, arg1=None):
     return _critical_section(arg0)
 

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -229,8 +229,8 @@ with_gil = _nogil()  # Actually not a context manager, but compilation will give
 del _nogil
 
 
-class _critical_section:
-    def __init__(self, arg0):
+class critical_section:
+    def __init__(self, arg0, arg1=None):
         # It's ambiguous if this is being used as a decorator or context manager
         # even with a callable arg.
         self.arg0 = arg0
@@ -240,8 +240,6 @@ class _critical_section:
         pass
     def __exit__(self, exc_class, exc, tb):
         return False
-def critical_section(arg0, arg1=None):
-    return _critical_section(arg0)
 
 
 # Emulated types


### PR DESCRIPTION
to let it be used as either a decorator or context manager.

I don't think the existing generic version works because the usages are:

```
@critical_section
def method(self, ...)
```

or

```
with critical_section(o1, [o2]):
    ...
```

which isn't the normal combination of arguments.