### PR TITLE
Some small bugfixes to call_once

### DIFF
--- a/Cython/Includes/libc/threads.pxd
+++ b/Cython/Includes/libc/threads.pxd
@@ -28,6 +28,7 @@ cdef extern from "<threads.h>" nogil:
     void thrd_yield()
     void thrd_exit(int res)
     void thrd_detach(thrd_t thr)
+    # Be very wary of deadlocks if calling thrd_join with the GIL.
     int thrd_join(thrd_t, int *res)
     enum:
         thrd_success
@@ -66,6 +67,7 @@ cdef extern from "<threads.h>" nogil:
     int cnd_init(cnd_t*)
     int cnd_signal(cnd_t*)
     int cnd_broadcast(cnd_t*)
+    # Be very wary of calling wait/timedwait with the GIL held.
     int cnd_wait(cnd_t*, mtx_t*)
     int cnd_timedwait(cnd_t*, mtx_t*, const timespec*)
     void cnd_destroy(cnd_t*)

--- a/Cython/Includes/libc/threads.pxd
+++ b/Cython/Includes/libc/threads.pxd
@@ -1,10 +1,6 @@
 from libc.time cimport timespec
 
 cdef extern from *:
-    # Not part of the C interface, but declaring this here so it isn't nogil
-    ctypedef void (*_once_func_type)() noexcept
-
-cdef extern from *:
     """
     #include <string.h>
     #include <threads.h>
@@ -16,12 +12,14 @@ cdef extern from *:
     void once_flag_init "__Pyx_once_flag_init"(once_flag*)
 
 cdef extern from "<threads.h>" nogil:
+    ctypedef void (*_once_func_type)() noexcept nogil
+
     # Threads
     ctypedef struct thrd_t:
         pass
     # Declare as noexcept because you'll regret trying to throw a Python exception from it
     # and nogil because it's a new thread, so you definitely don't have a Python threadstate yet.
-    ctypedef int (*thrd_start_t)(void*) nogil noexcept
+    ctypedef int (*thrd_start_t)(void*) noexcept nogil
 
     int thrd_create(thrd_t*, thrd_start_t, void*)
     int thrd_equal(thrd_t lhs, thrd_t rhs)
@@ -59,7 +57,7 @@ cdef extern from "<threads.h>" nogil:
         pass
     once_flag ONCE_FLAG_INIT
 
-    # Be careful with the GIL if the Cython function you're passing needs the GIL
+    # We strongly recommend not calling this with the GIL held.
     void call_once(once_flag* flag, _once_func_type func) noexcept
 
     # condition variables
@@ -77,7 +75,7 @@ cdef extern from "<threads.h>" nogil:
         pass
     enum:
         TSS_DTOR_ITERATIONS
-    ctypedef void (*tss_dtor_t)(void*) nogil noexcept
+    ctypedef void (*tss_dtor_t)(void*) noexcept nogil
     int tss_create(tss_t* key, tss_dtor_t destructor)
     void *tss_get(tss_t key)
     int tss_set(tss_t key, void* val)

--- a/Cython/Includes/libcpp/barrier.pxd
+++ b/Cython/Includes/libcpp/barrier.pxd
@@ -1,4 +1,7 @@
 cdef extern from "<barrier>" namespace "std" nogil:
+    # Note on thread safety:
+    # For any of the blocking functions here you should be very
+    # careful to ensure that you are not deadlocked on the GIL.
     cdef cppclass barrier[CompletionFunction = *]:
         cppclass arrival_token:
             pass

--- a/Cython/Includes/libcpp/latch.pxd
+++ b/Cython/Includes/libcpp/latch.pxd
@@ -1,6 +1,9 @@
 from libcpp cimport bool
 
 cdef extern from "<latch>" namespace "std" nogil:
+    # Note on thread safety:
+    # For any of the blocking functions, you should be very careful
+    # to ensure that you are not deadlocked on the GIL.
     cdef cppclass latch:
         latch(ptrdiff_t expected)
 

--- a/Cython/Includes/libcpp/mutex.pxd
+++ b/Cython/Includes/libcpp/mutex.pxd
@@ -1,6 +1,8 @@
 from libcpp cimport bool
 
 cdef extern from "<mutex>" namespace "std" nogil:
+    # For all these mutex classes, we strongly recommend you do not using any
+    # blocking lock function while holding the GIL (try_lock should be fine though).
     cppclass mutex:
         # may not be present, and we know nothing about it
         cppclass native_handle_type:
@@ -25,6 +27,9 @@ cdef extern from "<mutex>" namespace "std" nogil:
 
         native_handle_type native_handle() except+
 
+    # We strongly recommend not mixing recursive_mutex and the GIL at all.
+    # Because "unlock" may not actually unlock it, it's pretty hard to reason about
+    # avoiding deadlocks.
     cppclass recursive_mutex:
         # may not be present, and we know nothing about it
         cppclass native_handle_type:
@@ -36,6 +41,9 @@ cdef extern from "<mutex>" namespace "std" nogil:
 
         native_handle_type native_handle() except+
 
+    # We strongly recommend not mixing timed_recursive_mutex and the GIL at all.
+    # Because "unlock" may not actually unlock it, it's pretty hard to reason about
+    # avoiding deadlocks.
     cppclass timed_recursive_mutex:
         # may not be present, and we know nothing about it
         cppclass native_handle_type:
@@ -63,11 +71,14 @@ cdef extern from "<mutex>" namespace "std" nogil:
 
     # lock_guard is probably unusable without cpp_locals because it
     # can't be default-constructed or moved.
+    # We strongly recommend you do not use this while holding the GIL.
     cppclass lock_guard[T]:
         ctypedef T mutex_type
         lock_guard(mutex_type&) except+
         lock_guard(mutex_type&, adopt_lock_t)
 
+    # We strongly recommend that you do not use any blocking lock function with the GIL.
+    # (try_lock is fine though).
     cppclass unique_lock[T]:
         ctypedef T mutex_type
         unique_lock()
@@ -100,6 +111,7 @@ cdef extern from "<mutex>" namespace "std" nogil:
     # It's also a variadic template type so can take potentially unlimited number of
     # arguments. Cython doesn't support this, so if you want more than 26 arguments,
     # you're on your own.
+    # We strongly recommend that you do not use this while holding the GIL.
     cppclass scoped_lock[A=*, B=*, C=*, D=*, E=*, F=*, G=*, H=*, I=*, J=*, K=*,
                          L=*, M=*, N=*, O=*, P=*, Q=*, R=*, S=*, T=*, U=*, V=*,
                          W=*, X=*, Y=*, Z=*]:
@@ -109,6 +121,7 @@ cdef extern from "<mutex>" namespace "std" nogil:
         pass
 
     bool try_lock(...) except+
+    # We strongly recommend that you do not call "lock" while holding the GIL.
     void lock(...) except+
 
     # We can't enforce this in the interface, but you need to make sure that Callable

--- a/Cython/Includes/libcpp/mutex.pxd
+++ b/Cython/Includes/libcpp/mutex.pxd
@@ -1,9 +1,5 @@
 from libcpp cimport bool
 
-cdef extern from *:
-    # Not part of the C++ interface, but declaring this here so it isn't nogil
-    ctypedef void (*_once_func_type)() except+
-
 cdef extern from "<mutex>" namespace "std" nogil:
     cppclass mutex:
         # may not be present, and we know nothing about it
@@ -115,6 +111,7 @@ cdef extern from "<mutex>" namespace "std" nogil:
     bool try_lock(...) except+
     void lock(...) except+
 
-    # If we're passed a cdef function, make sure that it's specified without Python exceptions.
-    void call_once(once_flag&, _once_func_type callable) except +
+    # We can't enforce this in the interface, but you need to make sure that Callable
+    # doesn't require the GIL and doesn't throw Python exceptions.
+    # You should also not call this with the GIL held.
     void call_once[Callable](once_flag&, Callable& callable,  ...) except +

--- a/Cython/Includes/libcpp/mutex.pxd
+++ b/Cython/Includes/libcpp/mutex.pxd
@@ -1,7 +1,7 @@
 from libcpp cimport bool
 
 cdef extern from "<mutex>" namespace "std" nogil:
-    # For all these mutex classes, we strongly recommend you do not using any
+    # For all these mutex classes, we strongly recommend you do not use any
     # blocking lock function while holding the GIL (try_lock should be fine though).
     cppclass mutex:
         # may not be present, and we know nothing about it

--- a/Cython/Includes/libcpp/semaphore.pxd
+++ b/Cython/Includes/libcpp/semaphore.pxd
@@ -8,6 +8,13 @@ cdef extern from "<semaphore>" namespace "std" nogil:
     # don't need to use the templates. If you do though, then there's a
     # few tricks - e.g. you can define a class with a cname of "3" for
     # example.
+
+    # Note on thread-safety:
+    # You should use these classes without the GIL. It's very easy
+    # to deadlock with the GIL, and we're assuming that anyone going
+    # low enough level to be using semaphores doesn't want the overhead
+    # of Cython handling GIL safety.
+
     cdef cppclass counting_semaphore[LeastMaxValue=*]:
         counting_semaphore(ptrdiff_t desired)
 

--- a/Cython/Includes/libcpp/shared_mutex.pxd
+++ b/Cython/Includes/libcpp/shared_mutex.pxd
@@ -7,10 +7,12 @@ cdef extern from "<shared_mutex>" namespace "std" nogil:
         cppclass native_handle_type:
             pass
 
+        # We strongly recommend not calling lock with the GIL held (to avoid deadlocks)
         void lock() except+
         bool try_lock()
         void unlock()
 
+        # We strongly recommend not calling lock_shared with the GIL held (to avoid deadlocks)
         void lock_shared() except+
         bool try_lock_shared()
         void unlock_shared()
@@ -23,6 +25,8 @@ cdef extern from "<shared_mutex>" namespace "std" nogil:
         cppclass native_handle_type:
             pass
 
+        # We strongly recommend not calling lock with the GIL held (to avoid deadlocks)
+        # and moderately recommend not calling the timed lock functions with the GIL either.
         void lock() except+
         bool try_lock()
         bool try_lock_for[T](const T& duration) except+
@@ -46,15 +50,17 @@ cdef extern from "<shared_mutex>" namespace "std" nogil:
         shared_lock(mutex_type&, ...) except+
         #shared_lock(mutex_type&, defer_lock_t)
         #shared_lock(mutex_type&, try_to_lock_t) except+
-        ## this feels like it should be noexcet, but cppreference implies it isn't
+        ## this feels like it should be noexcept, but cppreference implies it isn't
         #shared_lock(mutex_type&, adopt_lock_t) except+
 
+        # We strongly recommend not calling lock with the GIL held (to avoid deadlocks)
         void lock() except+
         bool try_lock() except+
         bool try_lock_for[T](const T& duration) except+
         bool try_lock_until[T](const T& time_point) except+
         void unlock() except+
 
+        # We strongly recommend not calling lock_shared with the GIL held (to avoid deadlocks)
         void swap(shared_lock& other)
         # "release" is definitely not the same as unlock. Noted here because
         # DW always makes this mistake and regrets it and wants to save you

--- a/tests/run/cpp_mutex.pyx
+++ b/tests/run/cpp_mutex.pyx
@@ -1,7 +1,7 @@
 # mode: run
 # tag: cpp, cpp17, no-cpp-locals
 
-from __future__ import print_function
+# cython: language_level=3
 
 from libcpp.mutex cimport (
     mutex, once_flag, unique_lock, call_once,

--- a/tests/run/cpp_mutex.pyx
+++ b/tests/run/cpp_mutex.pyx
@@ -40,9 +40,8 @@ def test_unique_lock_more():
     # unlocked automatically when it exits scope
 
 
-cdef void call_me_once() noexcept nogil:
-    with gil:
-        print("Listen very carefully, I shall say this only once.")
+cdef void call_me_once() noexcept with gil:
+    print("Listen very carefully, I shall say this only once.")
 
 cdef extern from *:
     """

