### PR TITLE
Tune the string compression code

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -34,6 +34,7 @@ from ..StringIOTree import StringIOTree
 
 # Set up available compression algorithms for maximum compression.
 from zlib import compress as zlib_compress
+zlib_compress = partial(zlib_compress, level=9)
 try:
     from bz2 import compress as bz2_compress
 except ImportError:
@@ -62,7 +63,8 @@ else:
 
 compression_algorithms = [
     # Note: order is important and defines values for "CYTHON_COMPRESS_STRINGS" !
-    (1, 'zlib', partial(zlib_compress, level=9)),
+    # Later algorithms are excluded if prior ones beat them.
+    (1, 'zlib', zlib_compress),
     (2, 'bz2', bz2_compress),
     (3, 'zstd', zstd_compress),
     # LZMA is difficult to configure for efficient output from C code
@@ -2029,11 +2031,8 @@ class GlobalState:
                         text,
                     ))
 
-        c_consts.sort()
-        py_bytes_consts.sort()
-        py_unicode_consts.sort()
-
         # Generate C string constants.
+        c_consts.sort()
         decls_writer = self.parts['string_decls']
         for _, cname, escaped_value in c_consts:
             cliteral = StringEncoding.split_string_literal(escaped_value)
@@ -2069,47 +2068,76 @@ class GlobalState:
         first_interned: cython.Py_ssize_t = -1
         stringtab_pos: cython.Py_ssize_t = 0
 
-        # For (Unicode) text strings, the index stores the character lengths after UTF8 decoding.
-        for i, (is_interned, cname, text) in enumerate(text_strings):
+        # For (Unicode) text strings, the length index stores the byte lengths after UTF8 decoding.
+        text_strings.sort(key=operator.itemgetter(0, 2))
+        for is_interned, cname, text in text_strings:
             bytes_values.append(text.encode('utf-8'))
-            if first_interned == -1 and is_interned:
-                first_interned = i
+            if first_interned == -1:
+                if is_interned:
+                    first_interned = stringtab_pos
+            else:
+                assert is_interned, (
+                    f"All string entries after {first_interned} must be interned, but {stringtab_pos} is not: {text!r}")
             defines.putln(f"#define {cname} {Naming.stringtab_cname}[{stringtab_pos}]")
             stringtab_pos += 1
+
+        str_index = list(map(len, bytes_values))
 
         stringtab_bytes_start: cython.Py_ssize_t = len(text_strings)
 
-        # For bytes objects, the index stores the byte lengths, ignoring the initial Unicode string.
-        for _, cname, text in byte_strings:
-            bytes_values.append(text.byteencode() if text.encoding else text.utf8encode())
+        # For bytes objects, the length index stores the encoded byte lengths.
+        byte_strings = [
+            ((text.byteencode() if text.encoding else text.utf8encode()), cname)
+            for _, cname, text in byte_strings
+        ]
+        byte_strings.sort()
+        for text, cname in byte_strings:
+            bytes_values.append(text)
             defines.putln(f"#define {cname} {Naming.stringtab_cname}[{stringtab_pos}]")
             stringtab_pos += 1
 
-        index = list(map(len, bytes_values))
+        bytes_index = list(map(len, bytes_values[stringtab_bytes_start:]))
         concat_bytes = b''.join(bytes_values)
 
         w = self.parts['init_constants']
         w.putln("{")  # Start code block.
 
         # Store the index of string lengths.
-        w.putln(
-            "const struct { "
-            f"const unsigned int length: {max(index).bit_length()}; "
-            "} "
-            f"index[] = {{{','.join(['{%d}' % length for length in index])}}};",
-        )
+        for stype, index in [('str', str_index), ('bytes', bytes_index)]:
+            if not index:
+                continue
+            w.putln(
+                "const struct { "
+                f"const unsigned int length: {max(index).bit_length()}; "
+                "} "
+                f"{stype}_length_index[] = {{{','.join(['{%d}' % length for length in index])}}};",
+            )
 
         # Store and decompress the string data.
         self.use_utility_code(UtilityCode.load_cached("DecompressString", "StringTools.c"))
 
-        has_if = False
-        for algo_number, algo_name, compress in reversed(compression_algorithms):
+        min_size_seen = None
+        compressions = []
+        for algo_number, algo_name, compress in compression_algorithms:
             if compress is None:
                 continue
+
             compressed_bytes = compress(concat_bytes)
-            if len(compressed_bytes) >= len(concat_bytes) - 10:
+            compressed_size = len(compressed_bytes)
+            if compressed_size >= len(concat_bytes) - 15:
                 continue
 
+            if min_size_seen is None or compressed_size < min_size_seen:
+                min_size_seen = compressed_size
+            else:
+                # Avoid less widely used algorithms if they don't beat common ones
+                # (especially zlib) on the data at hand.
+                continue
+
+            compressions.append((algo_number, algo_name, compressed_bytes))
+
+        has_if = False
+        for algo_number, algo_name, compressed_bytes in reversed(compressions):
             if algo_name == 'zlib':
                 # Use zlib as fallback if the selected compression module is not available.
                 assert algo_number == 1, f"Compression algorithm no. 1 must be 'zlib' to be used as fallback."
