### PR TITLE
Fix some issues with C++ templated function overloading

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4325,11 +4325,34 @@ class IndexNode(_IndexingBaseNode):
 
     def analyse_as_c_function(self, env):
         base_type = self.base.type
+
         if base_type.is_fused:
             self.parse_indexed_fused_cdef(env)
         else:
             self.type_indices = self.parse_index_as_types(env)
             self.index = None  # FIXME: use a dedicated Node class instead of generic IndexNode
+
+            if hasattr(self.base, "entry"):
+                alternatives = self.base.entry.all_alternatives()
+                if len(alternatives) > 1:
+                    alternatives = [
+                        a for a in alternatives
+                        if (a.type.is_cfunction and
+                            a.type.templates is not None and
+                            len(a.type.templates) == len(self.type_indices))
+                    ]
+                    if len(alternatives) >= 1:
+                        self.base.entry  = alternatives[0]
+                        base_type = self.base.type = self.base.entry.type
+                    if len(alternatives) > 1:
+                        # warning rather than error because we used to just pick the first one in all cases.
+                        # TODO - a better lookup might work co-operatively with a surrounding CallNode to further
+                        # reduce the list of viable alternatives.
+                        warning(
+                            self.pos,
+                            "No unambiguous choice when parameterizing template function"
+                        )
+
             if base_type.templates is None:
                 error(self.pos, "Can only parameterize template functions.")
                 self.type = error_type

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -3783,7 +3783,11 @@ def p_c_func_or_var_declaration(s: PyrexScanner, pos, ctx):
         #if api:
         #    s.error("'api' not allowed with variable declaration")
         if is_const_method:
-            declarator.is_const_method = is_const_method
+            func_declarator = declarator
+            while isinstance(func_declarator, Nodes.CPtrDeclaratorNode):
+                # pointer return type
+                func_declarator = func_declarator.base
+            func_declarator.is_const_method = is_const_method
         declarators = [declarator]
         while s.sy == ',':
             s.next()

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3246,6 +3246,12 @@ class CFuncType(CType):
             return 0
         if not self._is_exception_compatible_with(other_type):
             return 0
+        if self.is_const_method != other_type.is_const_method:
+            return 0
+        len_self_templates = len(self.templates) if self.templates is not None else 0
+        len_other_templates = len(other_type.templates) if other_type.templates is not None else 0
+        if len_self_templates != len_other_templates:
+            return 0
         return 1
 
     def _is_exception_compatible_with(self, other_type):

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2861,8 +2861,6 @@ class CppClassScope(Scope):
                 error(pos, "Function signature does not match previous declaration")
         else:
             entry = self.declare(name, cname, type, pos, visibility)
-            if type.is_cfunction and not defining:
-                entry.is_inherited = 1
         entry.is_variable = 1
         if type.is_cfunction:
             entry.is_cfunction = 1


### PR DESCRIPTION
Don't mark extern C++ methods as "inherited" - this isn't correct and I think was probably only there to make the compiler ignore some signature mismatches.

Fix an issue where methods returning a pointer wouldn't be marked as a const method correctly (this was meaning that some const accessors for C++ allocator) were being seen as having the same signature, generating a warning.

Treat const methods/non-const methods as having a different signature. This means that both are declared as alternatives.

Treat methods with different numbers of template parameters as having different signatures (so that they appear in the list of alternative).

Add some logic to IndexNode to look at the list of alternatives and select one with a suitable number of template arguments when there's multiple options.

------------------------------------------

This fixes #6823 (at least the cut-down example provided - I'm not sure about the full issue that it was based on). However the whole "overloaded methods" thing is really quite fragile which makes me a bit nervous about it in general