### PR TITLE
Refcounting error in class cells

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10336,7 +10336,6 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
                 'PyList_Append(%s, %s);' % (
                     class_node.class_cell.result(),
                     self.py_result()))
-            self.generate_giveref(code)
 
         if self.defaults:
             code.putln(

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -10332,11 +10332,10 @@ class PyCFunctionNode(ExprNode, ModuleNameMixin):
         if def_node.requires_classobj:
             assert code.pyclass_stack, "pyclass_stack is empty"
             class_node = code.pyclass_stack[-1]
-            code.put_incref(self.py_result(), py_object_type)
             code.putln(
                 'PyList_Append(%s, %s);' % (
                     class_node.class_cell.result(),
-                    self.result()))
+                    self.py_result()))
             self.generate_giveref(code)
 
         if self.defaults:


### PR DESCRIPTION
This looks wrong to me - `PyList_Append` doesn't steal a reference. I haven't yet tested it against the complete test suite though so maybe I've missed something