### PR TITLE
[3.1.x] Try to simplify requirements, update line_profiler (#7036)

### DIFF
--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -92,31 +92,25 @@ echo "===================="
 echo "Installing requirements [python]"
 if [[ $PYTHON_VERSION == "3.1"[2-9]* ]]; then
   python -m pip install -U pip wheel setuptools || exit 1
-  if [[ $PYTHON_VERSION != *"t" && $PYTHON_VERSION != *"t-dev" ]]; then
-    # twine is not installable on freethreaded Python due to cryptography requirement
-    python -m pip install -U twine || exit 1
-  fi
-  if [[ $PYTHON_VERSION == "3.12"* ]]; then
-    python -m pip install --pre -r test-requirements-312.txt || exit 1
-  else
-    # Install packages one by one, allowing failures due to missing recent wheels.
-    cat test-requirements-312.txt | while read package; do python -m pip install --pre --only-binary ":all:" "$package" || true; done
-  fi
-  if [[ $PYTHON_VERSION == "3.13"* ]]; then
-    python -m pip install --pre -r test-requirements-313.txt || exit 1
-  fi
 else
   # Drop dependencies cryptography and nh3 (purely from twine) when removing support for PyPy3.8.
   python -m pip install -U pip "setuptools<60" wheel twine "cryptography<42" "nh3<0.2.19" || exit 1
-
-  if [[ $PYTHON_VERSION != *"-dev" || $COVERAGE == "1" ]]; then
-    python -m pip install -r test-requirements.txt || exit 1
-    if [[ $PYTHON_VERSION != "pypy"* && $PYTHON_VERSION != "graalpy"* && $PYTHON_VERSION != "3."[1]* ]]; then
-      python -m pip install -r test-requirements-cpython.txt || exit 1
-    elif [[ $PYTHON_VERSION == "pypy-2.7" ]]; then
-      python -m pip install -r test-requirements-pypy27.txt || exit 1
-    fi
-  fi
+fi
+if [[ $PYTHON_VERSION != *"t" && $PYTHON_VERSION != *"t-dev" ]]; then
+  # twine is not installable on freethreaded Python due to cryptography requirement
+  python -m pip install -U twine || exit 1
+fi
+if [[ $PYTHON_VERSION != *"-dev" ]]; then
+  python -m pip install --pre -r test-requirements.txt || exit 1
+else
+  # Install packages one by one, allowing failures due to missing recent wheels.
+  cat test-requirements.txt | while read package; do python -m pip install --pre --only-binary ":all:" "$package" || true; done
+fi
+if [[ $PYTHON_VERSION == "3.13"* ]]; then
+  python -m pip install --pre -r test-requirements-313.txt || exit 1
+fi
+if [[ $PYTHON_VERSION != "pypy"* && $PYTHON_VERSION != "graalpy"* ]]; then
+  python -m pip install -r test-requirements-cpython.txt || exit 1
 fi
 
 if [[ $TEST_CODE_STYLE == "1" ]]; then

--- a/runtests.py
+++ b/runtests.py
@@ -244,10 +244,11 @@ def exclude_test_on_platform(*platforms):
     return sys.platform in platforms
 
 
+def exclude_test_on_dev():
+    return sys.version_info.releaselevel != 'final'
+
+
 def update_linetrace_extension(ext):
-    if not IS_CPYTHON and sys.version_info[:2] < (3, 13):
-        # Tracing/profiling requires PEP-669 monitoring or old CPython tracing.
-        return EXCLUDE_EXT
     ext.define_macros.append(('CYTHON_TRACE', 1))
     return ext
 
@@ -479,9 +480,9 @@ EXT_EXTRAS = {
 TAG_EXCLUDERS = sorted({
     'no-macos':  exclude_test_on_platform('darwin'),
     'pstats': exclude_test_in_pyver((3,12)),
-    'coverage': exclude_test_in_pyver((3,12)),
+    'coverage': exclude_test_in_pyver((3,12)) or exclude_test_on_dev(),
     'monitoring': exclude_test_in_pyver((3,12)),
-    'trace': not IS_CPYTHON,
+    'trace': not IS_CPYTHON or exclude_test_in_pyver((3,12)),
 }.items())
 
 # TODO: use tags

--- a/test-requirements-312.txt
+++ b/test-requirements-312.txt
@@ -1,4 +1,0 @@
-numpy<2
-coverage
-pycodestyle
-setuptools

--- a/test-requirements-cpython.txt
+++ b/test-requirements-cpython.txt
@@ -1,4 +1,3 @@
 ipython
 pytest  # needed by IPython/Jupyter integration tests
-line_profiler<4  # currently 4 appears to collect no profiling info
-setuptools<60
+line_profiler != 4.*  # 4 collects no profiling info

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-numpy<2
+numpy
 coverage
 pycodestyle
 setuptools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 numpy<2
 coverage
 pycodestyle
-setuptools<60
+setuptools


### PR DESCRIPTION
The main point is to update line-profiler to allow the new version which should support Cython again.

Also tried to rationalize the requirements a little. test-requirements-312 seemed the same as test-requirements so I wasn't sure why we were diverging there for example.