### PR TITLE
Skip twine check on freethreading Python.

### DIFF
--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -92,7 +92,7 @@ echo "===================="
 echo "Installing requirements [python]"
 if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
   python -m pip install -U pip wheel setuptools || exit 1
-  if [[ $PYTHON_VERSION != "*t" ]]; then
+  if [[ $PYTHON_VERSION != *"t" ]]; then
     # twine is not installable on freethreaded Python due to cryptography requirement
     python -m pip install -U twine || exit 1
   fi
@@ -206,7 +206,7 @@ if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
     # Check for changelog entry in wheel metadata.
     fgrep -q '=======' $( [ -d ?ython-*.dist-info/ ] && echo "?ython-*.dist-info/METADATA" || echo "?ython*.egg-info/PKG-INFO" ) || {
         echo "ERROR: wheel METADATA lacks changelog - did you add a version entry?" ; exit 1; }
-    if [[ $PYTHON_VERSION != "*t" ]]; then
+    if [[ $PYTHON_VERSION != *"t" ]]; then
       # twine is not installable on freethreaded Python due to cryptography requirement
       twine check dist/*.whl
     fi

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -92,7 +92,7 @@ echo "===================="
 echo "Installing requirements [python]"
 if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
   python -m pip install -U pip wheel setuptools || exit 1
-  if [[ $PYTHON_VERSION != "*t"]]; then
+  if [[ $PYTHON_VERSION != "*t" ]]; then
     # twine is not installable on freethreaded Python due to cryptography requirement
     python -m pip install -U twine || exit 1
   fi
@@ -206,7 +206,7 @@ if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
     # Check for changelog entry in wheel metadata.
     fgrep -q '=======' $( [ -d ?ython-*.dist-info/ ] && echo "?ython-*.dist-info/METADATA" || echo "?ython*.egg-info/PKG-INFO" ) || {
         echo "ERROR: wheel METADATA lacks changelog - did you add a version entry?" ; exit 1; }
-    if [[ $PYTHON_VERSION != "*t"]]; then
+    if [[ $PYTHON_VERSION != "*t" ]]; then
       # twine is not installable on freethreaded Python due to cryptography requirement
       twine check dist/*.whl
     fi

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -91,7 +91,11 @@ echo "===================="
 # Install python requirements
 echo "Installing requirements [python]"
 if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
-  python -m pip install -U pip wheel setuptools twine || exit 1
+  python -m pip install -U pip wheel setuptools || exit 1
+  if [[ $PYTHON_VERSION != "*t"]]; then
+    # twine is not installable on freethreaded Python due to cryptography requirement
+    python -m pip install -U twine || exit 1
+  fi
   if [[ $PYTHON_VERSION == "3.12"* ]]; then
     python -m pip install --pre -r test-requirements-312.txt || exit 1
   else
@@ -202,7 +206,10 @@ if [[ $NO_CYTHON_COMPILE != "1" && $PYTHON_VERSION != "pypy"* ]]; then
     # Check for changelog entry in wheel metadata.
     fgrep -q '=======' $( [ -d ?ython-*.dist-info/ ] && echo "?ython-*.dist-info/METADATA" || echo "?ython*.egg-info/PKG-INFO" ) || {
         echo "ERROR: wheel METADATA lacks changelog - did you add a version entry?" ; exit 1; }
-    twine check dist/*.whl
+    if [[ $PYTHON_VERSION != "*t"]]; then
+      # twine is not installable on freethreaded Python due to cryptography requirement
+      twine check dist/*.whl
+    fi
   fi
 
   echo "Extension modules created during the build:"


### PR DESCRIPTION
It requires cryptography which isn't yet available.