### PR TITLE
Update C/C++ py_safe locking loops...

### DIFF
--- a/Cython/Includes/libcpp/mutex.pxd
+++ b/Cython/Includes/libcpp/mutex.pxd
@@ -318,40 +318,23 @@ cdef extern from *:
     }
 
     template <typename... LockTs>
-    void __pyx_py_safe_std_lock_slow_loop(LockTs& ...locks) {
-        while (true) {
-            PyThreadState *_save;
-            Py_UNBLOCK_THREADS
-            try {
-                #if defined(__cpp_lib_scoped_lock)
-                auto scoped_lock = std::scoped_lock(locks...);
-                #else
-                __pyx_std_lock_wrapper(locks...);
-                __pyx_libcpp_mutex_unlock(locks...);
-                #endif
-            } catch (...) {
-                // In this case, we probably can't reason about the state of the locks but we can at least
-                // make sure the GIL is consistent.
-                Py_BLOCK_THREADS
-                throw;
-            }
+    void __pyx_py_safe_std_lock_release_lock_reacquire(LockTs& ...locks) {
+        // Release the GIL, acquire the lock, then reacquire the GIL.
+        // This is safe provided the user never holds the GIL while trying
+        // to reacquire the lock (i.e. it's safe provided they always use
+        // the py-safe wrappers).
+        PyThreadState *_save;
+        Py_UNBLOCK_THREADS
+        try {
+            __pyx_std_lock_wrapper(locks...);
+        } catch (...) {
+            // In this case, we probably can't reason about the state of the locks but we can at least
+            // make sure the GIL is consistent.
             Py_BLOCK_THREADS
-            if (__pyx_std_try_lock_wrapper(locks...) == -1) {
-                return; // success
-            }
+            throw;
         }
-    }
-
-    template <typename... LockTs>
-    void __pyx_py_safe_std_lock_fast_loop(LockTs& ...locks) {
-        for (int i=0; i<100; ++i) {
-            Py_BEGIN_ALLOW_THREADS
-            Py_END_ALLOW_THREADS
-            if (__pyx_std_try_lock_wrapper(locks...) == -1) {
-                return; // success
-            }
-        }
-        __pyx_py_safe_std_lock_slow_loop(locks...);
+        Py_BLOCK_THREADS
+        return;
     }
 
     template <typename... LockTs>
@@ -374,7 +357,7 @@ cdef extern from *:
             // success!
             return;
         }
-        __pyx_py_safe_std_lock_fast_loop(locks...);
+        __pyx_py_safe_std_lock_release_lock_reacquire(locks...);
     }
 
     template <typename MutexT>

--- a/docs/src/userguide/freethreading.rst
+++ b/docs/src/userguide/freethreading.rst
@@ -415,10 +415,12 @@ the language standard libraries for more options.
 In addition to the plain standard library features, Cython (3.2) also produces "py_safe" versions
 of some of these features (e.g. ``call_once``, mutex ``lock``).  
 These ensure that the Python thread-state is released (if held) while blocking and then restored
-to its initial state after the call. The C++ version of ``py_safe_call_once`` also allows you to
-pass a Python callable.  Using the "py_safe" versions may be useful even in a function labelled
+to its initial state after the call.  The "py_safe" functions are only effective if you use
+them consistently every time you try to acquire the lock while you might be holding the Python
+thread-state.  This means you should use the "py_safe" versions even in a function labelled
 as ``nogil`` - remember that this says that a function *may* be called without an attached
-Python thread-state rather than ensuring that it definitely is. Therefore, avoiding deadlocks is still useful.
+Python thread-state rather than ensuring that it definitely is.
+The C++ version of ``py_safe_call_once`` also allows you to pass a Python callable.
 
 ``cython.critical_section`` vs GIL
 ----------------------------------


### PR DESCRIPTION
to match those in 3f00d92 (i.e. be a bit more usable in heavily contended cases).

This does make it slightly easier to deadlock them if someone fails to use the py_safe mechanism somewhere when they genuinely do have the GIL. However, I'm convinced
not to worry about that just because the GIL can be arbitrarily released and reacquired anyway by Python-like code, and so we can't guard against this deadlock.