### PR TITLE
Add arm64 wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -77,7 +77,7 @@ jobs:
               | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
               && cibuildwheel --print-build-identifiers --platform windows \
               | jq -nRc '{"only": inputs, "os": "windows-2022"}' \
-              && cibuildwheel --print-build-identifiers --platform windows \
+              && cibuildwheel --print-build-identifiers --platform windows --archs ARM64 \
               | jq -nRc '{"only": inputs, "os": "windows-11-arm"}'
             } | jq -sc
           )


### PR DESCRIPTION
Closes #7216 

This would add arm64 windows wheel builds to `wheels.yml`.