### PR TITLE
Change 64bit musllinux to ABI3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,6 +71,7 @@ jobs:
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux --archs "x86_64,aarch64" \
+              | grep -v musllinux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               | sed -e '/aarch64/s|ubuntu-latest|ubuntu-24.04-arm|' \
               && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
@@ -167,8 +168,8 @@ jobs:
           # Smaller set of platforms that we only provide Stable ABI wheels for
           CIBW_BUILD: |
             ${{
-                matrix.os == 'ubuntu-24.04-arm' && '*armv7l' ||
-                matrix.os == 'ubuntu-latest' && '*linux_i686' ||
+                matrix.os == 'ubuntu-24.04-arm' && '*armv7l *musllinux_aarch64' ||
+                matrix.os == 'ubuntu-latest' && '*linux_i686 *musllinux_x86_64' ||
                 matrix.os == 'windows-latest' && '*win32' ||
                 matrix.os == 'macos-latest' && '*macosx_x86_64' ||
                 matrix.os == 'windows-11-arm' && '*win_arm64' ||

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ skip = [
     # pure-Python wheels. cibuildwheel will identify Stable ABI wheels and
     # only build them for the one Python version. It will test them for all
     # Python versions though.
-    "cp38*i686", "cp38*win32", "cp38*win_arm64", "cp38-macosx_x86_64", "cp38*armv7l"
+    "cp38*i686", "cp38*win32", "cp38*win_arm64", "cp38-macosx_x86_64", "cp38*armv7l", "cp38*musllinux*"
 ]
 enable = ["cpython-prerelease"]
 # As a quick sanity check, run Cython on some of its own sources
@@ -37,6 +37,11 @@ environment = {CFLAGS = "-O3 -g0 -pipe -fPIC -march=armv8-a -mtune=cortex-a72", 
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"
+inherit.environment = "append"
+environment.CYTHON_LIMITED_API = "true"
+
+[[tool.cibuildwheel.overrides]]
+select = "*musllinux*"
 inherit.environment = "append"
 environment.CYTHON_LIMITED_API = "true"
 


### PR DESCRIPTION
Based on `pypinfo file` (and a bit of manual adding) they're about 1-2% of the manylinux builds so wouldn't meet our justification of a "major" platform (espeically for ARM).