### PR TITLE
Replace list with array in import code

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2879,12 +2879,12 @@ class BackquoteNode(ExprNode):
 class ImportNode(ExprNode):
     #  Used as part of import statement implementation.
     #  Implements result =
-    #    __import__(module_name, globals(), None, name_list, level)
+    #    __import__(module_name, globals(), None, list(name_tuple), level)
     #
     #  module_name   UnicodeNode            dotted name of module. Empty module
     #                       name means importing the parent package according
     #                       to level
-    #  name_list     ListNode or None      list of names to be imported
+    #  name_tuple     TupleNode or None      list of names to be imported
     #  level         int                   relative import level:
     #                       -1: attempt both relative import and absolute import;
     #                        0: absolute import;
@@ -2897,7 +2897,7 @@ class ImportNode(ExprNode):
     type = py_object_type
     is_temp = True
 
-    subexprs = ['module_name', 'name_list']
+    subexprs = ['module_name', 'name_tuple']
 
     def analyse_types(self, env):
         if self.level is None:
@@ -2913,9 +2913,9 @@ class ImportNode(ExprNode):
         self.module_name = module_name.coerce_to_pyobject(env)
         assert self.module_name.is_string_literal
 
-        if self.name_list:
-            name_list = self.name_list.analyse_types(env)
-            self.name_list = name_list.coerce_to_pyobject(env)
+        if self.name_tuple:
+            name_tuple = self.name_tuple.analyse_types(env)
+            self.name_tuple = name_tuple.coerce_to_pyobject(env)
 
         if self.level != 0:
             level = self.level if self.level > 0 else 1
@@ -2939,7 +2939,7 @@ class ImportNode(ExprNode):
         code.globalstate.use_utility_code(UtilityCode.load_cached("Import", "ImportExport.c"))
         import_code = "__Pyx_Import(%s, %s, %s, %d)" % (
             self.module_name.py_result(),
-            self.name_list.py_result() if self.name_list else '0',
+            self.name_tuple.py_result() if self.name_tuple else '0',
             module_qualname,
             self.level)
         tmp_submodule = code.funcstate.allocate_temp(self.type, manage_ref=False)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2879,13 +2879,13 @@ class BackquoteNode(ExprNode):
 class ImportNode(ExprNode):
     #  Used as part of import statement implementation.
     #  Implements result =
-    #    __import__(module_name, globals(), None, list(name_tuple), level)
+    #    __import__(module_name, globals(), None, list(imported_names), level)
     #
-    #  module_name   UnicodeNode            dotted name of module. Empty module
+    #  module_name    UnicodeNode            dotted name of module. Empty module
     #                       name means importing the parent package according
     #                       to level
-    #  name_tuple     TupleNode or None      list of names to be imported
-    #  level         int                   relative import level:
+    #  imported_names [ExprNode] or None list of names to be imported
+    #  level          int                   relative import level:
     #                       -1: attempt both relative import and absolute import;
     #                        0: absolute import;
     #                       >0: the number of parent directories to search
@@ -2897,7 +2897,7 @@ class ImportNode(ExprNode):
     type = py_object_type
     is_temp = True
 
-    subexprs = ['module_name', 'name_tuple']
+    subexprs = ['module_name', 'imported_names']
 
     def analyse_types(self, env):
         if self.level is None:
@@ -2913,9 +2913,10 @@ class ImportNode(ExprNode):
         self.module_name = module_name.coerce_to_pyobject(env)
         assert self.module_name.is_string_literal
 
-        if self.name_tuple:
-            name_tuple = self.name_tuple.analyse_types(env)
-            self.name_tuple = name_tuple.coerce_to_pyobject(env)
+        if self.imported_names is not None:
+            self.imported_names = [
+                name.analyse_types(env) for name in self.imported_names
+            ]
 
         if self.level != 0:
             level = self.level if self.level > 0 else 1
@@ -2937,15 +2938,24 @@ class ImportNode(ExprNode):
             module_qualname = code.get_py_string_const(self.module_qualname)
 
         code.globalstate.use_utility_code(UtilityCode.load_cached("Import", "ImportExport.c"))
-        import_code = "__Pyx_Import(%s, %s, %s, %d)" % (
+
+        if self.imported_names is not None:
+            code.putln("{")
+            code.putln(
+                f"PyObject *__pyx_imported_names[] = {{{','.join(n.result() for n in self.imported_names)}}};")
+
+        import_code = "__Pyx_Import(%s, %s, %d, %s, %d)" % (
             self.module_name.py_result(),
-            self.name_tuple.py_result() if self.name_tuple else '0',
+            '__pyx_imported_names' if self.imported_names is not None else '0',
+            len(self.imported_names) if self.imported_names is not None else 0,
             module_qualname,
             self.level)
         tmp_submodule = code.funcstate.allocate_temp(self.type, manage_ref=False)
         code.putln(
             f"{tmp_submodule} = {import_code}; {code.error_goto_if_null(tmp_submodule, self.pos)}"
         )
+        if self.imported_names is not None:
+            code.putln("}")
 
         if self.is_import_as_name and "." in self.module_name.value:
             # We need to get the submodules in this case

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1867,7 +1867,7 @@ def p_import_statement(s: PyrexScanner):
                     module_name=ExprNodes.IdentifierStringNode(pos, value=dotted_name),
                     is_import_as_name=bool(as_name),
                     level=0 if is_absolute else None,
-                    name_list=None))
+                    name_tuple=None))
         stats.append(stat)
     return Nodes.StatListNode(pos, stats=stats)
 
