### PR TITLE
Avoid error when tests are run in parallel

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2452,7 +2452,7 @@ def main():
     parser.add_option("--examples-dir", dest="examples_dir",
                       default=os.path.join(DISTDIR, 'docs', 'examples'),
                       help="Directory to look for documentation example tests")
-    parser.add_option("--work-dir", dest="work_dir", default=os.path.join(os.getcwd(), 'TEST_TMP'),
+    parser.add_option("--work-dir", dest="work_dir", default=os.path.join(os.getcwd(), 'TEST_TMP', str(os.getpid())),
                       help="working directory")
     parser.add_option("--cython-dir", dest="cython_dir", default=os.getcwd(),
                       help="Cython installation directory (default: use local source version)")


### PR DESCRIPTION
In my case, I was running two parallel instances of `python runtests.py [some test]` in two different folders, and see an error (which is evident because they're rewriting the same files)

This pull request changes the default directory. The `TEST_TMP` name should probably be kept because there are `make clean` etc. that relies on this name.

One potential disadvantage I can see with this is that with multiple `runtests` the folder size may grow indefinitely? A proper fix would be to use `mkdtemp` / `NamedTemporaryDirectory` and remember to clean it up at exit, I don't know why it was like this in the first place.
