### PR TITLE
Add warnings on likely misuse of critical_section

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.pxd
+++ b/Cython/Compiler/ParseTreeTransforms.pxd
@@ -72,6 +72,7 @@ cdef class GilCheck(VisitorTransform):
     cdef bint nogil
     cdef bint nogil_declarator_only
     cdef bint current_gilstat_node_knows_gil_state
+    cdef bint in_critical_section
 
 cdef class TransformBuiltinMethods(EnvTransform):
     cdef dict def_node_body_insertions

--- a/tests/errors/w_critical_sections.py
+++ b/tests/errors/w_critical_sections.py
@@ -1,0 +1,37 @@
+# mode: compile
+# tag: warnings
+
+import cython
+
+class PyC:
+    @cython.critical_section
+    def func(self):
+        return self.a
+
+@cython.cclass
+class ExtC:
+    a: cython.int
+
+    @cython.critical_section  # no warning, good
+    def func(self):
+        a = self.a  # OK
+        b = self.b  # Not OK
+        self.b = a  # Not OK
+        self.a = b  # OK
+
+def function(o1: ExtC, o2):
+    with cython.critical_section(o1, o2):
+        x = o1.a  # OK
+        y = o1.b  # Not OK
+        o2.a = x  # not OK
+    return y
+
+
+_WARNINGS = """
+7:4: @critical_section on method of a class that is not an extension type is unlikely to be useful
+9:19: Python attribute access is not usefully protected by critical_section
+18:16: Python attribute access is not usefully protected by critical_section
+19:12: Python attribute access is not usefully protected by critical_section
+25:14: Python attribute access is not usefully protected by critical_section
+26:10: Python attribute access is not usefully protected by critical_section
+"""


### PR DESCRIPTION
As a decorator of a Py-class function should be visible by default because I can think of almost no good reasons for it.

Python attribute access is a lower-level warning because it seems like it sometimes makes sense - while that operation isn't protected and will likely break the critical section it can be reasonable as part of a larger critical section.