### PR TITLE
Define missing C++ exception classes

### DIFF
--- a/Cython/Includes/libcpp/exception.pxd
+++ b/Cython/Includes/libcpp/exception.pxd
@@ -18,7 +18,7 @@ cdef extern from "<stdexcept>" namespace "std" nogil:
     # So they're most useful just as class names when implementing
     # exception handlers.
     cdef cppclass logic_error(exception):
-        pass  
+        pass
     cdef cppclass invalid_argument(logic_error):
         pass
     cdef cppclass domain_error(logic_error):
@@ -45,7 +45,7 @@ cdef extern from "<stdexcept>" namespace "std" nogil:
         pass
 
     cdef cppclass bad_exception(exception):
-        pass 
+        pass
 
 
 cdef extern from *:


### PR DESCRIPTION
I've put them in exception.pxd - most of them actually come from the header `<stdexcept>` but I don't think we're obliged to mirror the C++ header structure exactly.

I haven't done anything with exceptions definited in newer headers (e.g. `future_error`). They're numerous and scattered and somewhat version dependent.

Also added `current_exception` because I've been convinced that it can be used usefully.