### PR TITLE
Fix dependabot allow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
     schedule:
       interval: "monthly"
     allow:
-      dependency-name: "cibuildwheel"
+      - dependency-name: "cibuildwheel"


### PR DESCRIPTION
According to https://github.com/cython/cython/network/updates:

<img width="1157" height="271" alt="image" src="https://github.com/user-attachments/assets/bcc4854d-9f41-43a7-9e9d-18cac56ebda1" />