--- a/tests/run/cpp_mutex.pyx
+++ b/tests/run/cpp_mutex.pyx
@@ -1,6 +1,8 @@
 # mode: run
 # tag: cpp, cpp17, no-cpp-locals
 
+from __future__ import print_function
+
 from libcpp.mutex cimport (
     mutex, once_flag, unique_lock, call_once,
     adopt_lock, scoped_lock
@@ -8,6 +10,11 @@ from libcpp.mutex cimport (
 from libcpp.shared_mutex cimport (
     shared_mutex, shared_lock
 )
+
+# Note to readers: some of these tests are a bit lazy
+# with the GIL because they know the lock is only being
+# used from one thread. Be very careful with the GIL and
+# C++ locks to avoid deadlocks!
 
 def test_mutex():
     """
@@ -33,8 +40,9 @@ def test_unique_lock_more():
     # unlocked automatically when it exits scope
 
 
-cdef void call_me_once() noexcept:
-    print("Listen very carefully, I shall say this only once.")
+cdef void call_me_once() noexcept nogil:
+    with gil:
+        print("Listen very carefully, I shall say this only once.")
 
 cdef extern from *:
     """

--- a/tests/run/libc_threads.pyx
+++ b/tests/run/libc_threads.pyx
@@ -1,6 +1,8 @@
 # mode: run
 # tag: c11, no-cpp, no-macos
 
+from __future__ import print_function
+
 from libc cimport threads
 
 def test_mutex():
@@ -12,8 +14,11 @@ def test_mutex():
     threads.mtx_lock(&m)
     threads.mtx_unlock(&m)
 
-cdef void call_me_once() noexcept:
-    print("Listen very carefully, I shall say this only once.")
+cdef void call_me_once() noexcept nogil:
+    # with gil is only OK because it's a toy example with no other threads so no chance of deadlock.
+    # Do not copy this code!
+    with gil:
+        print("Listen very carefully, I shall say this only once.")
 
 def test_once():
     """
@@ -25,7 +30,7 @@ def test_once():
     threads.call_once(&flag, &call_me_once)
     threads.call_once(&flag, &call_me_once)
 
-cdef int my_thread_func(void* arg) nogil noexcept:
+cdef int my_thread_func(void* arg) noexcept nogil:
     cdef int x = (<int*>arg)[0]
     t = threads.thrd_current()  # compile test - nothing useful to do with it
     return x

--- a/tests/run/libc_threads.pyx
+++ b/tests/run/libc_threads.pyx
@@ -1,7 +1,7 @@
 # mode: run
 # tag: c11, no-cpp, no-macos
 
-from __future__ import print_function
+# cython: language_level=3
 
 from libc cimport threads
 

--- a/tests/run/libc_threads.pyx
+++ b/tests/run/libc_threads.pyx
@@ -14,11 +14,10 @@ def test_mutex():
     threads.mtx_lock(&m)
     threads.mtx_unlock(&m)
 
-cdef void call_me_once() noexcept nogil:
+cdef void call_me_once() noexcept with gil:
     # with gil is only OK because it's a toy example with no other threads so no chance of deadlock.
     # Do not copy this code!
-    with gil:
-        print("Listen very carefully, I shall say this only once.")
+    print("Listen very carefully, I shall say this only once.")
 
 def test_once():
     """


### PR DESCRIPTION
The called functions really should be "nogil" so enforce that before people start using it.

(Cherry-picked bug fixes from https://github.com/cython/cython/pull/6829)