### PR TITLE
Fix --embed-modules for package submodules

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3572,14 +3572,43 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             wmain = "wmain"
         else:
             wmain = Options.embed
+        def _sanitise_embed_name(name):
+            # name: EncodedString or str with dotted module name
+            try:
+                is_ascii = name.isascii()
+            except Exception:
+                # fallback if not EncodedString
+                is_ascii = all(ord(c) < 128 for c in name)
+            if is_ascii:
+                cname = name.replace('.', '_')
+            else:
+                puny = name.encode('punycode') if isinstance(name, str) else name.encode('punycode')
+                if isinstance(puny, bytes):
+                    puny = puny.replace(b'-', b'_').decode('ascii')
+                else:
+                    puny = str(puny).replace('-', '_')
+                cname = 'U_' + puny
+            if cname and cname[0].isdigit():
+                cname = '_' + cname
+            return cname
+
+        # Build a structure with import name and C identifier name for each embed module
+        embed_modules_ctx = []
+        for m in Options.embed_modules:
+            embed_modules_ctx.append((m, _sanitise_embed_name(m)))
+
+        # main module also needs a C-name (sanitised) for the PyInit symbol
+        main_cname = _sanitise_embed_name(env.module_name)
+
         main_method = TempitaUtilityCode.load_cached(
-                "MainFunction", "Embed.c",
-                context={
-                    'module_name': env.module_name,
-                    'module_is_main': module_is_main,
-                    'main_method': Options.embed,
-                    'wmain_method': wmain,
-                    'embed_modules': tuple(Options.embed_modules)})
+            "MainFunction", "Embed.c",
+            context={
+                'module_name': env.module_name,
+                'module_cname': main_cname,
+                'module_is_main': module_is_main,
+                'main_method': Options.embed,
+                'wmain_method': wmain,
+                'embed_modules': tuple(embed_modules_ctx)})
         code.globalstate.use_utility_code(main_method)
 
     def punycode_module_name(self, prefix, name):

--- a/Cython/Utility/Embed.c
+++ b/Cython/Utility/Embed.c
@@ -13,8 +13,8 @@
 #endif
 
 
-{{for mname in embed_modules}}
-    __Pyx_PyMODINIT_FUNC PyInit_{{mname}}(void) CYTHON_SMALL_CODE; /*proto*/
+{{for m in embed_modules}}
+    __Pyx_PyMODINIT_FUNC PyInit_{{m[1]}}(void) CYTHON_SMALL_CODE; /*proto*/
 {{endfor}}
 
 #if defined(_WIN32) || defined(WIN32) || defined(MS_WINDOWS)
@@ -35,8 +35,8 @@ static int __Pyx_main(int argc, wchar_t **argv)
     fpsetmask(m & ~FP_X_OFL);
 #endif
 
