### PR TITLE
Add a warning on assignments in pxd files

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6181,6 +6181,7 @@ class SingleAssignmentNode(AssignmentNode):
     #  first                    bool          Is this guaranteed the first assignment to lhs?
     #  is_overloaded_assignment bool          Is this assignment done via an overloaded operator=
     #  is_assignment_expression bool          Internally SingleAssignmentNode is used to implement assignment expressions
+    #  from_pxd_cvardef         bool          Was created from a CVarDef node in a pxd file
     #  exception_check
     #  exception_value
 
@@ -6189,6 +6190,7 @@ class SingleAssignmentNode(AssignmentNode):
     is_overloaded_assignment = False
     is_assignment_expression = False
     declaration_only = False
+    from_pxd_cvardef = False
 
     def analyse_declarations(self, env):
         from . import ExprNodes
@@ -6336,6 +6338,14 @@ class SingleAssignmentNode(AssignmentNode):
         elif rhs.type.is_pyobject:
             rhs = rhs.coerce_to_simple(env)
         self.rhs = rhs
+
+        if self.from_pxd_cvardef and not self.lhs.type.is_const:
+            warning(
+                self.pos,
+                "Assignment in pxd file will not be executed. Suggest declaring as const",
+                2
+            )
+
         return self
 
     def unroll(self, node, target_size, env):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -6342,7 +6342,7 @@ class SingleAssignmentNode(AssignmentNode):
         if self.from_pxd_cvardef and not self.lhs.type.is_const:
             warning(
                 self.pos,
-                "Assignment in pxd file will not be executed. Suggest declaring as const",
+                "Assignment in pxd file will not be executed. Suggest declaring as const.",
                 2
             )
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -260,7 +260,8 @@ class PostParse(ScopeTrackingTransform):
                         first_assignment = self.scope_type != 'module'
                         stats.append(Nodes.SingleAssignmentNode(node.pos,
                             lhs=ExprNodes.NameNode(node.pos, name=declbase.name),
-                            rhs=declbase.default, first=first_assignment))
+                            rhs=declbase.default, first=first_assignment,
+                            from_pxd_cvardef=node.in_pxd))
                         declbase.default = None
                 newdecls.append(decl)
             node.declarators = newdecls

--- a/tests/errors/w_pxd_assign.pxd
+++ b/tests/errors/w_pxd_assign.pxd
@@ -1,2 +1,4 @@
+# Assignment doesn't work so should generate a warning
+# (an error would be better but might break too much existing code).
 cdef double x = 1.0
 cdef const double y = 2.0

--- a/tests/errors/w_pxd_assign.pxd
+++ b/tests/errors/w_pxd_assign.pxd
@@ -1,0 +1,2 @@
+cdef double x = 1.0
+cdef const double y = 2.0

--- a/tests/errors/w_pxd_assign.pyx
+++ b/tests/errors/w_pxd_assign.pyx
@@ -5,5 +5,5 @@ print(x, y)
 x = 10
 
 _WARNINGS = """
-1:0: Assignment in pxd file will not be executed. Suggest declaring as const
+3:0: Assignment in pxd file will not be executed. Suggest declaring as const.
 """

--- a/tests/errors/w_pxd_assign.pyx
+++ b/tests/errors/w_pxd_assign.pyx
@@ -1,0 +1,9 @@
+# mode: compile
+# tag: warnings
+
+print(x, y)
+x = 10
+
+_WARNINGS = """
+1:0: Assignment in pxd file will not be executed. Suggest declaring as const
+"""


### PR DESCRIPTION
It looks like lots of executable statements end up silently getting dropped in pxd files. However this kind of "initialization/assignment" seems like a particularly easy mistake to make so I think it's worth a specific warning.

Fixes #7173