### PR TITLE
Docs: Fix C++ wrapping example in user guide

### DIFF
--- a/docs/src/userguide/wrapping_CPlusPlus.rst
+++ b/docs/src/userguide/wrapping_CPlusPlus.rst
@@ -667,9 +667,9 @@ in ``libcpp.typeindex``.
 Specify C++ language in setup.py
 ================================
 
-Instead of specifying the language in the source file (using a ``distutils``
-directive), it is possible to declare it in the :file:`setup.py` file.
-This is done by creating an :class:`~setuptools.Extension` object for your
+The target language (C or C++) can be specified either in each source file
+(as shown below) or in the :file:`setup.py` file.
+For the latter, create an :class:`~setuptools.Extension` object for your
 extension::
 
    from setuptools import Extension, setup
@@ -678,8 +678,11 @@ extension::
    setup(
        ext_modules=cythonize([
            Extension(
+               # Declare the extension module name (including package).
                "rect",
+               # List the main extension file together with additional source files.
                sources=["rect.pyx", "Rectangle.cpp"],
+               # Let Cython generate C++ code and setuptools use the C++ compiler.
                language="c++",
            )
        ])


### PR DESCRIPTION
The setup.py example for wrapping C++ code was outdated and caused a `ValueError`.

This commit updates the example to use `setuptools.Extension` to correctly specify the C++ language and source files.

The `cython_test` directory is added to provide a complete, working example that can be used for testing and verification.

Closes #3069  'Documentation example doesn't work'