### PR TITLE
includes/cpython: Fix PyByteArray_Resize signature to indicate except…

### DIFF
--- a/Cython/Includes/cpython/bytearray.pxd
+++ b/Cython/Includes/cpython/bytearray.pxd
@@ -23,7 +23,7 @@ cdef extern from "Python.h":
     # Return the contents of bytearray as a char array after checking for a NULL pointer.
     # The returned array always has an extra null byte appended.
 
-    int PyByteArray_Resize(object bytearray, Py_ssize_t len)
+    int PyByteArray_Resize(object bytearray, Py_ssize_t len) except -1
     # Resize the internal buffer of bytearray to len.
 
     char* PyByteArray_AS_STRING(object bytearray)


### PR DESCRIPTION
…ons properly

PyByteArray_Resize indicates raised exceptions via returning -1:

https://github.com/python/cpython/blob/2b61f6ac3960/Objects/bytearrayobject.c#L170-L247

and without proper `except -1` cython just ignores them:

    ---- 8< ---- (x.pyx)
    # cython: language_level=3
    from cpython.bytearray cimport PyByteArray_Resize

    cdef zzz(bytearray buf):
        PyByteArray_Resize(buf, 1)
    ---- 8< ----

    ---- 8< ---- (x.c)
    /* "x.pyx":4
     * from cpython.bytearray cimport PyByteArray_Resize *
     * cdef zzz(bytearray buf):             # <<<<<<<<<<<<<<
     *     PyByteArray_Resize(buf, 1)
     */

    static PyObject *__pyx_f_1x_zzz(PyObject *__pyx_v_buf) {
      PyObject *__pyx_r = NULL;
      __Pyx_RefNannyDeclarations
      __Pyx_RefNannySetupContext("zzz", 1);

      /* "x.pyx":5
     *
     * cdef zzz(bytearray buf):
     *     PyByteArray_Resize(buf, 1)             # <<<<<<<<<<<<<<
     */
      (void)(PyByteArray_Resize(__pyx_v_buf, 1));                           <-- NOTE

      /* "x.pyx":4
     * from cpython.bytearray cimport PyByteArray_Resize
     *
     * cdef zzz(bytearray buf):             # <<<<<<<<<<<<<<
     *     PyByteArray_Resize(buf, 1)
     */

      /* function exit code */
      __pyx_r = Py_None; __Pyx_INCREF(Py_None);
      __Pyx_XGIVEREF(__pyx_r);
      __Pyx_RefNannyFinishContext();
      return __pyx_r;
    }