### PR TITLE
Move cibuildwheel dependency to a file so dependabot can handle it

### DIFF
--- a/.github/cibuildwheel-requirement.txt
+++ b/.github/cibuildwheel-requirement.txt
@@ -1,0 +1,2 @@
+# This single dependency is in a pip dependency file so depandabot can handle it
+cibuildwheel == 3.2.1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
       github-actions:
         patterns:
           - "*"
+  # The following is designed to update only cibuildwheel, and is here so that
+  # it's kept in sync with github actions above.
+  - package-ecosystem: "pip"
+    directory: ".github"
+    schedule:
+      interval: "monthly"
+    allow:
+      dependency-name: "cibuildwheel"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -64,8 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install cibuildwheel
-        # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==3.2.1
+        # Nb. dependabot should keep cibuildwheel version pin consistent with job below
+        run: pipx install -r .github/cibuildwheel-requirement.txt
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -112,7 +112,7 @@ jobs:
           python-version: '3.13'
 
       - name: Build wheels
-        # Nb. keep cibuildwheel version pin consistent with generate-matrix job above
+        # Nb. dependabot should keep cibuildwheel version pin consistent with generate-matrix job above
         uses: pypa/cibuildwheel@v3.2.1
         with:
           only: ${{ matrix.only }}


### PR DESCRIPTION
Because it's a bit painful having the cibuildwheel action being updated by dependabot, but then having to remember to update its install via pipx at the same time.