### PR TITLE
Replace module state lookup with hash table

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -264,9 +264,11 @@ def exclude_test_if_no_gdb(*, _has_gdb=[None]):
     return not _has_gdb[0]
 
 
-def update_linetrace_extension(ext):
-    ext.define_macros.append(('CYTHON_TRACE', 1))
-    return ext
+def get_update_with_macro(macro):
+    def update(ext):
+        ext.define_macros.append(macro)
+        return ext
+    return update
 
 
 def update_numpy_extension(ext, set_api17_macro=True):
@@ -473,8 +475,9 @@ EXT_EXTRAS = {
     'tag:cpp17': update_cpp17_extension,
     'tag:cpp20': update_cpp20_extension,
     'tag:c11': update_c11_extension,
-    'tag:trace' : update_linetrace_extension,
+    'tag:trace' : get_update_with_macro(('CYTHON_TRACE', 1)),
     'tag:cppexecpolicies': require_gcc("9.1"),
+    'tag:module_state_utility_code' : get_update_with_macro(('CYTHON_TEST_MODULE_STATE_LOOKUP', 1))
 }
 
 TAG_EXCLUDERS = sorted({

--- a/tests/run/modulestatelookup_impl.pyx
+++ b/tests/run/modulestatelookup_impl.pyx
@@ -1,0 +1,132 @@
+# mode: run
+# tag: module_state_utility_code
+
+# cython: language_level=3
+
+# Currently this test only checks the adding/removal of modules
+# and not the thread safety.
+
+from cpython.ref cimport PyObject
+from libc.stdint cimport int64_t
+
+cdef extern from *:
+    ctypedef struct __Pyx_ModuleStateLookupData:
+        pass
+
+    __Pyx_ModuleStateLookupData* __Pyx_ModuleStateLookup_allocate_for_tests() except NULL
+    void __Pyx_ModuleStateLookup_free_for_tests(__Pyx_ModuleStateLookupData*)
+    PyObject *__Pyx_ModuleStateLookup_FindModule(__Pyx_ModuleStateLookupData*, int64_t)
+    int __Pyx_ModuleStateLookup_AddModule(__Pyx_ModuleStateLookupData*, int64_t, PyObject*) except -1
+    int __Pyx_ModuleStateLookup_RemoveModule(__Pyx_ModuleStateLookupData*, int64_t) except -1
+
+def test_module0():
+    """
+    >>> test_module0()
+    """
+    data = __Pyx_ModuleStateLookup_allocate_for_tests();
+    try:
+        assert __Pyx_ModuleStateLookup_FindModule(data, 0) == NULL
+
+        example_mod = object()
+        __Pyx_ModuleStateLookup_AddModule(data, 0, <PyObject*>example_mod)
+        assert __Pyx_ModuleStateLookup_FindModule(data, 0) == <PyObject*>example_mod
+
+        __Pyx_ModuleStateLookup_RemoveModule(data, 0)
+        assert __Pyx_ModuleStateLookup_FindModule(data, 0) == NULL
+    finally:
+        __Pyx_ModuleStateLookup_free_for_tests(data)
+
+def test_add_modules():
+    """
+    >>> test_add_modules()
+    """
+    data = __Pyx_ModuleStateLookup_allocate_for_tests();
+    try:
+        modules = [object() for _ in range(500)]
+        for n, module in enumerate(modules):
+            assert __Pyx_ModuleStateLookup_FindModule(data, n) == NULL
+            __Pyx_ModuleStateLookup_AddModule(data, n, <PyObject*>module)
+
+        for n, module in enumerate(modules):
+            assert __Pyx_ModuleStateLookup_FindModule(data, n) == <PyObject*>module
+    finally:
+        __Pyx_ModuleStateLookup_free_for_tests(data)
+
+def test_remove_modules():
+    """
+    test_remove_modules()
+    """
+    data = __Pyx_ModuleStateLookup_allocate_for_tests();
+    try:
+        modules = [object() for _ in range(500)]
+        for n, module in enumerate(modules):
+            try:
+                __Pyx_ModuleStateLookup_RemoveModule(data, n)
+            except SystemError:
+                pass  # expected
+            else:
+                assert False, "Didn't raise SystemError"
+            __Pyx_ModuleStateLookup_AddModule(data, n, <PyObject*>module)
+
+        for n, module in range(len(modules)):
+            __Pyx_ModuleStateLookup_RemoveModule(data, n)
+        for n, module in range(len(modules)):
+            assert __Pyx_ModuleStateLookup_FindModule(data, n) == NULL
+    finally:
+        __Pyx_ModuleStateLookup_free_for_tests(data)
+
+def test_random_add_removal():
+    """
+    >>> test_random_add_removal()
+    """
+    import random
+
+    generator = random.Random()
+    initial_state = generator.getstate()
+
+    data = __Pyx_ModuleStateLookup_allocate_for_tests();
+    try:
+        removed_modules = {n: object() for n in range(50)}
+        added_modules = {}
+
+        def do(mode):
+            if mode == "add":
+                count_to_add = generator.randint(0, len(removed_modules))
+                ids_to_add = generator.sample(list(removed_modules.keys()), count_to_add)
+                for id in ids_to_add:
+                    m = removed_modules.pop(id)
+                    __Pyx_ModuleStateLookup_AddModule(data, id, <PyObject*>m)
+                    added_modules[id] = m
+            elif mode == "remove":
+                count_to_remove = generator.randint(0, len(added_modules))
+                ids_to_remove = generator.sample(list(added_modules.keys()), count_to_remove)
+                for id in ids_to_remove:
+                    m = added_modules.pop(id)
+                    __Pyx_ModuleStateLookup_RemoveModule(data, id)
+                    removed_modules[id] = m
+            elif mode == "check":
+                for id, m in added_modules.items():
+                    assert __Pyx_ModuleStateLookup_FindModule(data, id) == <PyObject*>m
+                for id, m in removed_modules.items():
+                    assert __Pyx_ModuleStateLookup_FindModule(data, id) == NULL
+            else:
+                assert False, mode
+
+        mode = "add"
+
+        for count in range(100):
+            do(mode)
+
+            mode = generator.choices(
+                ("add", "remove", "check"),
+                (0.45, 0.45, 0.1),
+            )[0]
+
+        do("check")
+
+    except:
+        # Make debugging a little easier
+        print(f"Failed: state {initial_state}")
+        raise
+    finally:
+        __Pyx_ModuleStateLookup_free_for_tests(data)


### PR DESCRIPTION
When using multi-phase init and module state, use a hash table instead of bisection into an array. This should hopefully perform better on average (especially when there are many modules available).

Special case the 0th module so this one's always available quickly.

Make it so the implementation can be tested independently on subinterpreters/module state.