### PR TITLE
Improve error formatting without newline

### DIFF
--- a/Cython/Compiler/Errors.py
+++ b/Cython/Compiler/Errors.py
@@ -40,6 +40,8 @@ def context(position):
         s = "[unprintable code]\n"
     else:
         s = ''.join(F[max(0, position[1]-6):position[1]])
+        if not s.endswith('\n'):
+            s = f"{F}\n"
         s = '...\n%s%s^\n' % (s, ' '*(position[2]))
     s = '%s\n%s%s\n' % ('-'*60, s, '-'*60)
     return s


### PR DESCRIPTION
If there isn't a newline at the end of the error context insert one. This helps the arrow point to the right place.

For example

```
["f'{1#}'"]
```

(without a newline) gives with the fix

```
Error compiling Cython file:
------------------------------------------------------------
...
["f'{1#}'"]
     ^
------------------------------------------------------------

myfstring2.py:1:5: format string cannot include #
```

but before the fix

```
Error compiling Cython file:
------------------------------------------------------------
...
f'{1#}'     ^
------------------------------------------------------------

myfstring2.py:1:5: format string cannot include #
```