### PR TITLE
Fix code-generation with walrus+literals

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -24,6 +24,7 @@ import os.path
 import pathlib
 import re
 import sys
+from typing import Optional
 
 from .Errors import (
     error, warning, InternalError, CompileError, report_error, local_errors,
@@ -15222,27 +15223,28 @@ class AssignmentExpressionNode(ExprNode):
     child_attrs = ["rhs", "assignment"]  # This order is important for control-flow (i.e. xdecref) to be right
 
     is_temp: bool = False
-    rhs: ExprNode
+    rhs: Optional[ExprNode] = None
     assignment: SingleAssignmentNode
-    is_literal_assignment: bool = False
+    assignment_is_independent: bool = False
 
     def __init__(self, pos, lhs: NameNode, rhs: ExprNode, **kwds):
         super().__init__(pos, **kwds)
-        self.rhs = ProxyNode(rhs)
-        assign_expr_rhs = CloneNode(self.rhs)
         self.assignment = SingleAssignmentNode(
-            pos, lhs=lhs, rhs=assign_expr_rhs, is_assignment_expression=True)
+            pos, lhs=lhs, rhs=rhs, is_assignment_expression=True)
 
     @property
     def type(self):
-        return self.rhs.type
+        if self.rhs is not None:
+            return self.rhs.type
+        return self.assignment.rhs.type
 
     @property
     def target_name(self):
         return self.assignment.lhs.name
 
     def infer_type(self, env):
-        return self.rhs.infer_type(env)
+        rhs = self.rhs or self.assignment.rhs
+        return rhs.infer_type(env)
 
     def analyse_declarations(self, env):
         self.assignment.analyse_declarations(env)
@@ -15254,13 +15256,10 @@ class AssignmentExpressionNode(ExprNode):
         #   __pyx_t_1
         # (plus any reference counting that's needed)
 
-        self.rhs = self.rhs.analyse_types(env)
-        if not self.rhs.arg.result_in_temp():
-            if not self.rhs.arg.is_literal:
-                # for anything but the simplest cases (where it can be used directly)
-                # we convert rhs to a temp, because CloneNode requires arg to be a temp
-                self.rhs.arg = self.rhs.arg.coerce_to_temp(env)
-            else:
+        self.assignment = self.assignment.analyse_types(env)
+        rhs = self.assignment.rhs
+        if not rhs.result_in_temp():
+            if rhs.is_literal:
                 # For literals we can optimize by just using the literal twice
                 #
                 # We aren't including `self.rhs.is_name` in this optimization
@@ -15269,16 +15268,22 @@ class AssignmentExpressionNode(ExprNode):
                 # This is a special case of https://github.com/cython/cython/issues/4146
                 # TODO - once that's fixed general revisit this code and possibly
                 # use coerce_to_simple
-                self.assignment.rhs = copy.copy(self.rhs.arg)
-                self.rhs = self.rhs.arg  # take out of ProxyNode
-                self.is_literal_assignment = True
+                self.rhs = copy.copy(self.assignment.rhs)
+                self.assignment_is_independent = True
+            else:
+                # for anything but the simplest cases (where it can be used directly)
+                # we convert rhs to a temp, because CloneNode requires arg to be a temp
+                rhs = rhs.coerce_to_temp(env)
+        if not self.assignment_is_independent:
+            self.rhs = ProxyNode(rhs)
+            self.assignment.rhs = CloneNode(self.rhs)
+            self.rhs.arg = self.rhs.arg.coerce_to_temp(env)
 
         # TODO - there's a missed optimization in the code generation stage
         # if self.rhs.arg is temp: an incref/decref pair can be removed
         # (but needs a general mechanism to do that)
-        self.assignment = self.assignment.analyse_types(env)
 
-        if self.type.is_memoryviewslice and isinstance(self.assignment.rhs, CloneNode):
+        if self.type.is_memoryviewslice and self.assignment_is_independent:
             # In "put_assign_to_memviewslice", memoryviews don't generate reference
             # counting on assignment from temp. That lack of reference counting
             # essentially happens twice (since we use the temp twice), which we want to
