### PR TITLE
Fix C type of PyBool_Type

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -348,10 +348,7 @@ builtin_types_table = [
 
     ("type",    "&PyType_Type",     []),
 
-# This conflicts with the C++ bool type, and unfortunately
-# C++ is too liberal about PyObject* <-> bool conversions,
-# resulting in unintuitive runtime behavior and segfaults.
-#    ("bool",   "&PyBool_Type",     []),
+    ("bool",   "&PyBool_Type",     []),
 
     ("int",     "&PyLong_Type",     []),
     ("float",   "&PyFloat_Type",   []),
@@ -833,18 +830,8 @@ def init_builtins():
 
     float_type = builtin_scope.lookup('float').type
     int_type = builtin_scope.lookup('int').type
-    #bool_type  = builtin_scope.lookup('bool').type
+    bool_type  = builtin_scope.lookup('bool').type
     complex_type  = builtin_scope.lookup('complex').type
-
-    # Most entries are initialized via "declare_builtin_type()"", except for "bool"
-    # which is apparently a special case because it conflicts with C++ bool.
-    # Here, we only declare it as builtin name, not as actual type.
-    bool_type = PyrexTypes.BuiltinObjectType(EncodedString('bool'), "(&PyBool_Type)", "PyLongObject")
-    scope = CClassScope('bool', outer_scope=None, visibility='extern', parent_type=bool_type)
-    bool_type.set_scope(scope)
-    bool_type.is_final_type = True
-    bool_type.entry = builtin_scope.declare_var(EncodedString('bool'), bool_type, pos=None, cname="(&PyBool_Type)")
-    builtin_types['bool'] = bool_type
 
     sequence_types = (
         list_type,

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -839,11 +839,11 @@ def init_builtins():
     # Most entries are initialized via "declare_builtin_type()"", except for "bool"
     # which is apparently a special case because it conflicts with C++ bool.
     # Here, we only declare it as builtin name, not as actual type.
-    bool_type = PyrexTypes.BuiltinObjectType(EncodedString('bool'), "((PyObject*)&PyBool_Type)", "PyLongObject")
+    bool_type = PyrexTypes.BuiltinObjectType(EncodedString('bool'), "(&PyBool_Type)", "PyLongObject")
     scope = CClassScope('bool', outer_scope=None, visibility='extern', parent_type=bool_type)
     bool_type.set_scope(scope)
     bool_type.is_final_type = True
-    bool_type.entry = builtin_scope.declare_var(EncodedString('bool'), bool_type, pos=None, cname="((PyObject*)&PyBool_Type)")
+    bool_type.entry = builtin_scope.declare_var(EncodedString('bool'), bool_type, pos=None, cname="(&PyBool_Type)")
     builtin_types['bool'] = bool_type
 
     sequence_types = (

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -449,6 +449,26 @@ def pytypes_multi_union(a: Union[list, tuple, None], b: list | tuple | None):
     print((typeof(a), typeof(b)))
     return [a, b]
 
+def optional_py_bool(a: Optional[bool]):
+    """
+    >>> optional_py_bool(True)
+    True
+    >>> optional_py_bool(None)
+    """
+    return a
+
+ctypedef bint c_bool
+
+# Mostly a code-generation test. Although this doesn't quite make sense, it should
+# compile in some form.
+def optional_c_bool(a: Optional[c_bool]):
+    """
+    >>> optional_c_bool(True)
+    True
+    >>> optional_c_bool(None)
+    """
+    return a
+
 _WARNINGS = """
 15:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 15:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
@@ -472,6 +492,7 @@ _WARNINGS = """
 346:15: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
 437:32: Unknown type declaration in annotation, ignoring
 437:69: Unknown type declaration in annotation, ignoring
+452:32: Unknown type declaration in annotation, ignoring
 # DUPLICATE:
 75:44: Found C type name 'long' in a Python annotation. Did you mean to use 'cython.long'?
 75:44: Unknown type declaration 'long' in annotation, ignoring

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -492,7 +492,6 @@ _WARNINGS = """
 346:15: Annotation ignored since class-level attributes must be Python objects. Were you trying to set up an instance attribute?
 437:32: Unknown type declaration in annotation, ignoring
 437:69: Unknown type declaration in annotation, ignoring
-452:32: Unknown type declaration in annotation, ignoring
 # DUPLICATE:
 75:44: Found C type name 'long' in a Python annotation. Did you mean to use 'cython.long'?
 75:44: Unknown type declaration 'long' in annotation, ignoring

--- a/tests/run/cpp_bool.pyx
+++ b/tests/run/cpp_bool.pyx
@@ -3,6 +3,8 @@
 
 from libcpp cimport bool
 
+from typing import Optional
+
 def test_bool(bool a):
     """
     >>> test_bool(True)
@@ -39,3 +41,11 @@ def test_may_raise_exception(bool value, exception=None):
     RuntimeError
     """
     return may_raise_exception(value, exception)
+
+def test_as_annotation(value: Optional[bool]):
+    """
+    >>> test_as_annotation(True)
+    True
+    >>> test_as_annotation(None)
+    """
+    return value


### PR DESCRIPTION
For all other Python builtin types the cname evaluates to a PyTypeObject*

Fixes #6902

It's still a little inconsistent in when it evaluates bool as a type-checked argument. But at least it compiles.