### PR TITLE
docs: Automatically adapt year in copyright line

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,11 @@ import datetime
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "Cython"
-copyright = "2025, Stefan Behnel, Robert Bradshaw, Dag Sverre Seljebotn, Greg Ewing, William Stein, Gabriel Gellner, et al."
-authors = "Stefan Behnel, Robert Bradshaw, Dag Sverre Seljebotn, Greg Ewing, William Stein, Gabriel Gellner, et al."
+YEAR = datetime.date.today().strftime("%Y")
+
+project = 'Cython'
+authors = 'Stefan Behnel, Robert Bradshaw, Dag Sverre Seljebotn, Greg Ewing, William Stein, Gabriel Gellner, et al.'
+copyright = '%s, %s' % (YEAR, authors)
 
 ### Custom Cython Docs changes ###
 highlight_language = "cython"
@@ -23,7 +25,6 @@ issues_github_path = "cython/cython"
 sphinx_tabs_disable_tab_closing = True
 root_doc = "index"
 
-YEAR = datetime.date.today().strftime("%Y")
 # Looking up the release/version
 try:
     _match_version = re.compile(r'^\s*_*version\s*_*\s*=\s*["\']([^"\']+)["\'].*').match

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ import itertools
 from pathlib import Path
 import re
 import sys
+import datetime
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -21,6 +22,8 @@ imgmath_image_format = "svg"
 issues_github_path = "cython/cython"
 sphinx_tabs_disable_tab_closing = True
 root_doc = "index"
+
+YEAR = datetime.date.today().strftime("%Y")
 # Looking up the release/version
 try:
     _match_version = re.compile(r'^\s*_*version\s*_*\s*=\s*["\']([^"\']+)["\'].*').match

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ YEAR = datetime.date.today().strftime("%Y")
 
 project = 'Cython'
 authors = 'Stefan Behnel, Robert Bradshaw, Dag Sverre Seljebotn, Greg Ewing, William Stein, Gabriel Gellner, et al.'
-copyright = '%s, %s' % (YEAR, authors)
+copyright = f'{YEAR}, {authors}'
 
 ### Custom Cython Docs changes ###
 highlight_language = "cython"


### PR DESCRIPTION
Readding missed YEAR statement from regenerating conf.py for Sphinx.

ref: https://github.com/cython/cython/pull/7137
