### PR TITLE
Updated TypeSlots.py

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1129,13 +1129,11 @@ class SlotTable:
         #
         #-------------------------------------------------------------------------
 
+        def resolve_nonzero_as_bool(name):
+            return method_name_to_slot("__bool__")
 
-        MethodSlot(inquiry, "", "__nonzero__", resolve_method_slot)
+        MethodSlot(inquiry, "", "__nonzero__", resolve_nonzero_as_bool)
         MethodSlot(unaryfunc, "", "__long__", method_name_to_slot)
-        def resolve_method_slot(name):
-            if name == "__nonzero__":
-                return method_name_to_slot("__bool__")
-            return method_name_to_slot(name)
 
     def get_special_method_signature(self, name):
         #  Given a method name, if it is a special method,

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -1128,8 +1128,14 @@ class SlotTable:
         # but match the "fallback" argument of a slot that does
         #
         #-------------------------------------------------------------------------
-        MethodSlot(inquiry, "", "__nonzero__", method_name_to_slot)
+
+
+        MethodSlot(inquiry, "", "__nonzero__", resolve_method_slot)
         MethodSlot(unaryfunc, "", "__long__", method_name_to_slot)
+        def resolve_method_slot(name):
+            if name == "__nonzero__":
+                return method_name_to_slot("__bool__")
+            return method_name_to_slot(name)
 
     def get_special_method_signature(self, name):
         #  Given a method name, if it is a special method,


### PR DESCRIPTION
fixes #3056
**what was the problem?**
that defining both __bool__ and __nonzero__ methods in a cdef class can lead to a RecursionError which will ig cause infinite loop
so what i did was i created a function where if  __nonzero__ is called it will directly call _bool_ which will solve the infinite loop .