### PR TITLE
Add docs note on setting __module__ on cdef classes

### DIFF
--- a/docs/src/tutorial/cdef_classes.rst
+++ b/docs/src/tutorial/cdef_classes.rst
@@ -154,3 +154,11 @@ Attributes in cdef classes behave differently from attributes in regular classes
 
         .. literalinclude:: ../../examples/tutorial/cdef_classes/wave_function.pyx
             :caption: wave_function.pyx
+
+.. note::
+
+    By default, cdef classes are defined as "static types". This means that in
+    particular, setting the ``__module__`` attribute on the class will have no
+    effect when used in Python. If you wish to override this attribute, you
+    must add the compilation argument ``CYTHON_USE_TYPE_SPECS=1``. See
+    :ref:`C_macro_defines` for more details.

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -1326,6 +1326,8 @@ From Cython 3.1, this is still possible, but should be migrated to using the C m
 Before Cython 3.1, the ``CYTHON_CLINE_IN_TRACEBACK`` macro already works as described
 but the Cython option is needed to remove the compile-time cost.
 
+.. _C_macro_defines:
+
 C macro defines
 ===============
 


### PR DESCRIPTION
Closes #7231

I don't have a good understanding of what `CYTHON_USE_TYPE_SPECS=1` impacts, so just sticking to `__module__` for now; if we want to expand on this or make it more general, happy to workshop it.