### PR TITLE
Thread-safe bytearray indexing

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4626,12 +4626,14 @@ class IndexNode(_IndexingBaseNode):
                      and self.index.constant_result >= 0))
             boundscheck = bool(code.globalstate.directives['boundscheck'])
             has_gil = not self.in_nogil_context
-            if (self.base.type is bytearray_type and not has_gil and (boundscheck or wraparound)
+            if (self.base.type is bytearray_type and not has_gil and boundscheck
                     and code.globalstate.directives['freethreading_compatible']):
-                performance_hint(
-                    self.pos, "Indexing bytearrays with 'boundscheck' or 'wraparound' in a 'nogil' section "
-                        "requires reacquiring the Python thread-state on freethreaded builds.",
-                        code.globalstate)
+                # In principle this applies to 'wraparound' too. The warning only applies to
+                # 'boundscheck' just so there's an easy way to turn it off.
+                warning(
+                    self.pos, "Indexing a bytearray with 'boundscheck' enabled and without the GIL "
+                    "is not thread-safe on freethreaded Python "
+                    "(disable 'boundscheck' to turn off this warning)", 1)
             return ", %s, %d, %s, %d, %d, %d, %d" % (
                 self.original_index_type.empty_declaration_code(),
                 self.original_index_type.signed and 1 or 0,

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4626,6 +4626,12 @@ class IndexNode(_IndexingBaseNode):
                      and self.index.constant_result >= 0))
             boundscheck = bool(code.globalstate.directives['boundscheck'])
             has_gil = not self.in_nogil_context
+            if (self.base.type is bytearray_type and not has_gil and (boundscheck or wraparound)
+                    and code.globalstate.directives['freethreading_compatible']):
+                performance_hint(
+                    self.pos, "Indexing bytearrays with 'boundscheck' or 'wraparound' in a 'nogil' section "
+                        "requires reacquiring the Python thread-state on freethreaded builds.",
+                        code.globalstate)
             return ", %s, %d, %s, %d, %d, %d, %d" % (
                 self.original_index_type.empty_declaration_code(),
                 self.original_index_type.signed and 1 or 0,

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -341,9 +341,9 @@ static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ss
         // The aim isn't to make the character read-writes atomic (although practically they probably are).
         // For simplicity, skip the critical section if we don't have the GIL. It's the user's problem!
         __Pyx_PyCriticalSection cs;
-        if (has_gil) __Pyx_PyCriticalSection_Begin1(cs, string);
+        if (has_gil) __Pyx_PyCriticalSection_Begin1(&cs, string);
         result = __Pyx_GetItemInt_ByteArray_Fast_Locked(string, i, wraparound, boundscheck, has_gil);
-        if (has_gil) __Pyx_PyCriticalSection_End1(cs);
+        if (has_gil) __Pyx_PyCriticalSection_End1(&cs);
         return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS
@@ -405,9 +405,9 @@ static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ss
         // The aim isn't to make the character read-writes atomic (although practically they probably are).
         // For simplicity, skip the critical section if we don't have the GIL. It's the user's problem!
         __Pyx_PyCriticalSection cs;
-        if (has_gil) __Pyx_PyCriticalSection_Begin1(cs, string);
+        if (has_gil) __Pyx_PyCriticalSection_Begin1(&cs, string);
         result = __Pyx_SetItemInt_ByteArray_Fast_Locked(string, i, v, wraparound, boundscheck, has_gil);
-        if (has_gil) __Pyx_PyCriticalSection_End1(cs);
+        if (has_gil) __Pyx_PyCriticalSection_End1(&cs);
         return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -337,18 +337,13 @@ static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ss
 #endif
     if (wraparound | boundscheck) {
         int result;
-#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
-        PyGILState_STATE gil_state;
-        if (!has_gil) gil_state = PyGILState_Ensure();
         // What we're guarding here is just that the size isn't mutating from under us.
         // The aim isn't to make the character read-writes atomic (although practically they probably are).
-        __Pyx_BEGIN_CRITICAL_SECTION(string);
-#endif
+        // For simplicity, skip the critical section if we don't have the GIL. It's the user's problem!
+        __Pyx_PyCriticalSection cs;
+        if (has_gil) __Pyx_PyCriticalSection_Begin1(cs, string);
         result = __Pyx_GetItemInt_ByteArray_Fast_Locked(string, i, wraparound, boundscheck, has_gil);
-#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
-        __Pyx_END_CRITICAL_SECTION();
-        if (!has_gil) PyGILState_Release(gil_state);
-#endif
+        if (has_gil) __Pyx_PyCriticalSection_End1(cs);
         return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS
@@ -406,18 +401,13 @@ static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ss
 #endif
     if (wraparound | boundscheck) {
         int result;
-#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
-        PyGILState_STATE gil_state;
-        if (!has_gil) gil_state = PyGILState_Ensure();
         // What we're guarding here is just that the size isn't mutating from under us.
         // The aim isn't to make the character read-writes atomic (although practically they probably are).
-        __Pyx_BEGIN_CRITICAL_SECTION(string);
-#endif
+        // For simplicity, skip the critical section if we don't have the GIL. It's the user's problem!
+        __Pyx_PyCriticalSection cs;
+        if (has_gil) __Pyx_PyCriticalSection_Begin1(cs, string);
         result = __Pyx_SetItemInt_ByteArray_Fast_Locked(string, i, v, wraparound, boundscheck, has_gil);
-#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
-        __Pyx_END_CRITICAL_SECTION();
-        if (!has_gil) PyGILState_Release(gil_state);
-#endif
+        if (has_gil) __Pyx_PyCriticalSection_End1(cs);
         return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -323,7 +323,7 @@ static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast_Locked(PyObject* string
         return (unsigned char) (PyByteArray_AS_STRING(string)[i]);
         #endif
     } else {
-        __Pyx_SetStringIndexingError("bytearray index out of range", CYTHON_COMPILING_IN_CPYTHON_FREETHREADING || has_gil);
+        __Pyx_SetStringIndexingError("bytearray index out of range", has_gil);
         return -1;
     }
 }
@@ -387,7 +387,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast_Locked(PyObject* string
         #endif
         return 0;
     } else {
-        __Pyx_SetStringIndexingError("bytearray index out of range", CYTHON_COMPILING_IN_CPYTHON_FREETHREADING || has_gil);
+        __Pyx_SetStringIndexingError("bytearray index out of range", has_gil);
         return -1;
     }
 }

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -306,27 +306,50 @@ static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ss
                                                          int wraparound, int boundscheck, int has_gil);
 
 //////////////////// GetItemIntByteArray ////////////////////
