### PR TITLE
Account for limited API in version check for PyDict_GetItemStringRef

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -584,7 +584,7 @@ static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcnam
     d = PyObject_GetAttrString(module, "$api_name");
     if (!d)
         goto bad;
-#if PY_VERSION_HEX >= 0x030d0000
+#if (defined(Py_LIMITED_API) && Py_LIMITED_API >= 0x030d0000) || (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000)
     PyDict_GetItemStringRef(d, funcname, &cobj);
 #else
     cobj = PyDict_GetItemString(d, funcname);


### PR DESCRIPTION
It looks like this was just an oversight since the correct logic is present for [the other call in the same file](https://github.com/cython/cython/blob/05479ebf581309d5a40c802ce45943d402e8ae5c/Cython/Utility/ImportExport.c#L677).