### PR TITLE
Make fused function signatures a non-writeable dict-proxy

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1430,7 +1430,7 @@ static PyObject *__Pyx_FusedFunction_get_signatures(__pyx_FusedFunctionObject *f
     // No critical section - signatures should not be reassigned
     if (func->__signatures__) {
         // A dictproxy ensures that users can't (easily) mess with the internal data used in fused dispatch.
-        // For this rarely-used introspection function, it is unlikely to be worth the memory to cahce the proxy.
+        // For this rarely-used introspection function, it is unlikely to be worth the memory to cache the proxy.
         return PyDictProxy_New(func->__signatures__);
     } else {
         Py_RETURN_NONE;


### PR DESCRIPTION
Slightly related to #7383 (I think that classobj should be set once in advance and that's easier to reason about if people can't change the contents of `__signatures__`; however it's only fairly losely related).

I've only changed the user-visible attribute - I did consider changing the internal variable but then we can't use optimized access when dispatching (which seems worse).

My view is this should go into 3.3 and hopefully there's plenty of time for anyone who is doing silly things messing with `__signatures__` to complain if needed.