### PR TITLE
Improve Limited API handling in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ else:
 
 
 def compile_cython_modules(profile=False, coverage=False, compile_minimal=False, compile_more=False, cython_with_refnanny=False,
-                           cython_limited_api=False):
+                           cython_limited_api=None):
     source_root = os.path.abspath(os.path.dirname(__file__))
     compiled_modules = [
         "Cython.Plex.Actions",
@@ -150,7 +150,7 @@ def compile_cython_modules(profile=False, coverage=False, compile_minimal=False,
     extra_extension_args = {}
     if cython_limited_api:
         defines += [
-            ('Py_LIMITED_API', '0x03080000'),
+            ('Py_LIMITED_API', f'0x{cython_limited_api[0]:02x}{cython_limited_api[1]:02x}0000'),
         ]
         extra_extension_args['py_limited_api'] = True
 
@@ -322,6 +322,35 @@ def check_option(name):
 
     return False
 
+def check_limited_api_option(name):
+    def handle_arg(arg: str):
+        arg = arg.lower()
+        if arg == "true":
+            # The default Limited API version is 3.9, unless we're on a lower Python version
+            # (which is mainly for the sake of testing 3.8 on the CI)
+            if sys.version_info >= (3, 9):
+                return (3, 9)
+            else:
+                return sys.version_info[:2]
+        if arg == "false":
+            return None
+        major, minor = arg.split('.', 1)
+        return (int(major), int(minor))
+
+    cli_arg = "--" + name
+    for arg in sys.argv:
+        if arg.startswith(cli_arg):
+            sys.argv.remove(arg)
+            if '=' in arg:
+                return handle_arg(arg.split('=', 1)[1])
+            return handle_arg("true")
+
+    env_var_name = name.replace("-", "_").upper()
+    env_var = os.environ.get(env_var_name)
+    if env_var is None:
+        return None
+    return handle_arg(env_var)
+
 
 cython_profile = check_option('cython-profile')
 cython_coverage = check_option('cython-coverage')
@@ -346,11 +375,11 @@ if compile_cython_itself and sysconfig.get_config_var("Py_GIL_DISABLED"):
 if compile_cython_itself:
     cython_compile_more = check_option('cython-compile-all')
     cython_compile_minimal = check_option('cython-compile-minimal')
-    cython_limited_api = check_option('cython-limited-api')
+    cython_limited_api = check_limited_api_option('cython-limited-api')
     if cython_limited_api:
         setup_options = setup_args.setdefault('options', {})
         bdist_wheel_options = setup_options.setdefault('bdist_wheel', {})
-        bdist_wheel_options['py_limited_api'] = 'cp37'
+        bdist_wheel_options['py_limited_api'] = f'cp{cython_limited_api[0]}{cython_limited_api[1]}'
 
 
 setup_args.update(setuptools_extra_args)


### PR DESCRIPTION
The main aim is to bump the default version to 3.9. But I've also made it a little more configurable so that it's possible to pick the version.