### PR TITLE
Fix a couple of issues with __Pyx_Coroutine_get_frame

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1542,10 +1542,11 @@ static PyObject *
 __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
 {
 #if !CYTHON_COMPILING_IN_LIMITED_API
-    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    PyObject *frame;
+    #if PY_VERSION_HEX >= 0x030d0000
     Py_BEGIN_CRITICAL_SECTION(self);
     #endif
-    PyObject *frame = self->gi_frame;
+    frame = self->gi_frame;
     if (!frame) {
         if (unlikely(!self->gi_code)) {
             // Avoid doing something stupid, e.g. during garbage collection.
@@ -1576,7 +1577,7 @@ __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
         }
     }
     Py_INCREF(frame);
-    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    #if PY_VERSION_HEX >= 0x030d0000
     Py_END_CRITICAL_SECTION();
     #endif
     return frame;
@@ -1589,12 +1590,11 @@ __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
 
 static PyObject *
 __Pyx_Coroutine_get_frame(__pyx_CoroutineObject *self, void *context) {
-    PyObject *result;
     CYTHON_UNUSED_VAR(context);
     PyObject *frame = self->gi_frame;
-    if (!frame)
-        frame = __Pyx__Coroutine_get_frame(self);
-    return frame;
+    if (frame)
+        return __Pyx_NewRef(frame);
+    return __Pyx__Coroutine_get_frame(self);
 }
 
 static __pyx_CoroutineObject *__Pyx__Coroutine_New(

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1537,36 +1537,62 @@ __Pyx_Coroutine_set_qualname(__pyx_CoroutineObject *self, PyObject *value, void 
     return 0;
 }
 
+// called from in a critical section on self
 static PyObject *
-__Pyx_Coroutine_get_frame(__pyx_CoroutineObject *self, void *context)
+__Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
 {
 #if !CYTHON_COMPILING_IN_LIMITED_API
     PyObject *frame = self->gi_frame;
-    CYTHON_UNUSED_VAR(context);
     if (!frame) {
         if (unlikely(!self->gi_code)) {
             // Avoid doing something stupid, e.g. during garbage collection.
             Py_RETURN_NONE;
         }
+        // The coroutine doesn't know what module it's in so can't fill in proper globals.
+        // In principle this could be solved by storing a reference to the module in the coroutine,
+        // but in practice it probably isn't worth the extra memory.
+        // Therefore, just supply a blank dict.
+        PyObject *globals = PyDict_New();
+        if (unlikely(!globals)) return NULL;
         frame = (PyObject *) PyFrame_New(
             PyThreadState_Get(),            /*PyThreadState *tstate,*/
             (PyCodeObject*) self->gi_code,  /*PyCodeObject *code,*/
-            NAMED_CGLOBAL(moddict_cname),   /*PyObject *globals,*/
+            globals,                        /*PyObject *globals,*/
             0                               /*PyObject *locals*/
         );
+        Py_DECREF(globals);
         if (unlikely(!frame))
             return NULL;
-        // keep the frame cached once it's created
-        self->gi_frame = frame;
+        // handle potential race initializing the frame
+        if (unlikely(self->gi_frame)) {
+            Py_DECREF(frame);
+            frame = self->gi_frame;
+        } else {
+            // keep the frame cached once it's created
+            self->gi_frame = frame;
+        }
     }
     Py_INCREF(frame);
     return frame;
 #else
     // In the limited API there probably isn't much we can usefully do to get a frame
     CYTHON_UNUSED_VAR(self);
-    CYTHON_UNUSED_VAR(context);
     Py_RETURN_NONE;
 #endif
+}
+
+static PyObject *
+__Pyx_Coroutine_get_frame(__pyx_CoroutineObject *self, void *context) {
+    PyObject *result;
+    CYTHON_UNUSED_VAR(context);
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    Py_BEGIN_CRITICAL_SECTION(self);
+    #endif
+    result = __Pyx__Coroutine_get_frame(self);
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    Py_END_CRITICAL_SECTION();
+    #endif
+    return result;
 }
 
 static __pyx_CoroutineObject *__Pyx__Coroutine_New(

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1542,6 +1542,9 @@ static PyObject *
 __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
 {
 #if !CYTHON_COMPILING_IN_LIMITED_API
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    Py_BEGIN_CRITICAL_SECTION(self);
+    #endif
     PyObject *frame = self->gi_frame;
     if (!frame) {
         if (unlikely(!self->gi_code)) {
@@ -1573,6 +1576,9 @@ __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
         }
     }
     Py_INCREF(frame);
+    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    Py_END_CRITICAL_SECTION();
+    #endif
     return frame;
 #else
     // In the limited API there probably isn't much we can usefully do to get a frame
@@ -1585,14 +1591,10 @@ static PyObject *
 __Pyx_Coroutine_get_frame(__pyx_CoroutineObject *self, void *context) {
     PyObject *result;
     CYTHON_UNUSED_VAR(context);
-    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
-    Py_BEGIN_CRITICAL_SECTION(self);
-    #endif
-    result = __Pyx__Coroutine_get_frame(self);
-    #if PY_VERSION_HEX >= 0x030d0000 && !CYTHON_COMPILING_IN_LIMITED_API
-    Py_END_CRITICAL_SECTION();
-    #endif
-    return result;
+    PyObject *frame = self->gi_frame;
+    if (!frame)
+        frame = __Pyx__Coroutine_get_frame(self);
+    return frame;
 }
 
 static __pyx_CoroutineObject *__Pyx__Coroutine_New(

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1518,7 +1518,6 @@ __Pyx_Coroutine_set_qualname(__pyx_CoroutineObject *self, PyObject *value, void 
     return 0;
 }
 
-// called from in a critical section on self
 static PyObject *
 __Pyx__Coroutine_get_frame(__pyx_CoroutineObject *self)
 {


### PR DESCRIPTION
1. Potential race initializing it.
2. We can't usefully return a globals dictionary because the coroutine module is shared, and thus we don't actually know which module it comes from.

(picked out of a larger change in the interests of keeping that simple(r))