### PR TITLE
Fix order of CYTHON_UNUSED

### DIFF
--- a/Cython/Includes/libc/threads.pxd
+++ b/Cython/Includes/libc/threads.pxd
@@ -166,7 +166,7 @@ cdef extern from *:
         return lock_result;
     }
 
-    static CYTHON_UNUSED int __pyx_py_safe_mtx_lock(mtx_t* mutex) {
+    CYTHON_UNUSED static int __pyx_py_safe_mtx_lock(mtx_t* mutex) {
         PyGILState_STATE gil_state = __pyx_libc_threads_limited_api_ensure_gil();
         if (!__pyx_libc_threads_has_gil())
             return mtx_lock(mutex); /* No GIL, no problem */
@@ -175,7 +175,7 @@ cdef extern from *:
         return result;
     }
 
-    static CYTHON_UNUSED int __pyx_py_safe_cnd_wait( cnd_t* cond, mtx_t* mutex) {
+    CYTHON_UNUSED static int __pyx_py_safe_cnd_wait( cnd_t* cond, mtx_t* mutex) {
         __Pyx_UnknownThreadState thread_state = __Pyx_SaveUnknownThread();
         int result = cnd_wait(cond, mutex);
         if (__Pyx_UnknownThreadStateMayHaveHadGil(thread_state)) {
@@ -194,7 +194,7 @@ cdef extern from *:
         }
     }
 
-    static CYTHON_UNUSED int __pyx_py_safe_cnd_timedwait(cnd_t* cond, mtx_t* mutex, const struct timespec* time_point) {
+    CYTHON_UNUSED static int __pyx_py_safe_cnd_timedwait(cnd_t* cond, mtx_t* mutex, const struct timespec* time_point) {
         __Pyx_UnknownThreadState thread_state = __Pyx_SaveUnknownThread();
         int result = cnd_timedwait(cond, mutex, time_point);
         if (__Pyx_UnknownThreadStateMayHaveHadGil(thread_state)) {
@@ -213,7 +213,7 @@ cdef extern from *:
         }
     }
 
-    static CYTHON_UNUSED void __pyx_libc_threads_py_safe_call_once(once_flag* flag, void (*func)(void)) {
+    CYTHON_UNUSED static void __pyx_libc_threads_py_safe_call_once(once_flag* flag, void (*func)(void)) {
         __Pyx_UnknownThreadState thread_state = __Pyx_SaveUnknownThread();
         call_once(flag, func);
         __Pyx_RestoreUnknownThread(thread_state);


### PR DESCRIPTION
In C it generates a warning if in the wrong order
(in C++ it's an error, but given that this is a C standard library header I don't think that happens)