### PR TITLE
Remove Py2 InstanceType from Plex

### DIFF
--- a/Cython/Plex/Regexps.py
+++ b/Cython/Plex/Regexps.py
@@ -164,10 +164,10 @@ class RE:
                                             num, self.__class__.__name__, repr(value)))
 
     def wrong_type(self, num, value, expected):
-        got = type(value).__name__
-        raise Errors.PlexTypeError("Invalid type for argument %d of Plex.%s "
-                                   "(expected %s, got %s" % (
-                                       num, self.__class__.__name__, expected, got))
+        raise Errors.PlexTypeError(
+            f"Invalid type for argument {num:d} of {self.__class__.__qualname__} "
+            f"(expected {expected}, got {type(value).__name__}"
+        )
 
 #
 #     Primitive RE constructors

--- a/Cython/Plex/Regexps.py
+++ b/Cython/Plex/Regexps.py
@@ -164,11 +164,7 @@ class RE:
                                             num, self.__class__.__name__, repr(value)))
 
     def wrong_type(self, num, value, expected):
-        if type(value) == types.InstanceType:
-            got = "%s.%s instance" % (
-                value.__class__.__module__, value.__class__.__name__)
-        else:
-            got = type(value).__name__
+        got = type(value).__name__
         raise Errors.PlexTypeError("Invalid type for argument %d of Plex.%s "
                                    "(expected %s, got %s" % (
                                        num, self.__class__.__name__, expected, got))


### PR DESCRIPTION
It no longer exists in Python 3 so it fails. You only see the failure of course if you manage to misuse plex, so it isn't a "real" bug