### PR TITLE
Feature/fix tutorial setup py

### DIFF
--- a/docs/src/tutorial/cython_tutorial.rst
+++ b/docs/src/tutorial/cython_tutorial.rst
@@ -370,6 +370,7 @@ Now the ``setup.py`` looks like this:
                     ['primes.pyx',                  # Cython code file with primes() function
                      'primes_python_compiled.py'],  # Python code file with primes() function
                     annotate=True),                 # enables generation of the html annotation file
+                py_modules=["primes_python.py"],    # Tells setuptools to include this Python module as well
             )
 
 Now we can ensure that those two programs output the same values::

--- a/docs/src/tutorial/cython_tutorial.rst
+++ b/docs/src/tutorial/cython_tutorial.rst
@@ -339,7 +339,7 @@ Let's write the same program, but in Python:
 It is possible to take a plain (unannotated) ``.py`` file and to compile it with Cython.
 Let's create a copy of ``primes_python`` and name it ``primes_python_compiled``
 to be able to compare it to the (non-compiled) Python module.
-Then we compile that file with Cython, without changing the code.
+Then we compile that file with Cython, without changing the code. Your filenames must match exactly or setuptools will fail.
 Now the ``setup.py`` looks like this:
 
 .. tabs::
@@ -355,6 +355,7 @@ Now the ``setup.py`` looks like this:
                     ['primes.py',                   # Cython code file with primes() function
                      'primes_python_compiled.py'],  # Python code file with primes() function
                     annotate=True),                 # enables generation of the html annotation file
+                py_modules=["primes_python.py"],    # Tells setuptools to include this Python module as well
             )
 
     .. group-tab:: Cython


### PR DESCRIPTION

ref: https://docs.cython.org/en/latest/src/tutorial/cython_tutorial.html#id4


If you follow the tutorial verbatim, setup.py will fail with the following error:

```
setup.py build_ext --inplace 
error: Multiple top-level modules discovered in a flat-layout: ['primes_python', 'primes_python_compiled'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple modules
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.
```

Accounting for all of the files resolves the issue. 