### PR TITLE
Move _co_firsttraceable into __Pyx__PyCode_New

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2499,6 +2499,11 @@ static PyObject* __Pyx_PyCode_New(
         PyCode_NewWithPosOnlyArgs
       #endif
         (a, p, k, l, s, f, code, c, n, v, fv, cell, fn, name, name, fline, lnos, EMPTY(bytes));
+  
+    #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030c00A1
+    if (likely(result))
+        result->_co_firsttraceable = 0;
+    #endif
     return result;
   }
 #elif !CYTHON_COMPILING_IN_PYPY
@@ -2596,10 +2601,6 @@ static PyObject* __Pyx_PyCode_New(
         (int) descr.first_line,
         (__PYX_LIMITED_VERSION_HEX >= (0x030b0000) && line_table) ? line_table : EMPTY(bytes)
     );
-
-    #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030c00A1
-    ((PyCodeObject*) code_obj)->_co_firsttraceable = 0;
-    #endif
 
 done:
     Py_XDECREF(code_bytes);


### PR DESCRIPTION
because it seems to me that it's really part of the construction function.

Also add a check to make sure it's not NULL.

Small tidy up to 42d8d3281250aceb6148edcbf648c1c593da2e1d