### PR TITLE
Improve benchmarks scaling for sub-benchmarks

### DIFF
--- a/Demos/benchmarks/bm_cython.pyx
+++ b/Demos/benchmarks/bm_cython.pyx
@@ -197,7 +197,7 @@ def run_benchmark(repeat: bool, scale=1000):
     for name, func in globals().items():
         if not name.startswith('bm_'):
             continue
-        collected_timings[name] = repeat_to_accuracy(func, scale=scales[name], repeat=repeat)[0]
+        collected_timings[name] = repeat_to_accuracy(func, scale=scales[name], repeat=repeat, scale_to=scale)[0]
 
     for name, timings in collected_timings.items():
         print(f"{name}: {timings}")

--- a/Demos/benchmarks/bm_dataclasses.py
+++ b/Demos/benchmarks/bm_dataclasses.py
@@ -111,7 +111,7 @@ def run_benchmark(repeat=True, scale=10):
     points = benchmark_create(POINTS)
 
     collected_timings['create'] = repeat_to_accuracy(
-        timeit, benchmark_create, POINTS, scale=scales['create'], repeat=repeat)[0]
+        timeit, benchmark_create, POINTS, scale=scales['create'], repeat=repeat, scale_to=scale)[0]
 
     for name, bench_func in [
             ('float', benchmark_float),
@@ -119,7 +119,7 @@ def run_benchmark(repeat=True, scale=10):
             ('compare', benchmark_compare),
             ]:
         collected_timings[name] = repeat_to_accuracy(
-            timeit, bench_func, points, scale=scales[name], repeat=repeat)[0]
+            timeit, bench_func, points, scale=scales[name], repeat=repeat, scale_to=scale)[0]
 
     for name, timings in collected_timings.items():
         print(f"bm_dataclasses[{name}]: {timings}")

--- a/Demos/benchmarks/bm_unpack_sequence.py
+++ b/Demos/benchmarks/bm_unpack_sequence.py
@@ -130,7 +130,7 @@ def run_benchmark(repeat=True, scale=20_000):
     for name, func in globals().items():
         if name.startswith('bm_'):
             collected_timings[name] = repeat_to_accuracy(
-                func, scale=scales[name], repeat=repeat)[0]
+                func, scale=scales[name], repeat=repeat, scale_to=scale)[0]
 
     for name, timings in collected_timings.items():
         print(f"{name}: {timings}")

--- a/Demos/benchmarks/util.py
+++ b/Demos/benchmarks/util.py
@@ -9,11 +9,12 @@ import time
 
 
 def repeat_to_accuracy(func, *args,
-                       variance_threshold: float = .02,
+                       variance_threshold: float = .01,
                        scale=1,
                        repeat=True,
                        max_iterations: cython.long = 5_000,
                        min_iterations: cython.long = 5,
+                       scale_to=None,
                        ):
     """Repeatedly call and time the function
     until the variance of the timings is below 'variance_threshold'.
@@ -26,8 +27,13 @@ def repeat_to_accuracy(func, *args,
     times = []
     call_benchmark = partial(func, *args, scale, time.perf_counter)
 
+    if scale_to is None or scale_to == scale:
+        scale_factor = 1.0
+    else:
+        scale_factor = scale_to / scale
+
     # First counted run.
-    execution_time: float = call_benchmark()
+    execution_time: float = call_benchmark() * scale_factor
     times.append(execution_time)
 
     mean: float = execution_time
@@ -48,7 +54,7 @@ def repeat_to_accuracy(func, *args,
     count: cython.long
     for count in range(2, max_iterations + 1):
         # Time the function.
-        execution_time = call_benchmark()
+        execution_time = call_benchmark() * scale_factor
         times.append(execution_time)
 
         # Incrementally calculate mean and sum of squares.


### PR DESCRIPTION
… by scaling to the fastest benchmark instead of the slowest.

Scale back the timings of sub-benchmarks to the outer scale count to report comparable timings (which will be divided by the outer scale for reporting the per-loop runtime).