### PR TITLE
[3.1.x] Fix fused module attribute

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1665,6 +1665,10 @@ static PyMemberDef __pyx_FusedFunction_members[] = {
      READONLY,
      0},
     {"__self__", T_OBJECT_EX, offsetof(__pyx_FusedFunctionObject, self), READONLY, 0},
+    // For heap-types __module__ appears not to be inherited (so redeclare)
+    #if !CYTHON_COMPILING_IN_LIMITED_API
+    {"__module__", T_OBJECT, offsetof(PyCFunctionObject, m_module), 0, 0},
+    #endif
     {0, 0, 0, 0, 0},
 };
 
@@ -1673,6 +1677,10 @@ static PyGetSetDef __pyx_FusedFunction_getsets[] = {
     // a descriptor for the instance's __doc__, so rebuild the descriptor in our subclass
     // (all other descriptors are inherited)
     {"__doc__",  (getter)__Pyx_CyFunction_get_doc, (setter)__Pyx_CyFunction_set_doc, 0, 0},
+    // For heap-types __module__ appears not to be inherited (so redeclare)
+    #if CYTHON_COMPILING_IN_LIMITED_API
+    {"__module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
+    #endif
     {0, 0, 0, 0, 0}
 };
 

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -2,6 +2,11 @@
 # mode: run
 # tag: cyfunction
 
+cimport cython
+
+include "skip_limited_api_helper.pxi"
+
+import sys
 
 def inspect_isroutine():
     """
@@ -411,7 +416,6 @@ def test_firstlineno_decorated_function():
     return l2 - l1
 
 
-@skip_if_limited_api("https://bugs.python.org/issue38140 and/or https://bugs.python.org/issue40703", sys.version_info < (3, 9))
 def test_fused_module(cython.numeric arg):
     """
     See module-level docstring. doctest uses __module__ to decide what to run. So if it's wrong
@@ -419,16 +423,20 @@ def test_fused_module(cython.numeric arg):
     """
     pass
 
-__doc__ = """
->>> test_fused_module.__module__
-'cyfunction'
+__doc__ = ""
 
-# TODO gh-6841
-#>>> type(test_fused_module).__module__.startswith("_cython")
-# True
->>> test_fused_module.__module__ = "something_else"
->>> test_fused_module.__module__
-'something_else'
->>> del test_fused_module.__module__
->>> test_fused_module.__module__
-"""
+if not CYTHON_COMPILING_IN_LIMITED_API or sys.version_info >= (3, 9):
+    # https://bugs.python.org/issue38140 and/or https://bugs.python.org/issue40703
+    __doc__ += """
+    >>> test_fused_module.__module__
+    'cyfunction'
+
+    # TODO gh-6841
+    #>>> type(test_fused_module).__module__.startswith("_cython")
+    # True
+    >>> test_fused_module.__module__ = "something_else"
+    >>> test_fused_module.__module__
+    'something_else'
+    >>> del test_fused_module.__module__
+    >>> test_fused_module.__module__
+    """

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -409,3 +409,26 @@ def test_firstlineno_decorated_function():
     l1 = do_nothing.__code__.co_firstlineno
     l2 = test_firstlineno_decorated_function.__code__.co_firstlineno
     return l2 - l1
+
+
+@skip_if_limited_api("https://bugs.python.org/issue38140 and/or https://bugs.python.org/issue40703", sys.version_info < (3, 9))
+def test_fused_module(cython.numeric arg):
+    """
+    See module-level docstring. doctest uses __module__ to decide what to run. So if it's wrong
+    then we don't run the tests, and never find out about the failure!
+    """
+    pass
+
+__doc__ = """
+>>> test_fused_module.__module__
+'cyfunction'
+
+# TODO gh-6841
+#>>> type(test_fused_module).__module__.startswith("_cython")
+# True
+>>> test_fused_module.__module__ = "something_else"
+>>> test_fused_module.__module__
+'something_else'
+>>> del test_fused_module.__module__
+>>> test_fused_module.__module__
+"""

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -797,7 +797,7 @@ cdef fused confusing_fused_typedef:
 
 def test_dispatch_external_typedef(np.ndarray[confusing_fused_typedef] a):
     """
-    >>> test_dispatch_external_typedef(np.arange(-5, 5, dtype=np.int_))
+    >>> test_dispatch_external_typedef(np.arange(-5, 5, dtype=np.long))
     -2
     """
     print a[3]

--- a/tests/run/numpy_test.pyx
+++ b/tests/run/numpy_test.pyx
@@ -797,7 +797,8 @@ cdef fused confusing_fused_typedef:
 
 def test_dispatch_external_typedef(np.ndarray[confusing_fused_typedef] a):
     """
-    >>> test_dispatch_external_typedef(np.arange(-5, 5, dtype=np.long))
+    >>> dtype = np.int_ if np.version.version.startswith('1') else np.long 
+    >>> test_dispatch_external_typedef(np.arange(-5, 5, dtype=dtype))
     -2
     """
     print a[3]


### PR DESCRIPTION
Fixes #6897

Cherry-picked out of #6882 because I probably should have treated it as a separate issue.
I'd quite like to get this fix merged sooner rather than later because it's invisibly disabling most of the tests fused functions and I don't want to have to fix too many regressions there.