### PR TITLE
Build: Cover platform 'armv7l' with a abi3 binary wheel.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,7 +133,6 @@ jobs:
       matrix:
         os:
           - 'ubuntu-latest'
-          - 'ubuntu-24.04'
           - 'ubuntu-24.04-arm'
           - 'windows-latest'
           - 'windows-11-arm'
@@ -160,7 +159,6 @@ jobs:
           CIBW_BUILD: |
             ${{
                 matrix.os == 'ubuntu-24.04-arm' && '*armv7l' ||
-                matrix.os == 'ubuntu-24.04' && '*ppc64le' ||
                 matrix.os == 'ubuntu-latest' && '*linux_i686' ||
                 matrix.os == 'windows-latest' && '*win32' ||
                 matrix.os == 'macos-latest' && '*macosx_x86_64' ||

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ skip = [
     # pure-Python wheels. cibuildwheel will identify Stable ABI wheels and
     # only build them for the one Python version. It will test them for all
     # Python versions though.
-    "cp38*i686", "cp38*win32", "cp38*win_arm64", "cp38-macosx_x86_64", "cp38*armv7l", "cp38*ppc64le",
+    "cp38*i686", "cp38*win32", "cp38*win_arm64", "cp38-macosx_x86_64", "cp38*armv7l"
 ]
 enable = ["cpython-prerelease"]
 # As a quick sanity check, run Cython on some of its own sources
@@ -22,7 +22,7 @@ test-command = [
 ]
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64", "i686", "armv7l", "ppc64le"]
+archs = ["x86_64", "aarch64", "i686", "armv7l"]
 repair-wheel-command = "auditwheel repair --strip -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.linux.environment]
@@ -57,12 +57,6 @@ environment.CYTHON_LIMITED_API = "true"
 
 [[tool.cibuildwheel.overrides]]
 select = "*armv7l"
-inherit.environment = "append"
-environment.CFLAGS = "-O3 -g0 -pipe -fPIC"
-environment.CYTHON_LIMITED_API = "true"
-
-[[tool.cibuildwheel.overrides]]
-select = "*ppc64le"
 inherit.environment = "append"
 environment.CFLAGS = "-O3 -g0 -pipe -fPIC"
 environment.CYTHON_LIMITED_API = "true"


### PR DESCRIPTION
According to the download stats, these are not less widely used than Linux 32bit/x86, so probably deserve the same status.