### PR TITLE
Remove use of C abort function

### DIFF
--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -362,7 +362,7 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
 #endif
         } else {
             Py_FatalError(
-                __func__ " for type {{TYPE}} executed an unexpected code path. "
+                "__Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}}) executed an unexpected code path. "
                 "Please report this as a bug in Cython"
             );
             return 0; /* handled elsewhere */
@@ -378,7 +378,7 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
 #endif
         } else {
             Py_FatalError(
-                __func__ " for type {{TYPE}} executed an unexpected code path. "
+                "__Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}}) executed an unexpected code path. "
                 "Please report this as a bug in Cython"
             );
             return 0; /* handled elsewhere */

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -361,7 +361,7 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
             return ({{TYPE}}) __Pyx_{{BINOP}}_unsigned_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {
-            abort(); return 0; /* handled elsewhere */
+            Py_FatalError("Please report this as a bug in Cython - this code path should not be executed"); return 0; /* handled elsewhere */
         }
     } else {
         if ((sizeof({{TYPE}}) == sizeof(int))) {
@@ -373,7 +373,7 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
             return ({{TYPE}}) __Pyx_{{BINOP}}_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {
-            abort(); return 0; /* handled elsewhere */
+            Py_FatalError("Please report this as a bug in Cython - this code path should not be executed"); return 0; /* handled elsewhere */
         }
     }
 }

--- a/Cython/Utility/Overflow.c
+++ b/Cython/Utility/Overflow.c
@@ -361,7 +361,11 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
             return ({{TYPE}}) __Pyx_{{BINOP}}_unsigned_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {
-            Py_FatalError("Please report this as a bug in Cython - this code path should not be executed"); return 0; /* handled elsewhere */
+            Py_FatalError(
+                __func__ " for type {{TYPE}} executed an unexpected code path. "
+                "Please report this as a bug in Cython"
+            );
+            return 0; /* handled elsewhere */
         }
     } else {
         if ((sizeof({{TYPE}}) == sizeof(int))) {
@@ -373,7 +377,11 @@ static CYTHON_INLINE {{TYPE}} __Pyx_{{BINOP}}_{{NAME}}_checking_overflow({{TYPE}
             return ({{TYPE}}) __Pyx_{{BINOP}}_long_long_checking_overflow(a, b, overflow);
 #endif
         } else {
-            Py_FatalError("Please report this as a bug in Cython - this code path should not be executed"); return 0; /* handled elsewhere */
+            Py_FatalError(
+                __func__ " for type {{TYPE}} executed an unexpected code path. "
+                "Please report this as a bug in Cython"
+            );
+            return 0; /* handled elsewhere */
         }
     }
 }


### PR DESCRIPTION
It isn't available in the Limited API without an extra include (just because the Limited API includes slightly different headers than the full API).

Using `Py_FatalError` seems the most descriptive way of fixing it.