### PR TITLE
Improve releasing the GIL with an unknown state

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8899,6 +8899,10 @@ class GILStatNode(NogilTryFinallyStatNode):
         code.mark_pos(self.pos)
         code.begin_block()
         if self.state_temp:
+            # state-temps only happen inside generators which are inherently Python functions
+            # and thus we do always know whether we have the GIL. This is important because it
+            # means that the type of the state-temp is always PyThreadState*.
+            assert self.scope_gil_state_known
             self.state_temp.allocate(code)
             variable = self.state_temp.result()
         else:


### PR DESCRIPTION
There's three advantages:
1. We eliminate the use of `PyGILState_Check()` in this case, which is useful for subinterpreters because they can't really work with the `PyGILState` API.
2. On recent Limited API versions we eliminate the need to acquire and release the GIL - we can actually just swap it. This is behind a runtime version check because it's a behaviour rather than API difference.
3. On recent non-Limited API versions we eliminate a check and can just swap it out.