### PR TITLE
[3.2] Reintroduce test failing in python 3.7

### DIFF
--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -101,12 +101,11 @@ class BasicStarshipExt(object):
 T = TypeVar('T')
 
 
-# FIXME: this fails in Py3.7 now
-#class Box(Generic[T]):
-#    def __init__(self, content):
-#        self.content: T = content
-#
-#box = Box(content=5)
+class Box(Generic[T]):
+    def __init__(self, content):
+        self.content: T = content
+
+box = Box(content=5)
 
 
 class Cls(object):


### PR DESCRIPTION
Backport of #7300