### PR TITLE
Rewrite import-star name matching to avoid lengthy chains of if-elif comparisons

### DIFF
--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -182,18 +182,6 @@ static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObjec
 }
 
 
-//////////////////// CStringEquals.proto ////////////////////
-
-static CYTHON_INLINE int __Pyx_StrEq(const char *, const char *); /*proto*/
-
-//////////////////// CStringEquals ////////////////////
-
-static CYTHON_INLINE int __Pyx_StrEq(const char *s1, const char *s2) {
-    while (*s1 != '\0' && *s1 == *s2) { s1++; s2++; }
-    return *s1 == *s2;
-}
-
-
 //////////////////// UnicodeEquals.proto ////////////////////
 
 static CYTHON_INLINE int __Pyx_PyUnicode_Equals(PyObject* s1, PyObject* s2, int equals); /*proto*/

--- a/tests/run/import_star.pyx
+++ b/tests/run/import_star.pyx
@@ -1,6 +1,6 @@
 # mode: run
 
-cdef object executable, version_info
+cdef object executable, version_info, version
 cdef long hexversion
 
 ctypedef struct MyStruct:
@@ -18,11 +18,12 @@ from sys import *
 
 def test_cdefed_objects():
     """
-    >>> ex, vi = test_cdefed_objects()
+    >>> ex, vi, ver = test_cdefed_objects()
     >>> assert ex is not None
     >>> assert vi is not None
+    >>> assert ver is not None
     """
-    return executable, version_info
+    return executable, version_info, version
 
 
 def test_cdefed_cvalues():


### PR DESCRIPTION
Instead, use a bit of binary search on the name's first character to reduce the number of comparisons.

Reduces both the overall runtime overhead as well as the storage size.
E.g. `tests/memoryview/memslice.so` shrinks from 1134512 to 1129296 bytes, -5KB or 0.5%.