### PR TITLE
exclude type_slot code on PyPy

### DIFF
--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -526,7 +526,7 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i, 
     } else
     #endif
 #endif
-#if CYTHON_USE_TYPE_SLOTS
+#if CYTHON_USE_TYPE_SLOTS && !CYTHON_COMPILING_IN_PYPY
     {
         // inlined PySequence_GetItem() + special cased length overflow
         PyMappingMethods *mm = Py_TYPE(o)->tp_as_mapping;
@@ -605,7 +605,7 @@ static CYTHON_INLINE int __Pyx_SetItemInt_Fast(PyObject *o, Py_ssize_t i, PyObje
         }
     } else
 #endif
-#if CYTHON_USE_TYPE_SLOTS
+#if CYTHON_USE_TYPE_SLOTS && !CYTHON_COMPILING_IN_PYPY
     {
         // inlined PySequence_SetItem() + special cased length overflow
         PyMappingMethods *mm = Py_TYPE(o)->tp_as_mapping;


### PR DESCRIPTION
Pr #6936 added some new code paths in `GetItem_Int` and `SetItem_Int` that cause failures on PyPy when running the NumPy test suite (on pure-python subclasses of c-extension ndarray types). I think this goes back to a long-standing incompatibility between python-level `__getitem__ mapping to both `tp_as_sequence->sq_item` and `tp_as_mapping->mp_subscript` problems I have seen before but cannot find the previous discussion. The easiest solution is to ignore the whole mess on PyPy and fall back to the non-slot functions.

I checked that with this change, the PyPy test failures in the NumPy test suite are fixed and no new ones appear.