### PR TITLE
Further optimize Limited API setdefault slightly

### DIFF
--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -633,11 +633,11 @@ static CYTHON_INLINE PyObject *__Pyx_PyDict_SetDefault(PyObject *d, PyObject *ke
 
 static CYTHON_INLINE PyObject *__Pyx_PyDict_SetDefault(PyObject *d, PyObject *key, PyObject *default_value) {
     PyObject* value;
-#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX > 0x030C0000
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX >= 0x030C0000
     PyObject *args[] = {d, key, default_value};
     value = PyObject_VectorcallMethod(PYIDENT("setdefault"), args, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, NULL);
 #elif CYTHON_COMPILING_IN_LIMITED_API
-    value = PyObject_CallMethod(d, "setdefault", "OO", key, default_value);
+    value = PyObject_CallMethodObjArgs(d, PYIDENT("setdefault"), key, default_value, NULL);
 #elif PY_VERSION_HEX >= 0x030d0000
     PyDict_SetDefaultRef(d, key, default_value, &value);
 #else


### PR DESCRIPTION
Use PYIDENT (since it's in the stringtab we may as well use it).
Fix Limited API version check.
Use simpler calling protocol.

This was in but didn't make it into https://github.com/cython/cython/commit/1d72e6ca1b6c3ab915d80d408b65c90bfea2341f. A microbenchmarks suggests it's about 3 times faster.