### PR TITLE
Apply code style to non-py docs; allow whitespace in docs

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1864,7 +1864,7 @@ class TestCodeFormat(unittest.TestCase):
         result = style.check_files(paths)
         total_errors += result.total_errors
 
-        # chcks for non-Python docs source files
+        # checks for non-Python docs source files
         paths = []
         for codedir in ['docs']:
             paths += glob.iglob(os.path.join(self.cython_dir, codedir + "/**/*.p[yx][xdi]"), recursive=True)


### PR DESCRIPTION
1. Apply code-style checks to Cython files in the docs.
2. Allow spurious whitespace (i.e. blank lines with a bit of space and newlines at the end of file) for both .py and .pyx files. We'd already used this in .pyx files to make the spacing match, so it seems worthwhile to allow this for .py files too.