### PR TITLE
Fix result type analysis when mixing numeric C and Python types in conditional expressions

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -750,7 +750,7 @@ def init_builtin_types():
         elif name == 'str':
             objstruct_cname = 'PyUnicodeObject'
         elif name == 'bool':
-            objstruct_cname = None
+            objstruct_cname = None  # FIXME: should be 'PyLongObject'
         elif name == 'BaseException':
             objstruct_cname = "PyBaseExceptionObject"
         elif name == 'Exception':
@@ -823,12 +823,15 @@ def init_builtins():
     )
 
     # Set up type inference links between equivalent Python/C types
+    assert bool_type.name == 'bool', bool_type.name
     bool_type.equivalent_type = PyrexTypes.c_bint_type
     PyrexTypes.c_bint_type.equivalent_type = bool_type
 
+    assert float_type.name == 'float', float_type.name
     float_type.equivalent_type = PyrexTypes.c_double_type
     PyrexTypes.c_double_type.equivalent_type = float_type
 
+    assert complex_type.name == 'complex', complex_type.name
     complex_type.equivalent_type = PyrexTypes.c_double_complex_type
     PyrexTypes.c_double_complex_type.equivalent_type = complex_type
 

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -750,7 +750,7 @@ def init_builtin_types():
         elif name == 'str':
             objstruct_cname = 'PyUnicodeObject'
         elif name == 'bool':
-            objstruct_cname = None  # FIXME: should be 'PyLongObject'
+            objstruct_cname = 'PyLongObject'
         elif name == 'BaseException':
             objstruct_cname = "PyBaseExceptionObject"
         elif name == 'Exception':
@@ -810,8 +810,16 @@ def init_builtins():
 
     float_type = builtin_scope.lookup('float').type
     int_type = builtin_scope.lookup('int').type
-    bool_type  = builtin_scope.lookup('bool').type
+    #bool_type  = builtin_scope.lookup('bool').type
     complex_type  = builtin_scope.lookup('complex').type