+//@requires: ModuleSetupCode.c::CriticalSections
+
+static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast_Locked(PyObject* string, Py_ssize_t i,
+                                                                int wraparound, int boundscheck, int has_gil) {                                             
+    Py_ssize_t length = __Pyx_PyByteArray_GET_SIZE(string);
+    #if !CYTHON_ASSUME_SAFE_SIZE
+    if (unlikely(length < 0)) return -1;
+    #endif
+    if (wraparound & unlikely(i < 0)) i += length;
+    if ((!boundscheck) || likely(__Pyx_is_valid_index(i, length))) {
+        #if !CYTHON_ASSUME_SAFE_MACROS
+        char *asString = PyByteArray_AsString(string);
+        return likely(asString) ? (unsigned char) asString[i] : -1;
+        #else
+        return (unsigned char) (PyByteArray_AS_STRING(string)[i]);
+        #endif
+    } else {
+        __Pyx_SetStringIndexingError("bytearray index out of range", CYTHON_COMPILING_IN_CPYTHON_FREETHREADING || has_gil);
+        return -1;
+    }
+}
 
 static CYTHON_INLINE int __Pyx_GetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i,
                                                          int wraparound, int boundscheck, int has_gil) {
-    Py_ssize_t length;
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+    // In freethreaded Python, wraparound is expensive because it involves acquiring a lock and maybe also the GIL.
+    // Therefore we skip it if it isn't needed.
+    wraparound = wraparound && i<0;
+#endif
     if (wraparound | boundscheck) {
-        length = __Pyx_PyByteArray_GET_SIZE(string);
-        #if !CYTHON_ASSUME_SAFE_SIZE
-        if (unlikely(length < 0)) return -1;
-        #endif
-        if (wraparound & unlikely(i < 0)) i += length;
-        if ((!boundscheck) || likely(__Pyx_is_valid_index(i, length))) {
-            #if !CYTHON_ASSUME_SAFE_MACROS
-            char *asString = PyByteArray_AsString(string);
-            return likely(asString) ? (unsigned char) asString[i] : -1;
-            #else
-            return (unsigned char) (PyByteArray_AS_STRING(string)[i]);
-            #endif
-        } else {
-            __Pyx_SetStringIndexingError("bytearray index out of range", has_gil);
-            return -1;
-        }
+        int result;
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+        PyGILState_STATE gil_state;
+        if (!has_gil) gil_state = PyGILState_Ensure();
+        // What we're guarding here is just that the size isn't mutating from under us.
+        // The aim isn't to make the character read-writes atomic (although practically they probably are).
+        __Pyx_BEGIN_CRITICAL_SECTION(string);
+#endif
+        result = __Pyx_GetItemInt_ByteArray_Fast_Locked(string, i, wraparound, boundscheck, has_gil);
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+        __Pyx_END_CRITICAL_SECTION();
+        if (!has_gil) PyGILState_Release(gil_state);
+#endif
+        return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS
         char *asString = PyByteArray_AsString(string);
@@ -350,29 +373,52 @@ static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ss
                                                          int wraparound, int boundscheck, int has_gil);
 
 //////////////////// SetItemIntByteArray ////////////////////
+//@requires: ModuleSetupCode.c::CriticalSections
+
+static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast_Locked(PyObject* string, Py_ssize_t i, unsigned char v,
+                                                                int wraparound, int boundscheck, int has_gil) {
+    Py_ssize_t length = __Pyx_PyByteArray_GET_SIZE(string);
+    #if !CYTHON_ASSUME_SAFE_SIZE
+    if (unlikely(length < 0)) return -1;
+    #endif
+    if (wraparound & unlikely(i < 0)) i += length;
+    if ((!boundscheck) || likely(__Pyx_is_valid_index(i, length))) {
+        #if !CYTHON_ASSUME_SAFE_MACROS
+        char *asString = PyByteArray_AsString(string);
+        if (unlikely(!asString)) return -1;
+        asString[i] = (char)v;
+        #else
+        PyByteArray_AS_STRING(string)[i] = (char) v;
+        #endif
+        return 0;
+    } else {
+        __Pyx_SetStringIndexingError("bytearray index out of range", CYTHON_COMPILING_IN_CPYTHON_FREETHREADING || has_gil);
+        return -1;
+    }
+}
 
 static CYTHON_INLINE int __Pyx_SetItemInt_ByteArray_Fast(PyObject* string, Py_ssize_t i, unsigned char v,
                                                          int wraparound, int boundscheck, int has_gil) {
-    Py_ssize_t length;
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+    // In freethreaded Python, wraparound is expensive because it involves acquiring a lock and maybe also the GIL.
+    // Therefore we skip it if it isn't needed.
+    wraparound = wraparound && i<0;
+#endif
     if (wraparound | boundscheck) {
-        length = __Pyx_PyByteArray_GET_SIZE(string);
-        #if !CYTHON_ASSUME_SAFE_SIZE
-        if (unlikely(length < 0)) return -1;
-        #endif
-        if (wraparound & unlikely(i < 0)) i += length;
-        if ((!boundscheck) || likely(__Pyx_is_valid_index(i, length))) {
-            #if !CYTHON_ASSUME_SAFE_MACROS
-            char *asString = PyByteArray_AsString(string);
-            if (unlikely(!asString)) return -1;
-            asString[i] = (char)v;
-            #else
-            PyByteArray_AS_STRING(string)[i] = (char) v;
-            #endif
-            return 0;
-        } else {
-            __Pyx_SetStringIndexingError("bytearray index out of range", has_gil);
-            return -1;
-        }
+        int result;
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+        PyGILState_STATE gil_state;
+        if (!has_gil) gil_state = PyGILState_Ensure();
+        // What we're guarding here is just that the size isn't mutating from under us.
+        // The aim isn't to make the character read-writes atomic (although practically they probably are).
+        __Pyx_BEGIN_CRITICAL_SECTION(string);
+#endif
+        result = __Pyx_SetItemInt_ByteArray_Fast_Locked(string, i, v, wraparound, boundscheck, has_gil);
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+        __Pyx_END_CRITICAL_SECTION();
+        if (!has_gil) PyGILState_Release(gil_state);
+#endif
+        return result;
     } else {
         #if !CYTHON_ASSUME_SAFE_MACROS
         char *asString = PyByteArray_AsString(string);


### PR DESCRIPTION
This adds a critical section around `wraparound` or `boundcheck` bytearray indexing on freethreaded builds. This ensures the boundscheck is accurate and that the size doesn't change between the check and the indexing. A critical section is what Python does internally.

It's slightly debatable whether the lock should be applied with wraparound alone. Python itself calculates the wrapped index without a critical section, but then always does the boundscheck making it safe. I've chosen to lock but could see the argument either way.

Another question is what to do when we don't have the GIL. I've chosen to reacquire it (which should be relatively cheap on freethreaded builds because it's uncontended) but I think skipping the lock would also be defensible here. If I was starting from scratch I wouldn't allow indexing without the GIL but it's too late for that.