### PR TITLE
Remove exclusion of collection_type in test

### DIFF
--- a/Cython/Tests/TestShadow.py
+++ b/Cython/Tests/TestShadow.py
@@ -11,9 +11,7 @@ class TestShadow(unittest.TestCase):
         missing_directives = []
         extra_directives = []
         for full_directive in Options.directive_types.keys():
-            # Python 2 doesn't support "directive, *rest = full_directive.split('.')"
-            split_directive = full_directive.split('.')
-            directive, rest = split_directive[0], split_directive[1:]
+            directive, *rest = full_directive.split('.')
 
             scope = Options.directive_scopes.get(full_directive)
             if scope and len(scope) == 1 and scope[0] == "module":


### PR DESCRIPTION
See 9f518b7c3b6792a3f969617a11da83e600ac8764.

This should have been caught by the test, but I'd specifically excluded it when I first added `collection_type` for internal use only..