### PR TITLE
Implement cdef property setters on ext-types

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6354,7 +6354,7 @@ class SimpleCallNode(CallNode):
         arg_type = setter_entry.type.args[1].type
         arg1 = RawCNameExprNode(pos, type=arg_type)
         node = cls(pos, function=function, args=[obj, arg1])
-        return UtilNodes.CPropertySetNode(pos, func_node=node, type=arg_type, arg1=arg1)
+        return UtilNodes.CPropertySetNode(pos, call_node=node, type=arg_type, arg1=arg1)
 
     def analyse_as_type(self, env):
         attr = self.function.as_cython_attribute()

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -527,6 +527,9 @@ class CDeclaratorNode(Node):
 
     def declared_name(self):
         return None
+    
+    def set_declared_name(self, new_name):
+        raise NotImplementedError()
 
     def analyse_templates(self):
         # Only C++ functions have templates.
@@ -544,6 +547,9 @@ class CNameDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.name
+    
+    def set_declared_name(self, new_name):
+        self.name = new_name
 
     def analyse(self, base_type, env, nonempty=0, visibility=None, in_pxd=False):
         if nonempty and self.name == '':
@@ -575,6 +581,9 @@ class CPtrDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
+    
+    def set_declared_name(self, new_name):
+        self.base.set_declared_name(new_name)
 
     def analyse_templates(self):
         return self.base.analyse_templates()
@@ -591,6 +600,9 @@ class _CReferenceDeclaratorBaseNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
+    
+    def set_declared_name(self, new_name):
+        self.base.set_declared_name(new_name)
 
     def analyse_templates(self):
         return self.base.analyse_templates()
@@ -684,6 +696,9 @@ class CFuncDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
+    
+    def set_declared_name(self, new_name):
+        self.base.set_declared_name(new_name)
 
     def analyse_templates(self):
         if isinstance(self.base, CArrayDeclaratorNode):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -527,7 +527,7 @@ class CDeclaratorNode(Node):
 
     def declared_name(self):
         return None
-    
+
     def set_declared_name(self, new_name):
         raise NotImplementedError()
 
@@ -547,7 +547,7 @@ class CNameDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.name
-    
+
     def set_declared_name(self, new_name):
         self.name = new_name
 
@@ -581,7 +581,7 @@ class CPtrDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
-    
+
     def set_declared_name(self, new_name):
         self.base.set_declared_name(new_name)
 
@@ -600,7 +600,7 @@ class _CReferenceDeclaratorBaseNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
-    
+
     def set_declared_name(self, new_name):
         self.base.set_declared_name(new_name)
 
@@ -696,7 +696,7 @@ class CFuncDeclaratorNode(CDeclaratorNode):
 
     def declared_name(self):
         return self.base.declared_name()
-    
+
     def set_declared_name(self, new_name):
         self.base.set_declared_name(new_name)
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1957,7 +1957,7 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
 
     def _rename_property_function(self, node, name):
         if isinstance(node, Nodes.CFuncDefNode):
-            node.declarator.base.name = name
+            node.declarator.set_declared_name(name)
         else:
             node.name = name
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1869,13 +1869,24 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
 
         ret_node = node
         decorator_node = self._find_property_decorator(node)
-        if decorator_node:
+        if decorator_node and (name := node.declared_name()):
             if decorator_node.decorator.is_name:
-                name = node.declared_name()
-                if name:
-                    ret_node = self._add_property(node, name, decorator_node)
+                ret_node = self._add_property(node, name, decorator_node)
             else:
-                error(decorator_node.pos, "C property decorator can only be @property")
+                handler_name = self._map_property_attribute(decorator_node.decorator.attribute)
+                if handler_name:
+                    if handler_name == "__del__":
+                        error(decorator_node.pos,
+                              "Cannot have deleter for C property")
+                        ret_node = None
+                    elif decorator_node.decorator.obj.name != name:
+                        # CPython does not generate an error or warning, but not something useful either.
+                        error(decorator_node.pos,
+                            "Mismatching C property names, expected '%s', got '%s'" % (
+                                decorator_node.decorator.obj.name, name))
+                        ret_node = None
+                    else:
+                        ret_node = self._add_to_property(node, handler_name, decorator_node)
 
         if node.decorators:
             return self._reject_decorated_property(node, node.decorators[0])