@@ -15287,11 +15292,13 @@ class AssignmentExpressionNode(ExprNode):
         return self
 
     def coerce_to(self, dst_type, env):
-        if self.is_literal_assignment:
+        if self.assignment_is_independent:
             # rhs and assignment don't share a node, so just behave normally
             self.rhs = self.rhs.coerce_to(dst_type, env)
             return self
         if dst_type == self.assignment.rhs.type:
+            if self.rhs is None:
+                self = self.analyse_types(env)
             # in this quite common case (for example, when both lhs, and self are being coerced to Python)
             # we can optimize the coercion out by sharing it between
             # this and the assignment

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -15297,8 +15297,7 @@ class AssignmentExpressionNode(ExprNode):
             self.rhs = self.rhs.coerce_to(dst_type, env)
             return self
         if dst_type == self.assignment.rhs.type:
-            if self.rhs is None:
-                self = self.analyse_types(env)
+            assert self.rhs is not None
             # in this quite common case (for example, when both lhs, and self are being coerced to Python)
             # we can optimize the coercion out by sharing it between
             # this and the assignment

--- a/tests/run/extra_walrus.py
+++ b/tests/run/extra_walrus.py
@@ -41,6 +41,30 @@ def optimize_literals1():
 
 
 @cython.test_fail_if_path_exists("//CloneNode")
+@cython.test_fail_if_path_exists("//CoercionNode")
+def optimize_literals1_typed_int():
+    """
+    There's a small optimization for literals to avoid creating unnecessary temps
+    >>> optimize_literals1_typed_int()
+    10
+    """
+    x: cython.int = 5
+    return (x := 10)
+
+
+@cython.test_fail_if_path_exists("//CloneNode")
+@cython.test_fail_if_path_exists("//CoercionNode")
+def optimize_literals1_typed_object():
+    """
+    There's a small optimization for literals to avoid creating unnecessary temps
+    >>> optimize_literals1_typed_int()
+    10
+    """
+    x: object = 5
+    return (x := 10)
+
+
+@cython.test_fail_if_path_exists("//CloneNode")
 def optimize_literals2():
     """
     There's a small optimization for literals to avoid creating unnecessary temps

--- a/tests/run/extra_walrus.py
+++ b/tests/run/extra_walrus.py
@@ -57,7 +57,7 @@ def optimize_literals1_typed_int():
 def optimize_literals1_typed_object():
     """
     There's a small optimization for literals to avoid creating unnecessary temps
-    >>> optimize_literals1_typed_int()
+    >>> optimize_literals1_typed_object()
     10
     """
     x: object = 5

--- a/tests/run/extra_walrus.py
+++ b/tests/run/extra_walrus.py
@@ -40,8 +40,10 @@ def optimize_literals1():
     return (x := 10)
 
 
-@cython.test_fail_if_path_exists("//CloneNode")
-@cython.test_fail_if_path_exists("//CoercionNode")
+@cython.test_fail_if_path_exists(
+    "//CloneNode",
+    "//CoercionNode",
+)
 def optimize_literals1_typed_int():
     """
     There's a small optimization for literals to avoid creating unnecessary temps
@@ -52,8 +54,10 @@ def optimize_literals1_typed_int():
     return (x := 10)
 
 
-@cython.test_fail_if_path_exists("//CloneNode")
-@cython.test_fail_if_path_exists("//CoercionNode")
+@cython.test_fail_if_path_exists(
+    "//CloneNode",
+    "//CoercionNode",
+)
 def optimize_literals1_typed_object():
     """
     There's a small optimization for literals to avoid creating unnecessary temps


### PR DESCRIPTION
Fixes 2 issues:
1. `int` literals being coerced to Python objects got the integer passed instead of a Python pointer.
2. It failed to use cached Python integer constants (because coercion nodes got in the way).