### PR TITLE
Restore signatures of fused functions

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -122,7 +122,6 @@ class FusedCFuncDefNode(StatListNode):
 
         self.orig_py_func = self.node
         self.py_func = self.make_fused_cpdef(self.node, env, is_def=True)
-        self.py_func.code_object = CodeObjectNode(self.py_func)
 
     def copy_cdef(self, env):
         """
@@ -946,6 +945,8 @@ class FusedCFuncDefNode(StatListNode):
         self.specialized_pycfuncs = values
         for pycfuncnode in values:
             pycfuncnode.is_specialization = True
+        # use code object from first defnode to get as close to a correct signature as possible
+        self.py_func.code_object = CodeObjectNode(nodes[0])
 
     def generate_function_definitions(self, env, code):
         if self.py_func:

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -7,6 +7,8 @@ Test Python def functions without extern types
 cy = __import__("cython")
 cimport cython
 
+import inspect
+
 cdef extern from *:
     int __Pyx_CyFunction_Check(object)
 
@@ -511,3 +513,12 @@ def stress_test_thread_safety(n_threads):
     for t in threads:
         t.join()
     assert not failed_list, len(failed_list)
+
+def test_signature(arg1, arg2):
+    """
+    >>> parameters = inspect.signature(test_signature).parameters
+    >>> len(parameters)
+    2
+    >>> list(parameters.keys())
+    ['arg1', 'arg2']
+    """

--- a/tests/run/fused_def.pyx
+++ b/tests/run/fused_def.pyx
@@ -514,7 +514,7 @@ def stress_test_thread_safety(n_threads):
         t.join()
     assert not failed_list, len(failed_list)
 
-def test_signature(arg1, arg2):
+def test_signature(cython.floating arg1, cython.floating arg2):
     """
     >>> parameters = inspect.signature(test_signature).parameters
     >>> len(parameters)


### PR DESCRIPTION
Fixes #6855

Just restores the old behaviour whether they have a code object based on their first overload.