-    {{for mname in (module_name,) + embed_modules}}
-    if (PyImport_AppendInittab("{{mname}}", PyInit_{{mname}}) < 0) return 1;
+    {{for m in ( (module_name, module_cname), ) + embed_modules}}
+    if (PyImport_AppendInittab("{{m[0]}}", PyInit_{{m[1]}}) < 0) return 1;
     {{endfor}}
 
     {

--- a/tests/build/embed_modules_package.srctree
+++ b/tests/build/embed_modules_package.srctree
@@ -1,0 +1,156 @@
+```plaintext
+# mode: run
+# tag: embed
+
+CYTHONIZE -j2 pkg/module.pyx
+CYTHON --embed --embed-modules=pkg.module main_module.pyx
+PYTHON build.py main_module main_module.c pkg_module.c
+PYTHON run.py main_module
+
+################### build.py ########################
+
+import os
+import setuptools
+import sys
+import sysconfig
+from concurrent.futures import ThreadPoolExecutor
+
+IS_WINDOWS = sys.platform == 'win32'
+
+if IS_WINDOWS:
+    import distutils.msvc9compiler as setuptools_msvc  # from setuptools
+    ccompiler = setuptools_msvc.MSVCCompiler()
+    ccompiler.initialize()
+    compiler_exe = ccompiler.cc
+    linker_exe = ccompiler.linker
+else:
+    import distutils.unixccompiler as setuptools_cc  # from setuptools
+    ccompiler = setuptools_cc.UnixCCompiler()
+    compiler_exe = ccompiler.compiler
+    linker_exe = ccompiler.linker_exe
+
+
+def get_config_var(name, default='', *, _get_config_var=sysconfig.get_config_vars().get):
+    return _get_config_var(name, default)
+
+
+INCDIR = sysconfig.get_path('include')
+LIBDIR1 = get_config_var('LIBDIR')
+LIBDIR2 = get_config_var('LIBPL')
+PYLIB_DIR = get_config_var("installed_platbase")
+PYLIB = get_config_var('LIBRARY')
+PYLIB_DYN = get_config_var('LDLIBRARY')
+
+if sys.platform == 'darwin':
+    PYLIB_DYN = f'python{sys.version_info[0]}.{sys.version_info[1]}'
+elif PYLIB_DYN == PYLIB:
+    PYLIB_DYN = ''
+elif PYLIB_DYN:
+    PYLIB_DYN = os.path.splitext(PYLIB_DYN)[0]
+    if PYLIB_DYN.startswith('lib'):
+        PYLIB_DYN = PYLIB_DYN[3:]
+
+CFLAGS = get_config_var('CFLAGS') + ' ' + os.environ.get('CFLAGS', '')
+
+OBJ_EXT = ccompiler.obj_extension
+LIBS = get_config_var('LIBS')
+SYSLIBS = get_config_var('SYSLIBS')
+EXE_EXT = get_config_var('EXE')
+
+
+def compile(source_file):
+    ccompiler.compile(
+        sources=[source_file],
+        include_dirs=[INCDIR],
+        extra_postargs=CFLAGS.split(),
+    )
+
+
+def link_exe(objects, app_name):
+    library_dirs = [
+        libdir for libdir in
+        [LIBDIR1, LIBDIR2, os.path.join(PYLIB_DIR, "libs")]
+        if libdir and os.path.isdir(libdir)
+    ]
+    if PYLIB_DYN:
+        libraries = [PYLIB_DYN]
+    elif PYLIB:
+        objects = [*objects, os.path.join(LIBDIR1, PYLIB)]
+        libraries = [
+            lib[2:] if lib.startswith('-l') else lib
+            for lib in [*LIBS.split(), *SYSLIBS.split()]
+        ]
+    else:
+        libraries = []
+
+    ccompiler.link(
+        ccompiler.EXECUTABLE,
+        objects,
+        output_filename=app_name + EXE_EXT,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        runtime_library_dirs=[PYLIB_DIR],
+    )
+
+
+def main(args):
+    app_name, *c_files = args
+    c_base_names = [filename[:-2] for filename in c_files]
+
+    print("CFLAGS:", CFLAGS)
+    print(f"PYLIBS: {PYLIB!r} {PYLIB_DYN!r}")
+    print(f"LINK: {LIBDIR1!r} {LIBDIR2!r}")
+    print("LIBDIR1:", os.listdir(LIBDIR1))
+
+    compile_commands = [filename+'.c' for filename in c_base_names]
+    for command in compile_commands:
+        print("CC:", command)
+
+    with ThreadPoolExecutor() as pool:
+        for _ in pool.map(compile, compile_commands):
+            pass
+
+    link_exe(
+        [filename + OBJ_EXT for filename in c_base_names],
+        app_name=app_name,
+    )
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+
+
+################### run.py ########################
+
+import os
+import sys
+from subprocess import run
+from sysconfig import get_config_var
+
+EXE_EXT = get_config_var('EXE')
+PYLIB_DIR = get_config_var("installed_platbase")
+
+PATH = os.environ.get('PATH', '')
+sep = os.pathsep
+os.environ.update(PATH=f".{sep}{PYLIB_DIR}{sep}{PATH}")
+
+result = run([os.path.abspath(sys.argv[1] + EXE_EXT)], capture_output=True)
+assert b"DONE" in result.stdout, result.stdout
+
+
+################# main_module.pyx ####################
+
+import pkg.module as m
+
+assert __name__ == '__main__'
+
+assert m.attr == 'X', m.attr
+
+print("DONE", m.attr)
+
+
+################# pkg/module.pyx ####################
+
+attr = 'X'
+
+```


### PR DESCRIPTION
Sanitise module names passed to --embed-modules so generated C symbols are valid
(replace dots with underscores, handle non-ASCII via punycode and leading-digit prefix).
Update Embed.c template to use sanitized names and add a srctree test exercising
embedding a packaged submodule.