### PR TITLE
Make byte string constants immortal again (but not Unicode strings).

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2171,9 +2171,11 @@ class GlobalState:
         w.putln('}')
         w.putln('}')
 
-        # DISABLED: strings are not trivially immortal but require certain rules.
+        # Unicode strings are not trivially immortal but require certain rules.
         # See https://github.com/python/cpython/blob/920de7ccdcfa7284b6d23a124771b17c66dd3e4f/Objects/unicodeobject.c#L713-L739
-        #self.immortalize_constants("stringtab", len(index), w)
+        # But we can make bytes strings immortal.
+        if stringtab_bytes_start < len(index):
+            self.immortalize_constants(f"stringtab + {stringtab_bytes_start}", len(index) - stringtab_bytes_start, w)
 
         w.putln("}")  # close block
 


### PR DESCRIPTION
Previously implemented in
https://github.com/cython/cython/pull/7118
and disabled in
https://github.com/cython/cython/commit/02d05df63381862f312e5973787932fb106c664f