### PR TITLE
Skip fstring test_many_expressions on GraalPy

### DIFF
--- a/tests/run/test_fstring.pyx
+++ b/tests/run/test_fstring.pyx
@@ -9,6 +9,7 @@ import decimal
 import unittest
 import re
 import contextlib
+import platform
 
 from Cython.Build.Inline import cython_inline
 from Cython.TestUtils import CythonTest
@@ -768,6 +769,9 @@ y = (
 """, # this is equivalent to f'{}'
                              ])
 
+    @unittest.skipIf(
+        platform.python_implementation() == 'GraalVM',
+        "Intermittent 'returned NULL without an exception set'")
     def test_many_expressions(self):
         # Create a string with many expressions in it. Note that
         #  because we have a space in here as a literal, we're actually


### PR DESCRIPTION
It intermittently gives an error

> `SystemError: __call__ returned NULL without setting an exception`

I don't think we're in a position to easily fix it, so just disable it for now.