### PR TITLE
Add Python 3.13t to benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Setup python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.11"
 
@@ -318,7 +318,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.11"
 
@@ -343,20 +343,21 @@ jobs:
           fetch-tags: true
 
       - name: Setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v554.0
         with:
           # List special Pythons first to keep the 'normal' one as (last) "python3.xy".
           python-version: |
             3.10
             3.12
             3.13
+            3.13t
             3.14-dev
 
       - name: Run Benchmarks
         run: |
           # Run benchmarks in all Python versions, Limited C-API only in 3.14.
           LIMITED_API=--with-limited
-          for PYTHON in  python3.14  python3.13  python3.12  python3.10  ; do
+          for PYTHON in  python3.14  python3.13  python3.13t  python3.12  python3.10  ; do
               ${PYTHON} -m pip install setuptools
               ${PYTHON} Demos/benchmarks/run_benchmarks.py  --show-size --with-python  origin/3.0.x  3a7a936e099df468dcaa01829ae6567c577489c0  ${LIMITED_API} origin/master  ${LIMITED_API} HEAD
               LIMITED_API=


### PR DESCRIPTION
There's definitely some pessimizations both in our code (and I think in the interpreter) so it'd be good to see how much worse we are.

It's a bit ambiguous if we should use 3.13t or 3.14t, but I don't think it really matters for the sake of getting a quick glance. When 3.14 is out properly we should definitely update it though.