### PR TITLE
Remove Shadow.py _specialized_from_args

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -468,11 +468,6 @@ def fused_type(*args):
     return _FusedType()
 
 
-def _specialized_from_args(signatures, args, kwargs):
-    "Perhaps this should be implemented in a TreeFragment in Cython code"
-    raise Exception("yet to be implemented")
-
-
 py_int = typedef(int, "int")
 py_long = typedef(int, "long")  # for legacy Py2 code only
 py_float = typedef(float, "float")


### PR DESCRIPTION
This is the only reference to it in Cython.

It looks like it was originally added as part of the initial fused functions implementation, but the only use of it was deleted one commit later (e2bd21ab2ba48fbf6cc261bc13276890de6b45ef).