### PR TITLE
Optimise fused function dispatch

### DIFF
--- a/Cython/Utility/FusedFunction.pyx
+++ b/Cython/Utility/FusedFunction.pyx
@@ -1,26 +1,32 @@
+#################### match_signatures_single ####################
+
+@cname("__pyx_ff_match_signatures_single")
+cdef object match_signatures_single(signatures: dict, dest_type):
+    found_match = signatures.get(dest_type)
+    if found_match is None:
+        raise TypeError("No matching signature found")
+    return found_match
+
+
 #################### match_signatures ####################
 
 cimport cython
 
 @cname("__pyx_ff_index_signature")
 cdef object index_signature(dest_sig: tuple, signatures: dict, sigindex: dict):
-    if len(dest_sig) == 1:
-        # Single argument case is so simple, it's probably worth special casing.
-        matched_function = signatures.get(dest_sig[0])
-    else:
-        matched_function = None
-        for sig, function in signatures.items():
-            types = (<str> sig).strip('()').split('|')
+    matched_function = None
+    for sig, function in signatures.items():
+        types = (<str> sig).strip('()').split('|')
 
-            for type_name, dest_type in zip(types, dest_sig):
-                if dest_type is None:
-                    continue
-                if dest_type != type_name:
-                    break
-            else:
-                if matched_function is not None:
-                    raise TypeError("Function call with ambiguous argument types")
-                matched_function = function
+        for type_name, dest_type in zip(types, dest_sig):
+            if dest_type is None:
+                continue
+            if dest_type != type_name:
+                break
+        else:
+            if matched_function is not None:
+                raise TypeError("Function call with ambiguous argument types")
+            matched_function = function
 
     if matched_function is None:
         raise TypeError("No matching signature found")


### PR DESCRIPTION
Replaces the previous index with a a lazily initialised dict cache.

The new implementation speeds up the unambiguously matching cases into a single dict lookup and makes the first lookup and the mismatch cases expensive. This seems the right tradeoff.

We could potentially also cache signature mismatches, but then those could end up unbounded and bloat the cache, leading to potentially high memory usage and risking to open up a DOS attack vector if call signatures are somehow untrusted.

We could try to find a middle ground by only caching call signature mismatches that use "expected" argument types (i.e. those existing in any of the fused function signatures), but that would only be to speed up the exception raising. If we consider that an actual error, then users can probably live with a slow response.