### PR TITLE
Enable one more fstring error test

### DIFF
--- a/tests/run/test_fstring.pyx
+++ b/tests/run/test_fstring.pyx
@@ -1081,7 +1081,7 @@ y = (
 
         # but don't emit the paren warning in general cases
         with self.assertRaisesRegex(SyntaxError, "f-string: expecting a valid expression after '{'"):
-            eval("f'{+ lambda:None}'")
+            cy_eval("f'{+ lambda:None}'")
 
     def test_valid_prefixes(self):
         self.assertEqual(F'{1}', "1")


### PR DESCRIPTION
Previously it had been running in Python so wasn't confirming that Cython raised an error