### PR TITLE
Fix a crash in sys.monitoring

### DIFF
--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -157,18 +157,18 @@
               if (!__Pyx_PyThreadState_Current->tracing) {                                   \
                   if (likely($frame_code_cname)) Py_INCREF($frame_code_cname);               \
                   else $frame_code_cname = (PyObject*) __Pyx_createFrameCodeObject(funcname, srcfile, firstlineno); \
-                  if (unlikely(!$frame_code_cname)) goto_error;                              \
-                  ret = __Pyx__TraceStartFunc($monitoring_states_cname, $frame_code_cname, offset, skip_event); \
-              }                                                                              \
+                  if (unlikely(!$frame_code_cname)) ret = -1;                                \
+                  else ret = __Pyx__TraceStartFunc($monitoring_states_cname, $frame_code_cname, offset, skip_event); \
+              } else $frame_code_cname = NULL;                                               \
               PyGILState_Release(state);                                                     \
-          }                                                                                  \
+          } else $frame_code_cname = NULL;                                                   \
       } else {                                                                               \
           if (!__Pyx_PyThreadState_Current->tracing) {                                       \
               if (likely($frame_code_cname)) Py_INCREF($frame_code_cname);                   \
               else $frame_code_cname = (PyObject*) __Pyx_createFrameCodeObject(funcname, srcfile, firstlineno); \
-              if (unlikely(!$frame_code_cname)) goto_error;                                  \
-              ret = __Pyx__TraceStartFunc($monitoring_states_cname, $frame_code_cname, offset, skip_event); \
-          }                                                                                  \
+              if (unlikely(!$frame_code_cname)) ret = -1;                                    \
+              else ret = __Pyx__TraceStartFunc($monitoring_states_cname, $frame_code_cname, offset, skip_event); \
+          } else $frame_code_cname = NULL;                                                   \
       }                                                                                      \
       if (unlikely(ret == -1)) goto_error;                                                   \
   }


### PR DESCRIPTION
Fixes #7050

Happens with a function with monitoring/tracing is used within a sys.monitoring handler.  In this case, the reference counting of `__code__` is inconsistent.