### PR TITLE
Fix thread sanitizer error with fused function classobj

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1566,10 +1566,7 @@ __pyx_err:;
 
     if (likely(unbound_result_func)) {
         if (self->self) {
-            __pyx_FusedFunctionObject *unbound = (__pyx_FusedFunctionObject *) unbound_result_func;
-
-            // TODO: move this to InitClassCell
-            __Pyx_CyFunction_SetClassObj(unbound, __Pyx_CyFunction_GetClassObj(self));
+            assert(__Pyx_CyFunction_GetClassObj(unbound_result_func) == __Pyx_CyFunction_GetClassObj(self));
 
             result_func = __pyx_FusedFunction_descr_get(unbound_result_func,
                                                         self->self, self->self);
@@ -1667,7 +1664,7 @@ __pyx_FusedFunction_call(PyObject *func, PyObject *args, PyObject *kw)
         if (unlikely(!new_func))
             goto bad;
 
-        __Pyx_CyFunction_SetClassObj(new_func, __Pyx_CyFunction_GetClassObj(binding_func));
+        assert(__Pyx_CyFunction_GetClassObj(new_func) == __Pyx_CyFunction_GetClassObj(binding_func));
 
         func = (PyObject *) new_func;
     }


### PR DESCRIPTION
It turns out the value is already set so there's no reason to reset it each time a function is called and/or indexed. This is tested fairly thoroughly in `fused_def.test_fused_def_super`.

Fixes https://github.com/cython/cython/issues/7383