### PR TITLE
Enable no-copy optimization on Limited API

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7487,7 +7487,7 @@ class MergedDictNode(ExprNode):
                 # For the fairly plausible special case where item is a temporary
                 # with a refcount of 1 (so created specifically for us),
                 # avoid making a copy
-                code.putln("#if CYTHON_COMPILING_IN_CPYTHON")
+                code.putln("#if CYTHON_COMPILING_IN_CPYTHON || CYTHON_COMPILING_IN_LIMITED_API")
                 code.putln("if (Py_REFCNT(%s) == 1) {" % item.py_result())
                 code.putln("%s = %s;" % (self.result(), item.py_result()))
                 item.generate_post_assignment_code(code)


### PR DESCRIPTION
I think the intent of the guard was mainly disable to optimization on things like PyPy which aren't natively refcounted. I don't see why it'd be unreliable on the Limited API.