### PR TITLE
Fix error handling in nogil indexing of bytearray and str

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4617,11 +4617,12 @@ class IndexNode(_IndexingBaseNode):
                 not (isinstance(self.index.constant_result, int)
                      and self.index.constant_result >= 0))
             boundscheck = bool(code.globalstate.directives['boundscheck'])
-            return ", %s, %d, %s, %d, %d, %d" % (
+            has_gil = not self.in_nogil_context
+            return ", %s, %d, %s, %d, %d, %d, %d" % (
                 self.original_index_type.empty_declaration_code(),
                 self.original_index_type.signed and 1 or 0,
                 self.original_index_type.to_py_function,
-                is_list, wraparound, boundscheck)
+                is_list, wraparound, boundscheck, has_gil)
         else:
             return ""
 

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -445,14 +445,14 @@ static PyObject *__Pyx_PyDict_GetItem(PyObject *d, PyObject* key) {
 /////////////// GetItemInt.proto ///////////////
 //@substitute: tempita
 
-#define __Pyx_GetItemInt(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_GetItemInt(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck, has_gil) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
     __Pyx_GetItemInt_Fast(o, (Py_ssize_t)i, is_list, wraparound, boundscheck) : \
     (is_list ? (PyErr_SetString(PyExc_IndexError, "list index out of range"), (PyObject*)NULL) : \
                __Pyx_GetItemInt_Generic(o, to_py_func(i))))
 
 {{for type in ['List', 'Tuple']}}
-#define __Pyx_GetItemInt_{{type}}(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_GetItemInt_{{type}}(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck, has_gil) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
     __Pyx_GetItemInt_{{type}}_Fast(o, (Py_ssize_t)i, wraparound, boundscheck) : \
     (PyErr_SetString(PyExc_IndexError, "{{ type.lower() }} index out of range"), (PyObject*)NULL))
@@ -567,7 +567,7 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
 
 /////////////// SetItemInt.proto ///////////////
 
-#define __Pyx_SetItemInt(o, i, v, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_SetItemInt(o, i, v, type, is_signed, to_py_func, is_list, wraparound, boundscheck, has_gil) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
     __Pyx_SetItemInt_Fast(o, (Py_ssize_t)i, v, is_list, wraparound, boundscheck) : \
     (is_list ? (PyErr_SetString(PyExc_IndexError, "list assignment index out of range"), -1) : \
@@ -648,7 +648,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
 
 /////////////// DelItemInt.proto ///////////////
 
-#define __Pyx_DelItemInt(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck) \
+#define __Pyx_DelItemInt(o, i, type, is_signed, to_py_func, is_list, wraparound, boundscheck, has_gil) \
     (__Pyx_fits_Py_ssize_t(i, type, is_signed) ? \
     __Pyx_DelItemInt_Fast(o, (Py_ssize_t)i, is_list, wraparound) : \
     (is_list ? (PyErr_SetString(PyExc_IndexError, "list assignment index out of range"), -1) : \

--- a/tests/run/bytearray_coercion.pyx
+++ b/tests/run/bytearray_coercion.pyx
@@ -180,3 +180,19 @@ def nogil_assignment(bytearray x, int value):
     with nogil:
         x[0] = 'x'
         x[1] = value
+
+def nogil_indexing(bytearray x, int idx):
+    """
+    >>> b = bytearray(b'abc')
+    >>> nogil_indexing(b, 0)
+    'a'
+    >>> nogil_indexing(b, -1)
+    'c'
+    >>> nogil_indexing(b, 100)  # even though it's nogil, it should be able to fail
+    Traceback (most recent call last):
+        ...
+    IndexError: bytearray index out of range
+    """
+    with nogil:
+        xi = x[idx]
+    return chr(xi)

--- a/tests/run/unicode_indexing.pyx
+++ b/tests/run/unicode_indexing.pyx
@@ -268,3 +268,19 @@ def index_join_loop(unicode ustring):
     """
     cdef int i
     return u''.join([ ustring[i] for i in range(len(ustring)) ])
+
+
+def nogil_indexing(unicode ustring, int index):
+    """
+    >>> nogil_indexing("abc", 0)
+    'a'
+    >>> nogil_indexing("abc", -1)
+    'c'
+    >>> nogil_indexing("abc", 100)
+    Traceback (most recent call last):
+        ...
+    IndexError: string index out of range
+    """
+    with nogil:
+        u = ustring[index]
+    return u


### PR DESCRIPTION
Cython has an existing feature where it allows indexing of bytearray and str without the GIL. However it doesn't restore the GIL to report errors and so will crash given an out of bounds error. Fix and test that.

Notes:
1. That Cython doesn't allow nogil indexing of bytes. I don't attempt to change that here.
2. The whole thing feels *extremely* dubious in the Limited API but practically you get away with it (so I'm ignoring this...)