### PR TITLE
Bump ARM runs to Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,22 +105,22 @@ jobs:
             extra_hash: "-gcc11"
           # Arm64
           - os: ubuntu-22.04-arm
-            python-version: "3.12"
+            python-version: "3.13"
             backend: c
             env: {}
             extra_hash: "arm64"
           - os: ubuntu-22.04-arm
-            python-version: "3.12"
+            python-version: "3.13"
             backend: cpp
             env: {}
             extra_hash: "arm64"
           - os:  windows-11-arm
-            python-version: "3.12"
+            python-version: "3.13"
             backend: "c"
             extra_hash: "arm64"
             env: {}
           - os:  windows-11-arm
-            python-version: "3.12"
+            python-version: "3.13"
             backend: "cpp"
             extra_hash: "arm64"
             env: {}


### PR DESCRIPTION
Mainly because a lot of the profiling stuff doesn't work on Py 3.12 so we get slightly more complete coverage with 3.13.