### PR TITLE
Allow "list[int | None]()" etc.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12459,7 +12459,8 @@ class BitwiseOrNode(IntBinopNode):
 
     def _analyse_bitwise_or_none(self, env, operand_node):
         """Analyse annotations in form `[...] | None` and `None | [...]`"""
-        ttype = operand_node.analyse_as_type(env)
+        with env.new_c_type_context(False):
+            ttype = operand_node.analyse_as_type(env)
         if not ttype:
             return None
         if not ttype.can_be_optional():

--- a/tests/errors/e_typing_errors.pyx
+++ b/tests/errors/e_typing_errors.pyx
@@ -30,7 +30,7 @@ cdef ClassVar[list] x
 def union_pytypes(Union[int, None] i, Union[None, float] f, Union[complex, None] c, Union[long, None] l):
     pass
 
-def bitwise_or_pytypes(i: cython.int | None, f: None | cython.float , c: cython.complex | None, l: cython.long | None):
+def bitwise_or_ctypes(i: cython.int | None, f: None | cython.float , c: cython.complex | None, l: cython.long | None):
     pass
 
 # OK
@@ -47,6 +47,18 @@ def bitwise_or_not_recognized_type(x: DummyType | None, y: None | DummyType):
 cdef class Cls(object):
     cdef ClassVar[list] x
 
+def bitwise_or_pytypes(i: int | None, f: None | float , c: complex | None):
+    list[int | None]()
+    list[None | int]()
+    py_li: list[int | None] = []
+
+    tuple[float | None]()
+    tuple[None | float]()
+    py_tf: tuple[None | float] = ()
+
+    list[complex | None]()
+    list[None | complex]()
+    py_lc: list[complex | None] = []
 
 
 _ERRORS = """
@@ -68,8 +80,8 @@ _ERRORS = """
 30:50: typing.Union[...] cannot be applied to type float
 30:96: typing.Union[...] cannot be applied to type long
 
-33:32: '[...] | None' cannot be applied to type int
-33:61: '[...] | None' cannot be applied to type float
-33:79: '[...] | None' cannot be applied to type double complex
-33:105: '[...] | None' cannot be applied to type long
+33:31: '[...] | None' cannot be applied to type int
+33:60: '[...] | None' cannot be applied to type float
+33:78: '[...] | None' cannot be applied to type double complex
+33:104: '[...] | None' cannot be applied to type long
 """


### PR DESCRIPTION
We used to analyse the item type as C type instead of requiring a Python type here.

Fixes https://github.com/cython/cython/issues/6856