### PR TITLE
Use a fast and safe conversion from PyLong to C long.

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1258,10 +1258,8 @@ static {{c_ret_type}} __Pyx_Unpacked_{{cfunc_name}}(PyObject *op1, PyObject *op2
     }
     {{endif}}
 
-    // handle most common case first to avoid indirect branch and optimise branch prediction
-    if (likely(__Pyx_PyLong_IsCompact({{pyval}}))) {
-        {{ival}} = __Pyx_PyLong_CompactValue({{pyval}});
-    } else {
+    // Handle most common case (fits into 'long') first to avoid indirect branch and optimise branch prediction.
+    if (unlikely(!__Pyx_PyLong_CompactAsLong({{pyval}}, &{{ival}}))) {
         const digit* digits = __Pyx_PyLong_Digits({{pyval}});
         const Py_ssize_t size = __Pyx_PyLong_SignedDigitCount({{pyval}});
         switch (size) {

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -177,6 +177,8 @@ static CYTHON_INLINE Py_hash_t __Pyx_PyIndex_AsHash_t(PyObject*);
   typedef digit  __Pyx_compact_upylong;
   #endif
 
+  static CYTHON_INLINE int __Pyx_PyLong_CompactAsLong(PyObject *x, long *return_value); /*proto*/
+
   #if PY_VERSION_HEX >= 0x030C00A5
   #define __Pyx_PyLong_Digits(x)  (((PyLongObject*)x)->long_value.ob_digit)
   #else
@@ -433,6 +435,21 @@ static CYTHON_INLINE PyObject * __Pyx_PyBool_FromLong(long b) {
 static CYTHON_INLINE PyObject * __Pyx_PyLong_FromSize_t(size_t ival) {
     return PyLong_FromSize_t(ival);
 }
+
+#if CYTHON_USE_PYLONG_INTERNALS
+static CYTHON_INLINE int __Pyx_PyLong_CompactAsLong(PyObject *x, long *return_value) {
+    // Safely convert a compact (Py_ssize_t, usually max. 30 bits) PyLong into a C long.
+    if (unlikely(!__Pyx_PyLong_IsCompact(x)))
+        return 0;
+
+    Py_ssize_t value = __Pyx_PyLong_CompactValue(x);
+    if ((sizeof(long) < sizeof(Py_ssize_t)) && unlikely(value != (long) value))
+        return 0;
+
+    *return_value = (long) value;
+    return 1;
+}
+#endif
 
 
 /////////////// pybuiltin_invalid ///////////////


### PR DESCRIPTION
Previously, we assumed that a compact PyLong value always fits into a C `long`, which is usually true (<= 30 bits) but doesn't need to stay that way, given the `Py_ssize_t` return value when converting it.

Fixes https://github.com/cython/cython/issues/7134