### PR TITLE
Add missing ufunc decorator to type annotations

### DIFF
--- a/Cython/Shadow.pyi
+++ b/Cython/Shadow.pyi
@@ -38,14 +38,13 @@ _Decorator = Callable[[_C], _C]
 
 _func_deco: _Decorator
 
-cfunc = ccall = compile = _func_deco
+cfunc = ccall = compile = ufunc = _func_deco
 
 def locals(**kwargs: Any) -> _Decorator: ...
 
 def _class_deco(__cls: _TypeT) -> _TypeT: ...
 
-cclass = internal = c_api_binop_methods = type_version_tag = no_gc_clear = no_gc = total_ordering = \
-    ufunc = _class_deco
+cclass = internal = c_api_binop_methods = type_version_tag = no_gc_clear = no_gc = total_ordering = _class_deco
 
 # May be a bit hard to read but essentially means:
 # > Returns a callable that takes another callable with these parameters and *some*

--- a/Cython/Shadow.pyi
+++ b/Cython/Shadow.pyi
@@ -44,7 +44,8 @@ def locals(**kwargs: Any) -> _Decorator: ...
 
 def _class_deco(__cls: _TypeT) -> _TypeT: ...
 
-cclass = internal = c_api_binop_methods = type_version_tag = no_gc_clear = no_gc = _class_deco
+cclass = internal = c_api_binop_methods = type_version_tag = no_gc_clear = no_gc = total_ordering = \
+    ufunc = _class_deco
 
 # May be a bit hard to read but essentially means:
 # > Returns a callable that takes another callable with these parameters and *some*


### PR DESCRIPTION
- Add ufunc to the decorator assignment in Shadow.pyi
- Fixes mypy error: Module has no attribute 'ufunc'
- Resolves issue where @cython.ufunc was not recognized by type checkers https://github.com/cython/cython/issues/7109