### PR TITLE
HTML annotation UI: toggle +/- symbols for expand/collapse state

### DIFF
--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -108,9 +108,11 @@ class AnnotationCCodeWriter(CCodeWriter):
 
     # on-click toggle function to show/hide C source code
     _onclick_attr = ' onclick="{}"'.format((
-        "(function(s){"
-        "    s.display =  s.display === 'block' ? 'none' : 'block'"
-        "})(this.nextElementSibling.style)"
+        "(function(f, s, c) {"
+        "    c = f.nodeValue == '+';"
+        "    s.display = c ? 'block' : 'none';"
+        "    f.nodeValue = c ? '−' : '+'"
+        "})(this.firstChild, this.nextElementSibling.style)"
         ).replace(' ', '')  # poor dev's JS minification
     )
 

--- a/Cython/Compiler/Annotate.py
+++ b/Cython/Compiler/Annotate.py
@@ -108,6 +108,7 @@ class AnnotationCCodeWriter(CCodeWriter):
 
     # on-click toggle function to show/hide C source code
     _onclick_attr = ' onclick="{}"'.format((
+        # Use local JS variables by declaring them as function arguments.
         "(function(f, s, c) {"
         "    c = f.nodeValue == '+';"
         "    s.display = c ? 'block' : 'none';"


### PR DESCRIPTION
This change makes it slightly more readable to see which lines have been expanded.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/04f54f02-3720-40a3-ad83-62a3b9486581" />
