### PR TITLE
Fix ext_attribute_cache test

### DIFF
--- a/tests/run/ext_attribute_cache.pyx
+++ b/tests/run/ext_attribute_cache.pyx
@@ -27,7 +27,7 @@ cdef class ImplicitAttrCache(object):
 @cython.type_version_tag(True)
 cdef class ExplicitAttrCache(object):
     """
-    >>> flag = test_flag(ImplicitAttrCache)
+    >>> flag = test_flag(ExplicitAttrCache)
     >>> print(flag)
     True
     """


### PR DESCRIPTION
I'm not completely sure why it's failing in my pattern matching branch. However, the test doesn't really make sense as is.