### PR TITLE
Fix a C warning about de-const casts.

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1092,6 +1092,7 @@ class MemoryViewSliceType(PyrexType):
                 from_py_function=from_py_function,
                 dtype=self.dtype.empty_declaration_code(),
                 error_condition=error_condition,
+                dtype_is_const=self.dtype.is_const,
             )
 
         utility = TempitaUtilityCode.load_cached(

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -741,7 +741,7 @@ static CYTHON_INLINE int {{set_function}}(char *itemp, PyObject *obj); /* proto 
 
 {{if to_py_function}}
 static CYTHON_INLINE PyObject *{{get_function}}(const char *itemp) {
-    return (PyObject *) {{to_py_function}}(*(const {{dtype}} *) itemp);
+    return (PyObject *) {{to_py_function}}(*({{dtype}} {{'' if dtype_is_const else 'const'}} *) itemp);
 }
 {{endif}}
 


### PR DESCRIPTION
The generated functions take a `const` argument but then we cast it to a non-`const` type. The first is incorrect for the setter function and the second for the getter function.