### PR TITLE
Fix type inference of type bitwise or

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12222,7 +12222,7 @@ class BinopNode(ExprNode):
             elif type1.is_pyunicode_ptr:
                 type1 = Builtin.unicode_type
             if type1.is_builtin_type or type2.is_builtin_type:
-                if type1 is type2 and self.operator in '**%+&^':
+                if type1 is type2 and type1 is not type_type and self.operator in '**%+&^':
                     # FIXME: at least these operators should be safe - others?
                     return type1
                 result_type = self.infer_builtin_types_operation(type1, type2)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12222,7 +12222,7 @@ class BinopNode(ExprNode):
             elif type1.is_pyunicode_ptr:
                 type1 = Builtin.unicode_type
             if type1.is_builtin_type or type2.is_builtin_type:
-                if type1 is type2 and type1 is not type_type and self.operator in '**%+&^':
+                if type1 is type2 and type1 is not type_type and self.operator in '**%+|&^':
                     # FIXME: at least these operators should be safe - others?
                     return type1
                 result_type = self.infer_builtin_types_operation(type1, type2)
@@ -12524,14 +12524,6 @@ class BitwiseOrNode(IntBinopNode):
         elif self.operand2.is_none:
             return self._analyse_bitwise_or_none(env, self.operand1)
         return None
-
-    def infer_builtin_types_operation(self, type1, type2):
-        if type1 is type_type or type2 is type_type:
-            # the result is a subclass of 'type' but not an exact instance of 'type'.
-            return py_object_type
-        if type1 is type2 and type1.is_builtin_type:
-            return type1
-        return super().infer_builtin_types_operation(type1, type2)
 
 
 class AddNode(NumBinopNode):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12221,12 +12221,8 @@ class BinopNode(ExprNode):
                 type1 = Builtin.bytes_type
             elif type1.is_pyunicode_ptr:
                 type1 = Builtin.unicode_type
-            if type1 is Builtin.type_type or type2 is Builtin.type_type:
-                # This only really applies to | - the result is a subclass of 'type'
-                # but not an exact instance of 'type'.
-                return py_object_type 
-            elif type1.is_builtin_type or type2.is_builtin_type:
-                if type1 is type2 and self.operator in '**%+|&^':
+            if type1.is_builtin_type or type2.is_builtin_type:
+                if type1 is type2 and self.operator in '**%+&^':
                     # FIXME: at least these operators should be safe - others?
                     return type1
                 result_type = self.infer_builtin_types_operation(type1, type2)
@@ -12528,6 +12524,14 @@ class BitwiseOrNode(IntBinopNode):
         elif self.operand2.is_none:
             return self._analyse_bitwise_or_none(env, self.operand1)
         return None
+
+    def infer_builtin_types_operation(self, type1, type2):
+        if type1 is type_type or type2 is type_type:
+            # the result is a subclass of 'type' but not an exact instance of 'type'.
+            return py_object_type
+        if type1 is type2 and type1.is_builtin_type:
+            return type1
+        return super().infer_builtin_types_operation(type1, type2)
 
 
 class AddNode(NumBinopNode):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12221,7 +12221,11 @@ class BinopNode(ExprNode):
                 type1 = Builtin.bytes_type
             elif type1.is_pyunicode_ptr:
                 type1 = Builtin.unicode_type
-            if type1.is_builtin_type or type2.is_builtin_type:
+            if type1 is Builtin.type_type or type2 is Builtin.type_type:
+                # This only really applies to | - the result is a subclass of 'type'
+                # but not an exact instance of 'type'.
+                return py_object_type 
+            elif type1.is_builtin_type or type2.is_builtin_type:
                 if type1 is type2 and self.operator in '**%+|&^':
                     # FIXME: at least these operators should be safe - others?
                     return type1

--- a/tests/run/isinstance.pyx
+++ b/tests/run/isinstance.pyx
@@ -211,3 +211,25 @@ def test_exceptions(exc):
         if type(e) is OSError:
             return "OSError"
         return f"E:{type(e).__name__}"
+
+
+def skip_if_less_than_310(f):
+    import sys
+    if sys.version_info < (3, 10):
+        return None
+    else:
+        return f
+
+@skip_if_less_than_310
+def test_union(tp):
+    """
+    >>> test_union([])
+    True
+    >>> test_union(b'hello')
+    True
+    >>> test_union(list)
+    False
+    >>> test_union(1)
+    False
+    """
+    return isinstance(tp, list | bytes)

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -1096,3 +1096,13 @@ def variable_with_name_of_type_exttype(SomeExtType x):
     SomeExtType = SomeExtType.get()
     assert typeof(SomeExtType) == "SomeExtType", typeof(SomeExtType)
     return SomeExtType
+
+def type_bitwise_or(actually_run_it, type t1, type t2):
+    """
+    >>> import sys
+    >>> type_bitwise_or(sys.version_info >= (3, 10), list, int)
+    """
+    if actually_run_it:
+        t3 = t1 | t2
+    # Generic object, not "type"
+    assert typeof(t3) == "Python object", typeof(t3)


### PR DESCRIPTION
`type | type` does not give `type` (it gives a subclass of `type`). This was giving an over-optimization, and causing `instance` to fail.

Fixes https://github.com/cython/cython/issues/6420