### PR TITLE
Clarify the explanatory isolation comment @ `coverage_cmd_src_pkg_layout` test

### DIFF
--- a/tests/run/coverage_cmd_src_pkg_layout.srctree
+++ b/tests/run/coverage_cmd_src_pkg_layout.srctree
@@ -2,7 +2,24 @@
 # tag: coverage,trace
 
 """
-# Install without build isolation as this currently fails in Py3.14.0.
+# Install without build isolation is required as importing Cython in
+# `setup.py` fails in ephemeral temporary build virtualenvs.
+# Sometimes, pip does no use PEP 517 mechanisms when neither
+# `pyproject.toml` is present, nor `--use-pep517` is passed and falls
+# back to running the legacy `setup.py bdist_wheel` mechanism.
+# pip 25.1 deprecated that mechanism and it is scheduled for removal
+# in pip 25.3 [1]. However, some environments seem to make use of it
+# already, which creates difference in behavior between the CI and
+# some contributor's local runtimes. With `--use-pep517` active, it
+# also implies `--build-isolation` that causes the build to fail.
+# Using `--no-build-isolation` makes `pip install` behave
+# consistently across runtimes and keep the `Cython` importable
+# accessible to `setup.py`.
+# Another way could be figuring out how to point `pyproject.toml`'s
+# `[build-system].requires` to a Cython copy under test and letting
+# pip provision that into the ephemeral build env.
+#
+# [1]: https://github.com/pypa/pip/issues/6334
 PYTHON -m pip install --no-build-isolation .
 PYTHON setup.py build_ext --inplace
 PYTHON -m coverage run --source=pkg coverage_test.py


### PR DESCRIPTION
This is a follow-up for https://github.com/cython/cython/pull/7197#discussion_r2418988906

TL;DR, in some environments (for me, it's pyenv's Python 3.13.7/3.14.0 in virtualenvs under Gentoo Linux), running said test explodes as follows:

```python-traceback
$ ./runtests.py coverage_cmd_src_pkg_layout --no-capture
GNU gdb (Gentoo 16.3 vanilla) 16.3
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Python 3.14.0 (main, Oct  9 2025, 22:40:37) [GCC 14.3.1 20250801]

Running tests against Cython 3.2.0a0 c00a9c97812b4536c2016751697e06f74801e26b + uncommitted changes
Using Cython language level 2.
Test dependency found: 'numpy' version 2.3.3
Test dependency not found: 'pythran'
Test dependency not found: 'setuptools.sandbox'
Test dependency found: 'asyncio' version 3.14.0
Test dependency found: 'pstats' version 3.14.0
Test dependency found: 'posix' version 3.14.0
Test dependency found: 'array' version 3.14.0
Test dependency found: 'Cython.Coverage' version 3.2.0a0
Test dependency found: 'Cython.Coverage' version 3.2.0a0
Test dependency found: 'IPython.testing.globalipapp' version 9.6.0
Test dependency not found: 'jedi_BROKEN_AND_DISABLED'
Test dependency found: 'test.support' version 3.14.0
Backends: c,cpp

Processing ~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      Traceback (most recent call last):
        File "~/.pyenv/versions/cython-pyenv-py3.14.0/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "~/.pyenv/versions/cython-pyenv-py3.14.0/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "~/.pyenv/versions/cython-pyenv-py3.14.0/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-u8cphrh2/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-u8cphrh2/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/tmp/pip-build-env-u8cphrh2/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-u8cphrh2/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 3, in <module>
      ModuleNotFoundError: No module named 'Cython'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
[-1] ['~/.pyenv/versions/cython-pyenv-py3.14.0/bin/python3', '-m', 'pip', 'install', '.']

Final directory layout of 'coverage_cmd_src_pkg_layout':
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/setup.py
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/.coveragerc
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/coverage_test.py
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/collect_coverage.py
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/src/pkg/__init__.py
~/src/github/cython/cython/TEST_TMP/run/coverage_cmd_src_pkg_layout/src/pkg/module1.pyx

======================================================================
FAIL: runTest (__main__.EndToEndTest.runTest)
[-1] End-to-end coverage_cmd_src_pkg_layout
----------------------------------------------------------------------
Traceback (most recent call last):
  File "~/src/github/cython/cython/./runtests.py", line 2094, in runTest
    self.assertEqual(0, res, "non-zero exit status, last output was:\n%r\n-- stdout:%s\n-- stderr:%s\n" % (
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ' '.join(command), out[-1], err[-1]))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 0 != 1 : non-zero exit status, last output was:
'~/.pyenv/versions/cython-pyenv-py3.14.0/bin/python3 -m pip install .'
-- stdout:
-- stderr:

----------------------------------------------------------------------
Ran 1 test in 1.180s

FAILED (failures=1)
Most expensive pipeline stages:
Times:
etoe-run    :     0.94 sec  (   1,  0.943 / run) - slowest: 'c:coverage_cmd_src_pkg_layout(1)' (0.94s)
ALL DONE
```