### PR TITLE
Sets both .not_none and .or_none to False for annotated arguments.

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1037,6 +1037,13 @@ class CArgDeclNode(Node):
             elif not self.or_none and arg_type.can_be_optional():
                 self.not_none = True
 
+            # Set both .not_none and .or_none to False so that cpdef f(a: T)
+            # and cpdef f(a: T | None) are equivalent to cpdef f(T a) --
+            # cpdef f(T not None a) and cpdef f(T or None a) are currently
+            # not allowed
+            self.not_none = False
+            self.or_none = False
+
         if arg_type:
             self.type_from_annotation = True
         return arg_type

--- a/tests/run/cross_mod_nonecheck.srctree
+++ b/tests/run/cross_mod_nonecheck.srctree
@@ -1,0 +1,49 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import annotated_func_caller; annotated_func_caller.test()"
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from distutils.core import setup
+
+setup(
+    ext_modules = cythonize("*.py"),
+    )
+
+######## annotated_func_impl.pxd ########
+cdef class T:
+    cdef Py_ssize_t attr
+
+cpdef func(T a)
+
+######## annotated_func_impl.py ########
+#cython: nonecheck=True
+
+import cython
+
+@cython.cclass
+class T:
+    def __init__(self):
+        self.attr = 0
+
+@cython.ccall
+def func(a: T):
+    return a.attr
+
+######## annotated_func_caller.pxd ########
+cimport annotated_func_impl
+
+######## annotated_func_caller.py ########
+#cython: nonecheck=True
+
+import cython
+import annotated_func_impl
+
+@cython.ccall
+def test():
+    try:
+        annotated_func_impl.func(None)
+    except:
+        pass
+    else:
+        assert 0, 'annotated_func_impl.func(None) needs to raise an exception'


### PR DESCRIPTION
This makes the none flags for cpdef f(a: T) equivalent to those for cpdef(T a) which fixes possible cross module call segfaults.

Added run/cross_mod_nonecheck to check that something tests for None before accessing an attribue on a C pointer -- doesn't segfault because it's returning part of the memory for the None instance.

Note that not all tests succeed. If there is interest in merging this, I can fixup the other tests and / or limit the scope of this.