### PR TITLE
Deduplicate import code

### DIFF
--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -516,7 +516,7 @@ static int __Pyx_ImportFunction_$cyversion(PyObject *module, const char *funcnam
         void *p;
     } tmp;
     int result = __Pyx_ImportFromPxd_$cyversion(module, funcname, &tmp.p, sig, "function");
-    if (likely(result == 0)) {
+    if (result == 0) {
         *f = tmp.fp;
     }
     return result;


### PR DESCRIPTION
The function and variable import code is identical except for a cast and a tiny difference in the error message.

(The same applies to the export code, but that's sufficiently short that I'm not convinced it's worth it).