### PR TITLE
[WIP] Handle `bytes`-like objects in C-string conversion

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -290,13 +290,24 @@ static CYTHON_INLINE const char* __Pyx_PyObject_AsStringAndSize(PyObject* o, Py_
         return PyByteArray_AsString(o);
 #endif
 
-    } else
-    {
+    } elif(PyBytes_Check(o)) {
         char* result;
         int r = PyBytes_AsStringAndSize(o, &result, length);
         if (unlikely(r < 0)) {
             return NULL;
         } else {
+            return result;
+        }
+    } else {
+        char* result;
+        Py_buffer view;
+        int r = PyObject_GetBuffer(o, &view, PyBUF_SIMPLE);
+        if (unlikely(r < 0)) {
+            return NULL;
+        } else {
+            result = (char*) view.buf;
+            *length = view.len;
+            PyBuffer_Release(view);
             return result;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/6750

In `__Pyx_PyObject_AsStringAndSize` handle `bytes`-like objects (such as `const char[:]`) by adding support for [the Python Buffer Protocol]( https://docs.python.org/3/c-api/buffer.html ).