### PR TITLE
Avoid pessimizing sequence checks on 'range'

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3065,7 +3065,12 @@ class IteratorNode(ScopedExprNode):
         if not is_builtin_sequence:
             # reversed() not currently optimised (see Optimize.py)
             assert not self.reversed, "internal error: reversed() only implemented for list/tuple objects"
-        self.may_be_a_sequence = not sequence_type.is_builtin_type
+        # range is a *very* common builtin function which we know doesn't produce a sequence
+        is_range = (isinstance(self.sequence, CallNode) and
+                    self.sequence.function.is_name and
+                    self.sequence.function.name == "range" and
+                    self.sequence.function.entry.is_builtin)
+        self.may_be_a_sequence = not sequence_type.is_builtin_type and not is_range
         if self.may_be_a_sequence:
             code.putln(
                 "if (likely(PyList_CheckExact(%s)) || PyTuple_CheckExact(%s)) {" % (


### PR DESCRIPTION
It's possible that we might want to generalize this rule, rather than leave it as a very specific special-case. However: `range` is going to be a very common function to be looping over and we know the result isn't a tuple or list. So let's not tell that compiler that it is.