### PR TITLE
Fix dealloc from class inherited from a pxd file

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -479,7 +479,8 @@ class ConstructorSlot(InternalMethodSlot):
             # delegate GC methods to its parent - iff the parent
             # functions are defined in the same module
             slot_code = self._parent_slot_function(scope)
-            return slot_code or '0'
+            if  slot_code is not None:
+                return slot_code
         return InternalMethodSlot.slot_code(self, scope)
 
     def spec_value(self, scope):

--- a/tests/run/exttype_dealloc_pxd.srctree
+++ b/tests/run/exttype_dealloc_pxd.srctree
@@ -1,0 +1,53 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import b; b.run()"
+
+######## setup.py ########
+
+from Cython.Build.Dependencies import cythonize
+from setuptools import setup
+
+setup(
+    ext_modules = cythonize("*.pyx"),
+)
+
+####### a.pxd ########
+
+cdef class BaseClass:
+    pass
+
+####### a.pyx ########
+
+BaseClass_dealloc_calls = 0
+
+cdef class BaseClass:
+    def __dealloc__(self):
+        global BaseClass_dealloc_calls
+        BaseClass_dealloc_calls += 1
+
+####### b.pyx #########
+
+import sys
+
+cimport a
+import a
+
+cdef class InheritsFromPxd(a.BaseClass):
+    pass  # no dealloc
+
+derived_class_dealloc_calls = 0
+
+cdef class InheritsFromInheritsFromPxd(InheritsFromPxd):
+    def __dealloc__(self):
+        global derived_class_dealloc_calls
+        derived_class_dealloc_calls += 1
+
+def run():
+    # This is mostly a "no-crash" test, but we do some validation
+    # (on CPython only, because this won't be reliable with a GC)
+    x = a.BaseClass()
+    x = InheritsFromPxd()
+    x = InheritsFromInheritsFromPxd()
+    del x
+    if sys.implementation.name == "cpython":
+        assert a.BaseClass_dealloc_calls == 3
+        assert derived_class_dealloc_calls == 1


### PR DESCRIPTION
If we don't manage to look up the base classes dealloc function then we really need to implement our own.

With static types it's fine as is - the base class dealloc function is automatically inherited. With heap types, if we leave the dealloc slot as 0, then it sets the
dealloc function to an unsuitable default (which can end up causing infinite loops). Therefore we do need to provide an implementation.