### PR TITLE
Run abi3audit on ABI3 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ environment.CYTHON_LIMITED_API = "true"
 inherit.test-requires = "append"
 test-requires = ["abi3audit>=0.0.22"]
 inherit.test-command = "append"
-test-command = ["abi3audit {wheel}"]
+test-command = ["abi3audit --strict --report {wheel}"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64", "x86", "ARM64"]


### PR DESCRIPTION
In addition to a little bit of cleanup on the toml file mainly to reduce duplication.

The cibuildwheel documentation recommends running it as part of "repair wheel" rather than the tests. I didn't do that mainly because I could specify test requirements but not a repair wheel requirement. The consequence is that it gets run multiple times.

I also dropped the override on the "armv7l" CFLAGS so it didn't get a few flags related to x86_64 (which didn't cause problems but seemed a bit silly)