### PR TITLE
Fix a possible race when setting up the common types

### DIFF
--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -52,7 +52,7 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
     if (!abi_module_dict) goto done;
 
 
-    get_item_ref_result = __Pyx_PyDict_GetItemRef(abi_module, py_object_name, &cached_type);
+    get_item_ref_result = __Pyx_PyDict_GetItemRef(abi_module_dict, py_object_name, &cached_type);
     if (get_item_ref_result == 1) {
       verify_type:;
         Py_ssize_t basicsize;

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -86,8 +86,8 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
     if (unlikely(__Pyx_fix_up_extension_type_from_spec(spec, (PyTypeObject *) cached_type) < 0)) goto bad;
 
     new_cached_type = __Pyx_PyDict_SetDefault(abi_module_dict, py_object_name, cached_type, 1);
-    if (unlikely(!new_cached_type)) goto bad;
     if (unlikely(new_cached_type != cached_type)) {
+        if (unlikely(!new_cached_type)) goto bad;
         // race to initialize it - use the value that's already been set.
         Py_DECREF(cached_type);
         cached_type = new_cached_type;

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -98,7 +98,7 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
 
 done:
     Py_XDECREF(abi_module);
-    Py_XDECREF(py_object_name);
+    Py_DECREF(py_object_name);
     // NOTE: always returns owned reference, or NULL on error
     assert(cached_type == NULL || PyType_Check(cached_type));
     return (PyTypeObject *) cached_type;

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -35,7 +35,7 @@ static int __Pyx_VerifyCachedType(PyObject *cached_type,
     if (unlikely(!py_basicsize)) return -1;
     basicsize = PyLong_AsSsize_t(py_basicsize);
     Py_DECREF(py_basicsize);
-    py_basicsize = 0;
+    py_basicsize = NULL;
     if (unlikely(basicsize == (Py_ssize_t)-1) && PyErr_Occurred()) return -1;
 #else
     basicsize = ((PyTypeObject*) cached_type)->tp_basicsize;

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -16,6 +16,7 @@ static PyTypeObject* __Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
 //@requires:ExtensionTypes.c::FixUpExtensionType
 //@requires: FetchSharedCythonModule
 //@requires:StringTools.c::IncludeStringH
+//@requires:Optimize.c::dict_setdefault
 
 static int __Pyx_VerifyCachedType(PyObject *cached_type,
                                const char *name,
@@ -36,16 +37,24 @@ static int __Pyx_VerifyCachedType(PyObject *cached_type,
 }
 
 static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec *spec, PyObject *bases) {
-    PyObject *abi_module, *cached_type = NULL;
+    PyObject *abi_module = NULL, *cached_type = NULL, *abi_module_dict, *new_cached_type, *py_object_name;
+    int get_item_ref_result;
     // get the final part of the object name (after the last dot)
     const char* object_name = strrchr(spec->name, '.');
     object_name = object_name ? object_name+1 : spec->name;
 
-    abi_module = __Pyx_FetchSharedCythonABIModule();
-    if (!abi_module) return NULL;
+    py_object_name = PyUnicode_FromString(object_name);
+    if (!py_object_name) return NULL;
 
-    cached_type = PyObject_GetAttrString(abi_module, object_name);
-    if (cached_type) {
+    abi_module = __Pyx_FetchSharedCythonABIModule();
+    if (!abi_module) goto done;
+    abi_module_dict = PyModule_GetDict(abi_module);
+    if (!abi_module_dict) goto done;
+
+
+    get_item_ref_result = __Pyx_PyDict_GetItemRef(abi_module, py_object_name, &cached_type);
+    if (get_item_ref_result == 1) {
+      verify_type:;
         Py_ssize_t basicsize;
 #if CYTHON_COMPILING_IN_LIMITED_API
         PyObject *py_basicsize;
@@ -66,19 +75,30 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyObject *module, PyType_Spec
             goto bad;
         }
         goto done;
+    } else if (unlikely(get_item_ref_result == -1)) {
+        goto bad;
     }
 
-    if (!PyErr_ExceptionMatches(PyExc_AttributeError)) goto bad;
-    PyErr_Clear();
     // We pass the ABI module reference to avoid keeping the user module alive by foreign type usages.
     CYTHON_UNUSED_VAR(module);
     cached_type = __Pyx_PyType_FromModuleAndSpec(abi_module, spec, bases);
     if (unlikely(!cached_type)) goto bad;
     if (unlikely(__Pyx_fix_up_extension_type_from_spec(spec, (PyTypeObject *) cached_type) < 0)) goto bad;
-    if (PyObject_SetAttrString(abi_module, object_name, cached_type) < 0) goto bad;
+
+    new_cached_type = __Pyx_PyDict_SetDefault(abi_module_dict, py_object_name, cached_type, 1);
+    if (unlikely(!new_cached_type)) goto bad;
+    if (unlikely(new_cached_type != cached_type)) {
+        // race to initialize it - use the value that's already been set.
+        Py_DECREF(cached_type);
+        cached_type = new_cached_type;
+        goto verify_type;
+    } else {
+        Py_DECREF(new_cached_type);
+    }
 
 done:
-    Py_DECREF(abi_module);
+    Py_XDECREF(abi_module);
+    Py_XDECREF(py_object_name);
     // NOTE: always returns owned reference, or NULL on error
     assert(cached_type == NULL || PyType_Check(cached_type));
     return (PyTypeObject *) cached_type;


### PR DESCRIPTION
If two Cython modules are being imported simultaneously there's a possible race. This ensures that the type that's set up first is always used.