### PR TITLE
Implement "unified" lookup mechanism for module state

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2089,7 +2089,7 @@ class NameNode(AtomicExprNode):
     allow_null = False
     nogil = False
     inferred_type = None
-    module_state_lookup = ""
+    module_state_lookup = False
 
     def as_cython_attribute(self):
         return self.cython_attribute
@@ -2420,7 +2420,7 @@ class NameNode(AtomicExprNode):
         if entry.scope.is_module_scope and (
                 entry.is_pyglobal or entry.is_cclass_var_entry):
             # TODO - eventually this should apply to cglobals too
-            self.module_state_lookup = env.name_in_module_state("")
+            self.module_state_lookup = True
 
     def check_identifier_kind(self):
         # Check that this is an appropriate kind of name for use in an
@@ -2525,7 +2525,9 @@ class NameNode(AtomicExprNode):
             return "<error>"  # There was an error earlier
         if self.entry.is_cpp_optional and not self.is_target:
             return "(*%s)" % entry.cname
-        return self.module_state_lookup + entry.cname
+        if self.module_state_lookup:
+            return f"__PYX_GET_MODULE_STATE()->{entry.cname}"
+        return entry.cname
 
     def generate_result_code(self, code):
         entry = self.entry

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1231,11 +1231,6 @@ class Scope:
     def add_include_file(self, filename, verbatim_include=None, late=False):
         self.outer_scope.add_include_file(filename, verbatim_include, late)
 
-    def name_in_module_state(self, cname):
-        # TODO - override to give more choices depending on the type of scope
-        # e.g. slot, function, method
-        return f"{Naming.modulestateglobal_cname}->{cname}"
-
     def find_shared_usages_of_type(self, type_check_predicate, _seen_scopes=None):
         if _seen_scopes is None:
             _seen_scopes = set()

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -878,8 +878,18 @@ static CYTHON_INLINE void *__Pyx__PyModule_GetState(PyObject *op)
 // Define a macro with a cast because the modulestate type isn't known yet and
 // is a typedef struct so impossible to forward declare
 #define __Pyx_PyModule_GetState(o) ($modulestatetype_cname *)__Pyx__PyModule_GetState(o)
+#define __PYX_GET_MODULE_STATE_FALLBACK() (__Pyx_PyModule_GetState(__Pyx_State_FindModule(&$pymoduledef_cname)))
+#define __PYX_GET_MODULE_STATE_UTILITY_CODE() __PYX_GET_MODULE_STATE_FALLBACK()
+#if CYTHON_USE_TYPE_SPECS && ((!CYTHON_COMPILING_IN_LIMITED_API && PY_VERSION_HEX >= 0x030B0000) || \
+      __PYX_LIMITED_VERSION_HEX >= 0x030d0000)
+#define __PYX_GET_MODULE_STATE_FROM_CCLASS(obj) (__Pyx_PyModule_GetState(PyType_GetModuleByDef(Py_TYPE(obj), &$pymoduledef_cname)))
 #else
-#define __Pyx_PyModule_GetState(op) ((void)op,$modulestateglobal_cname)
+#define __PYX_GET_MODULE_STATE_FROM_CCLASS(obj) __PYX_GET_MODULE_STATE_FALLBACK()
+#endif
+#else
+#define __PYX_GET_MODULE_STATE() (&$modulestateglobal_cname)
+#define __PYX_GET_MODULE_STATE_UTILITY_CODE() __PYX_GET_MODULE_STATE()
+#define __Pyx_PyModule_GetState(op) ((void)op,&$modulestateglobal_cname)
 #endif
 
 // The "Try" variants may return NULL on static types with the Limited API on earlier versions


### PR DESCRIPTION
The idea is that all lookups for the module state go through `__PYX_GET_MODULE_STATE()` and the code generation no longer needs to care about what type of lookup it might be (so doesn't need to know anything about the scope).

At the start of each function we create a temporary definition for __PYX_GET_MODULE_STATE() using one of a number of mechanisms depending on what information is available in the scope.

-----------------------------------------------------------

The is very much a draft - I've only tested that it compiled on a single file so I complete expect it to fail. It's more a request for comments on the general approach.