### PR TITLE
Export PYTHON_GIL=0 for all free-threading tests

### DIFF
--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -229,7 +229,7 @@ if [[ $PYTHON_VERSION == "graalpy"* ]]; then
 fi
 
 export CFLAGS="$CFLAGS $EXTRA_CFLAGS"
-if [[ $PYTHON_VERSION == "3.13t" ]]; then
+if [[ $PYTHON_VERSION == *"t" ]]; then
   export PYTHON_GIL=0
 fi
 python runtests.py \


### PR DESCRIPTION
Not just 3.13t