### PR TITLE
see if not hashing the directory helps ccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,9 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
 
+    env:
+        CCACHE_NOHASHDIR: 1
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
For the benchmarks it looks like it's reporting a 0% cache hit rate, which doesn't seem worthwhile. 

In principle the directory affects it I think, and the benchmark runner uses a temp directory, so try to exclude that. 

I'm not quite sure how I know it's worked though - possibly just run the benchmarks twice and see what happens?