### PR TITLE
[Tests] builtin_exceptions: fix PythonFinalizationError min version

### DIFF
--- a/tests/run/builtin_exceptions.py
+++ b/tests/run/builtin_exceptions.py
@@ -18,10 +18,10 @@ except ImportError:
 
 NEWER_EXCEPTIONS = {
     # Remove when increasing minimal supported Python version.
-    'PythonFinalizationError': (3, 10),
     'EncodingWarning': (3, 10),
     'ExceptionGroup': (3, 11),
     'BaseExceptionGroup': (3, 11),
+    'PythonFinalizationError': (3, 13),
 }
 
 


### PR DESCRIPTION
Change `PythonFinalizationError` the minimal supported Python version from `(3, 10)` to `(3, 13)`:

> exception PythonFinalizationError
> ...
> Added in version 3.13: Previously, a plain RuntimeError was raised.
> — https://docs.python.org/3/library/exceptions.html#PythonFinalizationError