### PR TITLE
MNT: simplify cibuildwheel configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,9 @@
 requires = ["setuptools"]
 
 [tool.cibuildwheel]
+project-requires-python = ">=3.9"
 build-verbosity = 2
 skip = [
-    # Unsupported versions:
-    "cp36*", "cp37*", "cp38*",
     # These platforms are served with the generic Python wheel:
     "pp*",
     "gp*",


### PR DESCRIPTION
With cibuildwheel 3.x, which you're already using, you don't need to explicitly skip pypy or graalpy: they're already unselected by default. There's also a simpler way to express the minimum Python version supported, that does *not* require setting up the full `[project]` table in `pyproject.toml`