### PR TITLE
Don't check alignment on the opaque object ABI

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -4082,7 +4082,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             # working when a builtin type is imported but not actually used.
             code.putln('0, 0,')
         else:
+            code.putln('#if !CYTHON_OPAQUE_OBJECTS')
             code.putln(f'sizeof({objstruct}), {alignment_func}({objstruct}),')
+            code.putln('#else')
+            code.putln('0, 0,')
+            code.putln("#endif")
         code.putln('#else')
         code.putln(f'sizeof({sizeof_objstruct}), {alignment_func}({sizeof_objstruct}),')
         code.putln("#endif")


### PR DESCRIPTION
This fixes the compiler errors related to alignment I was seeing over at https://github.com/numpy/numpy/issues/30704#issuecomment-3786016359. 

@da-woods said that he had disabled these checks but I think this extra bit is needed to actually disable them for all types.

Note that the PR is targeting https://github.com/cython/cython/tree/freethreading-limited-api-preview