### PR TITLE
Add an option to runtests to run with a specific Limited API version

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2448,7 +2448,7 @@ def main():
         help="do not capture stdout, stderr in srctree tests. Makes pdb.set_trace interactive")
     parser.add_argument(
         "--limited-api", dest="limited_api", nargs='?', default=False, const=True, action="store",
-        help="Compiles Cython using CPython's LIMITED_API")
+        help="Compiles Cython using CPython's LIMITED_API. You can optional specify a version in the form '3.11'")
     parser.add_argument('cmd_args', nargs='*')
 
     options = parser.parse_args(args)

--- a/runtests.py
+++ b/runtests.py
@@ -2449,8 +2449,9 @@ def main():
         "--no-capture", dest="capture", default=True, action="store_false",
         help="do not capture stdout, stderr in srctree tests. Makes pdb.set_trace interactive")
     parser.add_argument(
-        "--limited-api", dest="limited_api", nargs='?', default=False, const=True, action="store",
-        help="Compiles Cython using CPython's LIMITED_API. You can optional specify a version in the form '3.11'")
+        "--limited-api", dest="limited_api", nargs='?', default='', const="%d.%d" % sys.version_info[:2], action="store",
+        help=("Use CPython's Limited API. "
+              "Accepts an optional API version in the form '3.11', otherwise uses current."))
     parser.add_argument('cmd_args', nargs='*')
 
     options = parser.parse_args(args)

--- a/runtests.py
+++ b/runtests.py
@@ -2335,8 +2335,10 @@ def main():
         help="do not regression test reference counting")
     parser.add_argument(
         "--no-fork", dest="fork",
-        action="store_false", default=True, deprecated=True,
-        help="does nothing, argument kept for compatibility only")
+        action="store_false", default=True,
+        help="does nothing, argument kept for compatibility only",
+        # 'deprecated' added in Python 3.13
+        **({'deprecated': True} if sys.version_info >= (3, 13) else {}))
     parser.add_argument(
         "--sys-pyregr", dest="system_pyregr",
         action="store_true", default=False,

--- a/runtests.py
+++ b/runtests.py
@@ -2738,24 +2738,21 @@ def runtests(options, cmd_args, coverage=None):
 
     sys_version_or_limited_version = sys.version_info
     if options.limited_api:
-        if options.limited_api is True:
-            CDEFS.append(("Py_LIMITED_API", '(PY_VERSION_HEX & 0xffff0000)'))
-        else:
-            limited_api_version = re.match(r"^(\d+)[.](\d+)$", options.limited_api)
-            if not limited_api_version:
-                sys.stderr.write('Limited API version string should be in the form "3.11"\n')
-                exit(1)
-            limited_api_major_version = int(limited_api_version.group(1))
-            limited_api_minor_version = int(limited_api_version.group(2))
-            CDEFS.append((
-                "Py_LIMITED_API",
-                f"0x{limited_api_major_version:02x}{limited_api_minor_version:02x}0000")
-            )
-            sys_version_or_limited_version = (
-                limited_api_major_version,
-                limited_api_minor_version,
-                0
-            )
+        limited_api_version = re.match(r"^(\d+)[.](\d+)$", options.limited_api)
+        if not limited_api_version:
+            sys.stderr.write('Limited API version string should be in the form "3.11"\n')
+            exit(1)
+        limited_api_major_version = int(limited_api_version.group(1))
+        limited_api_minor_version = int(limited_api_version.group(2))
+        CDEFS.append((
+            "Py_LIMITED_API",
+            f"0x{limited_api_major_version:02x}{limited_api_minor_version:02x}0000")
+        )
+        sys_version_or_limited_version = (
+            limited_api_major_version,
+            limited_api_minor_version,
+            0
+        )
         CFLAGS.append('-Wno-unused-function')
 
     if WITH_CYTHON:


### PR DESCRIPTION
I don't propose using this on the CI (there's just too many combinations to test) but I think it's a useful thing to be able to do locally.