### PR TITLE
Prevent ctuples from being 'const'

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8317,8 +8317,14 @@ class SequenceNode(ExprNode):
         return self
 
     def coerce_to_ctuple(self, dst_type, env):
+        if dst_type.is_reference:
+            dst_type = dst_type.ref_base_type
+        if dst_type.is_cv_qualified:
+            # ctuples are passed by value and must always be assignable, never const.
+            return self.coerce_to_ctuple(dst_type.cv_base_type, env)
         if self.type == dst_type:
             return self
+
         assert not self.mult_factor
         if len(self.args) != dst_type.size:
             error(self.pos, "trying to coerce sequence to ctuple of wrong length, expected %d, got %d" % (

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8317,11 +8317,8 @@ class SequenceNode(ExprNode):
         return self
 
     def coerce_to_ctuple(self, dst_type, env):
-        if dst_type.is_reference:
-            dst_type = dst_type.ref_base_type
-        if dst_type.is_cv_qualified:
-            # ctuples are passed by value and must always be assignable, never const.
-            return self.coerce_to_ctuple(dst_type.cv_base_type, env)
+        # ctuples are passed by value and must always be assignable, never const.
+        dst_type = PyrexTypes.remove_cv_ref(dst_type, remove_fakeref=True)
         if self.type == dst_type:
             return self
 

--- a/tests/run/cpp_stl_vector.pyx
+++ b/tests/run/cpp_stl_vector.pyx
@@ -285,8 +285,25 @@ def test_insert():
 
 
 #  Tests GitHub issue #1788.
+# https://github.com/cython/cython/issues/1788
+
 cdef cppclass MyVector[T](vector):
     pass
 
 cdef cppclass Ints(MyVector[int]):
     pass
+
+
+# Tests Github issue #6864
+# https://github.com/cython/cython/issues/6864
+
+ctypedef (int, int)  int_ctuple2
+
+def test_ctuple_items():
+    """
+    >>> test_ctuple_items()
+    [(1, 2), (3, 4), (5, 6)]
+    """
+    cdef vector[int_ctuple2] v = [(1, 2), (3, 4)]
+    v.push_back((5, 6))  # takes const argument
+    return v


### PR DESCRIPTION
They are always passed by value and need to be assignable.

Closes https://github.com/cython/cython/issues/6864