### PR TITLE
Make it an error if we lose state during auto-unpickling

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2332,7 +2332,7 @@ if VALUE is not None:
                     cdef bint use_setstate
                     state = ({members})
                     _dict = getattr(self, '__dict__', None)
-                    if _dict is not None:
+                    if _dict is not None and _dict:
                         state += (_dict,)
                         use_setstate = True
                     else:

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -641,20 +641,32 @@ static int __Pyx_UpdateUnpickledDict(PyObject *obj, PyObject *state, Py_ssize_t 
 //@requires: ObjectHandling.c::PyObjectCallMethod1
 
 static int __Pyx__UpdateUnpickledDict(PyObject *obj, PyObject *state, Py_ssize_t index) {
-    // Since we received a dict from pickling, we assume that we're unpickling an object that has one, too.
+    PyObject *state_dict = __Pyx_PySequence_ITEM(state, index);
+    if (unlikely(!state_dict)) {
+        return -1;
+    }
+
+    int non_empty = PyObject_IsTrue(state_dict);
+    if (non_empty == 0) {
+        // Nothing to do.
+        Py_DECREF(state_dict);
+        return 0;
+    } else if (unlikely(non_empty == -1)) {
+        return -1;
+    }
+
+    // Since we received a non-empty dict from pickling,
+    // we assume that we're unpickling an object that has one, too.
     PyObject *dict;
     #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
     dict = PyObject_GetAttrString(obj, "__dict__");
     #else
     dict = PyObject_GenericGetDict(obj, NULL);
     #endif
-    // It is debatable if it is a fatal error if we cannot reassign the state of the dict because
-    // the unpickled object does not have a '__dict__'. But the user should probably know.
-    if (unlikely(!dict)) return -1;
-
-    PyObject *state_dict = __Pyx_PySequence_ITEM(state, index);
-    if (unlikely(!state_dict)) {
-        Py_DECREF(dict);
+    if (unlikely(!dict)) {
+        // It is debatable if it is a fatal error if we cannot reassign the state of the dict because
+        // the unpickled object does not have a '__dict__'. But the user should probably know.
+        Py_DECREF(state_dict);
         return -1;
     }
 


### PR DESCRIPTION
Auto-unpickling from an object that had a "__dict__" to an object that does not have it should not pass silently.
To mitigate the error effect, we avoid pickling and unpickling empty state dicts.