### PR TITLE
Enable Limited API 3.9 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,17 @@ jobs:
             extra_hash: "-codestyle"
           # Limited API
           - os: ubuntu-22.04
+            python-version: "3.9"
+            backend: "c,cpp"
+            env: { LIMITED_API: "--limited-api --abi3audit" }
+            extra_hash: "-limited_api"
+          - os: ubuntu-22.04
             python-version: "3.11"
             backend: "c,cpp"
             env: { LIMITED_API: "--limited-api --abi3audit" }
             extra_hash: "-limited_api"
           - os: ubuntu-22.04
             python-version: "3.12"
-            backend: "c,cpp"
-            env: { LIMITED_API: "--limited-api --abi3audit" }
-            extra_hash: "-limited_api"
-          - os: ubuntu-22.04
-            python-version: "3.13"
             backend: "c,cpp"
             env: { LIMITED_API: "--limited-api --abi3audit" }
             extra_hash: "-limited_api"

--- a/tests/memoryview_tests.txt
+++ b/tests/memoryview_tests.txt
@@ -39,6 +39,12 @@ run[.]special_methods_T561
 run[.]cythonscope
 run[.]shared_utility
 
+# np.ndarray type buffers
+run[.]numpy_attributes
+run[.]numpy_test
+run[.]numpy_bufacc_T155
+run[.]numpy_parallel
+
 # generic filters
 buffer
 memoryview

--- a/tests/run/tuple_constants.pyx
+++ b/tests/run/tuple_constants.pyx
@@ -1,6 +1,9 @@
 
 cimport cython
 
+cdef extern from *:
+    int CYTHON_COMPILING_IN_LIMITED_API
+
 module_level_tuple = (1,2,3)
 second_module_level_tuple = (1,2,3)  # should be deduplicated to be the same as the first
 string_module_level_tuple = ("1", "2")
@@ -38,8 +41,9 @@ def test_deduplicated_args():
     import sys
     check_identity_of_co_varnames = (
         not hasattr(sys, "pypy_version_info") and  # test doesn't work on PyPy (which is probably fair enough)
-        sys.version_info < (3, 11)  # on Python 3.11 co_varnames returns a new, dynamically-calculated tuple
-                                    # each time it is run
+        sys.version_info < (3, 11) and # on Python 3.11 co_varnames returns a new, dynamically-calculated tuple
+                                       # each time it is run.
+        not CYTHON_COMPILING_IN_LIMITED_API
     )
     if check_identity_of_co_varnames:
         assert func1.__code__.co_varnames is func2.__code__.co_varnames


### PR DESCRIPTION
Mainly because this is the version that we use to distribute Cython with on the more obscure platforms.

I've swapped out the 3.13 Limited API to avoid increasing the total number of runs. However that could be changed. I don't think 3.13 was significant with changes to the Limited API - practically most people are using 3.11 (for memoryviews) or 3.12 (for vectorcall).