### PR TITLE
Automate the shared utility module generation from a setuptools build

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1091,12 +1091,13 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                 c_file = file_in_build_dir(source)
                 module_options = CompilationOptions(
                     options, shared_c_file_path=c_file, shared_utility_qualified_name=None)
-                if Utils.is_cython_generated_file(c_file):
-                    from .SharedModule import generate_shared_module
-                    print(f"Generating shared module '{m.name}'")
-                    generate_shared_module(module_options)
-                else:
+                if not Utils.is_cython_generated_file(c_file):
                     print(f"Warning: Shared module source file is not a Cython file - not creating '{m.name}' as '{c_file}'")
+                elif force or not Utils.file_generated_by_this_cython(c_file):
+                    from .SharedModule import generate_shared_module
+                    if not quiet:
+                        print(f"Generating shared module '{m.name}'")
+                    generate_shared_module(module_options)
             else:
                 c_file = source
                 if build_dir:

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -1027,7 +1027,10 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
             # infer FQMN from source files
             full_module_name = None
 
-        if m.np_pythran:
+        np_pythran = getattr(m, 'np_pythran', False)
+        py_limited_api = getattr(m, 'py_limited_api', False)
+
+        if np_pythran:
             options = pythran_options
         elif m.language == 'c++':
             options = cpp_options
@@ -1038,7 +1041,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
         for source in m.sources:
             base, ext = os.path.splitext(source)
             if ext in ('.pyx', '.py'):
-                c_file = base + ('.cpp' if m.language == 'c++' or m.np_pythran else '.c')
+                c_file = base + ('.cpp' if m.language == 'c++' or np_pythran else '.c')
 
                 # setup for out of place build directory if enabled
                 c_file = file_in_build_dir(c_file)
@@ -1074,11 +1077,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                     if not force and cache:
                         fingerprint = cache.transitive_fingerprint(
                                 source, deps.all_dependencies(source), options,
-                                FingerprintFlags(
-                                    m.language or 'c',
-                                    getattr(m, 'py_limited_api', False),
-                                    getattr(m, 'np_pythran', False)
-                                )
+                                FingerprintFlags(m.language or 'c', py_limited_api, np_pythran)
                         )
                     else:
                         fingerprint = None

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -738,6 +738,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
 
     explicit_modules = {m.name for m in patterns if isinstance(m, extension_classes)}
     deps = create_dependency_tree(ctx, quiet=quiet)
+    shared_utility_qualified_name = ctx.shared_utility_qualified_name
 
     to_exclude = set()
     if not isinstance(exclude, list):
@@ -769,6 +770,18 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
                     print("Warning: Multiple cython sources found for extension '%s': %s\n"
                           "See https://cython.readthedocs.io/en/latest/src/userguide/sharing_declarations.html "
                           "for sharing declarations among Cython files." % (pattern.name, cython_sources))
+            elif shared_utility_qualified_name and pattern.name == shared_utility_qualified_name:
+                # This is the shared utility code file.
+                m, _ = create_extension(pattern, dict(
+                    name=shared_utility_qualified_name,
+                    sources=pattern.sources or [
+                        shared_utility_qualified_name.replace('.', os.sep) + ('.cpp' if pattern.language == 'c++' else '.c')],
+                    language=pattern.language,
+                ))
+                m.np_pythran = False
+                m.shared_utility_qualified_name = None
+                module_list.append(m)
+                continue
             else:
                 # ignore non-cython modules
                 module_list.append(pattern)
@@ -826,7 +839,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
                 # Create the new extension
                 m, metadata = create_extension(template, kwds)
                 m.np_pythran = np_pythran or getattr(m, 'np_pythran', False)
-                m.shared_utility_qualified_name = ctx.shared_utility_qualified_name
+                m.shared_utility_qualified_name = shared_utility_qualified_name
                 if m.np_pythran:
                     update_pythran_extension(m)
                 module_list.append(m)
