### PR TITLE
Enable test_fstrings on the Limited API

### DIFF
--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -77,7 +77,7 @@ unicode_formatting
 # Py_UNICODE
 builtin_ord
 for_in_string
-fstring
+run[.]fstring$
 run[.]inop
 run[.]notinop
 py_unicode_strings


### PR DESCRIPTION
The "run/fstrings" test is rightly disabled because it deliberately uses `Py_UNICODE`. However the exclusion was broader than it needed to be and included at least one other working test.