### PR TITLE
Explicitly mark refnanny as freethreading_compatible

### DIFF
--- a/Cython/Runtime/refnanny.pyx
+++ b/Cython/Runtime/refnanny.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, auto_pickle=False
+# cython: language_level=3, auto_pickle=False, freethreading_compatible=True
 
 from cpython.ref cimport PyObject, Py_INCREF, Py_CLEAR, Py_XDECREF, Py_XINCREF
 from cpython.exc cimport PyErr_Fetch, PyErr_Restore


### PR DESCRIPTION
We have actually made the effort to make this work right, so let's say so.

This is mostly so that any users who are using refnanny to audit their own code aren't thrown back to single-threaded mode just on account of refnanny.