### PR TITLE
Fixup shared metaclass in 3.1.x

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3083,6 +3083,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("%s = PyUnicode_FromStringAndSize(\"\", 0); %s" % (
             empty_unicode, code.error_goto_if_null(empty_unicode, self.pos)))
 
+        code.putln("/*--- Initialize various global constants etc. ---*/")
+        code.put_error_if_neg(self.pos, f"__Pyx_InitConstants({Naming.modulestatevalue_cname})")
+        code.putln("stringtab_initialized = 1;")
+        code.put_error_if_neg(self.pos, "__Pyx_InitGlobals()")  # calls any utility code
+
         shared_types = ('CyFunction', 'FusedFunction', 'Coroutine', 'Generator', 'AsyncGen')
         code.put("#if 0")
         for ext_type in shared_types:
@@ -3099,11 +3104,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("/*--- Library function declarations ---*/")
         if env.directives['np_pythran']:
             code.put_error_if_neg(self.pos, "_import_array()")
-
-        code.putln("/*--- Initialize various global constants etc. ---*/")
-        code.put_error_if_neg(self.pos, f"__Pyx_InitConstants({Naming.modulestatevalue_cname})")
-        code.putln("stringtab_initialized = 1;")
-        code.put_error_if_neg(self.pos, "__Pyx_InitGlobals()")  # calls any utility code
 
         code.putln("if (%s) {" % self.is_main_module_flag_cname())
         code.put_error_if_neg(self.pos, 'PyObject_SetAttr(%s, %s, %s)' % (

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3083,7 +3083,15 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("%s = PyUnicode_FromStringAndSize(\"\", 0); %s" % (
             empty_unicode, code.error_goto_if_null(empty_unicode, self.pos)))
 
-        for ext_type in ('CyFunction', 'FusedFunction', 'Coroutine', 'Generator', 'AsyncGen'):
+        shared_types = ('CyFunction', 'FusedFunction', 'Coroutine', 'Generator', 'AsyncGen')
+        code.put("#if 0")
+        for ext_type in shared_types:
+            code.put(f" || defined(__Pyx_{ext_type}_USED)")
+        code.putln("")
+        code.put_error_if_neg(self.pos, f"__pyx_CommonTypesMetaclass_init({env.module_cname})")
+        code.putln("#endif")
+
+        for ext_type in shared_types:
             code.putln("#ifdef __Pyx_%s_USED" % ext_type)
             code.put_error_if_neg(self.pos, "__pyx_%s_init(%s)" % (ext_type, env.module_cname))
             code.putln("#endif")

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -151,11 +151,6 @@ Py_VISIT(traverse_module_state->__pyx_CommonTypesMetaclassType);
 
 Py_CLEAR(clear_module_state->__pyx_CommonTypesMetaclassType);
 
-//////////////////// CommonTypesMetaclass.init //////////////////
-//@substitute: naming
-
-if (likely(__pyx_CommonTypesMetaclass_init($module_cname) == 0)); else
-
 /////////////////////////// CommonTypesMetaclass.proto ////////////////////////
 
 static int __pyx_CommonTypesMetaclass_init(PyObject *module); /* proto */


### PR DESCRIPTION
Initialization was happening after cyfunction (and the other shared types) were already initialized.