### PR TITLE
Fix UnboundLocalError with non-ascii names

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2986,10 +2986,10 @@ class CCodeWriter:
 
         if not unbound_check_code:
             unbound_check_code = entry.type.check_for_null_code(entry.cname)
-        self.putln('if (unlikely(!%s)) { %s("%s"); %s }' % (
+        self.putln('if (unlikely(!%s)) { %s(%s); %s }' % (
                                 unbound_check_code,
                                 func,
-                                entry.name,
+                                entry.name.as_c_string_literal(),
                                 self.error_goto(pos)))
 
     def set_error_info(self, pos, used=False):


### PR DESCRIPTION
Fixes #6800

It was generating the C code

```c
__Pyx_RaiseUnboundLocalError("进程对象");
```

Essentially you don't see the error any more in 3.1 because of 3eb16fd8229ddf89396405e2b571435fb2e2ddec. However I think it's a bit compiler-dependent whether that's actually acceptable in a source file. So it's probably better to encode the string if we can.