@@ -952,6 +965,7 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
     cpp_options = CompilationOptions(**options); cpp_options.cplus = True
     ctx = Context.from_options(c_options)
     options = c_options
+    shared_utility_qualified_name = ctx.shared_utility_qualified_name
     module_list, module_metadata = create_extension_list(
         module_list,
         exclude=exclude,
@@ -985,6 +999,17 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                                 os.path.dirname(_relpath(filepath, root)))
             copy_once_if_newer(filepath_abs, mod_dir)
 
+    def file_in_build_dir(c_file):
+        if not build_dir:
+            return c_file
+        if os.path.isabs(c_file):
+            c_file = os.path.splitdrive(c_file)[1]
+            c_file = c_file.split(os.sep, 1)[1]
+        c_file = os.path.join(build_dir, c_file)
+        dir = os.path.dirname(c_file)
+        safe_makedirs_once(dir)
+        return c_file
+
     modules_by_cfile = collections.defaultdict(list)
     to_compile = []
     for m in module_list:
@@ -1002,28 +1027,21 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
             # infer FQMN from source files
             full_module_name = None
 
+        if m.np_pythran:
+            options = pythran_options
+        elif m.language == 'c++':
+            options = cpp_options
+        else:
+            options = c_options
+
         new_sources = []
         for source in m.sources:
             base, ext = os.path.splitext(source)
             if ext in ('.pyx', '.py'):
-                if m.np_pythran:
-                    c_file = base + '.cpp'
-                    options = pythran_options
-                elif m.language == 'c++':
-                    c_file = base + '.cpp'
-                    options = cpp_options
-                else:
-                    c_file = base + '.c'
-                    options = c_options
+                c_file = base + ('.cpp' if m.language == 'c++' or m.np_pythran else '.c')
 
                 # setup for out of place build directory if enabled
-                if build_dir:
-                    if os.path.isabs(c_file):
-                        c_file = os.path.splitdrive(c_file)[1]
-                        c_file = c_file.split(os.sep, 1)[1]
-                    c_file = os.path.join(build_dir, c_file)
-                    dir = os.path.dirname(c_file)
-                    safe_makedirs_once(dir)
+                c_file = file_in_build_dir(c_file)
 
                 # write out the depfile, if requested
                 if depfile:
@@ -1068,12 +1086,25 @@ def cythonize(module_list, exclude=None, nthreads=0, aliases=None, quiet=False, 
                         priority, source, c_file, fingerprint, quiet,
                         options, not exclude_failures, module_metadata.get(m.name),
                         full_module_name, show_all_warnings))
-                new_sources.append(c_file)
                 modules_by_cfile[c_file].append(m)
+            elif shared_utility_qualified_name and m.name == shared_utility_qualified_name:
+                # Generate shared utility code module now.
+                c_file = file_in_build_dir(source)
+                module_options = CompilationOptions(
+                    options, shared_c_file_path=c_file, shared_utility_qualified_name=None)
+                if Utils.is_cython_generated_file(c_file):
+                    from .SharedModule import generate_shared_module
+                    print(f"Generating shared module '{m.name}'")
+                    generate_shared_module(module_options)
+                else:
+                    print(f"Warning: Shared module source file is not a Cython file - not creating '{m.name}' as '{c_file}'")
             else:
-                new_sources.append(source)
+                c_file = source
                 if build_dir:
                     copy_to_build_dir(source)
+
+            new_sources.append(c_file)
+
         m.sources = new_sources
 
     to_compile.sort()

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -8,6 +8,7 @@ from Cython.Compiler import (
 from Cython.Compiler.StringEncoding import EncodedString
 from Cython.Compiler.Scanning import FileSourceDescriptor
 
+
 def create_shared_library_pipeline(context, scope, options, result):
 
     parse = Pipeline.parse_stage_factory(context)
@@ -47,6 +48,7 @@ def create_shared_library_pipeline(context, scope, options, result):
         set_cimport_from_pyx(orig_cimport_from_pyx),
     ]
 
