### PR TITLE
Add a CyFunction abstract base class

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -118,6 +118,7 @@ static PyObject * __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS_METHOD(PyObject 
 //@requires: ObjectHandling.c::CachedMethodType
 //@requires: ExtensionTypes.c::CallTypeTraverse
 //@requires: ModuleSetupCode.c::CriticalSections
+//@requires: CommonStructures.c::RegisterABC
 //@substitute: naming
 
 #if CYTHON_COMPILING_IN_LIMITED_API
@@ -1242,6 +1243,7 @@ static int __pyx_CyFunction_init(PyObject *module) {
     if (unlikely(mstate->__pyx_CyFunctionType == NULL)) {
         return -1;
     }
+    __Pyx_RegisterCommonTypeWithAbc((PyObject*)mstate->__pyx_CyFunctionType, "cython_function_or_method_abc");
     return 0;
 }
 

--- a/tests/run/abcs.srctree
+++ b/tests/run/abcs.srctree
@@ -1,0 +1,36 @@
+UNSET CFLAGS
+PYTHON setup.py build_ext --inplace
+
+##################### setup.py ################
+
+from Cython.Build.Dependencies import cythonize
+
+from setuptools import setup
+
+setup(
+  ext_modules = cythonize("*.pyx"),
+)
+
+#################### test_it.py #################
+
+import m1
+import m2
+import cython_runtime
+
+# This is because Limited API and regular API have different cython ABIs 
+assert type(m1.f) != type(m2.f)
+assert isinstance(m1.f, cython_runtime.cython_function.cython_function_or_method_abc)
+assert isinstance(m2.f, cython_runtime.cython_function.cython_function_or_method_abc)
+assert not isinstance(lambda: None, cython_runtime.cython_function.cython_function_or_method_abc)
+
+#################### m1.pyx ####################
+
+def f():
+    pass
+
+#################### m2.pyx ####################
+
+# distutils: extra_compile_args = -DPy_LIMITED_API=0x03070000
+
+def f():
+    pass


### PR DESCRIPTION
This should provide a version independent way of identifying a Cython function (at least going forwards) - all future versions of versions of Cython will match the same abstract base.

In principle it could be extended to other shared types if useful (e.g. generator, coroutine).

(This does periodically come up as a request, although I can't find an existing issue. I think this is a better alternative to https://github.com/cython/cython/pull/6754 at least)