### PR TITLE
Only `#include <type_traits>` for C++11

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2308,7 +2308,10 @@ static void __Pyx_FastGilFuncInit(void) {
 // In C++ a variable must actually be initialized to make returning
 // it defined behaviour, and there doesn't seem to be a viable compiler trick to
 // avoid that.
+#if __cplusplus > 201103L
 #include <type_traits>
+#endif
+
 template <typename T>
 static void __Pyx_pretend_to_initialize(T* ptr) {
     // In C++11 we have enough introspection to work out which types it's actually


### PR DESCRIPTION
This header was only added in C++11, and not all compilers make it available when compiling for older C++ standard versions.

The call to `std::is_trivially_default_constructible` is appropriately guarded below, but the include was not.