### PR TITLE
Clear any memoryview prange temps with the GIL

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -9863,7 +9863,7 @@ class ParallelStatNode(StatNode, ParallelNode):
         if self.is_parallel and not self.is_nested_prange:
             code.putln("/* Clean up any temporaries */")
             for temp, type in sorted(self.temps):
-                code.put_xdecref_clear(temp, type, have_gil=False)
+                code.put_xdecref_clear(temp, type, have_gil=True)
 
     def setup_parallel_control_flow_block(self, code):
         """


### PR DESCRIPTION
We're definitely holding it at this stage so we should let them know that.

(It's a very minor defect - it'll make it slightly faster because we won't try to acquire the GIL but nothing is actually broken with the existing code)