+
+    # Most entries are initialized via "declare_builtin_type()"", except for "bool"
+    # which is apparently a special case because it conflicts with C++ bool.
+    # Here, we only declare it as builtin name, not as actual type.
+    bool_type = PyrexTypes.BuiltinObjectType(EncodedString('bool'), "((PyObject*)&PyBool_Type)", "PyLongObject")
+    bool_type.is_final_type = True
+    bool_type.entry = builtin_scope.declare_var(EncodedString('bool'), bool_type, pos=None, cname="((PyObject*)&PyBool_Type)")
+    builtin_types['bool'] = bool_type
 
     sequence_types = (
         list_type,

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -13382,8 +13382,11 @@ class CondExprNode(ExprNode):
             self.type = PyrexTypes.CFakeReferenceType(self.type.ref_base_type)
         if self.type.is_pyobject:
             self.result_ctype = py_object_type
-        elif self.true_val.is_ephemeral() or self.false_val.is_ephemeral():
-            error(self.pos, "Unsafe C derivative of temporary Python reference used in conditional expression")
+        elif self.type.is_ptr:
+            if self.true_val.is_ephemeral():
+                error(self.true_val.pos, "Unsafe C derivative of temporary Python reference used in conditional expression")
+            if self.false_val.is_ephemeral():
+                error(self.false_val.pos, "Unsafe C derivative of temporary Python reference used in conditional expression")
 
         if true_val_type.is_pyobject or false_val_type.is_pyobject or self.type.is_pyobject:
             if true_val_type != self.type:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -5453,6 +5453,19 @@ def independent_spanning_type(type1, type2):
         # type so that we do not lose the ability to coerce to a
         # Python bool if we have to.
         return py_object_type
+    elif resolved_type1.is_pyobject != resolved_type2.is_pyobject:
+        # e.g. PyFloat + double => double
+        if resolved_type1.is_pyobject and resolved_type1.equivalent_type == resolved_type2:
+            return resolved_type2
+        if resolved_type2.is_pyobject and resolved_type2.equivalent_type == resolved_type1:
+            return resolved_type1
+        # PyInt + C int => PyInt
+        if resolved_type1.is_int and resolved_type2.is_builtin_type and resolved_type2.name == 'int':
+            return resolved_type2
+        if resolved_type2.is_int and resolved_type1.is_builtin_type and resolved_type1.name == 'int':
+            return resolved_type1
+        # e.g. PyInt + double => object
+        return py_object_type
 
     span_type = _spanning_type(type1, type2)
     if span_type is None:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1281,11 +1281,6 @@ class BuiltinScope(Scope):
             Scope.__init__(self, "__builtin__", PreImportScope(), None)
         self.type_names = {}
 
-        # Most entries are initialized in init_builtins, except for "bool"
-        # which is apparently a special case because it conflicts with C++ bool
-        bool_type = PyrexTypes.BuiltinObjectType('bool', "((PyObject*)&PyBool_Type)")
-        self.declare_var("bool", bool_type, pos=None, cname="((PyObject*)&PyBool_Type)")
-
     def lookup(self, name, language_level=None):
         # 'language_level' is passed by ModuleScope
         if name == 'unicode' or name == 'basestring':

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1283,7 +1283,8 @@ class BuiltinScope(Scope):
 
         # Most entries are initialized in init_builtins, except for "bool"
         # which is apparently a special case because it conflicts with C++ bool
-        self.declare_var("bool", py_object_type, None, "((PyObject*)&PyBool_Type)")
+        bool_type = PyrexTypes.BuiltinObjectType('bool', "((PyObject*)&PyBool_Type)")
+        self.declare_var("bool", bool_type, pos=None, cname="((PyObject*)&PyBool_Type)")
 
     def lookup(self, name, language_level=None):
         # 'language_level' is passed by ModuleScope

--- a/tests/errors/charptr_from_temp.pyx
+++ b/tests/errors/charptr_from_temp.pyx
@@ -65,5 +65,6 @@ _ERRORS = """
 44:10: Storing unsafe C derivative of temporary Python reference
 44:10: Py_UNICODE* has been removed in Python 3.12. This conversion to a Py_UNICODE* will no longer compile in the latest Python versions. Use Python C API functions like PyUnicode_AsWideCharString if you need to obtain a wchar_t* on Windows (and free the string manually after use).
 52:7: Storing unsafe C derivative of temporary Python reference
-52:7: Unsafe C derivative of temporary Python reference used in conditional expression
+52:9: Unsafe C derivative of temporary Python reference used in conditional expression
+52:34: Unsafe C derivative of temporary Python reference used in conditional expression
 """

--- a/tests/run/if_else_expr.pyx
+++ b/tests/run/if_else_expr.pyx
@@ -114,8 +114,10 @@ def performance_gh5197(patternsList):
         except Exception as e:
             matched.append('Error at Index:%s-%s' %(_, patternsList[_]))
 
+
 cdef accept_int(int x):
     return x
+
 
 def test_mixed_int_bool_coercion(x):
     """
@@ -127,3 +129,18 @@ def test_mixed_int_bool_coercion(x):
     5
     """
     return accept_int(False if x is None else x)
+
+
+def test_mixed_result_type(s: str):
+    """
+    >>> test_mixed_result_type('1')
+    1
+    >>> test_mixed_result_type('-5')
+    -5
+    >>> test_mixed_result_type('1.')
+    1.0
+    >>> test_mixed_result_type('.1')
+    0.1
+    """
+    result = float(s) if '.' in s else int(s)
+    return result


### PR DESCRIPTION
The spanning type is not necessarily the correct result type when mixing numeric types in conditional expressions. This specifically shows when one is a Python object type that could coerce to the C numeric type of the other side (but shouldn't).

While fixing this, I noticed that we accidentally set `bint` as an `equivalent_type` on `object` that was intended for `bool`. `bool` really shouldn't be that special…

Fixes https://github.com/cython/cython/issues/6854