### PR TITLE
CI: drop numpy<2 pin

### DIFF
--- a/test-requirements-312.txt
+++ b/test-requirements-312.txt
@@ -1,4 +1,4 @@
-numpy<2
+numpy
 coverage
 pycodestyle
 setuptools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-numpy<2
+numpy
 coverage
 pycodestyle
 setuptools<60


### PR DESCRIPTION
This was added in a799b1b8c6d584f1a8df1853abdad047b69d3aca but per that commit:
> Once NumPy releases 2.0.0rc1, these pins should be reverted.

numpy 2.0.0 was released nearly a year ago, so drop it.