### PR TITLE
Don't abi3audit cython-inline files

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1131,7 +1131,8 @@ class CythonCompileTestCase(unittest.TestCase):
         if not self.abi3audit:
             return
         shared_libs = [ file for file in os.listdir(self.workdir)
-                        if os.path.splitext(file)[1] in ('.so', '.dll') ]
+                        if (os.path.splitext(file)[1] in ('.so', '.dll')
+                                and not file.startswith('_cython_inline')) ]
         if not shared_libs:
             return
         shared_libs = [ os.path.join(self.workdir, file) for file in shared_libs ]


### PR DESCRIPTION
test_coroutines_pep492 seems unique in that it builds the inline files inplace. The other way to fix this would be to remove

```
lib_dir=os.path.dirname(__file__)
```

from that. I haven't dne this because I think building in place is probably a good thing.

Ideally of course we'd propagate the cflags to cython_inline. I've done this for the srctree tests, but the inline ones are more adhoc so that's probably harder.