### PR TITLE
Fix multiprocessing on embedded executable

### DIFF
--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -27,7 +27,8 @@ static int __Pyx_main(int argc, wchar_t **argv)
     fpsetmask(m & ~FP_X_OFL);
 #endif
 
-    {{for mname in (module_name,) + embed_modules}}
+    if (PyImport_AppendInittab("__main__", PyInit_{{module_name}}) < 0) return 1;
+    {{for mname in embed_modules}}
     if (PyImport_AppendInittab("{{mname}}", PyInit_{{mname}}) < 0) return 1;
     {{endfor}}
 
@@ -64,7 +65,7 @@ static int __Pyx_main(int argc, wchar_t **argv)
     { /* init module '{{module_name}}' as '__main__' */
       PyObject* m = NULL;
       {{module_is_main}} = 1;
-      m = PyImport_ImportModule("{{module_name}}");
+      m = PyImport_ImportModule("__main__");
 
       if (!m && PyErr_Occurred()) {
           PyErr_Print(); /* This exits with the right code if SystemExit. */


### PR DESCRIPTION
Fixes #7146

originally broken in https://github.com/cython/cython/commit/0045f57a95563a409a8ccf0d62815229d80b7e7f.

My general enthusiasm for embedded mode isn't great so doesn't currently extend to converting the example in the issue into a test. Although given that I can't find any other embedding tests I don't think I'm the only one that feels that way.