### PR TITLE
Fix issue with unicode cpdef args

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3708,6 +3708,12 @@ class CFuncTypeArg(BaseType):
             self.cname = cname
         else:
             self.cname = Naming.var_prefix + name
+            if not self.cname.isascii():
+                # We have to be careful here not to create a circular import of Symtab.
+                # This creates a cname to match a Symtab entry that'll be created later
+                # - in an ideal world the name here would be taken from the entry...
+                from .Symtab import punycodify_name
+                self.cname = punycodify_name(self.cname)
         if annotation is not None:
             self.annotation = annotation
         self.type = type

--- a/tests/run/unicode_identifiers.pxd
+++ b/tests/run/unicode_identifiers.pxd
@@ -8,3 +8,4 @@ cdef class Γναμε2:
     cdef εxciting_cdef(self)
     cpdef boring_cpdef(self)
     cpdef εxciting_cpdef(self)
+    cpdef cpdef_with_exciting_arg(self, ααα)

--- a/tests/run/unicode_identifiers.pyx
+++ b/tests/run/unicode_identifiers.pyx
@@ -174,6 +174,12 @@ cdef class Γναμε2:
     cpdef εxciting_cpdef(self):
         """docstring"""
         return 2
+    cpdef cpdef_with_exciting_arg(self, ααα):
+        """
+        >>> Γναμε2().cpdef_with_exciting_arg(5)
+        5
+        """
+        return ααα
 
 cdef class Derived(Γναμε2):
     pass


### PR DESCRIPTION
Unicode characters got into the function argument name, but inside the function the variable was properly escaped.