### PR TITLE
Switch to PyErr_GetRaisedException() where possible

### DIFF
--- a/Cython/Compiler/Buffer.py
+++ b/Cython/Compiler/Buffer.py
@@ -386,13 +386,13 @@ def put_assign_to_buffer(lhs_cname, rhs_cname, buf_entry,
         # can consider working around this later.
         exc_temps = tuple(code.funcstate.allocate_temp(PyrexTypes.py_object_type, manage_ref=False)
                           for _ in range(3))
-        code.putln('__Pyx_PyErr_Fetch(&%s, &%s, &%s);' % exc_temps)
+        code.putln('__Pyx_PyErr_FetchException(&%s, &%s, &%s);' % exc_temps)
         code.putln('if (%s) {' % code.unlikely("%s == -1" % (getbuffer % lhs_cname)))
         code.putln('Py_XDECREF(%s); Py_XDECREF(%s); Py_XDECREF(%s);' % exc_temps)  # Do not refnanny these!
         code.globalstate.use_utility_code(raise_buffer_fallback_code)
         code.putln('__Pyx_RaiseBufferFallbackError();')
         code.putln('} else {')
-        code.putln('__Pyx_PyErr_Restore(%s, %s, %s);' % exc_temps)
+        code.putln('__Pyx_PyErr_RestoreException(%s, %s, %s);' % exc_temps)
         code.putln('}')
         code.putln('%s = %s = %s = 0;' % exc_temps)
         for t in exc_temps:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1837,9 +1837,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.start_slotfunc(scope, PyrexTypes.c_void_type, "tp_finalize", "PyObject *o", needs_funcstate=False)
         code.putln("PyObject *etype, *eval, *etb;")
-        code.putln("__Pyx_PyErr_Fetch(&etype, &eval, &etb);")
+        code.putln("__Pyx_PyErr_FetchException(&etype, &eval, &etb);")
         code.putln("%s(o);" % entry.func_cname)
-        code.putln("__Pyx_PyErr_Restore(etype, eval, etb);")
+        code.putln("__Pyx_PyErr_RestoreException(etype, eval, etb);")
         code.putln("}")
         code.exit_cfunc_scope()
 
@@ -2017,13 +2017,13 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.putln("{")
         code.putln("PyObject *etype, *eval, *etb;")
-        code.putln("__Pyx_PyErr_Fetch(&etype, &eval, &etb);")
+        code.putln("__Pyx_PyErr_FetchException(&etype, &eval, &etb);")
         # increase the refcount while we are calling into user code
         # to prevent recursive deallocation
         code.putln("Py_SET_REFCNT(o, Py_REFCNT(o) + 1);")
         code.putln("%s(o);" % entry.func_cname)
         code.putln("Py_SET_REFCNT(o, Py_REFCNT(o) - 1);")
-        code.putln("__Pyx_PyErr_Restore(etype, eval, etb);")
+        code.putln("__Pyx_PyErr_RestoreException(etype, eval, etb);")
         code.putln("}")
 
     def generate_traverse_function(self, scope, code, cclass_entry):
@@ -3365,9 +3365,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         # fetch/restore the error indicator because PyState_RemoveModule might fail itself
         code.putln("if (pystate_addmodule_run) {")
         code.putln("PyObject *tp, *value, *tb;")
-        code.putln("__Pyx_PyErr_Fetch(&tp, &value, &tb);")
+        code.putln("__Pyx_PyErr_FetchException(&tp, &value, &tb);")
         code.putln("PyState_RemoveModule(&%s);" % Naming.pymoduledef_cname)
-        code.putln("__Pyx_PyErr_Restore(tp, value, tb);")
+        code.putln("__Pyx_PyErr_RestoreException(tp, value, tb);")
         code.putln("}")
         code.putln("#endif")
         code.putln('} else if (!PyErr_Occurred()) {')

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -221,7 +221,7 @@ static void __Pyx_Coroutine_AwaitableIterError(PyObject *source) {
     PyObject *exc, *val, *val2, *tb;
     __Pyx_TypeName source_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(source));
     assert(PyErr_Occurred());
-    __Pyx_PyErr_Fetch(&exc, &val, &tb);
+    __Pyx_PyErr_FetchException(&exc, &val, &tb);
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
     PyErr_NormalizeException(&exc, &val, &tb);
     if (tb != NULL) {
@@ -235,14 +235,14 @@ static void __Pyx_Coroutine_AwaitableIterError(PyObject *source) {
         "'async for' received an invalid object from __anext__: " __Pyx_FMT_TYPENAME, source_type_name);
     __Pyx_DECREF_TypeName(source_type_name);
 
-    __Pyx_PyErr_Fetch(&exc, &val2, &tb);
+    __Pyx_PyErr_FetchException(&exc, &val2, &tb);
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
     PyErr_NormalizeException(&exc, &val2, &tb);
 #endif
     Py_INCREF(val);
     PyException_SetCause(val2, val);
     PyException_SetContext(val2, val);
-    __Pyx_PyErr_Restore(exc, val2, tb);
+    __Pyx_PyErr_RestoreException(exc, val2, tb);
 #endif
 }
 
@@ -273,9 +273,9 @@ static PyObject *__Pyx__Coroutine_GetAwaitableIter(PyObject *obj) {
             // We need to distinguish between "doesn't have __await__" vs "__await__ failed"
             if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
                 PyObject *type, *value, *traceback;
-                __Pyx_PyErr_Fetch(&type, &value, &traceback);
+                __Pyx_PyErr_FetchException(&type, &value, &traceback);
                 int has_attr = PyObject_HasAttr(obj, PYIDENT("__await__"));
-                __Pyx_PyErr_Restore(type, value, traceback);
+                __Pyx_PyErr_RestoreException(type, value, traceback);
                 if (!has_attr) goto slot_error;
             }
         }

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -889,7 +889,7 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
     // frame, and then customizing the details of the code to match.
     // We then run the code object and use the generated frame to set the traceback.
 
