### PR TITLE
Allow construction of non-moveable C++ classes

### DIFF
--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -110,6 +110,7 @@ public:
     using __Pyx_Optional_BaseType<T>::has_value;
     using __Pyx_Optional_BaseType<T>::operator*;
     using __Pyx_Optional_BaseType<T>::operator->;
+    using __Pyx_Optional_BaseType<T>::emplace;
 #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1600)
     __Pyx_Optional_Type& operator=(const __Pyx_Optional_Type& rhs) {
         this->emplace(*rhs);

--- a/tests/run/cpp_locals_directive.pyx
+++ b/tests/run/cpp_locals_directive.pyx
@@ -10,21 +10,26 @@ from libcpp cimport bool as cppbool
 
 cdef extern from *:
     r"""
-    static void print_C_destructor();
+    static void print_MoveableC_destructor();
+    static void print_NonMoveableC_constructor1(int);
+    static void print_NonMoveableC_constructor2(int, int);
 
-    class C {
+    class NoThrowTag{};
+
+    class MoveableC {
         public:
-            C() = delete; // look! No default constructor
-            C(int x, bool print_destructor=true) : x(x), print_destructor(print_destructor) {}
-            C(C&& rhs) : x(rhs.x), print_destructor(rhs.print_destructor) {
+            MoveableC() = delete; // look! No default constructor
+            MoveableC(int x, bool print_destructor=true) : x(x), print_destructor(print_destructor) {}
+            MoveableC(NoThrowTag, int x, bool print_destructor) : MoveableC(x, print_destructor) {}
+            MoveableC(MoveableC&& rhs) : x(rhs.x), print_destructor(rhs.print_destructor) {
                 rhs.print_destructor = false; // moved-from instances are deleted silently
             }
             // also test that we don't require the assignment operator
-            C& operator=(C&& rhs) = delete;
-            C(const C& rhs) = delete;
-            C& operator=(const C& rhs) = default;
-            ~C() {
-                if (print_destructor) print_C_destructor();
+            MoveableC& operator=(MoveableC&& rhs) = delete;
+            MoveableC(const MoveableC& rhs) = delete;
+            MoveableC& operator=(const MoveableC& rhs) = default;
+            ~MoveableC() {
+                if (print_destructor) print_MoveableC_destructor();
             }
 
             int getX() const { return x; }
@@ -34,25 +39,50 @@ cdef extern from *:
             bool print_destructor;
     };
 
-    C make_C(int x) {
-        return C(x);
+    MoveableC make_MoveableC(int x) {
+        return MoveableC(x);
     }
+
+    class NonMoveableC {
+        public:
+            NonMoveableC() = delete; // look! No default constructor
+            NonMoveableC(int a) { print_NonMoveableC_constructor1(a); }
+            NonMoveableC(int a, int b) { print_NonMoveableC_constructor2(a, b); }
+            NonMoveableC(const NonMoveableC&) = delete;
+            NonMoveableC(NonMoveableC&&) = delete;
+
+            NonMoveableC& operator=(const NonMoveableC&) = delete;
+            NonMoveableC& operator=(NonMoveableC&&) = delete;
+    };
     """
-    cdef cppclass C:
-        C(int)
-        C(int, cppbool)
+    cdef cppclass NoThrowTag:
+        NoThrowTag()
+    cdef cppclass MoveableC:
+        # These don't really through, but test the code generation as if they did
+        MoveableC(int) except +
+        MoveableC(int, cppbool) except +
+        MoveableC(NoThrowTag, int, cppbool)
         int getX() const
-    C make_C(int) except +  # needs a temp to receive
+    MoveableC make_MoveableC(int) except +  # needs a temp to receive
+    cdef cppclass NonMoveableC:
+        NonMoveableC(int)
+        NonMoveableC(int, int)
 
 # this function just makes sure the output from the destructor can be captured by doctest
-cdef void print_C_destructor "print_C_destructor" () with gil:
-    print("~C()")
+cdef void print_MoveableC_destructor "print_MoveableC_destructor" () with gil:
+    print("~MoveableC()")
+
+cdef void print_NonMoveableC_constructor1 "print_NonMoveableC_constructor1" (int a) with gil:
+    print(f"NonMoveableC({a})")
+
+cdef void print_NonMoveableC_constructor2 "print_NonMoveableC_constructor2" (int a, int b) with gil:
+    print(f"NonMoveableC({a}, {b})")
 
 def maybe_assign_infer(assign, value, do_print):
     """
     >>> maybe_assign_infer(True, 5, True)
     5
-    ~C()
+    ~MoveableC()
     >>> maybe_assign_infer(False, 0, True)
     Traceback (most recent call last):
         ...
@@ -60,7 +90,7 @@ def maybe_assign_infer(assign, value, do_print):
     >>> maybe_assign_infer(False, 0, False)  # no destructor call here
     """
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     if do_print:
         print(x.getX())
 
@@ -68,88 +98,88 @@ def maybe_assign_cdef(assign, value):
     """
     >>> maybe_assign_cdef(True, 5)
     5
-    ~C()
+    ~MoveableC()
     >>> maybe_assign_cdef(False, 0)
     Traceback (most recent call last):
         ...
     UnboundLocalError: local variable 'x' referenced before assignment
     """
-    cdef C x
+    cdef MoveableC x
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     print(x.getX())
 
 def maybe_assign_annotation(assign, value):
     """
     >>> maybe_assign_annotation(True, 5)
     5
-    ~C()
+    ~MoveableC()
     >>> maybe_assign_annotation(False, 0)
     Traceback (most recent call last):
         ...
     UnboundLocalError: local variable 'x' referenced before assignment
     """
-    x: C
+    x: MoveableC
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     print(x.getX())
 
 def maybe_assign_directive1(assign, value):
     """
     >>> maybe_assign_directive1(True, 5)
     5
-    ~C()
+    ~MoveableC()
     >>> maybe_assign_directive1(False, 0)
     Traceback (most recent call last):
         ...
     UnboundLocalError: local variable 'x' referenced before assignment
     """
-    x = cython.declare(C)
+    x = cython.declare(MoveableC)
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     print(x.getX())
 
-@cython.locals(x=C)
+@cython.locals(x=MoveableC)
 def maybe_assign_directive2(assign, value):
     """
     >>> maybe_assign_directive2(True, 5)
     5
-    ~C()
+    ~MoveableC()
     >>> maybe_assign_directive2(False, 0)
     Traceback (most recent call last):
         ...
     UnboundLocalError: local variable 'x' referenced before assignment
     """
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     print(x.getX())
 
 def maybe_assign_nocheck(assign, value):
     """
     >>> maybe_assign_nocheck(True, 5)
     5
-    ~C()
+    ~MoveableC()
 
     # unfortunately it's quite difficult to test not assigning because there's a decent chance it'll crash
     """
     if assign:
-        x = C(value)
+        x = MoveableC(value)
     with cython.initializedcheck(False):
         print(x.getX())
 
 def uses_temp(value):
     """
-    needs a temp to handle the result of make_C - still doesn't use the default constructor
+    needs a temp to handle the result of make_MoveableC - still doesn't use the default constructor
     >>> uses_temp(10)
     10
-    ~C()
+    ~MoveableC()
     """
 
-    x = make_C(value)
+    x = make_MoveableC(value)
     print(x.getX())
 
 # c should not be optional - it isn't easy to check this, but we can at least check it compiles
-cdef void has_argument(C c):
+cdef void has_argument(MoveableC c):
     print(c.getX())
 
 def call_has_argument():
@@ -157,20 +187,20 @@ def call_has_argument():
     >>> call_has_argument()
     50
     """
-    has_argument(C(50, False))
+    has_argument(MoveableC(50, False))
 
-cdef class HoldsC:
+cdef class HoldsMoveableC:
     """
-    >>> inst = HoldsC(True, False)
-    >>> inst.getCX()
+    >>> inst = HoldsMoveableC(True, False)
+    >>> inst.getMoveableCX()
     10
     >>> access_from_function_with_different_directive(inst)
     10
     10
-    >>> inst.getCX()  # it was changed in access_from_function_with_different_directive
+    >>> inst.getMoveableCX()  # it was changed in access_from_function_with_different_directive
     20
-    >>> inst = HoldsC(False, False)
-    >>> inst.getCX()
+    >>> inst = HoldsMoveableC(False, False)
+    >>> inst.getMoveableCX()
     Traceback (most recent call last):
         ...
     AttributeError: C++ attribute 'value' is not initialized
@@ -179,23 +209,23 @@ cdef class HoldsC:
         ...
     AttributeError: C++ attribute 'value' is not initialized
     """
-    cdef C value
+    cdef MoveableC value
     def __cinit__(self, initialize, print_destructor):
         if initialize:
-            self.value = C(10, print_destructor)
+            self.value = MoveableC(10, print_destructor)
 
-    def getCX(self):
+    def getMoveableCX(self):
         return self.value.getX()
 
-cdef acceptC(C& c):
+cdef acceptMoveableC(MoveableC& c):
     return c.getX()
 
 @cython.cpp_locals(False)
-def access_from_function_with_different_directive(HoldsC c):
-    # doctest is in HoldsC class
-    print(acceptC(c.value))  # this originally tried to pass a __Pyx_Optional<C> as a C instance
+def access_from_function_with_different_directive(HoldsMoveableC c):
+    # doctest is in HoldsMoveableC class
+    print(acceptMoveableC(c.value))  # this originally tried to pass a __Pyx_Optional<MoveableC> as a MoveableC instance
     print(c.value.getX())
-    c.value = C(20, False) # make sure that we can change it too
+    c.value = MoveableC(NoThrowTag(), 20, False) # make sure that we can change it too
 
 def dont_test_on_pypy(f):
     import sys
@@ -203,20 +233,20 @@ def dont_test_on_pypy(f):
         return f
 
 @dont_test_on_pypy  # non-deterministic destruction
-def testHoldsCDestruction(initialize):
+def testHoldsMoveableCDestruction(initialize):
     """
-    >>> testHoldsCDestruction(True)
-    ~C()
-    >>> testHoldsCDestruction(False)  # no destructor
+    >>> testHoldsMoveableCDestruction(True)
+    ~MoveableC()
+    >>> testHoldsMoveableCDestruction(False)  # no destructor
     """
-    x = HoldsC(initialize, True)
+    x = HoldsMoveableC(initialize, True)
     del x
 
-cdef C global_var
+cdef MoveableC global_var
 
 def initialize_global_var():
     global global_var
-    global_var = C(-1, False)
+    global_var = MoveableC(-1, False)
 
 def read_global_var():
     """
@@ -229,3 +259,39 @@ def read_global_var():
     -1
     """
     print(global_var.getX())
+
+def test_nonmoveable(arg1, arg2=None):
+    """
+    >>> test_nonmoveable(5)
+    NonMoveableC(5)
+    >>> test_nonmoveable(5, 6)
+    NonMoveableC(5, 6)
+    """
+    cdef NonMoveableC nm
+    if arg2 is None:
+        nm = NonMoveableC(<int>arg1)
+    else:
+        nm = NonMoveableC(<int>arg1, <int>arg2)
+
+cdef NonMoveableC global_nonmoveable
+
+def test_global_nonmoveable(arg):
+    """
+    >>> test_global_nonmoveable(2)
+    NonMoveableC(2)
+    """
+    global global_nonmoveable
+    global_nonmoveable = NonMoveableC(arg)
+
+cdef class HoldsNonMoveableC:
+    """
+    >>> v = HoldsNonMoveableC(None)
+    >>> v = HoldsNonMoveableC(10)
+    NonMoveableC(10)
+    """
+
+    cdef NonMoveableC c
+
+    def __init__(self, arg):
+        if arg is not None:
+            self.c = NonMoveableC(arg)


### PR DESCRIPTION
... with the cpp_locals directive.

This is mainly with a view to some of the C++ thread synchronization classes (like std::latch), which are neither default constructable nor-moveable, so fits in badly with Cython's code-generation.

They can be constructed using "emplace" instead and so this is what I do.

(I have a longer-term view to make this work outside of cpp_locals, which I think is still viable for simple cases. However, that needs a bit more thought about how to make it work).