### PR TITLE
Fix __Pyx_Owned_Py_None

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -103,7 +103,7 @@ static CYTHON_INLINE PyObject *__Pyx_XNewRef(PyObject *obj) {
 #endif
 }
 
-static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(b);
+static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(int b);
 static CYTHON_INLINE PyObject * __Pyx_PyBool_FromLong(long b);
 static CYTHON_INLINE int __Pyx_PyObject_IsTrue(PyObject*);
 static CYTHON_INLINE int __Pyx_PyObject_IsTrueAndDecref(PyObject*);
@@ -420,7 +420,7 @@ static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject* o) {
   }
 }
 
-static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(b) {
+static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(int b) {
     CYTHON_UNUSED_VAR(b);
     return __Pyx_NewRef(Py_None);
 }

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -421,6 +421,7 @@ static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject* o) {
 }
 
 static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(b) {
+    CYTHON_UNUSED_VAR(b);
     return __Pyx_NewRef(Py_None);
 }
 

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -103,7 +103,7 @@ static CYTHON_INLINE PyObject *__Pyx_XNewRef(PyObject *obj) {
 #endif
 }
 
-#define __Pyx_Owned_Py_None(b) __Pyx_NewRef(Py_None)
+static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(b);
 static CYTHON_INLINE PyObject * __Pyx_PyBool_FromLong(long b);
 static CYTHON_INLINE int __Pyx_PyObject_IsTrue(PyObject*);
 static CYTHON_INLINE int __Pyx_PyObject_IsTrueAndDecref(PyObject*);
@@ -420,6 +420,9 @@ static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject* o) {
   }
 }
 
+static CYTHON_INLINE PyObject *__Pyx_Owned_Py_None(b) {
+    return __Pyx_NewRef(Py_None);
+}
 
 static CYTHON_INLINE PyObject * __Pyx_PyBool_FromLong(long b) {
   return b ? __Pyx_NewRef(Py_True) : __Pyx_NewRef(Py_False);


### PR DESCRIPTION
We're using it like a function (i.e. casting to void to mark it unused) so it has to be a function.

Fixes #6781