@@ -1939,6 +1950,17 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
                 error(deco.pos, "Property methods with additional decorators are not supported")
         return node
 
+    def _get_property_function_name(self, node):
+        if isinstance(node, Nodes.CFuncDefNode):
+            return node.declared_name()
+        return node.name
+
+    def _rename_property_function(self, node, name):
+        if isinstance(node, Nodes.CFuncDefNode):
+            node.declarator.base.name = name
+        else:
+            node.name = name
+
     def _add_property(self, node, name, decorator_node):
         if len(node.decorators) > 1:
             return self._reject_decorated_property(node, decorator_node)
@@ -1946,40 +1968,42 @@ class DecoratorTransform(ScopeTrackingTransform, SkipDeclarations):
         properties = self._properties[-1]
         is_cproperty = isinstance(node, Nodes.CFuncDefNode)
         body = Nodes.StatListNode(node.pos, stats=[node])
+        node_type = Nodes.PropertyNode
         if is_cproperty:
-            if name in properties:
-                error(node.pos, "C property redeclared")
             if 'inline' not in node.modifiers:
                 error(node.pos, "C property method must be declared 'inline'")
-            prop = Nodes.CPropertyNode(node.pos, doc=node.doc, name=name, body=body)
-        elif name in properties:
+            node_type = Nodes.CPropertyNode
+        if name in properties:
             prop = properties[name]
             if prop.is_cproperty:
                 error(node.pos, "C property redeclared")
             else:
-                node.name = EncodedString("__get__")
+                self._rename_property_function(node, EncodedString("__get__"))
                 prop.pos = node.pos
                 prop.doc = node.doc
                 prop.body.stats = [node]
             return None
         else:
-            node.name = EncodedString("__get__")
-            prop = Nodes.PropertyNode(
+            self._rename_property_function(node, EncodedString("__get__"))
+            prop = node_type(
                 node.pos, name=name, doc=node.doc, body=body)
         properties[name] = prop
         return prop
 
     def _add_to_property(self, node, name, decorator):
         properties = self._properties[-1]
-        prop = properties[node.name]
-        if prop.is_cproperty:
-            error(node.pos, "C property redeclared")
-            return None
-        node.name = name
+        prop = properties[self._get_property_function_name(node)]
+        self._rename_property_function(node, name)
+        if isinstance(node, Nodes.CFuncDefNode):
+            if 'inline' not in node.modifiers:
+                error(node.pos, "C property method must be declared 'inline'")
         node.decorators.remove(decorator)
         stats = prop.body.stats
         for i, stat in enumerate(stats):
-            if stat.name == name:
+            if self._get_property_function_name(stat) == name:
+                if prop.is_cproperty:
+                    error(node.pos, "C property redeclared")
+                    return None
                 stats[i] = node
                 break
         else:

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2765,7 +2765,7 @@ class CClassScope(ClassScope):
         """
         property_entry = self.declare_property(name, doc=doc, ctype=type, pos=pos)
         cfunc_entry = property_entry.scope.declare_cfunction(
-            name=name,
+            name="__get__",
             type=PyrexTypes.CFuncType(
                 type,
                 [PyrexTypes.CFuncTypeArg("self", self.parent_type, pos=None)],
@@ -3030,16 +3030,20 @@ class PropertyScope(Scope):
     def declare_cfunction(self, name, type, pos, *args, **kwargs):
         """Declare a C property function.
         """
-        if type.return_type.is_void:
-            error(pos, "C property method cannot return 'void'")
+        if name=="__get__" and type.return_type.is_void:
+            error(pos, "C property getter cannot return 'void'")
+        elif name == "__set__" and not type.return_type.is_void:
+            error(pos, "C property setter must return 'void'")
 
+        if name == "__get__" and len(type.args) != 1:
+            error(pos, "C property getter must have a single (self) argument")
+        elif name == "__set__" and len(type.args) != 2:
+            error(pos, "C property setter must have two arguments (self and value)")
+        elif not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
+            error(pos, "C property method must have a single (object) argument")
         if type.args and type.args[0].type is py_object_type:
             # Set 'self' argument type to extension type.
             type.args[0].type = self.parent_scope.parent_type
-        elif len(type.args) != 1:
-            error(pos, "C property method must have a single (self) argument")
-        elif not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
-            error(pos, "C property method must have a single (object) argument")
 
         entry = Scope.declare_cfunction(self, name, type, pos, *args, **kwargs)
         entry.is_cproperty = True

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -3030,17 +3030,20 @@ class PropertyScope(Scope):
     def declare_cfunction(self, name, type, pos, *args, **kwargs):
         """Declare a C property function.
         """
-        if name=="__get__" and type.return_type.is_void:
-            error(pos, "C property getter cannot return 'void'")
-        elif name == "__set__" and not type.return_type.is_void:
-            error(pos, "C property setter must return 'void'")
+        if name=="__get__":
+            if type.return_type.is_void:
+                error(pos, "C property getter cannot return 'void'")
+            if len(type.args) != 1:
+                error(pos, "C property getter must have a single (self) argument")
 
-        if name == "__get__" and len(type.args) != 1:
-            error(pos, "C property getter must have a single (self) argument")
-        elif name == "__set__" and len(type.args) != 2:
-            error(pos, "C property setter must have two arguments (self and value)")
-        elif not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
-            error(pos, "C property method must have a single (object) argument")
+        if name=="__set__":
+            if not type.return_type.is_void:
+                error(pos, "C property setter must return 'void'")
+            if len(type.args) != 2:
+                error(pos, "C property setter must have two arguments (self and value)")
+
+        if not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
+            error(pos, "self argument of C property method must be an object")
         if type.args and type.args[0].type is py_object_type:
             # Set 'self' argument type to extension type.
             type.args[0].type = self.parent_scope.parent_type

--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -387,3 +387,27 @@ class HasNoGilNode(AtomicExprNode):
 
     def calculate_result_code(self):
         return str(int(self.in_nogil_context))
+
+
+class CPropertySetNode(ExprNodes.ExprNode):
+    subexprs = ['func_node']
+    arg1 : ExprNodes.RawCNameExprNode
+    func_node : ExprNodes.ExprNode  # most likely a call node
+
+    def is_lvalue(self):
+        return True
+
+    def analyse_types(self, env):
+        self.func_node = self.func_node.analyse_types(env)
+        return self
+
+    def generate_assignment_code(self, rhs, code, overloaded_assignment=False, exception_check=None, exception_value=None):
+        assert not overloaded_assignment
+        assert exception_check is None, exception_check
+        assert exception_value is None, exception_value
+        self.arg1.set_cname(rhs.result())
+
+        self.func_node.generate_evaluation_code(code)
+
+        rhs.generate_disposal_code(code)
+        rhs.free_temps(code)

--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -390,15 +390,15 @@ class HasNoGilNode(AtomicExprNode):
 
 
 class CPropertySetNode(ExprNodes.ExprNode):
-    subexprs = ['func_node']
+    subexprs = ['call_node']
     arg1 : ExprNodes.RawCNameExprNode
-    func_node : ExprNodes.ExprNode  # most likely a call node
+    call_node : ExprNodes.ExprNode
 
     def is_lvalue(self):
         return True
 
     def analyse_types(self, env):
-        self.func_node = self.func_node.analyse_types(env)
+        self.call_node = self.call_node.analyse_types(env)
         return self
 
     def generate_assignment_code(self, rhs, code, overloaded_assignment=False, exception_check=None, exception_value=None):
@@ -407,7 +407,7 @@ class CPropertySetNode(ExprNodes.ExprNode):
         assert exception_value is None, exception_value
         self.arg1.set_cname(rhs.result())
 
-        self.func_node.generate_evaluation_code(code)
+        self.call_node.generate_evaluation_code(code)
 
         rhs.generate_disposal_code(code)
         rhs.free_temps(code)

--- a/tests/errors/cdef_class_cdef_properties.pyx
+++ b/tests/errors/cdef_class_cdef_properties.pyx
@@ -1,0 +1,94 @@
+# mode: error
+
+cdef extern from *:
+    cdef class some_module.C[object CObj]:
+        @property
+        cdef no_inline1(self):
+            return 1
+
+        @property
+        cdef inline no_inline2(self):
+            return 1
+
+        @no_inline2.setter
+        cdef void no_inline2(self, arg):
+            pass
+
+        @property
+        cdef inline wrong_args(self, arg):
+            return 1
+
+        @wrong_args.setter
+        cdef inline void wrong_args(self):
+            pass
+        
+        @property
+        cdef inline void wrong_return(self):
+            pass
+
+        @wrong_return.setter
+        cdef inline int wrong_return(self, arg):
+            return 0
+
+        @property
+        cdef inline multiple_defs1(self):
+            pass
+
+        @property
+        cdef inline multiple_defs1(self):
+            pass
+
+        @property
+        cdef inline multiple_defs2(self):
+            pass
+
+        @multiple_defs2.getter
+        cdef inline multiple_defs2(self):
+            pass
+
+        @property
+        cdef inline multiple_defs3(self):
+            return 1
+
+        @multiple_defs3.setter
+        cdef inline void multiple_defs3(self, arg):
+            pass
+        
+        @multiple_defs3.setter
+        cdef inline multiple_defs3(self, arg):
+            pass
+
+        @property
+        cdef inline mismatched_name(self):
+            return 1
+
+        @mismatched_name.setter
+        cdef inline hmmmmm(self):
+            pass
+
+        @property
+        cdef inline has_deleter(self):
+            return 1
+
+        @has_deleter.deleter
+        cdef inline void has_deleter(self):
+            pass
+
+_ERRORS = """
+5:8: C property method must be declared 'inline'
+13:8: C property method must be declared 'inline'
+17:8: C property getter must have a single (self) argument
+21:8: C property setter must have two arguments (self and value)
+25:8: C property getter cannot return 'void'
+29:8: C property setter must return 'void'
+37:8: C property redeclared
+45:8: C property redeclared
+57:8: C property redeclared
+65:8: Mismatching C property names, expected 'mismatched_name', got 'hmmmmm'
+73:8: Cannot have deleter for C property
+
+# Spurious
+69:8: Previous declaration is here
+73:8: 'has_deleter' redeclared
+"""
+            

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -58,6 +58,8 @@ fastcall
 r_extcomplex2
 longintrepr
 run[.]no_gc
+# Would work on 3.12 and up (but not worth the effort to adapt it)
+run[.]ext_attr_setter
 
 # Inherit builtin type: PEP697
 builtin_subtype_methods_T653

--- a/tests/limited_api_bugs.txt
+++ b/tests/limited_api_bugs.txt
@@ -58,8 +58,6 @@ fastcall
 r_extcomplex2
 longintrepr
 run[.]no_gc
-# Would work on 3.12 and up (but not worth the effort to adapt it)
-run[.]ext_attr_setter
 
 # Inherit builtin type: PEP697
 builtin_subtype_methods_T653

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -3,6 +3,25 @@
 cimport cython
 
 cdef extern from *:
+    """
+    #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
+    // Replacement functions for older versions of Python.
+    // (It would be better to use functions which are always available
+    // but DW didn't realise these were version-dependent when he wrote the
+    // tests, and it doesn't really invalidate the tests anyway.)
+    static PyObject *PyException_GetArgs(PyObject *ex) {
+        return PyObject_GetAttrString(ex, "args");
+    }
+
+    static void PyException_SetArgs(PyObject *ex, PyObject *value) {
+        if (PyObject_SetAttrString(ex, "args", value) < 0) {
+            PyErr_WriteUnraisable(NULL);
+            PyErr_Clear();
+        }
+    }
+    #endif
+    """
+
     object PyException_GetArgs(object)
     void PyException_SetArgs(object, object) noexcept
 

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -1,0 +1,188 @@
+# mode: run
+
+cimport cython
+
+cdef extern from *:
+    object PyException_GetArgs(object)
+    void PyException_SetArgs(object, object) noexcept
+
+    # Exception is just an easy class to use to test arbitrary getters/setters
+    # without needing to define our own class.
+    ctypedef class __builtin__.Exception[object PyObject, check_size ignore]:
+        @property
+        cdef inline args_obj(self):
+            return PyException_GetArgs(self)
+
+        @args_obj.setter
+        cdef inline void args_obj(self, obj):
+            PyException_SetArgs(self, obj)
+
+        @property
+        cdef inline int arg0_int(self):
+            # Fails if there isn't at least one argument, or it isn't an int
+            return PyException_GetArgs(self)[0]
+
+        @arg0_int.setter
+        cdef inline void arg0_int(self, int value):
+            PyException_SetArgs(self, (value,))
+
+        # This property returns the first arg whatever it is,
+        # but only accepts a C string.
+        @property
+        cdef inline arg0_mixed_str(self):
+            # Fails if there isn't at least one argument
+            return PyException_GetArgs(self)[0]
+
+        @arg0_mixed_str.setter
+        cdef inline void arg0_mixed_str(self, const char* value):
+            PyException_SetArgs(self, (value,))
+
+        # This property returns the first argument as a double,
+        # but accepts any Python object
+        @property
+        cdef inline double arg0_mixed_double(self):
+            # Fails if there isn't at least one argument and it isn't a double
+            return PyException_GetArgs(self)[0]
+
+        @arg0_mixed_double.setter
+        cdef inline void arg0_mixed_double(self, value):
+            PyException_SetArgs(self, (value,))
+
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_get_obj(Exception e):
+    """
+    >>> test_get_obj(Exception(1, 2))
+    (1, 2)
+    >>> test_get_obj(Exception())
+    ()
+    """
+    return e.args_obj
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_get_obj_temp(*args):
+    """
+    >>> test_get_obj_temp(1, 2)
+    (1, 2)
+    >>> test_get_obj_temp()
+    ()
+    """
+    return Exception(*args).args_obj
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_set_obj(o):
+    """
+    >>> test_set_obj((1, 2))
+    Exception(1, 2)
+    >>> test_set_obj(())
+    Exception()
+    """
+    e = Exception()
+    e.args_obj = o
+    return e
+
+def forward(o):
+    return o
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_set_obj_from_temp(o):
+    """
+    >>> test_set_obj_from_temp((1, 2))
+    Exception(1, 2)
+    >>> test_set_obj_from_temp(())
+    Exception()
+    """
+    e = Exception()
+    e.args_obj = forward(o)
+    return e
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_set_obj_temp(*args):
+    """
+    Setting to a temp isn't hugely useful because we can't check the result
+    so it's mostly a no-crash test
+    >>> test_set_obj_temp(1, 2)
+    >>> test_set_obj_temp()
+    """
+    Exception().args_obj = args
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_get_int(Exception e):
+    """
+    >>> test_get_int(Exception(10))
+    10
+    >>> test_get_int(Exception())  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    IndexError: ...
+    >>> test_get_int(Exception(None))  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
+    """
+    return e.arg0_int
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_set_int(value):
+    """
+    >>> test_set_int(10)
+    Exception(10)
+    >>> test_set_int(None)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
+    """
+    e = Exception()
+    e.arg0_int = value
+    return e
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_mixed_str(const char* s):
+    """
+    >>> test_mixed_str(b"Hello")
+    b'Hello'
+    """
+    e = Exception()
+    e.arg0_mixed_str = s
+    return e.arg0_mixed_str
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_fail_mixed_str(v):
+    """
+    >>> test_fail_mixed_str([1, 2, 3])  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
+    """
+    Exception().arg0_mixed_str = v
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_mixed_double(v):
+    """
+    >>> test_mixed_double(5.5)
+    5.5
+    """
+    e = Exception()
+    e.arg0_mixed_double = v
+    return e.arg0_mixed_double
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_fail_mixed_double(Exception e):
+    """
+    >>> test_fail_mixed_double(Exception("not a double"))  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    TypeError: ...
+    """
+    return e.arg0_mixed_double


### PR DESCRIPTION
Previously we'd only supported getters.

With opaque objects, people exposing external types may want to hide being accessor functions more rather than exposing the class directly. This change should allow them to do so.