### PR TITLE
Don't put the DEL character in character strings

### DIFF
--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -295,7 +295,7 @@ def escape_byte_string(s):
     append, extend = s_new.append, s_new.extend
     for b in s:
         if b >= 127:
-            extend((f'\\{b:03o}').encode('ASCII'))
+            extend(b'\\%03o' % b)
         else:
             append(b)
     return s_new.decode('ASCII')

--- a/Cython/Compiler/StringEncoding.py
+++ b/Cython/Compiler/StringEncoding.py
@@ -272,10 +272,12 @@ def escape_char(c):
     elif c == "'":
         return "\\'"
     n = ord(c)
-    if n < 32 or n > 127:
+    if n < 32 or n >= 127:
         # hex works well for characters
         return "\\x%02X" % n
     else:
+        # strictly £, @ and ` (which fall in this list) are only allowed
+        # in C23. But practically they're well-supported earlier.
         return c
 
 def escape_byte_string(s):
@@ -292,7 +294,7 @@ def escape_byte_string(s):
     s_new = bytearray()
     append, extend = s_new.append, s_new.extend
     for b in s:
-        if b >= 128:
+        if b >= 127:
             extend((f'\\{b:03o}').encode('ASCII'))
         else:
             append(b)


### PR DESCRIPTION
Fixes #6982

I can find conflicting sources on whether it's printable or not, but it doesn't look great in my editor and it doesn't appear in the C language standard of what's allowed to appear in a character constant (https://en.cppreference.com/w/c/language/charset.html).

I don't think it's causing problems with real compilers but equally I don't think it hurts to escape it instead.