### PR TITLE
Bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
       matrix:
         # Tests [amd64]
         #
-        # FIXME: 'cpp' tests seems to fail due to compilation errors (numpy_pythran_unit)
-        # in all python versions and test failures (builtin_float) in 3.5<
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022, macos-15]
         backend: [c, cpp]
         python-version:
           - "3.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,10 +213,10 @@ jobs:
 #            python-version: 3.13t
 #            backend: "cpp"
 #            allowed_failure: true
-          - os: macos-13
+          - os: macos-15
             python-version: 3.13t
             backend: "c"
-          - os: macos-13
+          - os: macos-15
             python-version: 3.13t
             backend: "cpp"
 

--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,4 @@
 ipython
 pytest  # needed by IPython/Jupyter integration tests
-line_profiler<4, >=4.1  # currently 4 appears to collect no profiling info
+line_profiler ~=4.0  # currently 4 appears to collect no profiling info
 setuptools<60

--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,4 @@
 ipython
 pytest  # needed by IPython/Jupyter integration tests
-line_profiler<4  # currently 4 appears to collect no profiling info
+line_profiler<4, >=4.1  # currently 4 appears to collect no profiling info
 setuptools<60

--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,4 @@
 ipython
 pytest  # needed by IPython/Jupyter integration tests
-line_profiler ~=4.0  # currently 4 appears to collect no profiling info
+line_profiler
 setuptools<60

--- a/tests/run/line_profile_test.srctree
+++ b/tests/run/line_profile_test.srctree
@@ -20,6 +20,8 @@ setup(
 
 ######## test_profile.py ###########
 
+import os
+os.environ['LINE_PROFILE'] = '1'
 try:
     import line_profiler
 except ImportError:


### PR DESCRIPTION
macos-13 is being removed relatively soon

https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/