### PR TITLE
Keep defining module alive with CYTHON_USE_MODULE_STATE

### DIFF
--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -102,9 +102,15 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyTypeObject *metaclass, PyOb
         goto bad;
     }
 
-    // We pass the ABI module reference to avoid keeping the user module alive by foreign type usages.
+#if !CYTHON_USE_MODULE_STATE
+    // Without module-state, pass the ABI module reference to avoid keeping the user module alive by foreign type usages.
+    // With module-state it's important to keep the user module alive though.
     CYTHON_UNUSED_VAR(module);
-    cached_type = __Pyx_PyType_FromMetaclass(metaclass, abi_module, spec, bases);
+#endif
+    cached_type = __Pyx_PyType_FromMetaclass(
+        metaclass,
+        CYTHON_USE_MODULE_STATE ? module : abi_module,
+        spec, bases);
     if (unlikely(!cached_type)) goto bad;
     if (unlikely(__Pyx_fix_up_extension_type_from_spec(spec, (PyTypeObject *) cached_type) < 0)) goto bad;
 

--- a/Cython/Utility/CommonStructures.c
+++ b/Cython/Utility/CommonStructures.c
@@ -102,11 +102,8 @@ static PyTypeObject *__Pyx_FetchCommonTypeFromSpec(PyTypeObject *metaclass, PyOb
         goto bad;
     }
 
-#if !CYTHON_USE_MODULE_STATE
     // Without module-state, pass the ABI module reference to avoid keeping the user module alive by foreign type usages.
     // With module-state it's important to keep the user module alive though.
-    CYTHON_UNUSED_VAR(module);
-#endif
     cached_type = __Pyx_PyType_FromMetaclass(
         metaclass,
         CYTHON_USE_MODULE_STATE ? module : abi_module,


### PR DESCRIPTION
In this case, most of the shared types use the contents of the module state and so the lifetime is potentially important.