+
 def generate_shared_module(options):
     Errors.init_thread()
     Errors.open_listing_file(None)
@@ -70,4 +72,5 @@ def generate_shared_module(options):
         err, enddata = Pipeline.run_pipeline(pipeline, comp_src)
         if err is None:
             shutil.copy(c_file, dest_c_file)
-        return err, enddata
+
+    return err, enddata

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -504,9 +504,11 @@ The compilation process now consist of three steps:
 Compiling shared module using setuptools
 ----------------------------------------
 
-If setuptools is used in the build process, the fully qualified module name
+If ``setuptools`` is used in the build process, the fully qualified module name
 of the shared utility module can be specified using the ``shared_utility_qualified_name``
-parameter of :func:`cythonize` (instead of the ``--shared`` argument).
+parameter of :func:`cythonize` (instead of the ``--shared`` command line argument).
+To generate the extension sources of the shared module from ``cythonize()``,
+you need to explicitly pass an ``Extension`` object describing the module.
 The :file:`setup.py` file would be:
 
 .. code-block:: python
@@ -518,17 +520,14 @@ The :file:`setup.py` file would be:
 
     extensions = [
         Extension("*", ["**/*.pyx"]),
-        Extension("mypkg.shared._cyutility", sources=["mypkg/shared/_cyutility.c"])
+        # Providing 'sources' is optional for the shared module.
+        # If missing, the module package will be used for the path in 'build_dir'.
+        Extension("mypkg.shared._cyutility", sources=["mypkg/shared/_cyutility.c"]),
     ]
 
     setup(
       ext_modules = cythonize(extensions, shared_utility_qualified_name = 'mypkg.shared._cyutility')
     )
-
-.. note::
-
-   The shared utility :file:`_cyutility.c` file still needs to be generated manually
-   using the command ``cython --generate-shared=...``.
 
 
 .. _integrating_multiple_modules:

--- a/tests/memoryview/memoryview_shared_utility.srctree
+++ b/tests/memoryview/memoryview_shared_utility.srctree
@@ -1,16 +1,30 @@
 # tag: numpy
 
 """
-PYTHON setup.py build_ext --inplace
+PYTHON setup_with_sources.py build_ext --inplace
+PYTHON -c "import test_shared_utility"
+
+PYTHON setup_with_builddir.py build_ext --inplace
+PYTHON -c "import test_shared_utility"
+
+PYTHON setup_without_sources.py build_ext --inplace
 PYTHON -c "import test_shared_utility"
 """
 
-######## setup.py ########
+######## setup_with_sources.py ########
 
 from Cython.Build import cythonize
-from Cython.Compiler import Options
 from setuptools import setup, Extension
 import numpy
+
+import pathlib
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
+for path, _, files in pathlib.Path.cwd().walk():
+    for filename in files:
+        file = path / filename
+        if file.suffix.lower() in ext_to_delete:
+            print(f"deleting {file}")
+            file.unlink()
 
 extensions = [
     Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
@@ -18,8 +32,76 @@ extensions = [
 ]
 
 setup(
-  ext_modules = cythonize(extensions, shared_utility_qualified_name = 'pkg2.CythonShared')
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+    )
 )
+
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+
+
+######## setup_with_builddir.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+import numpy
+
+import pathlib
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
+for path, _, files in pathlib.Path.cwd().walk():
+    for filename in files:
+        file = path / filename
+        if file.suffix.lower() in ext_to_delete:
+            print(f"deleting {file}")
+            file.unlink()
+
+extensions = [
+    Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        build_dir = "build",
+    )
+)
+
+assert pathlib.Path("build/pkg2/CythonShared.c").exists()
+assert not pathlib.Path("pkg2/CythonShared.c").exists()
+
+
+######## setup_without_sources.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+import numpy
+
+import pathlib
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
+for path, _, files in pathlib.Path.cwd().walk():
+    for filename in files:
+        file = path / filename
+        if file.suffix.lower() in ext_to_delete:
+            print(f"deleting {file}")
+            file.unlink()
+
+extensions = [
+    Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
+    Extension("pkg2.CythonShared", sources=[]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+    )
+)
+
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
 
 
 ######## test_shared_utility.py ########

