### PR TITLE
docs: Use pip for readthedocs build to fix setuptools failure.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 python:
   install:
     - requirements: doc-requirements.txt
-    - method: setuptools  # runs setup.py
+    - method: pip
       path: .
 
 sphinx:


### PR DESCRIPTION
Trial fix.