### PR TITLE
Update list of builtin functions and types

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -227,7 +227,10 @@ builtin_function_table = [
     #('aiter',     "",     "",      ""),
     #('anext',     "",     "",      ""),
     #('ascii',     "",     "",      ""),
-    #('bin',       "",     "",      ""),
+    BuiltinFunction('bin',       "O",     "O",      "__Pyx_PyNumber_Bin", builtin_return_type='str',
+                    utility_code=UtilityCode(
+                        proto="#define __Pyx_PyNumber_Bin(obj) PyNumber_ToBase((obj), 2)",
+                        name="PyNumber_Bin")),
     #('breakpoint', "",     "",      ""),
     BuiltinFunction('callable',   "O",    "b",     "__Pyx_PyCallable_Check",
                     utility_code = UtilityCode.load("CallableCheck", "ObjectHandling.c")),

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -224,27 +224,34 @@ builtin_function_table = [
                     utility_code=UtilityCode.load("py_abs", "Builtins.c")),
     #('all',       "",     "",      ""),
     #('any',       "",     "",      ""),
+    #('aiter',     "",     "",      ""),
+    #('anext',     "",     "",      ""),
     #('ascii',     "",     "",      ""),
     #('bin',       "",     "",      ""),
+    #('breakpoint', "",     "",      ""),
     BuiltinFunction('callable',   "O",    "b",     "__Pyx_PyCallable_Check",
                     utility_code = UtilityCode.load("CallableCheck", "ObjectHandling.c")),
     BuiltinFunction('chr',        "i",    "O",      "PyUnicode_FromOrdinal", builtin_return_type='str'),
-    #('cmp', "",   "",     "",      ""), # int PyObject_Cmp(PyObject *o1, PyObject *o2, int *result)
     #('compile',   "",     "",      ""), # PyObject* Py_CompileString(    char *str, char *filename, int start)
     BuiltinFunction('delattr',    "OO",   "r",     "__Pyx_PyObject_DelAttr",
                     utility_code=UtilityCode.load("PyObjectDelAttr", "ObjectHandling.c")),
     BuiltinFunction('dir',        "O",    "O",     "PyObject_Dir"),
     BuiltinFunction('divmod',     "OO",   "O",     "PyNumber_Divmod",
                     specialiser=_generate_divmod_function),
+    #('enumerate', "",     "",      ""),
+    #('eval',      "",     "",      ""),
     BuiltinFunction('exec',       "O",    "O",     "__Pyx_PyExecGlobals",
                     utility_code = pyexec_globals_utility_code),
     BuiltinFunction('exec',       "OO",   "O",     "__Pyx_PyExec2",
                     utility_code = pyexec_utility_code),
     BuiltinFunction('exec',       "OOO",  "O",     "__Pyx_PyExec3",
                     utility_code = pyexec_utility_code),
-    #('eval',      "",     "",      ""),
-    #('execfile',  "",     "",      ""),
     #('filter',    "",     "",      ""),
+    BuiltinFunction('format',    "OO",     "O",      "PyObject_Format", builtin_return_type='str'),
+    BuiltinFunction('format',    "O",      "O",      "__Pyx_PyObject_Format1", builtin_return_type='str',
+                    utility_code=UtilityCode(
+                        proto="#define __Pyx_PyObject_Format1(obj) PyObject_Format((obj), NULL)",
+                        name="PyObject_Format1")),
     BuiltinFunction('getattr3',   "OOO",  "O",     "__Pyx_GetAttr3",     "getattr",
                     utility_code=getattr3_utility_code),  # Pyrex legacy
     BuiltinFunction('getattr',    "OOO",  "O",     "__Pyx_GetAttr3",
@@ -254,10 +261,14 @@ builtin_function_table = [
     BuiltinFunction('hasattr',    "OO",   "b",     "__Pyx_HasAttr",
                     utility_code = UtilityCode.load("HasAttr", "Builtins.c")),
     BuiltinFunction('hash',       "O",    "h",     "PyObject_Hash"),
-    #('hex',       "",     "",      ""),
+    #('help',      "",     "",      ""),
+    BuiltinFunction('hex',       "O",     "O",      "__Pyx_PyNumber_Hex", builtin_return_type='str',
+                    utility_code=UtilityCode(
+                        proto="#define __Pyx_PyNumber_Hex(obj) PyNumber_ToBase((obj), 16)",
+                        name="PyNumber_Hex")),
     #('id',        "",     "",      ""),
     #('input',     "",     "",      ""),
-    BuiltinFunction('intern',     "O",    "O",     "__Pyx_Intern",
+    BuiltinFunction('intern',     "O",    "O",     "__Pyx_Intern",  # Py2 legacy
                     utility_code = UtilityCode.load("Intern", "Builtins.c")),
     BuiltinFunction('isinstance', "OO",   "b",     "PyObject_IsInstance"),
     BuiltinFunction('issubclass', "OO",   "b",     "PyObject_IsSubclass"),
@@ -269,11 +280,14 @@ builtin_function_table = [
     #('max',       "",     "",      ""),
     #('min',       "",     "",      ""),
     BuiltinFunction('next',       "O",    "O",     "__Pyx_PyIter_Next",
-                    utility_code = iter_next_utility_code),   # not available in Py2 => implemented here
+                    utility_code = iter_next_utility_code),
     BuiltinFunction('next',      "OO",    "O",     "__Pyx_PyIter_Next2",
-                    utility_code = iter_next_utility_code),  # not available in Py2 => implemented here
-    #('oct',       "",     "",      ""),
-    #('open',       "ss",   "O",     "PyFile_FromString"),   # not in Py3
+                    utility_code = iter_next_utility_code),
+    BuiltinFunction('oct',       "O",     "O",      "__Pyx_PyNumber_Oct", builtin_return_type='str',
+                    utility_code=UtilityCode(
+                        proto="#define __Pyx_PyNumber_Oct(obj) PyNumber_ToBase((obj), 8)",
+                        name="PyNumber_Oct")),
+    #('open',      "ss",   "O",     ""),   # no C-API equivalent in Py3
 ] + [
     BuiltinFunction('ord',        None,    None,   "__Pyx_long_cast",
                     func_type=PyrexTypes.CFuncType(
@@ -297,22 +311,19 @@ builtin_function_table = [
     BuiltinFunction('pow',        "OOO",  "O",     "PyNumber_Power"),
     BuiltinFunction('pow',        "OO",   "O",     "__Pyx_PyNumber_Power2",
                     utility_code = UtilityCode.load("pow2", "Builtins.c")),
-    #('range',     "",     "",      ""),
-    #('raw_input', "",     "",      ""),
-    #('reduce',    "",     "",      ""),
-    BuiltinFunction('reload',     "O",    "O",     "PyImport_ReloadModule"),
+    #('print',     "",     "",      ""),
+    #('property',  "",     "",      ""),
+    BuiltinFunction('reload',     "O",    "O",     "PyImport_ReloadModule"),  # legacy Py2
     BuiltinFunction('repr',       "O",    "O",     "PyObject_Repr", builtin_return_type='str'),
+    #('reversed',  "",     "",      ""),
     #('round',     "",     "",      ""),
     BuiltinFunction('setattr',    "OOO",  "r",     "PyObject_SetAttr"),
-    #('sum',       "",     "",      ""),
     #('sorted',    "",     "",      ""),
+    #('sum',       "",     "",      ""),
     #('type',       "O",    "O",     "PyObject_Type"),
-    BuiltinFunction('unichr',     "i",    "O",      "PyUnicode_FromOrdinal", builtin_return_type='str'),
+    BuiltinFunction('unichr',     "i",    "O",      "PyUnicode_FromOrdinal", builtin_return_type='str'),  # legacy Py2
     #('vars',      "",     "",      ""),
     #('zip',       "",     "",      ""),
-    #  Can't do these easily until we have builtin type entries.
-    #('typecheck',  "OO",   "i",     "PyObject_TypeCheck", False),
-    #('issubtype',  "OO",   "i",     "PyType_IsSubtype",   False),
 
     # Put in namespace append optimization.
     BuiltinFunction('__Pyx_PyObject_Append', "OO",  "O",     "__Pyx_PyObject_Append"),
@@ -325,24 +336,28 @@ builtin_function_table = [
 
 # Builtin types
 #  bool
-#  buffer
+#  bytearray
+#  bytes
 #  classmethod
+#  complex
 #  dict
 #  enumerate
-#  file
 #  float
+#  frozenset
 #  int
 #  list
 #  long
+#  memoryview
 #  object
 #  property
+#  range
+#  set
 #  slice
 #  staticmethod
-#  super
 #  str
+#  super
 #  tuple
 #  type
-#  xrange
 
 builtin_types_table = [
 
@@ -411,6 +426,8 @@ builtin_types_table = [
                                                   utility_code=UtilityCode.load("py_dict_clear", "Optimize.c")),
                                     BuiltinMethod("copy",   "T",   "T", "PyDict_Copy")]),
 
+    ("range",  "&PyRange_Type",    []),
+
     ("slice",  "&PySlice_Type",    [BuiltinProperty("start", PyrexTypes.py_object_type, '__Pyx_PySlice_Start',
                                                     utility_code=slice_accessor_utility_code),
                                     BuiltinProperty("stop", PyrexTypes.py_object_type, '__Pyx_PySlice_Stop',
@@ -468,7 +485,7 @@ types_that_construct_their_instance = frozenset({
     'type', 'bool', 'int', 'float', 'complex',
     'bytes', 'unicode', 'bytearray', 'str',
     'tuple', 'list', 'dict', 'set', 'frozenset',
-    'memoryview',
+    'memoryview', 'range',
     # All builtin exception types create their own instance.
     *filter(PyrexTypes.is_exception_type_name, KNOWN_PYTHON_BUILTINS),
 })
@@ -810,7 +827,8 @@ def init_builtins():
         pos=None, cname='__pyx_assertions_enabled()', is_cdef=True)
     entry.utility_code = UtilityCode.load_cached("AssertionsEnabled", "Exceptions.c")
 
-    global type_type, list_type, tuple_type, dict_type, set_type, frozenset_type, slice_type
+    global type_type, list_type, tuple_type, dict_type, set_type, frozenset_type
+    global slice_type, range_type
     global bytes_type, unicode_type, bytearray_type
     global float_type, int_type, bool_type, complex_type
     global memoryview_type, py_buffer_type
@@ -822,6 +840,7 @@ def init_builtins():
     set_type   = builtin_scope.lookup('set').type
     frozenset_type = builtin_scope.lookup('frozenset').type
     slice_type   = builtin_scope.lookup('slice').type
+    range_type   = builtin_scope.lookup('range').type
 
     bytes_type = builtin_scope.lookup('bytes').type
     unicode_type = builtin_scope.lookup('str').type

--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -226,7 +226,7 @@ builtin_function_table = [
     #('any',       "",     "",      ""),
     #('aiter',     "",     "",      ""),
     #('anext',     "",     "",      ""),
-    #('ascii',     "",     "",      ""),
+    BuiltinFunction('ascii',     "O",     "O",      "PyObject_ASCII", builtin_return_type='str'),
     BuiltinFunction('bin',       "O",     "O",      "__Pyx_PyNumber_Bin", builtin_return_type='str',
                     utility_code=UtilityCode(
                         proto="#define __Pyx_PyNumber_Bin(obj) PyNumber_ToBase((obj), 2)",

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3099,12 +3099,7 @@ class IteratorNode(ScopedExprNode):
         if not is_builtin_sequence:
             # reversed() not currently optimised (see Optimize.py)
             assert not self.reversed, "internal error: reversed() only implemented for list/tuple objects"
-        # range is a *very* common builtin function which we know doesn't produce a sequence
-        is_range = (isinstance(self.sequence, CallNode) and
-                    self.sequence.function.is_name and
-                    self.sequence.function.name == "range" and
-                    self.sequence.function.entry.is_builtin)
-        self.may_be_a_sequence = not sequence_type.is_builtin_type and not is_range
+        self.may_be_a_sequence = not sequence_type.is_builtin_type
         if self.may_be_a_sequence:
             code.putln(
                 "if (likely(PyList_CheckExact(%s)) || PyTuple_CheckExact(%s)) {" % (

--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1025,20 +1025,19 @@ class ControlFlowAnalysis(CythonTransform):
                                     sequence = sequence.args[0]
         if isinstance(sequence, ExprNodes.SimpleCallNode):
             function = sequence.function
-            if sequence.self is None and function.is_name:
+            if sequence.self is None and function.is_name and function.name in ('range', 'xrange'):
                 entry = env.lookup(function.name)
-                if not entry or entry.is_builtin:
-                    if function.name in ('range', 'xrange'):
-                        is_special = True
-                        for arg in sequence.args[:2]:
-                            self.mark_assignment(target, arg, rhs_scope=node.iterator.expr_scope)
-                        if len(sequence.args) > 2:
-                            self.mark_assignment(target, self.constant_folder(
-                                ExprNodes.binop_node(node.pos,
-                                                     '+',
-                                                     sequence.args[0],
-                                                     sequence.args[2])),
-                                                rhs_scope=node.iterator.expr_scope)
+                if entry and entry.is_type and entry.type is Builtin.range_type:
+                    is_special = True
+                    for arg in sequence.args[:2]:
+                        self.mark_assignment(target, arg, rhs_scope=node.iterator.expr_scope)
+                    if len(sequence.args) > 2:
+                        self.mark_assignment(target, self.constant_folder(
+                            ExprNodes.binop_node(node.pos,
+                                                    '+',
+                                                    sequence.args[0],
+                                                    sequence.args[2])),
+                                            rhs_scope=node.iterator.expr_scope)
 
         if not is_special:
             # A for-loop basically translates to subsequent calls to

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -93,9 +93,9 @@ def initial_compile_time_env():
     names = (
         'False', 'True',
         'abs', 'all', 'any', 'ascii', 'bin', 'bool', 'bytearray', 'bytes',
-        'chr', 'cmp', 'complex', 'dict', 'divmod', 'enumerate', 'filter',
+        'chr', 'complex', 'dict', 'divmod', 'enumerate', 'filter',
         'float', 'format', 'frozenset', 'hash', 'hex', 'int', 'len',
-        'list', 'map', 'max', 'min', 'oct', 'ord', 'pow', 'range',
+        'list', 'map', 'max', 'min', 'next', 'oct', 'ord', 'pow', 'range',
         'repr', 'reversed', 'round', 'set', 'slice', 'sorted', 'str',
         'sum', 'tuple', 'zip',
         ### defined below in a platform independent way
@@ -113,8 +113,8 @@ def initial_compile_time_env():
     from functools import reduce
     benv.declare('reduce', reduce)
     benv.declare('unicode', str)
-    benv.declare('long', getattr(builtins, 'long', getattr(builtins, 'int')))
-    benv.declare('xrange', getattr(builtins, 'xrange', getattr(builtins, 'range')))
+    benv.declare('long', int)
+    benv.declare('xrange', range)
 
     denv = CompileTimeScope(benv)
     return denv

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -103,13 +103,9 @@ def initial_compile_time_env():
     )
 
     for name in names:
-        try:
-            benv.declare(name, getattr(builtins, name))
-        except AttributeError:
-            # ignore, likely Py3
-            pass
+        benv.declare(name, getattr(builtins, name))
 
-    # Py2/3 adaptations
+    # legacy Py2 names
     from functools import reduce
     benv.declare('reduce', reduce)
     benv.declare('unicode', str)

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1331,9 +1331,13 @@ class BuiltinScope(Scope):
         scope.directives = {}
         type.set_scope(scope)
         self.type_names[name] = 1
+
         entry = self.declare_type(name, type, None, visibility='extern')
         if utility_code:
             entry.utility_code = utility_code
+        if name == 'range' and 'xrange' not in self.entries:
+            # Keep supporting legacy Py2 'xrange' because it's still in use.
+            self.entries['xrange'] = entry
 
         var_entry = Entry(
             name=entry.name,

--- a/Cython/Compiler/TypeInference.py
+++ b/Cython/Compiler/TypeInference.py
@@ -122,20 +122,19 @@ class MarkParallelAssignments(EnvTransform):
                                     sequence = sequence.args[0]
         if isinstance(sequence, ExprNodes.SimpleCallNode):
             function = sequence.function
-            if sequence.self is None and function.is_name:
+            if sequence.self is None and function.is_name and function.name in ('range', 'xrange'):
                 entry = iterator_scope.lookup(function.name)
-                if not entry or entry.is_builtin:
-                    if function.name in ('range', 'xrange'):
-                        is_special = True
-                        for arg in sequence.args[:2]:
-                            self.mark_assignment(target, arg)
-                        if len(sequence.args) > 2:
-                            self.mark_assignment(
-                                target,
-                                ExprNodes.binop_node(node.pos,
-                                                     '+',
-                                                     sequence.args[0],
-                                                     sequence.args[2]))
+                if not entry or entry.is_type and entry.type is Builtin.range_type:
+                    is_special = True
+                    for arg in sequence.args[:2]:
+                        self.mark_assignment(target, arg)
+                    if len(sequence.args) > 2:
+                        self.mark_assignment(
+                            target,
+                            ExprNodes.binop_node(node.pos,
+                                                    '+',
+                                                    sequence.args[0],
+                                                    sequence.args[2]))
         if not is_special:
             # A for-loop basically translates to subsequent calls to
             # __getitem__(), so using an IndexNode here allows us to

--- a/tests/run/builtin_functions.pyx
+++ b/tests/run/builtin_functions.pyx
@@ -1,0 +1,50 @@
+# mode: run
+
+"""
+Tests for assorted builtin functions that do not merit their own test file.
+"""
+
+import cython
+from cython import typeof
+
+
+def test_format():
+    """
+    >>> test_format()
+    ('123', '7b')
+    """
+    s1 = format(123)
+    assert typeof(s1) == 'str object', typeof(s1)
+    s2 = format(123, 'x')
+    assert typeof(s2) == 'str object', typeof(s2)
+    return s1, s2
+
+
+def test_hex(n):
+    """
+    >>> test_hex(5)
+    '0x5'
+    >>> test_hex(55)
+    '0x37'
+    >>> test_hex('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    """
+    s = hex(n)
+    assert typeof(s) == 'str object', typeof(s)
+    return s
+
+
+def test_oct(n):
+    """
+    >>> test_oct(5)
+    '0o5'
+    >>> test_oct(55)
+    '0o67'
+    >>> test_oct('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    """
+    s = oct(n)
+    assert typeof(s) == 'str object', typeof(s)
+    return s

--- a/tests/run/builtin_functions.pyx
+++ b/tests/run/builtin_functions.pyx
@@ -20,6 +20,23 @@ def test_format():
     return s1, s2
 
 
+def test_ascii(n):
+    """
+    >>> ascii(5)
+    '5'
+    >>> test_ascii(5)
+    '5'
+
+    >>> ascii('\\N{SNOWMAN}')
+    "'\\\\u2603'"
+    >>> test_ascii('\\N{SNOWMAN}')
+    "'\\\\u2603'"
+    """
+    s = ascii(n)
+    assert typeof(s) == 'str object', typeof(s)
+    return s
+
+
 def test_bin(n):
     """
     >>> test_bin(5)

--- a/tests/run/builtin_functions.pyx
+++ b/tests/run/builtin_functions.pyx
@@ -39,10 +39,19 @@ def test_ascii(n):
 
 def test_bin(n):
     """
+    >>> bin(5)
+    '0b101'
     >>> test_bin(5)
     '0b101'
+
+    >>> bin(55)
+    '0b110111'
     >>> test_bin(55)
     '0b110111'
+
+    >>> bin('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
     >>> test_bin('abc')  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: ...
@@ -54,10 +63,19 @@ def test_bin(n):
 
 def test_hex(n):
     """
+    >>> hex(5)
+    '0x5'
     >>> test_hex(5)
     '0x5'
+
+    >>> hex(55)
+    '0x37'
     >>> test_hex(55)
     '0x37'
+
+    >>> hex('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
     >>> test_hex('abc')  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: ...
@@ -69,10 +87,19 @@ def test_hex(n):
 
 def test_oct(n):
     """
+    >>> oct(5)
+    '0o5'
     >>> test_oct(5)
     '0o5'
+
     >>> test_oct(55)
     '0o67'
+    >>> oct(55)
+    '0o67'
+
+    >>> oct('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
     >>> test_oct('abc')  # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: ...

--- a/tests/run/builtin_functions.pyx
+++ b/tests/run/builtin_functions.pyx
@@ -20,6 +20,21 @@ def test_format():
     return s1, s2
 
 
+def test_bin(n):
+    """
+    >>> test_bin(5)
+    '0b101'
+    >>> test_bin(55)
+    '0b110111'
+    >>> test_bin('abc')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    """
+    s = bin(n)
+    assert typeof(s) == 'str object', typeof(s)
+    return s
+
+
 def test_hex(n):
     """
     >>> test_hex(5)

--- a/tests/run/builtin_ord.pyx
+++ b/tests/run/builtin_ord.pyx
@@ -8,6 +8,19 @@ ustring_with_a = u'abcdefg'
 ustring_without_a = u'bcdefg'
 
 
+def infer_return_type(ch):
+    """
+    >>> infer_return_type('5')
+    53
+    >>> infer_return_type('ab')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ValueError: ...
+    """
+    n = ord(ch)
+    assert cython.typeof(n) == 'long', cython.typeof(n)
+    return n
+
+
 @cython.test_assert_path_exists(
     # ord() should receive and return a C value
     '//ReturnStatNode//CoerceToPyTypeNode//SimpleCallNode')

--- a/tests/run/builtin_range.pyx
+++ b/tests/run/builtin_range.pyx
@@ -1,0 +1,43 @@
+# mode: run
+
+import cython
+
+
+def calls():
+    """
+    >>> calls()
+    """
+    r1 = range(3)
+    assert cython.typeof(r1) == 'range object', cython.typeof(r1)
+
+    r2 = range(1, 3)
+    assert cython.typeof(r2) == 'range object', cython.typeof(r2)
+
+    r3 = range(1, 3, 1)
+    assert cython.typeof(r3) == 'range object', cython.typeof(r3)
+
+
+def arg_type(r: range):
+    """
+    >>> arg_type(range(3))
+    0
+    1
+    2
+    >>> arg_type([])
+    Traceback (most recent call last):
+    TypeError: Argument 'r' has incorrect type (expected range, got list)
+    """
+    for i in r:
+        print(i)
+
+
+def attributes(r: range):
+    """
+    >>> attributes(range(2))
+    (0, 2, 1)
+    >>> attributes(range(1,2))
+    (1, 2, 1)
+    >>> attributes(range(1,2,3))
+    (1, 2, 3)
+    """
+    return r.start, r.stop, r.step

--- a/tests/run/for_in_range_T372.pyx
+++ b/tests/run/for_in_range_T372.pyx
@@ -144,3 +144,22 @@ def test_enum_range():
         assert 0 <= <int>i < <int>n
         assert cython.typeof(i) == "RangeEnum", cython.typeof(i)
     return cython.typeof(i)
+
+
+@cython.test_assert_path_exists("//ForFromStatNode",
+                                "//ForFromStatNode//PrintStatNode//CoerceToPyTypeNode")
+@cython.test_fail_if_path_exists("//ForInStatNode")
+def test_negindex_inferred_xrange():
+    """
+    >>> test_negindex_inferred_xrange()
+    5
+    4
+    3
+    2
+    (2, 0)
+    """
+    cdef int n = 5
+    for i in xrange(n, 1, -1):
+        print i
+        n = 0
+    return i,n

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -420,26 +420,28 @@ def increment():
     a += 1
     assert typeof(a) == "long"
 
+
 def loop():
     """
     >>> loop()
     """
     for a in range(10):
         pass
-    assert typeof(a) == "long"
+    assert typeof(a) == "long", typeof(a)
 
     b = 1.0
     for b in range(5):
         pass
-    assert typeof(b) == "double"
+    assert typeof(b) == "double", typeof(b)
 
     for c from 0 <= c < 10 by .5:
         pass
-    assert typeof(c) == "double"
+    assert typeof(c) == "double", typeof(c)
 
     for d in range(0, 10L, 2):
         pass
-    assert typeof(a) == "long"
+    assert typeof(d) == "long", typeof(d)
+
 
 def loop_over_charptr():
     """


### PR DESCRIPTION
Add functions: `ascii`, `bin`, `format`, `hex`, `oct`
Add type: `range`

Looks like PyPy doesn't currently define `PyFilter_Type` and `PyZip_Type`, unlike CPython, but it defines `PyRange_Type`.