--- a/tests/memoryview/memoryview_shared_utility.srctree
+++ b/tests/memoryview/memoryview_shared_utility.srctree
@@ -1,7 +1,6 @@
 # tag: numpy
 
 """
-CYTHON --generate-shared=pkg2/CythonShared.c
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import test_shared_utility"
 """
@@ -15,7 +14,7 @@ import numpy
 
 extensions = [
     Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
-    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"])
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"]),
 ]
 
 setup(

--- a/tests/memoryview/memoryview_shared_utility.srctree
+++ b/tests/memoryview/memoryview_shared_utility.srctree
@@ -1,30 +1,39 @@
 # tag: numpy
 
 """
+PYTHON delete_generated_files.py
 PYTHON setup_with_sources.py build_ext --inplace
 PYTHON -c "import test_shared_utility"
 
+PYTHON delete_generated_files.py
 PYTHON setup_with_builddir.py build_ext --inplace
 PYTHON -c "import test_shared_utility"
 
+PYTHON delete_generated_files.py
 PYTHON setup_without_sources.py build_ext --inplace
 PYTHON -c "import test_shared_utility"
 """
+
+######## delete_generated_files.py ########
+
+import os
+from pathlib import Path
+
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
+for directory, _, files in os.walk(os.getcwd()):
+    path = Path(directory)
+    for filename in files:
+        file = path / filename
+        if file.suffix.lower() in ext_to_delete:
+            print(f"Deleting {file}")
+            file.unlink()
+
 
 ######## setup_with_sources.py ########
 
 from Cython.Build import cythonize
 from setuptools import setup, Extension
 import numpy
-
-import pathlib
-ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
-for path, _, files in pathlib.Path.cwd().walk():
-    for filename in files:
-        file = path / filename
-        if file.suffix.lower() in ext_to_delete:
-            print(f"deleting {file}")
-            file.unlink()
 
 extensions = [
     Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
@@ -38,6 +47,7 @@ setup(
     )
 )
 
+import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 
 
@@ -46,15 +56,6 @@ assert pathlib.Path("pkg2/CythonShared.c").exists()
 from Cython.Build import cythonize
 from setuptools import setup, Extension
 import numpy
-
-import pathlib
-ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
-for path, _, files in pathlib.Path.cwd().walk():
-    for filename in files:
-        file = path / filename
-        if file.suffix.lower() in ext_to_delete:
-            print(f"deleting {file}")
-            file.unlink()
 
 extensions = [
     Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
@@ -69,6 +70,7 @@ setup(
     )
 )
 
+import pathlib
 assert pathlib.Path("build/pkg2/CythonShared.c").exists()
 assert not pathlib.Path("pkg2/CythonShared.c").exists()
 
@@ -78,15 +80,6 @@ assert not pathlib.Path("pkg2/CythonShared.c").exists()
 from Cython.Build import cythonize
 from setuptools import setup, Extension
 import numpy
-
-import pathlib
-ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
-for path, _, files in pathlib.Path.cwd().walk():
-    for filename in files:
-        file = path / filename
-        if file.suffix.lower() in ext_to_delete:
-            print(f"deleting {file}")
-            file.unlink()
 
 extensions = [
     Extension("*", ["**/*.pyx"], include_dirs=[numpy.get_include()]),
@@ -100,6 +93,7 @@ setup(
     )
 )
 
+import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
 


### PR DESCRIPTION
This avoids a two-step build where users have to generate the shared module C file before running `setup.py` or `pip wheel`, which might actually not be feasible in practice.