### PR TITLE
Add freethreaded dev version of Python to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           - "3.13"
           - "3.13t"
           - "3.14-dev"
+          - "3.14t-dev"
         env: [{}]
 
         exclude:
@@ -65,6 +66,8 @@ jobs:
 
         include:
           - python-version: "3.14-dev"
+            allowed_failure: true
+          - python-version: "3.14t-dev"
             allowed_failure: true
 
           # Ubuntu sub-jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
           - os: windows-2019
             python-version: 3.13t
             backend: "cpp"
+          - os: windows-2019
+            python-version: 3.14t-dev
+            backend: "c"
+          - os: windows-2019
+            python-version: 3.14t-dev
+            backend: "cpp"
 
         include:
           - python-version: "3.14-dev"


### PR DESCRIPTION
There's definitely differences in what headers they include (for example) so I think we should be checking this too.