### PR TITLE
Expand isolated limited API tests

### DIFF
--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -16,22 +16,36 @@ PYTHON run.py limited_multi_phase
 ##################### setup.py ################################
 
 import sysconfig
-from setuptools import setup
+from setuptools import setup, Extension
 from Cython.Build import cythonize
+import os
+import sys
 
 if sysconfig.get_config_var("Py_GIL_DISABLED"):
     print("Skipping isolated_limited_api tests on free-threading build")
     exit(0)  # At least for 3.13, freethreading and limited API don't mix
 
 modules = [
-    "limited_single_phase.pyx",
-    "limited_single_phase_modstate.pyx",
-    "limited_multi_phase.pyx"
+    "limited_single_phase",
+    "limited_single_phase_modstate",
+    "limited_multi_phase"
 ]
 
-setup(
-    ext_modules = cythonize(modules),
-)
+for version in range(8, sys.version_info[1]+1):
+    all_extensions = []
+    for module in modules:
+        version_hex = f"0x03{version:02x}0000"
+        ext = Extension(
+            f"{module}_{version}",
+            sources=[f"{module}.pyx"],
+            define_macros=[('Py_LIMITED_API', version_hex)],
+            py_limited_api=True)
+        all_extensions.append(ext)
+    setup(
+        ext_modules = cythonize(all_extensions),
+    )
+    for module in modules:
+        os.remove(f"{module}.c")  # make sure it's rebuilt on the next version loop
 
 ##################### run.py ##################################
 
@@ -45,82 +59,86 @@ if sysconfig.get_config_var("Py_GIL_DISABLED"):
     print("Skipping isolated_limited_api tests on free-threading build")
     exit(0)  # At least for 3.13, freethreading and limited API don't mix
 
+
+def run_one(module_name):
+    limited = __import__(module_name)
+
+    limited.fib(11)
+
+    assert limited.lsum(list(range(10))) == 90
+    assert limited.lsum(tuple(range(10))) == 90
+    assert limited.lsum(iter(range(10))) == 45
+
+    try:
+        limited.raises()
+    except RuntimeError:
+        pass
+
+    limited.catches()
+
+    limited.C()
+    limited.D()
+    limited.E()
+    if sys.version_info >= (3, 9):
+        # Weak-referenceable classes won't work in Python <3.9 because
+        # of an interpreter bug (https://github.com/python/cpython/issues/82321).
+        # This depends on the interpreter version, not the limited API version.
+        weakref.ref(limited.D())
+        weakref.ref(limited.E())
+
+    assert limited.C.cm() == limited.C().cm() == limited.C
+    assert limited.D.cm() == limited.D().cm() == limited.D
+
+    assert limited.decode(b'a', bytearray(b'b')) == "ab"
+
+    assert limited.cast_float(1) == 1.0
+    assert limited.cast_float("2.0") == 2.0
+    assert limited.cast_float(bytearray(b"3")) == 3.0
+
+    gen = limited.my_generator(1)
+    assert next(gen) == 1
+    assert next(gen) == 1
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+    else:
+        assert False  # should have finished
+
+    gen = limited.my_generator("raise")
+    try:
+        next(gen)
+    except RuntimeError:
+        pass
+    else:
+        assert False  # should have raised
+
+    assert limited.add_one(2) == 3
+    assert limited.float_equals(1.5)
+    assert not limited.float_equals(2)
+    assert not limited.float_equals(None)
+    assert limited.float_equals(decimal.Decimal("1.5"))
+
 module_name = sys.argv[1]
 
-limited = __import__(module_name)
-
-limited.fib(11)
-
-assert limited.lsum(list(range(10))) == 90
-assert limited.lsum(tuple(range(10))) == 90
-assert limited.lsum(iter(range(10))) == 45
-
-try:
-    limited.raises()
-except RuntimeError:
-    pass
-
-limited.catches()
-
-limited.C()
-limited.D()
-limited.E()
-if sys.version_info >= (3, 9):
-    # Weak-referenceable classes won't work in Python <3.9 because
-    # of an interpreter bug (https://github.com/python/cpython/issues/82321).
-    # This depends on the interpreter version, not the limited API version.
-    weakref.ref(limited.D())
-    weakref.ref(limited.E())
-
-assert limited.C.cm() == limited.C().cm() == limited.C
-assert limited.D.cm() == limited.D().cm() == limited.D
-
-assert limited.decode(b'a', bytearray(b'b')) == "ab"
-
-assert limited.cast_float(1) == 1.0
-assert limited.cast_float("2.0") == 2.0
-assert limited.cast_float(bytearray(b"3")) == 3.0
-
-gen = limited.my_generator(1)
-assert next(gen) == 1
-assert next(gen) == 1
-try:
-    next(gen)
-except StopIteration:
-    pass
-else:
-    assert False  # should have finished
-
-gen = limited.my_generator("raise")
-try:
-    next(gen)
-except RuntimeError:
-    pass
-else:
-    assert False  # should have raised
-
-assert limited.add_one(2) == 3
-assert limited.float_equals(1.5)
-assert not limited.float_equals(2)
-assert not limited.float_equals(None)
-assert limited.float_equals(decimal.Decimal("1.5"))
-
+for version in range(8, sys.version_info[1]+1):
+    run_one(f"{module_name}_{version}")
 
 ##################### limited_single_phase.pyx ################
 
-# distutils: extra_compile_args = -DPy_LIMITED_API=0x03070000 -DCYTHON_PEP489_MULTI_PHASE_INIT=0
+# distutils: extra_compile_args = -DCYTHON_PEP489_MULTI_PHASE_INIT=0
 
 include 'limited.pxi'
 
 ##################### limited_multi_phase.pyx ################
 
-# distutils: extra_compile_args = -DPy_LIMITED_API=0x03070000 -DCYTHON_PEP489_MULTI_PHASE_INIT=1
+# distutils: extra_compile_args = -DCYTHON_PEP489_MULTI_PHASE_INIT=1
 
 include 'limited.pxi'
 
 ##################### limited_single_phase_modstate.pyx ################
 
-# distutils: extra_compile_args = -DPy_LIMITED_API=0x03070000 -DCYTHON_PEP489_MULTI_PHASE_INIT=0 -DCYTHON_USE_MODULE_STATE=1
+# distutils: extra_compile_args = -DCYTHON_PEP489_MULTI_PHASE_INIT=0 -DCYTHON_USE_MODULE_STATE=1
 
 include 'limited.pxi'
 


### PR DESCRIPTION
They're now a little useless (since we cover the Limited API pretty thoroughly with the regular tests). So expand them a little to cover different version combinations. It's probably reasonable to do this for this small set of tests while it'd be prohibitive on the full CI.