### PR TITLE
runtests use concurrent.futures.ProcessPoolExecutor

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2521,7 +2521,8 @@ def main():
         merged_pipeline_stats = defaultdict(lambda: (0, 0))
         with time_stamper_thread(interval=keep_alive_interval, open_shards=open_shards):
             futures = [ pool.submit(runtests_callback, task) for task in tasks ]
-            for shard_num, shard_stats, pipeline_stats, return_code, failure_output in as_completed(futures):
+            for future in as_completed(futures):
+                shard_num, shard_stats, pipeline_stats, return_code, failure_output = future.result()
                 open_shards.remove(shard_num)
                 if return_code != 0:
                     error_shards.append(shard_num)

--- a/runtests.py
+++ b/runtests.py
@@ -2535,10 +2535,8 @@ def main():
                     old_time, old_count = merged_pipeline_stats[stage_name]
                     merged_pipeline_stats[stage_name] = (old_time + stage_time, old_count + stage_count)
 
-        pool.close()
-        pool.join()
-        pool.terminate()  # graalpy seems happier if we terminate now rather than leaving it to the gc
-
+        pool.shutdown()
+        
         total_time = time.time() - total_time
         sys.stderr.write("Sharded tests run in %d seconds (%.1f minutes)\n" % (round(total_time), total_time / 60.))
         if error_shards:


### PR DESCRIPTION
instead of multiprocessing.Pool.

The main advantage of this is that it can apparently detect segmentation faults (https://stackoverflow.com/questions/24370930/multiprocessing-pool-hangs-if-child-causes-a-segmentation-fault) so it won't hang forever if one of the processes crash.

It should be available on all Python versions we care about.