### PR TITLE
Avoid creating traceback in more except clauses

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8388,28 +8388,9 @@ class ExceptClauseNode(Node):
         return Builtin.builtin_types["BaseException"]
 
     def body_may_need_exception(self):
-        body = self.body
-        if isinstance(body, StatListNode):
-            for node in body.stats:
-                if isinstance(node, PassStatNode):
-                    continue
-                elif isinstance(node, ReturnStatNode):
-                    body = node
-                    break
-                else:
-                    return True
-            else:
-                # No user code found (other than 'pass').
-                return False
-
-        if isinstance(body, ReturnStatNode):
-            value = body.value
-            if value is None or value.is_literal:
-                return False
-            # There might be other safe cases, but literals seem the safest for now.
-
-        # If we cannot prove that the exception is unused, it may be used.
-        return True
+        from .ParseTreeTransforms import HasNoExceptionHandlingVisitor
+        visitor = HasNoExceptionHandlingVisitor()
+        return not visitor(self.body)
 
     def generate_handling_code(self, code, end_label):
         code.mark_pos(self.pos)

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -171,7 +171,7 @@ def copy_inherited_directives(outer_directives, **new_directives):
     #  otherwise they can produce very misleading test failures
     new_directives_out = dict(outer_directives)
     for name in ('test_assert_path_exists', 'test_fail_if_path_exists', 'test_assert_c_code_has', 'test_fail_if_c_code_has',
-                 'critical_section'):
+                 'test_body_needs_exception_handling', 'critical_section'):
         new_directives_out.pop(name, None)
     new_directives_out.update(new_directives)
     return new_directives_out
