### PR TITLE
Avoid immortalizing anything shared on freethreading

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -2434,7 +2434,7 @@ class GlobalState:
         # because setting the refcount isn't thread-safe. The chances are that most of the constants
         # that this applies to are already immortal though so that isn't a great loss.
         writer.putln("#if PY_VERSION_HEX < 0x030E0000")
-        writer.putln("if (Py_REFCNT(table[i]) == 1)")
+        writer.putln("if (_Py_IsOwnedByCurrentThread(table[i]) && Py_REFCNT(table[i]) == 1)")
         writer.putln("#else")
         writer.putln("if (PyUnstable_Object_IsUniquelyReferenced(table[i]))")
         writer.putln("#endif")


### PR DESCRIPTION
Py_SET_REFCNT isn't thread-safe so there's the
risk of races if another thread is accessing it at the same time. This will mostly apply to things that are already immortal so I don't think we'll lose much from the check.

On Python 3.13t we have to use a slightly weaker check than the full "IsUniquelyReferenced" - I think this is fine because we know that our "1" reference is not yet accessible anywhere external, however I've still chosen to use the full check where available.