### PR TITLE
Don't include absolute paths when using `--embed-positions`

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10358,11 +10358,9 @@ class CodeObjectNode(ExprNode):
 
         func_name_result = code.get_py_string_const(func.name, identifier=True)
         # FIXME: better way to get the module file path at module init time? Encoding to use?
-        file_path = func.pos[0].get_filenametable_entry()
-        if os.path.isabs(file_path):
-            file_path = func.pos[0].get_description()
+        file_path = func.pos[0].get_relative_path()
         # Always use / as separator
-        file_path = StringEncoding.EncodedString(pathlib.Path(file_path).as_posix())
+        file_path = StringEncoding.EncodedString(file_path.as_posix())
         file_path_result = code.get_py_string_const(file_path)
 
         if func.node_positions:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -961,12 +961,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("static const char* const %s[] = {" % Naming.filetable_cname)
         if code.globalstate.filename_list:
             for source_desc in code.globalstate.filename_list:
-                file_path = source_desc.get_filenametable_entry()
-                if isabs(file_path):
-                    # never include absolute paths
-                    file_path = source_desc.get_description()
                 # Always use / as separator
-                file_path = pathlib.Path(file_path).as_posix()
+                file_path = source_desc.get_relative_path().as_posix()
                 escaped_filename = as_encoded_filename(file_path)
                 code.putln('%s,' % escaped_filename.as_c_string_literal())
         else:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -37,7 +37,7 @@ IMPLICIT_CLASSMETHODS = {"__init_subclass__", "__class_getitem__"}
 
 
 def relative_position(pos):
-    return (pos[0].get_filenametable_entry(), pos[1])
+    return (pos[0].get_relative_path().as_posix(), pos[1])
 
 
 def embed_position(pos, docstring):

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -4,22 +4,25 @@
 #
 
 
+from pathlib import Path
+
 import cython
+
 cython.declare(make_lexicon=object, lexicon=object,
                print_function=object, error=object, warning=object,
                os=object, platform=object)
 
 import os
 import platform
-from unicodedata import normalize
 from contextlib import contextmanager
+from unicodedata import normalize
 
 from .. import Utils
-from ..Plex.Scanners import Scanner
 from ..Plex.Errors import UnrecognizedInput
-from .Errors import error, warning, hold_errors, release_errors, CompileError
-from .Lexicon import any_string_prefix, make_lexicon, IDENT
+from ..Plex.Scanners import Scanner
+from .Errors import CompileError, error, hold_errors, release_errors, warning
 from .Future import print_function
+from .Lexicon import IDENT, any_string_prefix, make_lexicon
 
 debug_scanner = 0
 trace_scanner = 0
@@ -232,6 +235,13 @@ class FileSourceDescriptor(SourceDescriptor):
 
     def get_description(self):
         return self._short_path_description
+
+    def get_relative_path(self) -> Path:
+        file_path = Path(self.file_path)
+        if file_path.is_absolute():
+            return Path(self.get_description())
+        else:
+            return file_path
 
     def get_error_description(self):
         path = self.filename
@@ -559,7 +569,7 @@ def tentatively_scan(scanner: PyrexScanner):
         initial_state = (scanner.sy, scanner.systring, scanner.position())
         try:
             yield errors
-        except CompileError as e:
+        except CompileError:
             pass
         finally:
             if errors:

--- a/tests/build/run_cython_not_in_cwd.srctree
+++ b/tests/build/run_cython_not_in_cwd.srctree
@@ -5,9 +5,9 @@
 # relative paths from CWD.
 #
 
-CYTHON src/pkg/mod.pyx -o build/src/pkg/mod1.pyx.c
+CYTHON src/pkg/mod.pyx --embed-positions -o build/src/pkg/mod1.pyx.c
 CD build
-CYTHON ../src/pkg/mod.pyx -o src/pkg/mod2.pyx.c
+CYTHON ../src/pkg/mod.pyx --embed-positions -o src/pkg/mod2.pyx.c
 CD ..
 PYTHON check_paths_from_cython.py
 


### PR DESCRIPTION
Currently, invoking cython with `embed-positions` from a folder not containing the source code, will result in the absolute paths being embedded. This is fixed by always embedding the relative paths.

Since there are a couple of places where a relative path of a `SourceDescriptor` is needed, a new method `get_relative_path` is introduced and reused. 