### PR TITLE
Fix placement new of c++ class typedefs

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -3175,10 +3175,10 @@ class CCodeWriter:
         error_handling = self.error_goto(pos)
         self.putln(f"{trace_func}({retvalue_cname}{extra_arg}, {self.pos_to_offset(pos)}, {bool(nogil):d}, {error_handling});")
 
-    def put_cpp_placement_new(self, target, decl_code,
-                              _utility_code=UtilityCode("#include <new>")):
+    def put_cpp_placement_new(self, target,
+                              _utility_code=UtilityCode.load("DefaultPlacementNew", "CppSupport.cpp")):
         self.globalstate.use_utility_code(_utility_code)
-        self.putln(f"new((void*)&({target})) {decl_code}();")
+        self.putln(f"__Pyx_default_placement_construct(&({target}));")
 
     def putln_openmp(self, string):
         self.putln("#ifdef _OPENMP")

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4369,11 +4369,7 @@ class CppClassType(CType):
         code.putln(f"__Pyx_call_destructor({extra_access_code}{entry.cname});")
 
     def generate_explicit_construction(self, code, entry, extra_access_code=""):
-        if entry.is_cpp_optional:
-            decl_code = self.cpp_optional_declaration_code("")
-        else:
-            decl_code = self.empty_declaration_code()
-        code.put_cpp_placement_new(f"{extra_access_code}{entry.cname}", decl_code)
+        code.put_cpp_placement_new(f"{extra_access_code}{entry.cname}")
 
 
 class EnumMixin:

--- a/Cython/Utility/CppSupport.cpp
+++ b/Cython/Utility/CppSupport.cpp
@@ -131,3 +131,13 @@ public:
     using __Pyx_Optional_BaseType<T>::operator=; // the chances are emplace can't work...
 #endif
 };
+
+//////////////////////// DefaultPlacementNew.proto ///////////////////////
+
+#include <new>
+
+// avoid having to know the name of the class being constructed (e.g. when user is accessing through a typedef)
+template<typename T>
+void __Pyx_default_placement_construct(T* x) {
+    new (static_cast<void*>(x)) T();
+}

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -630,6 +630,7 @@
 #endif
 
 // Work around clang bug https://stackoverflow.com/questions/21847816/c-invoke-nested-template-class-destructor
+// (even without the clang bug, the need not to know the typename is generally a benefit)
 template<typename T>
 void __Pyx_call_destructor(T& x) {
     x.~T();

--- a/tests/run/cpp_classes.pyx
+++ b/tests/run/cpp_classes.pyx
@@ -267,3 +267,31 @@ def test_nested_del_repeat():
     del create_to_delete()[f(f(0))]
     del create_to_delete()[f(f(0))]
     del create_to_delete()[f(f(0))]
+
+cdef extern from *:
+    """
+    class SomeClass {
+      public:
+        int some_value;
+        SomeClass()
+            : some_value(10101)
+        {
+        }
+    };
+    """
+    cdef cppclass ThisClassDoesntExist:
+        int some_value
+    ctypedef ThisClassDoesntExist SomeClass
+
+cdef class TestMisleadingName:
+    """
+    The code must be generated using SomeClass rather than ThisClassDoesntExist
+
+    >>> x = TestMisleadingName()
+    >>> x.get_some_value()
+    10101
+    >>> del x
+    """
+    cdef SomeClass a
+    def get_some_value(self):
+        return self.a.some_value


### PR DESCRIPTION
This way uses templates to work out what constructor to call so we don't need to care about the name.

Fixes #6821