### PR TITLE
Fix bugs in cygdb script for Windows usage

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -53,10 +53,8 @@ def make_command_file(path_to_debug_info, prefix_code='',
                 import sys
                 virtualenv = os.getenv('VIRTUAL_ENV')
                 if virtualenv:
-                    if sys.platform == "win32":
-                        path_to_activate_this_py = os.path.join(virtualenv, 'Scripts', 'activate_this.py')
-                    else:
-                        path_to_activate_this_py = os.path.join(virtualenv, 'bin', 'activate_this.py')
+                    scripts_dir = 'Scripts' if sys.platform == "win32" else 'bin'
+                    path_to_activate_this_py = os.path.join(virtualenv, scripts_dir, 'activate_this.py')
                     print("gdb command file: Activating virtualenv: %s; path_to_activate_this_py: %s" % (
                         virtualenv, path_to_activate_this_py))
                     with open(path_to_activate_this_py) as f:


### PR DESCRIPTION
Windows uses backslashes in file paths, so the simple string insertion of `__file__` resulted in a `SyntaxError` complaining about truncated Unicode escapes.

Virtual environments on Windows use the `Scripts` directory instead of the `bin` directory, so the loading of `activate_this.py` raised a `FileNotFoundError`.

I have verified that these changes fix the issues on my machine.

Possibly related: #3629, #7016