### PR TITLE
Fix two-step prange type inference

### DIFF
--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1071,6 +1071,9 @@ class ControlFlowAnalysis(CythonTransform):
         # Condition with iterator
         self.flow.loops.append(LoopDescr(next_block, condition_block))
         self._visit(node.iterator)
+        if isinstance(node, Nodes.ParallelRangeNode):
+            for arg in node.args:
+                self._visit(arg)
         # Target assignment
         self.flow.nextblock()
 

--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1070,7 +1070,6 @@ class ControlFlowAnalysis(CythonTransform):
         next_block = self.flow.newblock()
         # Condition with iterator
         self.flow.loops.append(LoopDescr(next_block, condition_block))
-        # For ParallelRangeNode, args are hidden in node.iterator
         self._visit(node.iterator)
         # Target assignment
         self.flow.nextblock()

--- a/Cython/Compiler/FlowControl.py
+++ b/Cython/Compiler/FlowControl.py
@@ -1070,10 +1070,8 @@ class ControlFlowAnalysis(CythonTransform):
         next_block = self.flow.newblock()
         # Condition with iterator
         self.flow.loops.append(LoopDescr(next_block, condition_block))
+        # For ParallelRangeNode, args are hidden in node.iterator
         self._visit(node.iterator)
-        if isinstance(node, Nodes.ParallelRangeNode):
-            for arg in node.args:
-                self._visit(arg)
         # Target assignment
         self.flow.nextblock()
 

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -10352,10 +10352,14 @@ class ParallelRangeNode(ParallelStatNode):
 
     valid_keyword_arguments = ['schedule', 'nogil', 'num_threads', 'chunksize', 'use_threads_if']
 
+    class DummyIteratorNode(Node):
+        child_attrs = ["args"]
+
     def __init__(self, pos, **kwds):
         super().__init__(pos, **kwds)
-        # Pretend to be a ForInStatNode for control flow analysis
-        self.iterator = PassStatNode(pos)
+        # Pretend to be a ForInStatNode for control flow analysis,
+        # ensuring that the args get visited when the iterator would be.
+        self.iterator = ParallelRangeNode.DummyIteratorNode(pos, args=self.args)
 
     def analyse_declarations(self, env):
         super().analyse_declarations(env)

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -10359,7 +10359,7 @@ class ParallelRangeNode(ParallelStatNode):
         super().__init__(pos, **kwds)
         # Pretend to be a ForInStatNode for control flow analysis,
         # ensuring that the args get visited when the iterator would be.
-        self.iterator = ParallelRangeNode.DummyIteratorNode(pos, args=self.args)
+        self.iterator = self.DummyIteratorNode(pos, args=self.args)
 
     def analyse_declarations(self, env):
         super().analyse_declarations(env)

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -889,3 +889,15 @@ def test_prange_type_inference_3(short start, short end, short step):
         pass
     # Addition in "step" makes it expand the type to "int"
     assert cython.typeof(i) == "int", cython.typeof(i)
+
+def test_type_inference_two_step(unsigned char[:] x):
+    """
+    >>> ba = bytearray(b'\\0'*50)
+    >>> test_type_inference_two_step(ba)
+    >>> for n, c in enumerate(ba):
+    ...     assert c==n, c
+    """
+    length = x.shape[0]  # type of length should be inferred...
+    for n in prange(length, nogil=True):  # then used to infer the type of n
+        x[n] = n
+    assert cython.typeof(n) == "Py_ssize_t", cython.typeof(n)


### PR DESCRIPTION
Fix type inference on prange target when the type of the arguments to prange needs infering themselves.

Fixes #6974