### PR TITLE
[3.2.x] Pass options during creating instance of `CythonUtilityCodeContext` (#7508)

### DIFF
--- a/Cython/Compiler/TreeFragment.py
+++ b/Cython/Compiler/TreeFragment.py
@@ -22,12 +22,12 @@ from . import UtilNodes
 
 
 class StringParseContext(Main.Context):
-    def __init__(self, name, include_directories=None, compiler_directives=None, cpp=False):
+    def __init__(self, name, include_directories=None, compiler_directives=None, cpp=False, options=None):
         if include_directories is None:
             include_directories = []
         if compiler_directives is None:
             compiler_directives = {}
-        Main.Context.__init__(self, include_directories, compiler_directives, cpp=cpp, language_level='3')
+        Main.Context.__init__(self, include_directories, compiler_directives, cpp=cpp, language_level='3', options=options)
         self.module_name = name
 
     def find_module(self, module_name, from_module=None, pos=None, need_pxd=1, absolute_fallback=True, relative_import=False):

--- a/Cython/Compiler/UtilityCode.py
+++ b/Cython/Compiler/UtilityCode.py
@@ -125,7 +125,8 @@ class CythonUtilityCode(Code.UtilityCodeBase):
         from . import Pipeline, ParseTreeTransforms
         context = CythonUtilityCodeContext(
             self.name, compiler_directives=self.compiler_directives,
-            cpp=cython_scope.is_cpp() if cython_scope else False)
+            cpp=cython_scope.is_cpp() if cython_scope else False,
+            options=cython_scope.context.options if cython_scope else None)
         context.prefix = self.prefix
         context.cython_scope = cython_scope
         #context = StringParseContext(self.name)


### PR DESCRIPTION
Passing options to `CythonUtilityCodeContext` ensures correct value of the `shared_utility_qualified_name` attribute.

Fixes https://github.com/cython/cython/issues/7504