### PR TITLE
Allow annotations to be used in .pxd files and other declarations

### DIFF
--- a/tests/run/annotation_typing.pxd
+++ b/tests/run/annotation_typing.pxd
@@ -1,0 +1,3 @@
+
+# This is here to test whether annotations work in a declaration
+cdef optional_str(s: str | None)

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -491,6 +491,15 @@ def optional_c_bool(a: Optional[c_bool]):
     """
     return a
 
+cdef optional_str(s: str | None):
+    """
+    >>> optional_str('')
+    ''
+    >>> repr(optional_str(None))
+    'None'
+    """
+    return s
+
 
 _WARNINGS = """
 15:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.


### PR DESCRIPTION
Fixes #6945