### PR TITLE
Fix utility code passing context to requirements

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -510,6 +510,7 @@ class UtilityCodeBase:
                 if not issubclass(cls, TempitaUtilityCode):
                     return TempitaUtilityCode.load(util_code_name, from_file, **kwargs)
             orig_kwargs = kwargs.copy()
+            orig_kwargs.pop("context", None)  # Don't pass context on to requirements
             for name, values in tags.items():
                 if name in kwargs:
                     continue

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -510,7 +510,6 @@ class UtilityCodeBase:
                 if not issubclass(cls, TempitaUtilityCode):
                     return TempitaUtilityCode.load(util_code_name, from_file, **kwargs)
             orig_kwargs = kwargs.copy()
-            orig_kwargs.pop("context", None)  # Don't pass context on to requirements
             for name, values in tags.items():
                 if name in kwargs:
                     continue

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -899,6 +899,9 @@ class TempitaUtilityCode(UtilityCode):
     def __init__(self, name=None, proto=None, impl=None, init=None, file=None, context=None, **kwargs):
         if context is None:
             context = {}
+        else:
+            # prevent changes propagating back if context is shared between multiple utility codes.
+            context = context.copy()
         proto = sub_tempita(proto, context, file, name)
         impl = sub_tempita(impl, context, file, name)
         init = sub_tempita(init, context, file, name)


### PR DESCRIPTION
The issue is that if a requirement has `{{py: ...}}` tempita code, it can modify the context meaning different substitutions are made.

This was an issue in https://github.com/cython/cython/pull/6774 (but I think it's worth taking independently of that since it was awkward to debug)