### PR TITLE
Allow casting C values to Python 'bool'

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8,7 +8,7 @@ cython.declare(error=object, warning=object, warn_once=object, InternalError=obj
                CompileError=object, UtilityCode=object, TempitaUtilityCode=object,
                StringEncoding=object, operator=object, local_errors=object, report_error=object,
                Naming=object, Nodes=object, PyrexTypes=object, py_object_type=object,
-               list_type=object, tuple_type=object, set_type=object, dict_type=object,
+               list_type=object, tuple_type=object, set_type=object, dict_type=object, bool_type=object,
                unicode_type=object, bytes_type=object, type_type=object,
                Builtin=object, Symtab=object, Utils=object, find_coercion_error=object,
                debug_disposal_code=object, debug_temp_alloc=object, debug_coercion=object,
@@ -44,7 +44,7 @@ from .PyrexTypes import c_char_ptr_type, py_object_type, typecast, error_type, \
 from . import TypeSlots
 from .Builtin import (
     list_type, tuple_type, set_type, dict_type, type_type,
-    unicode_type, bytes_type, bytearray_type,
+    unicode_type, bytes_type, bytearray_type, bool_type,
     slice_type
 )
 from . import Builtin
@@ -11858,7 +11858,11 @@ class TypecastNode(ExprNode):
             if not self.type.is_numeric and not self.type.is_cpp_class:
                 error(self.pos, "Casting temporary Python object to non-numeric non-Python type")
         if to_py and not from_py:
-            if self.type.is_pybytes_type and self.operand.type.is_int:
+            if self.type is bool_type:
+                # Allow "<bool>" to cast C values directly to Python bool.
+                # We explicitly exclude Python arguments here to keep the 'bool' type check.
+                return self.operand.coerce_to_boolean(env)
+            elif self.type.is_pybytes_type and self.operand.type.is_int:
                 return CoerceIntToBytesNode(self.operand, env)
             elif self.operand.type.can_coerce_to_pyobject(env):
                 self.result_ctype = py_object_type

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9,7 +9,7 @@ cython.declare(error=object, warning=object, warn_once=object, InternalError=obj
                StringEncoding=object, operator=object, local_errors=object, report_error=object,
                Naming=object, Nodes=object, PyrexTypes=object, py_object_type=object,
                list_type=object, tuple_type=object, set_type=object, dict_type=object, bool_type=object,
-               unicode_type=object, bytes_type=object, type_type=object,
+               unicode_type=object, bytes_type=object, type_type=object, int_type=object,
                Builtin=object, Symtab=object, Utils=object, find_coercion_error=object,
                debug_disposal_code=object, debug_temp_alloc=object, debug_coercion=object,
                bytearray_type=object, slice_type=object,
@@ -44,7 +44,7 @@ from .PyrexTypes import c_char_ptr_type, py_object_type, typecast, error_type, \
 from . import TypeSlots
 from .Builtin import (
     list_type, tuple_type, set_type, dict_type, type_type,
-    unicode_type, bytes_type, bytearray_type, bool_type,
+    unicode_type, bytes_type, bytearray_type, int_type, bool_type,
     slice_type
 )
 from . import Builtin
@@ -11860,7 +11860,6 @@ class TypecastNode(ExprNode):
         if to_py and not from_py:
             if self.type is bool_type:
                 # Allow "<bool>" to cast C values directly to Python bool.
-                # We explicitly exclude Python arguments here to keep the 'bool' type check.
                 return self.operand.coerce_to_boolean(env)
             elif self.type.is_pybytes_type and self.operand.type.is_int:
                 return CoerceIntToBytesNode(self.operand, env)
@@ -11886,6 +11885,20 @@ class TypecastNode(ExprNode):
                 warning(self.pos, "No conversion from %s to %s, python object pointer used." % (
                     self.type, self.operand.type))
         elif from_py and to_py:
+            if self.type.is_builtin_type and self.operand.type.is_builtin_type:
+                self_type = self.type.get_container_type() or self.type
+                operand_type = self.operand.type.get_container_type() or self.operand.type
+                if self_type != operand_type:
+                    if operand_type is bool_type and self_type is int_type:
+                        # 'bool' is an 'int' subclass, so this cast is not entirely useless.
+                        # It is difficult to test, though, because bool/int are shadowed by C bint/int.
+                        pass
+                    else:
+                        warning(
+                            self.pos,
+                            f"Cast from '{self.operand.type}' to '{self_type.name}' is invalid at runtime. "
+                            f"Did you mean to call '{self_type.name}()'?"
+                        )
             if self.typecheck:
                 self.operand = PyTypeTestNode(self.operand, self.type, env, notnone=True)
             elif isinstance(self.operand, SliceIndexNode):

--- a/tests/run/bool_cast.pyx
+++ b/tests/run/bool_cast.pyx
@@ -1,0 +1,61 @@
+# mode: run
+# tag: bool, bint, builtin
+
+def cast_to_bool(x):
+    """
+    >>> cast_to_bool(0)
+    (0, 0)
+    >>> cast_to_bool(1)
+    (1, 1)
+    >>> cast_to_bool(2)
+    (1, 1)
+    >>> cast_to_bool(-1)
+    (1, 1)
+    """
+    cdef int int_x = x
+    cdef signed char schar_x = x
+
+    int_bool_int_x = <int> <bool> int_x
+    int_bool_schar_x = <int> <bool> schar_x
+
+    return (int_bool_int_x, int_bool_schar_x)
+
+
+def cast_bint_to_char(x):
+    """
+    >>> cast_bint_to_char(0)
+    0
+    >>> cast_bint_to_char(1)
+    1
+    >>> cast_bint_to_char(2)
+    1
+    >>> cast_bint_to_char(256)
+    1
+    """
+    return <char> <bint> x
+
+
+def cast_bool_call_to_char(x):
+    """
+    >>> cast_bool_call_to_char(0)
+    0
+    >>> cast_bool_call_to_char(1)
+    1
+    >>> cast_bool_call_to_char(256)
+    1
+    """
+    return <char> bool(x)
+
+
+def call_arg_typing(x: bool):
+    """
+    >>> call_arg_typing(0)
+    (False, 0, 0)
+    >>> call_arg_typing(1)
+    (True, 1, 1)
+    >>> call_arg_typing(2)
+    (True, 1, 1)
+    >>> call_arg_typing(2000)
+    (True, 1, 1)
+    """
+    return (x, <char> x, <int> x)

--- a/tests/run/bool_cast.pyx
+++ b/tests/run/bool_cast.pyx
@@ -1,5 +1,16 @@
 # mode: run
-# tag: bool, bint, builtin
+# tag: bool, bint, builtin, warnings
+
+import cython
+
+
+def warn_about_invalid_cast_to_bool(x: list):
+    ok1 = <object> x
+    ok2 = <list> x
+    nok = <bool> x
+
+    return (ok1, ok2, nok)
+
 
 def cast_to_bool(x):
     """
@@ -9,11 +20,13 @@ def cast_to_bool(x):
     (1, 1)
     >>> cast_to_bool(2)
     (1, 1)
+    >>> cast_to_bool(100)
+    (1, 1)
     >>> cast_to_bool(-1)
     (1, 1)
     """
-    cdef int int_x = x
-    cdef signed char schar_x = x
+    int_x: cython.int = x
+    schar_x: cython.schar = x
 
     int_bool_int_x = <int> <bool> int_x
     int_bool_schar_x = <int> <bool> schar_x
@@ -30,6 +43,8 @@ def cast_bint_to_char(x):
     >>> cast_bint_to_char(2)
     1
     >>> cast_bint_to_char(256)
+    1
+    >>> cast_bint_to_char(12345)
     1
     """
     return <char> <bint> x
@@ -59,3 +74,8 @@ def call_arg_typing(x: bool):
     (True, 1, 1)
     """
     return (x, <char> x, <int> x)
+
+
+_WARNINGS = """
+10:10: Cast from 'list object' to 'bool' is invalid at runtime. Did you mean to call 'bool()'?
+"""


### PR DESCRIPTION
We'd previously used the default type coercion and then tried to cast the resulting object to `bool`. That almost never works and leads to surprising errors. Instead, we can just allow `<bool> cvalue` and use the truthiness of the C value.

We now also warn about invalid casts between Python builtins that make no sense at runtime. This is especially interesting for `<bool>` since it might seem reasonable to assume a truthiness check also for Python objects, whereas the cast really only sets the type information. There's `bool()` for converting the type.

Closes https://github.com/cython/cython/issues/7513