### PR TITLE
"Fix" lambdas in embedsignatures

### DIFF
--- a/Cython/CodeWriter.py
+++ b/Cython/CodeWriter.py
@@ -482,11 +482,12 @@ class ExpressionWriter(TreeVisitor):
     A Cython code writer that is intentionally limited to expressions.
     """
 
-    def __init__(self, result=None):
+    def __init__(self, result=None, allow_unknown_nodes=False):
         super().__init__()
         if result is None:
             result = ""
         self.result = result
+        self.allow_unknown_nodes = allow_unknown_nodes
         self.precedence = [0]
 
     def write(self, tree):
@@ -508,7 +509,11 @@ class ExpressionWriter(TreeVisitor):
             self.visit(items[-1])
 
     def visit_Node(self, node):
-        raise AssertionError("Node not handled by serializer: %r" % node)
+        if self.allow_unknown_nodes:
+            self.put("...")
+        else:
+            breakpoint()
+            raise AssertionError("Node not handled by serializer: %r" % node)
 
     # TODO: Remove redundancy below. Most constants serialise fine as just "repr(node.value)".
 

--- a/Cython/Compiler/AutoDocTransforms.py
+++ b/Cython/Compiler/AutoDocTransforms.py
@@ -50,7 +50,7 @@ class EmbedSignature(CythonTransform):
         self.class_node = None
 
     def _fmt_expr(self, node):
-        writer = ExpressionWriter()
+        writer = ExpressionWriter(allow_unknown_nodes=True)
         result = writer.write(node)
         # print(type(node).__name__, '-->', result)
         return result

--- a/tests/run/embedsignatures.pyx
+++ b/tests/run/embedsignatures.pyx
@@ -571,3 +571,14 @@ Foo.m31(self, double[::1] a)
 Foo.m32(self, a: tuple[()]) -> tuple[tuple[()]]
 
 """
+
+def has_lambda(arg=lambda z: z+1):
+    pass
+
+# Currently the lambda is shown as an Ellipsis because it's unformatable
+# (and in this context, failure is basically OK). If that changes and we're able to
+# print it properly then update the test.
+__doc__ += """
+>>> print(has_lambda.__doc__)
+has_lambda(arg=...)
+"""

--- a/tests/run/embedsignatures_clinic.pyx
+++ b/tests/run/embedsignatures_clinic.pyx
@@ -149,3 +149,16 @@ add docstring
 ($self, other)
 
 """
+
+def has_lambda(arg=lambda z: z+1):
+    pass
+
+# Currently the lambda is shown as an Ellipsis because it's unformatable
+# (and in this context, failure is basically OK). If that changes and we're able to
+# print it properly then update the test.
+__doc__ += """
+>>> print(has_lambda.__doc__)
+None
+>>> print(has_lambda.__text_signature__)
+(arg=...)
+"""

--- a/tests/run/embedsignatures_python.pyx
+++ b/tests/run/embedsignatures_python.pyx
@@ -305,3 +305,14 @@ m61(self, a: complex) -> complex
 m71(self, a: complex) -> complex
 
 """
+
+def has_lambda(arg=lambda z: z+1):
+    pass
+
+# Currently the lambda is shown as an Ellipsis because it's unformatable
+# (and in this context, failure is basically OK). If that changes and we're able to
+# print it properly then update the test.
+__doc__ += """
+>>> print(has_lambda.__doc__)
+has_lambda(arg=...)
+"""


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/6880

My view is that it's fine if there's unserializable stuff in a signature and we should ignore it rather than fail with an assertion.