### PR TITLE
Use PyCallable_Check() instead of type slots for callable() in PyPy

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -1296,7 +1296,9 @@ static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
 
 /////////////// CallableCheck.proto ///////////////
 
-#if CYTHON_USE_TYPE_SLOTS
+// PyPy does not set tp_call on classes with metaclass.
+// See https://github.com/cython/cython/issues/6892
+#if CYTHON_USE_TYPE_SLOTS && !CYTHON_COMPILING_IN_PYPY
 #define __Pyx_PyCallable_Check(obj)   (Py_TYPE(obj)->tp_call != NULL)
 #else
 #define __Pyx_PyCallable_Check(obj)   PyCallable_Check(obj)

--- a/tests/run/builtin_callable.pyx
+++ b/tests/run/builtin_callable.pyx
@@ -19,6 +19,8 @@ def test_callable(x):
 
     >>> class M(type): pass
     >>> class X(metaclass=M): pass
+    >>> callable(X)
+    True
     >>> test_callable(X)
     True
 

--- a/tests/run/builtin_callable.pyx
+++ b/tests/run/builtin_callable.pyx
@@ -17,6 +17,11 @@ def test_callable(x):
     >>> test_callable(C())
     False
 
+    >>> class M(type): pass
+    >>> class X(metaclass=M): pass
+    >>> test_callable(X)
+    True
+
     >>> test_callable(int)
     True
     >>> test_callable(test_callable)


### PR DESCRIPTION
Fixes #6892