### PR TITLE
Fix version parse error

### DIFF
--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -1,6 +1,9 @@
 # cython.* namespace for pure mode.
 from __future__ import annotations
 
+# Possible version formats: "3.1.0", "3.1.0a1", "3.1.0a1.dev0"
+__version__ = "3.3.0a0"
+
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -21,10 +24,6 @@ _C_Or_TypeT = TypeVar('_C_Or_TypeT', _C, _TypeT)
 _Decorator = Callable[[_C_Or_TypeT], _C_Or_TypeT]
 _FuncDecorator = Callable[[_C], _C]
 _ClassDecorator = Callable[[_TypeT], _TypeT]
-
-# Possible version formats: "3.1.0", "3.1.0a1", "3.1.0a1.dev0"
-__version__ = "3.3.0a0"
-
 
 # BEGIN shameless copy from Cython/minivect/minitypes.py
 


### PR DESCRIPTION
Fixes #7449

My fault - when I merged typing into Shadow.py I moved the version too far down so the config no longer found it (it assumes the version was in the first 5 lines)