### PR TITLE
Add test for "contended" nogil in nogil

### DIFF
--- a/tests/run/nogil.pyx
+++ b/tests/run/nogil.pyx
@@ -245,14 +245,14 @@ _PERFORMANCE_HINTS = """
 39:0: Exception check on 'release_gil_in_nogil2' will always require the GIL to be acquired.
 49:28: Exception check after calling 'release_gil_in_nogil' will always require the GIL to be acquired.
 51:29: Exception check after calling 'release_gil_in_nogil2' will always require the GIL to be acquired.
-65:32: Exception check after calling 'release_gil_in_nogil' will always require the GIL to be acquired.
-74:0: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired.
-78:0: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired.
-87:24: Exception check after calling 'get_gil_in_nogil' will always require the GIL to be acquired.
-89:25: Exception check after calling 'get_gil_in_nogil2' will always require the GIL to be acquired.
-152:0: Exception check on 'copy_array_exception' will always require the GIL to be acquired.
-203:28: Exception check after calling 'copy_array_exception' will always require the GIL to be acquired.
-206:0: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
-214:30: Exception check after calling 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
-217:36: Exception check after calling 'voidexceptnogil_in_other_pxd' will always require the GIL to be acquired.
+67:32: Exception check after calling 'release_gil_in_nogil' will always require the GIL to be acquired.
+76:0: Exception check on 'get_gil_in_nogil' will always require the GIL to be acquired.
+80:0: Exception check on 'get_gil_in_nogil2' will always require the GIL to be acquired.
+89:24: Exception check after calling 'get_gil_in_nogil' will always require the GIL to be acquired.
+91:25: Exception check after calling 'get_gil_in_nogil2' will always require the GIL to be acquired.
+154:0: Exception check on 'copy_array_exception' will always require the GIL to be acquired.
+205:28: Exception check after calling 'copy_array_exception' will always require the GIL to be acquired.
+208:0: Exception check on 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
+216:30: Exception check after calling 'voidexceptnogil_in_pxd' will always require the GIL to be acquired.
+219:36: Exception check after calling 'voidexceptnogil_in_other_pxd' will always require the GIL to be acquired.
 """


### PR DESCRIPTION
Test for #7312.

Possibly "contended" isn't quite the right word, but I'm not 100% sure of the exact failure mechanism. The test does crash without the fix.