@@ -1944,14 +1944,14 @@ def p_from_import_statement(s: PyrexScanner, first_statement: cython.bint = 0):
                 ExprNodes.IdentifierStringNode(name_pos, value=name))
             items.append(
                 (name, ExprNodes.NameNode(name_pos, name=as_name or name)))
-        import_list = ExprNodes.ListNode(
+        import_list = ExprNodes.TupleNode(
             imported_names[0][0], args=imported_name_strings)
         return Nodes.FromImportStatNode(pos,
             module = ExprNodes.ImportNode(dotted_name_pos,
                 module_name = ExprNodes.IdentifierStringNode(pos, value = dotted_name),
                 is_import_as_name = False,
                 level = level,
-                name_list = import_list),
+                name_tuple = import_list),
             items = items)
 
 

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1867,7 +1867,7 @@ def p_import_statement(s: PyrexScanner):
                     module_name=ExprNodes.IdentifierStringNode(pos, value=dotted_name),
                     is_import_as_name=bool(as_name),
                     level=0 if is_absolute else None,
-                    name_tuple=None))
+                    imported_names=None))
         stats.append(stat)
     return Nodes.StatListNode(pos, stats=stats)
 
@@ -1944,14 +1944,12 @@ def p_from_import_statement(s: PyrexScanner, first_statement: cython.bint = 0):
                 ExprNodes.IdentifierStringNode(name_pos, value=name))
             items.append(
                 (name, ExprNodes.NameNode(name_pos, name=as_name or name)))
-        import_list = ExprNodes.TupleNode(
-            imported_names[0][0], args=imported_name_strings)
         return Nodes.FromImportStatNode(pos,
             module = ExprNodes.ImportNode(dotted_name_pos,
                 module_name = ExprNodes.IdentifierStringNode(pos, value = dotted_name),
                 is_import_as_name = False,
                 level = level,
-                name_tuple = import_list),
+                imported_names = imported_name_strings),
             items = items)
 
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -37,9 +37,6 @@ static int __Pyx__Import_Lookup(PyObject *qualname, PyObject **imported_names, P
     if (imported_names) {
         for (i = 0; i < len_imported_names; i++) {
             PyObject *imported_name = imported_names[i];
-            if (unlikely(!imported_name)) {
-                goto error;
-            }
             int has_imported_attribute = PyObject_HasAttr(imported_module, imported_name);
             if (!has_imported_attribute) {
                 goto not_found;

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -104,7 +104,7 @@ static PyObject *__Pyx_Import(PyObject *name, PyObject **imported_names, Py_ssiz
         from_list = PyList_New(len_imported_names);
         if (unlikely(!from_list)) goto bad;
         for (Py_ssize_t i=0; i<len_imported_names; ++i) {
-            if (PyList_SetItem(from_list, __Pyx_NewRef(imported_names[i]), i) < 0) goto bad;
+            if (PyList_SetItem(from_list, i, __Pyx_NewRef(imported_names[i])) < 0) goto bad;
         }
 #endif
     } 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -37,7 +37,12 @@ static int __Pyx__Import_Lookup(PyObject *qualname, PyObject **imported_names, P
     if (imported_names) {
         for (i = 0; i < len_imported_names; i++) {
             PyObject *imported_name = imported_names[i];
+#if __PYX_LIMITED_VERSION_HEX < 0x030d0000
             int has_imported_attribute = PyObject_HasAttr(imported_module, imported_name);
+#else
+            int has_imported_attribute = PyObject_HasAttrWithError(imported_module, imported_name);
+            if (unlikely(has_imported_attribute == -1)) goto error;
+#endif
             if (!has_imported_attribute) {
                 goto not_found;
             }

--- a/tests/errors/nogil.pyx
+++ b/tests/errors/nogil.pyx
@@ -122,7 +122,6 @@ _ERRORS = u"""
 34:15: Assignment of Python object not allowed without gil
 34:15: Python import not allowed without gil
 35:13: Python import not allowed without gil
-35:25: Constructing Python list not allowed without gil
 36:17: Iterating over Python object not allowed without gil
 38:11: Discarding owned Python object not allowed without gil
 38:11: Indexing Python object not allowed without gil


### PR DESCRIPTION
Avoid creating a Python list in cases where it isn't needed for the "from_list" part of the import code.

Follow up to #7035