### PR TITLE
BLD: avoid deprecated pypi trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0.1"]
 
 [tool.cibuildwheel]
 build-verbosity = 2

--- a/setup.py
+++ b/setup.py
@@ -454,10 +454,10 @@ def run_build():
 
         """) + collect_changelog(version),
         license='Apache-2.0',
+        license_files=["LICENSE.txt"],
         classifiers=[
             dev_status(version),
             "Intended Audience :: Developers",
-            "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",


### PR DESCRIPTION
This avoids the following deprecation warning, which I hit when I built Cython in a CI env with `-Werror`

```
********************************************************************************
              Please consider removing the following classifiers in favor of a
      SPDX license expression:

              License :: OSI Approved :: Apache Software License

              See
      https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
      for details.
      
      ********************************************************************************
```

setuptools 77.0.0 (yanked) was the first release to support the replacement, so I'm setting 77.0.1 as the lower bound.