@@ -270,6 +270,7 @@ _directive_defaults = {
 # test support
     'test_assert_path_exists' : [],
     'test_fail_if_path_exists' : [],
+    'test_body_needs_exception_handling' : None,
     'test_assert_c_code_has' : [],
     'test_fail_if_c_code_has' : [],
 
@@ -381,6 +382,7 @@ directive_types = {
     'dataclasses.field': DEFER_ANALYSIS_OF_ARGUMENTS,
     'embedsignature.format': one_of('c', 'clinic', 'python'),
     'subinterpreters_compatible': one_of('no', 'shared_gil', 'own_gil'),
+    'test_body_needs_exception_handling': bool,
 }
 
 for key, val in _directive_defaults.items():
@@ -416,6 +418,7 @@ directive_scopes = {  # defaults to available everywhere
     'test_fail_if_path_exists' : ('function', 'class', 'cclass'),
     'test_assert_c_code_has' : ('module',),
     'test_fail_if_c_code_has' : ('module',),
+    'test_body_needs_exception_handling' : ('with statement',),
     'freelist': ('cclass',),
     'formal_grammar': ('module',),
     'emit_code_comments': ('module',),
@@ -456,6 +459,7 @@ immediate_decorator_directives = {
     'auto_pickle', 'internal', 'collection_type', 'total_ordering',
     # testing directives
     'test_fail_if_path_exists', 'test_assert_path_exists',
+    'test_body_needs_exception_handling',
 }
 
 

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -89,6 +89,9 @@ def test_assert_path_exists(*paths):
 def test_fail_if_path_exists(*paths):
     return _empty_decorator
 
+def test_body_needs_exception_handling(value):
+    return _empty_decorator
+
 class _EmptyDecoratorAndManager:
     def __call__(self, x):
         return x

--- a/Cython/TestUtils.py
+++ b/Cython/TestUtils.py
@@ -285,6 +285,18 @@ class TreeAssertVisitor(VisitorTransform):
             self._c_patterns.extend(directives['test_assert_c_code_has'])
         if 'test_fail_if_c_code_has' in directives:
             self._c_antipatterns.extend(directives['test_fail_if_c_code_has'])
+        if 'test_body_needs_exception_handling' in directives:
+            value = directives['test_body_needs_exception_handling']
+            if value is not None:
+                from .Compiler.ParseTreeTransforms import HasNoExceptionHandlingVisitor
+                visitor = HasNoExceptionHandlingVisitor()
+                result = not visitor(node.body)
+                if value != result:
+                    visitor(node.body)
+                    Errors.error(
+                        node.pos,
+                        "Node had unexpected exception handling value"
+                    )
 
     def visit_ModuleNode(self, node):
         self._module_pos = node.pos

--- a/tests/compile/except_clause_needs_exception.pyx
+++ b/tests/compile/except_clause_needs_exception.pyx
@@ -1,0 +1,151 @@
+# mode: compile
+# tag: cpp, no-cpp-locals
+
+# This test tests a small optimization for except clauses where they can
+# potentially omit some exception handling code if sufficiently simple.
+# The optimization is performed explicitly because it's completely
+# unobservable. Therefore, it's hard to test behaviourally.
+
+cimport cython
+
+cdef cppclass CppClass:
+    int attr
+    CppClass():
+        pass
+
+def return_empty():
+    with cython.test_body_needs_exception_handling(False):
+        return
+
+def return_none():
+    with cython.test_body_needs_exception_handling(False):
+        return None
+
+def return_int():
+    with cython.test_body_needs_exception_handling(False):
+        return 100
+
+def return_str_literal():
+    with cython.test_body_needs_exception_handling(False):
+        return "I'm always in the module cache!"
+
+def return_arg(arg):
+    with cython.test_body_needs_exception_handling(False):
+        return arg
+
+def return_assigned():
+    x = object()
+    with cython.test_body_needs_exception_handling(False):
+        return x
+
+def result_maybe_unassigned(arg):
+    if arg:
+        x = object
+    with cython.test_body_needs_exception_handling(True):
+        return x
+
+py_global = None
+cdef int c_global = 0
+
+def return_py_global():
+    with cython.test_body_needs_exception_handling(True):
+        return py_global
+
+def return_c_global():
+    with cython.test_body_needs_exception_handling(True):
+        return c_global
+
+def test_pass():
+    with cython.test_body_needs_exception_handling(False):
+        pass
+
+cdef void noexcept_func() noexcept:
+    pass
+
+def call_noexcept_func():
+    with cython.test_body_needs_exception_handling(True):
+        noexcept_func()
+
+def test_assignment(arg):
+    global py_global, c_global
+
+    some_value = 5
+    with cython.test_body_needs_exception_handling(False):
+        a = 2
+        b = None
+        c = some_value
+        d = arg
+
+    if arg:
+        some_other_value = object()
+    with cython.test_body_needs_exception_handling(True):
+        e = some_other_value
+    with cython.test_body_needs_exception_handling(True):
+        some_other_value = None  # may call destructor
+    cdef float some_c_value = 0.0
+    with cython.test_body_needs_exception_handling(False):
+        some_c_value = 1.0  # no destructor
+
+    with cython.test_body_needs_exception_handling(True):
+        py_global = True
+    with cython.test_body_needs_exception_handling(False):
+        c_global = 1
+
+    cdef CppClass cpp_instance1
+    cdef CppClass cpp_instance2
+
+    with cython.test_body_needs_exception_handling(True):
+        cpp_instance1 = cpp_instance2  # operator= can be non-trivial
+
+def test_memoryview_assignment(obj):
+    cdef int[:] obj_view = obj
+    cdef int[:] uninitialized_view
+    cdef int[:] a, b, c
+
+    with cython.test_body_needs_exception_handling(True):
+        a = obj  # this can fail
+    
+    with cython.test_body_needs_exception_handling(False):
+        b = obj_view
+
+    with cython.test_body_needs_exception_handling(True):
+        a = obj_view  # now may be assigned - destructor
+
+cdef class CClass:
+    cdef int x
+    cdef object y
+    cdef int[:] z
+
+def test_attr_assignment(CClass arg):
+    cdef int[:] mview = arg
+    cdef int[:] unassigned_mview
+    with cython.test_body_needs_exception_handling(False):
+        arg.x = 5
+        # something = arg.x  # This currently fails because of a "CoerceToTemp". Ideally it'd pass.
+    o = object()
+    with cython.test_body_needs_exception_handling(True):
+        arg.y = o  # maybe destructor
+    with cython.test_body_needs_exception_handling(True):
+        arg.z = mview  # maybe destructor
+    with cython.test_body_needs_exception_handling(True):
+        unassigned_mview = arg.z  # needs initialized check
+    with cython.test_body_needs_exception_handling(True):
+        arg.unknown_attr = 1
+    with cython.test_body_needs_exception_handling(True):
+        b = arg.unknown_attr
+
+def test_maybe_unassigned_int(arg):
+    cdef int a, b
+    if arg:
+        maybe_unassigned = 5
+    with cython.test_body_needs_exception_handling(False):
+        b = maybe_unassigned
+
+@cython.cpp_locals(True)
+def test_cpp_locals(arg):
+    if arg:
+        maybe_unassigned = CppClass()
+    with cython.test_body_needs_exception_handling(True):
+        maybe_unassigned.attr = 1
+    with cython.test_body_needs_exception_handling(True):
+        a = arg.maybe_unassigned


### PR DESCRIPTION
In addition to just "returning literals", also avoid creating a traceback for a lot of simple assignments, and some safe variable reads.

Follow up to https://github.com/cython/cython/pull/6602 covering a few more cases that I believe it's possible to reason about.