### PR TITLE
Allow unknown types to be specified as the return type with ->

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2697,8 +2697,7 @@ class CFuncDefNode(FuncDefNode):
         if self.directive_returns is not None:
             base_type = self.directive_returns.analyse_as_type(env)
             if base_type is None:
-                error(self.directive_returns.pos, "Not a type")
-                base_type = PyrexTypes.error_type
+                base_type = self.base_type.analyse(env)
         else:
             base_type = self.base_type.analyse(env)
         self.is_static_method = 'staticmethod' in env.directives and not env.lookup_here('staticmethod')

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -491,6 +491,29 @@ def optional_c_bool(a: Optional[c_bool]):
     """
     return a
 
+# Parsing / code-generation tests for now
+# XXX defining as @cython.ccall so doctests would work fails with function
+# redeclaration errors
+class PyClass:
+
+    def __repr__(self):
+        return 'PyClass()'
+
+@cython.cfunc
+def unknown_pyclass(a: PyClass) -> PyClass:
+    """
+    >>> unknown_pyclass(PyClass())
+    PyClass()
+    """
+    return a
+
+@cython.cfunc
+def none_as_type(a: None) -> None:
+    """
+    >>> repr(unknown_pyclass(None))
+    'None'
+    """
+    return a
 
 _WARNINGS = """
 15:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
@@ -524,4 +547,6 @@ _WARNINGS = """
 222:0: 'struct_convert' redeclared
 241:0: 'exception_default' redeclared
 272:0: 'exception_default_uint' redeclared
+511:20: Unknown type declaration in annotation, ignoring
+511:29: Unknown type declaration in annotation, ignoring
 """


### PR DESCRIPTION
This matches the behavior of type names specified with annotation for arguments and also allows -> None to be used