### PR TITLE
Fix an off-by-one error when padding Unicode characters with the ':c' formatting type

### DIFF
--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -902,13 +902,14 @@ static CYTHON_INLINE int __Pyx_CheckUnicodeValue(int value) {
 }
 
 static PyObject* __Pyx_PyUnicode_FromOrdinal_Padded(int value, Py_ssize_t ulength, char padding_char) {
-    if (likely(ulength <= 250)) {
+    Py_ssize_t padding_length = ulength - 1;
+    if (likely((padding_length <= 250) && (value < 0xD800 || value > 0xDFFF))) {
         // Encode to UTF-8 / Latin1 buffer, then decode.
         char chars[256];
 
         if (value <= 255) {
             // Simple Latin1 result, fast to decode.
-            memset(chars, padding_char, (size_t) (ulength - 1));
+            memset(chars, padding_char, (size_t) padding_length);
             chars[ulength-1] = (char) value;
             return PyUnicode_DecodeLatin1(chars, ulength, NULL);
         }
@@ -933,8 +934,8 @@ static PyObject* __Pyx_PyUnicode_FromOrdinal_Padded(int value, Py_ssize_t ulengt
             value >>= 6;
             *--cpos = (char) (0xf0 | (value & 0x07));
         }
-        cpos -= ulength;
-        memset(cpos, padding_char, (size_t) (ulength - 1));
+        cpos -= padding_length;
+        memset(cpos, padding_char, (size_t) padding_length);
         return PyUnicode_DecodeUTF8(cpos, chars + sizeof(chars) - cpos, NULL);
     }
 
@@ -948,7 +949,7 @@ static PyObject* __Pyx_PyUnicode_FromOrdinal_Padded(int value, Py_ssize_t ulengt
 
         padding_uchar = PyUnicode_FromOrdinal(padding_char);
         if (unlikely(!padding_uchar)) return NULL;
-        padding = PySequence_Repeat(padding_uchar, ulength - 1);
+        padding = PySequence_Repeat(padding_uchar, padding_length);
         Py_DECREF(padding_uchar);
         if (unlikely(!padding)) return NULL;
 
@@ -1000,7 +1001,13 @@ static const char DIGITS_HEX[2*16+1] = {
 
 /////////////// CIntToPyUnicode.proto ///////////////
 
-static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char, char format_char);
+#define {{TO_PY_FUNCTION}}(value, width, padding_char, format_char) ( \
+    ((format_char) == ('c')) ? \
+        __Pyx_uchar_{{TO_PY_FUNCTION}}(value, width, padding_char) : \
+        __Pyx__{{TO_PY_FUNCTION}}(value, width, padding_char, format_char) \
+    )
+static CYTHON_INLINE PyObject* __Pyx_uchar_{{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char);
+static CYTHON_INLINE PyObject* __Pyx__{{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char, char format_char);
 
 /////////////// CIntToPyUnicode ///////////////
 //@requires: StringTools.c::IncludeStringH
@@ -1012,7 +1019,32 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t wid
 
 // NOTE: inlining because most arguments are constant, which collapses lots of code below
 
-static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char, char format_char) {
+static CYTHON_INLINE PyObject* __Pyx_uchar_{{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char) {
+#ifdef __Pyx_HAS_GCC_DIAGNOSTIC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+    const {{TYPE}} neg_one = ({{TYPE}}) -1, const_zero = ({{TYPE}}) 0;
+#ifdef __Pyx_HAS_GCC_DIAGNOSTIC
+#pragma GCC diagnostic pop
+#endif
+    const int is_unsigned = neg_one > const_zero;
+
+    // This check is just an awful variation on "(0 <= value <= 1114111)",
+    // but without C compiler complaints about compile time constant conditions depending on the signed/unsigned TYPE.
+    if (unlikely(!(is_unsigned || value == 0 || value > 0) ||
+                    !(sizeof(value) <= 2 || value & ~ ({{TYPE}}) 0x01fffff || __Pyx_CheckUnicodeValue((int) value)))) {
+        // PyUnicode_FromOrdinal() and chr() raise ValueError, f-strings raise OverflowError. :-/
+        PyErr_SetString(PyExc_OverflowError, "%c arg not in range(0x110000)");
+        return NULL;
+    }
+    if (width <= 1) {
+        return PyUnicode_FromOrdinal((int) value);
+    }
+    return __Pyx_PyUnicode_FromOrdinal_Padded((int) value, width, padding_char);
+}
+
+static CYTHON_INLINE PyObject* __Pyx__{{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t width, char padding_char, char format_char) {
     // simple and conservative C string allocation on the stack: each byte gives at most 3 digits, plus sign
     char digits[sizeof({{TYPE}})*3+2];
     // 'dpos' points to end of digits array + 1 initially to allow for pre-decrement looping
@@ -1030,22 +1062,6 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value, Py_ssize_t wid
 #pragma GCC diagnostic pop
 #endif
     const int is_unsigned = neg_one > const_zero;
-
-    // Format 'c' (unicode character) is really a different thing but included for practical reasons.
-    if (format_char == 'c') {
-        // This check is just an awful variation on "(0 <= value <= 1114111)",
-        // but without C compiler complaints about compile time constant conditions depending on the signed/unsigned TYPE.
-        if (unlikely(!(is_unsigned || value == 0 || value > 0) ||
-                     !(sizeof(value) <= 2 || value & ~ ({{TYPE}}) 0x01fffff || __Pyx_CheckUnicodeValue((int) value)))) {
-            // PyUnicode_FromOrdinal() and chr() raise ValueError, f-strings raise OverflowError. :-/
-            PyErr_SetString(PyExc_OverflowError, "%c arg not in range(0x110000)");
-            return NULL;
-        }
-        if (width <= 1) {
-            return PyUnicode_FromOrdinal((int) value);
-        }
-        return __Pyx_PyUnicode_FromOrdinal_Padded((int) value, width, padding_char);
-    }
 
     if (format_char == 'X') {
         hex_digits += 16;

--- a/tests/run/fstring.pyx
+++ b/tests/run/fstring.pyx
@@ -571,15 +571,29 @@ def format_decoded_bytes(bytes value):
 )
 def format_uchar(int x):
     """
-    >>> format_uchar(0)
-    ('\\x00', '           \\x00', '       \\x00')
-    >>> format_uchar(13)
-    ('\\r', '           \\r', '       \\r')
+    >>> char, right8, right12, _ = format_uchar(0)
+    >>> (char, right8, right12)
+    ('\\x00', '       \\x00', '           \\x00')
+    >>> char, right8, right12, _ = format_uchar(13)
+    >>> (char, right8, right12)
+    ('\\r', '       \\r', '           \\r')
+
+    >>> for c in range(1114111 + 1):
+    ...     char, right8, right12, right252 = format_uchar(c)
+    ...     assert right8[:-1] == ' ' * 7, (c, right8)
+    ...     assert char == right8[-1], (char, right8)
+    ...     assert right12[:-1] == ' ' * 11, (c, right12)
+    ...     assert char == right12[-1], (char, right12)
+    ...     assert right252[:-1] == ' ' * 251, (c, right252)
+    ...     assert char == right252[-1], (char, right252)
+    ...     assert ord(char) == c, (c, char)
+
     >>> format_uchar(1114111 + 1)
     Traceback (most recent call last):
     OverflowError: %c arg not in range(0x110000)
     """
-    return f"{x:c}", f"{x:12c}", f"{x:>8c}"
+    # 252 is just outside the fast path size (padding > 250 characters).
+    return f"{x:c}", f"{x:>8c}", f"{x:12c}", f"{x:>252c}"
 
 
 @cython.test_fail_if_path_exists(


### PR DESCRIPTION
Also fix an exception when trying to format lone surrogates this way.

And, along the way, I finally split the `:c` formatting from the other integer formatting functions because it really is a different thing. The decision is currently taken from a C macro because the (cached) type conversion function cannot currently depend on the format string but only on the Cython type of the formatted C value. The C compiler should be happy to discard the unused function respectively.

Closes https://github.com/cython/cython/issues/7298