-    __Pyx_PyErr_Fetch(&exc_type, &exc_value, &exc_traceback);
+    __Pyx_PyErr_FetchException(&exc_type, &exc_value, &exc_traceback);
 
     code_object = $global_code_object_cache_find(c_line ? -c_line : py_line);
     if (!code_object) {
@@ -929,7 +929,7 @@ static void __Pyx_AddTraceback(const char *funcname, int c_line,
     success = 1;
 
   bad:
-    __Pyx_PyErr_Restore(exc_type, exc_value, exc_traceback);
+    __Pyx_PyErr_RestoreException(exc_type, exc_value, exc_traceback);
     Py_XDECREF(code_object);
     Py_XDECREF(py_py_line);
     Py_XDECREF(py_funcname);

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -601,11 +601,11 @@ typedef uintptr_t  __pyx_uintptr_t;
 // #define __PYX_RUNTIME_REINTERPRET(type, var) (*(type *)(&var))
 
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
-#define __Pyx_PyErr_Fetch(petype, peval, petb) PyErr_Fetch(petype, peval, petb)
-#define __Pyx_PyErr_Restore(etype, eval, etb) PyErr_Restore(etype, eval, etb)
+#define __Pyx_PyErr_FetchException(petype, peval, petb) PyErr_Fetch(petype, peval, petb)
+#define __Pyx_PyErr_RestoreException(etype, eval, etb) PyErr_Restore(etype, eval, etb)
 #else
-#define __Pyx_PyErr_Fetch(petype, peval, petb) *(petype)=NULL; *(peval)=PyErr_GetRaisedException(); *(petb)=NULL
-#define __Pyx_PyErr_Restore(etype, eval, etb) PyErr_SetRaisedException(eval)
+#define __Pyx_PyErr_FetchException(petype, peval, petb) *(petype)=NULL; *(peval)=PyErr_GetRaisedException(); *(petb)=NULL
+#define __Pyx_PyErr_RestoreException(etype, eval, etb) PyErr_SetRaisedException(eval)
 #endif
 
 


### PR DESCRIPTION
Where supported, turn 3 arg "PyErr_Fetch/PyErr_Restore" into single value PyErr_Get/SetRaisedException.

This should hopefully improve things like `tp_dealloc` a little where we stash then restore the exception