### PR TITLE
CI: Fix PyPy3.8 build

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1833,7 +1833,7 @@ static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject *args, PyObject *
 // See https://github.com/cython/cython/issues/6867
 static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject **args, Py_ssize_t nargs, PyObject *kwnames) {
         return _PyObject_Vectorcall
-            (method, args ? args+1 : NULL, nargs ? (size_t) nargs-1 : 0, kwnames);
+            (method, args ? args+1 : NULL, nargs ? nargs-1 : 0, kwnames);
 }
 #else
 static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1828,6 +1828,13 @@ static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject *args, PyObject *
     Py_DECREF(selfless_args);
     return result;
 }
+#elif CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x03090000
+// PyPy 3.8 does not define 'args' as 'const'.
+// See https://github.com/cython/cython/issues/6867
+static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject **args, Py_ssize_t nargs, PyObject *kwnames) {
+        return _PyObject_Vectorcall
+            (method, args ? args+1 : NULL, nargs ? (size_t) nargs-1 : 0, kwnames);
+}
 #else
 static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames) {
     return

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -106,7 +106,8 @@ if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
     python -m pip install --pre -r test-requirements-313.txt || exit 1
   fi
 else
-  python -m pip install -U pip "setuptools<60" wheel twine || exit 1
+  # Drop dependencies cryptography and nh3 (purely from twine) when removing support for PyPy3.8.
+  python -m pip install -U pip "setuptools<60" wheel twine "cryptography<42" "nh3<0.2.19" || exit 1
 
   if [[ $PYTHON_VERSION != *"-dev" || $COVERAGE == "1" ]]; then
     python -m pip install -r test-requirements.txt || exit 1


### PR DESCRIPTION
- Downgrade the cryptography (twine) dependency to 41.x which still has binary wheels for it.
- Downgrade nh3 to 0.2.18 which uses PyO3  0.22 (0.23.0 dropped PyPy3.8 support).