### PR TITLE
Integrate bytes indexing into the existing infrastructure

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2286,45 +2286,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
         elif isinstance(arg, ExprNodes.SimpleCallNode):
             if node.type.is_int or node.type.is_float:
                 return self._optimise_numeric_cast_call(node, arg)
-        elif arg.is_subscript:
-            index_node = arg.index
-            if isinstance(index_node, ExprNodes.CoerceToPyTypeNode):
-                index_node = index_node.arg
-            if index_node.type.is_int:
-                return self._optimise_int_indexing(node, arg, index_node)
         return node
-
-    PyBytes_GetItemInt_func_type = PyrexTypes.CFuncType(
-        PyrexTypes.c_char_type, [
-            PyrexTypes.CFuncTypeArg("bytes", Builtin.bytes_type, None),
-            PyrexTypes.CFuncTypeArg("index", PyrexTypes.c_py_ssize_t_type, None),
-            PyrexTypes.CFuncTypeArg("check_bounds", PyrexTypes.c_int_type, None),
-            ],
-        exception_value = "((char)-1)",
-        exception_check = True)
-
-    def _optimise_int_indexing(self, coerce_node, arg, index_node):
-        env = self.current_env()
-        bound_check_bool = 1 if env.directives['boundscheck'] else 0
-        if arg.base.type is Builtin.bytes_type:
-            if coerce_node.type in (PyrexTypes.c_char_type, PyrexTypes.c_uchar_type):
-                # bytes[index] -> char
-                bound_check_node = ExprNodes.IntNode.for_int(coerce_node.pos, bound_check_bool)
-                node = ExprNodes.PythonCapiCallNode(
-                    coerce_node.pos, "__Pyx_PyBytes_GetItemInt",
-                    self.PyBytes_GetItemInt_func_type,
-                    args=[
-                        arg.base.as_none_safe_node("'NoneType' object is not subscriptable"),
-                        index_node.coerce_to(PyrexTypes.c_py_ssize_t_type, env),
-                        bound_check_node,
-                        ],
-                    is_temp=True,
-                    utility_code=UtilityCode.load_cached(
-                        'bytes_index', 'StringTools.c'))
-                if coerce_node.type is not PyrexTypes.c_char_type:
-                    node = node.coerce_to(coerce_node.type, env)
-                return node
-        return coerce_node
 
     float_float_func_types = {
         float_type: PyrexTypes.CFuncType(

--- a/tests/run/bytes_indexing.pyx
+++ b/tests/run/bytes_indexing.pyx
@@ -20,9 +20,13 @@ def index_literal(int i):
     return b"12345"[i]
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_literal_char_cast(int i):
     """
     >>> index_literal_char_cast(0) == ord('1')
@@ -40,9 +44,13 @@ def index_literal_char_cast(int i):
     return <char>(b"12345"[i])
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_nonliteral_char_cast(int i):
     """
     >>> index_nonliteral_char_cast(0) == ord('1')
@@ -60,9 +68,13 @@ def index_nonliteral_char_cast(int i):
     return <char>(b12345[i])
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_literal_uchar_cast(int i):
     """
     >>> index_literal_uchar_cast(0) == ord('1')
@@ -80,9 +92,13 @@ def index_literal_uchar_cast(int i):
     return <unsigned char>(b"12345"[i])
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_nonliteral_uchar_cast(int i):
     """
     >>> index_nonliteral_uchar_cast(0) == ord('1')
@@ -100,9 +116,13 @@ def index_nonliteral_uchar_cast(int i):
     return <unsigned char>(b12345[i])
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_literal_char_coerce(int i):
     """
     >>> index_literal_char_coerce(0) == ord('1')
@@ -121,9 +141,13 @@ def index_literal_char_coerce(int i):
     return result
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 def index_nonliteral_char_coerce(int i):
     """
     >>> index_nonliteral_char_coerce(0) == ord('1')
@@ -142,9 +166,13 @@ def index_nonliteral_char_coerce(int i):
     return result
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 @cython.boundscheck(False)
 def index_literal_char_coerce_no_check(int i):
     """
@@ -161,9 +189,13 @@ def index_literal_char_coerce_no_check(int i):
     return result
 
 
-@cython.test_assert_path_exists("//PythonCapiCallNode")
-@cython.test_fail_if_path_exists("//IndexNode",
-                                 "//CoerceFromPyTypeNode")
+@cython.test_assert_path_exists(
+    "//IndexNode",
+)
+@cython.test_fail_if_path_exists(
+    "//PythonCapiCallNode",
+    "//CoerceFromPyTypeNode",
+)
 @cython.boundscheck(False)
 def index_nonliteral_char_coerce_no_check(int i):
     """


### PR DESCRIPTION
This used to be special because bytes indexing returned a bytes string (not an int) in Python 2.x, but that's long gone now.

Closes https://github.com/cython/cython/issues/6997