@@ -2133,8 +2161,7 @@ class GlobalState:
             w.putln(f'if (likely(bytes)); else {{ Py_DECREF(data); {w.error_goto(self.module_pos)} }}')
             w.putln('#endif')
 
-        if has_if:
-            w.putln(f"#else /* compression: none ({len(concat_bytes)} bytes) */")
+        w.putln(f"{'#else ' if has_if else ''}/* compression: none ({len(concat_bytes)} bytes) */")
         escaped_bytes = StringEncoding.split_string_literal(
             StringEncoding.escape_byte_string(concat_bytes))
         w.putln(f'const char* const bytes = "{escaped_bytes}";', safe=True)
@@ -2156,7 +2183,7 @@ class GlobalState:
             # because it must copy Unicode slices between different character sizes.
             # We avoid this by repeatedly calling PyUnicode_DecodeUTF8() for each substring.
             w.putln(f"for ({'int' if stringtab_bytes_start < 2**15 else 'Py_ssize_t'} i = 0; i < {stringtab_bytes_start}; i++) {{")
-            w.putln("Py_ssize_t bytes_length = index[i].length;")
+            w.putln("Py_ssize_t bytes_length = str_length_index[i].length;")
 
             w.putln("PyObject *string = PyUnicode_DecodeUTF8(bytes + pos, bytes_length, NULL);")
             if first_interned >= 0:
@@ -2171,9 +2198,9 @@ class GlobalState:
             w.putln("}")  # for()
 
         # Unpack byte strings.
-        if stringtab_bytes_start < len(index):
-            w.putln(f"for ({'int' if len(index) < 2**15 else 'Py_ssize_t'} i = {stringtab_bytes_start}; i < {len(index)}; i++) {{")
-            w.putln("Py_ssize_t bytes_length = index[i].length;")
+        if stringtab_bytes_start < len(bytes_values):
+            w.putln(f"for ({'int' if len(bytes_values) < 2**15 else 'Py_ssize_t'} i = {stringtab_bytes_start}; i < {len(bytes_values)}; i++) {{")
+            w.putln(f"Py_ssize_t bytes_length = bytes_length_index[i-{stringtab_bytes_start}].length;")
 
             w.putln("PyObject *string = PyBytes_FromStringAndSize(bytes + pos, bytes_length);")
             w.putln("stringtab[i] = string;")
@@ -2189,7 +2216,7 @@ class GlobalState:
         w.putln("Py_XDECREF(data);")
 
         # Set up hash values.
-        w.putln(f"for (Py_ssize_t i = 0; i < {len(index)}; i++) {{")
+        w.putln(f"for (Py_ssize_t i = 0; i < {len(bytes_values)}; i++) {{")
         w.putln("if (unlikely(PyObject_Hash(stringtab[i]) == -1)) {")
         w.putln(w.error_goto(self.module_pos))
         w.putln('}')
@@ -2198,8 +2225,8 @@ class GlobalState:
         # Unicode strings are not trivially immortal but require certain rules.
         # See https://github.com/python/cpython/blob/920de7ccdcfa7284b6d23a124771b17c66dd3e4f/Objects/unicodeobject.c#L713-L739
         # But we can make bytes strings immortal.
-        if stringtab_bytes_start < len(index):
-            self.immortalize_constants(f"stringtab + {stringtab_bytes_start}", len(index) - stringtab_bytes_start, w)
+        if stringtab_bytes_start < len(bytes_values):
+            self.immortalize_constants(f"stringtab + {stringtab_bytes_start}", len(bytes_values) - stringtab_bytes_start, w)
 
         w.putln("}")  # close block
 

--- a/tests/run/string_compression.srctree
+++ b/tests/run/string_compression.srctree
@@ -46,12 +46,19 @@ with open("module.c") as f:
             algorithms.append(entry)
 
 print(algorithms)
-assert algorithms[-1] == ('!= 0', 'zlib'), algorithms
-assert algorithms[-2] == ('== 2', 'bz2'), algorithms
-assert algorithms[:-3] in ([], [('== 3', 'zstd')]), algorithms
+assert 1 <= len(algorithms) <= 3, algorithms
 
-assert len(algorithms) in (2, 3), algorithms
-
+i = len(algorithms) - 1
+if i >= 0 and algorithms[i][1] == 'zlib':
+    assert algorithms[i][0] == '!= 0', algorithms
+    i -= 1
+if i >= 0 and algorithms[i][1] == 'bz2':
+    assert algorithms[i][0] == '== 2', algorithms
+    i -= 1
+if i >= 0 and algorithms[i][1] == 'zstd':
+    assert algorithms[i][0] == '== 3', algorithms
+    i -= 1
+assert i == -1, (i, algorithms)
 
 macro_usage_count = 0
 with open("short_text.c") as f:
@@ -249,7 +256,7 @@ def long_docstring():
     lumières filatantes, les groissis trichetent une mélodie oubliée.
     """
 
-# Cython 3.13+ strips leading whitespace from docstrings.
+# Python 3.13+ strips leading whitespace from docstrings.
 assert len(long_docstring.__doc__) in (1486, 1398), len(long_docstring.__doc__)
 assert long_docstring.__doc__[:4] == 'Arc-', long_docstring.__doc__[:10]
 


### PR DESCRIPTION
- Avoid generating compression variants that are worse than zlib for the given data.
- Split the length index for str and bytes to compact them independently.