### PR TITLE
[3.2.x] Fix flow control issue with walrus+exceptions (#7514)

### DIFF
--- a/tests/run/extra_walrus.py
+++ b/tests/run/extra_walrus.py
@@ -1,5 +1,5 @@
 # mode: run
-# tag: pure3.8
+# tag: pure3.10
 
 # These are extra tests for the assignment expression/walrus operator/named expression that cover things
 # additional to the standard Python test-suite in tests/run/test_named_expressions.pyx
@@ -353,3 +353,160 @@ def genexp_scope():
     i = 0
     # i needs to refer to the loop variable, not the function one
     return tuple(x for i in range(5) if (x := i))
+
+def return_x(x):
+    return x
+
+def in_try_block_1(x):
+    """
+    >>> in_try_block_1(True)
+    'Except return True'
+    >>> in_try_block_1(False)
+    'Normal return False'
+    """
+    try:
+        if (a := return_x(x)):
+            raise RuntimeError
+        return f'Normal return {a}'
+    except:
+        return f'Except return {a}'
+
+
+def return_false():
+    return False
+
+def if_in_try_block_2(x):
+    """
+    >>> if_in_try_block_2(True)
+    'Except return True'
+    >>> if_in_try_block_2(False)
+    'Normal return False'
+    """
+    try:
+        if return_false():
+            raise RuntimeError
+        elif (a := return_x(x)):
+            raise RuntimeError
+        return f'Normal return {a}'
+    except:
+        return f'Except return {a}'
+
+def if_in_try_block_3(x):
+    """
+    >>> if_in_try_block_3(True)
+    'Except return True'
+    >>> if_in_try_block_3(False)
+    'Normal return False'
+    """
+    try:
+        if (a := return_x(x)):
+            raise RuntimeError
+        else:
+            pass
+        return f'Normal return {a}'
+    except:
+        return f'Except return {a}'
+
+def if_in_try_block_4(x):
+    """
+    >>> if_in_try_block_4(True)
+    'Normal return True'
+    >>> if_in_try_block_4(False)
+    'Except return False'
+    """
+    try:
+        if (a := return_x(x)):
+            pass
+        else:
+            raise RuntimeError
+        return f'Normal return {a}'
+    except:
+        return f'Except return {a}'
+
+def while_in_try_block(x):
+    """
+    >>> while_in_try_block(True)
+    'Except return True'
+    >>> while_in_try_block(False)
+    'Normal return False'
+    """
+    try:
+        while (a := return_x(x)):
+            raise ValueError("Not found")
+        return f'Normal return {a}'
+    except:
+        return f'Except return {a}'
+
+def raise_something():
+    raise RuntimeError
+
+def except_in_try_block(x):
+    """
+    >>> except_in_try_block(True)
+    'Normal return ValueError'
+    >>> except_in_try_block(False)
+    'Except return RuntimeError'
+    """
+    try:
+        try:
+            raise_something()
+        except (a := return_x(ValueError if x else RuntimeError)):
+            raise RuntimeError()
+        except:
+            pass
+
+        return f'Normal return {a.__name__}'
+    except Exception:
+        return f'Except return {a.__name__}'
+
+def for_in_try_block_1(x):
+    """
+    >>> for_in_try_block_1(10)
+    'Except return 10'
+    >>> for_in_try_block_2(0)
+    'Normal return 0'
+    """
+    try:
+        for x in range(a := x):
+            raise RuntimeError()
+
+        return f'Normal return {a}'
+    except Exception:
+        return f'Except return {a}'
+
+def for_in_try_block_2(x):
+    """
+    >>> for_in_try_block_2(10)
+    'Except return 10'
+    >>> for_in_try_block_2(0)
+    'Normal return 0'
+    """
+    try:
+        for x in (a := return_x(range(x))):
+            raise RuntimeError()
+
+        return f'Normal return {a.stop}'
+    except Exception:
+        return f'Except return {a.stop}'
+
+class ContextManager:
+    def __init__(self, value):
+        self.value = value
+    def __enter__(self):
+        pass
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self.value
+
+def with_in_try_block(x):
+    """
+    >>> with_in_try_block(True)
+    'Normal return True'
+    >>> with_in_try_block(False)
+    'Except return False'
+    """
+    try:
+        with (a := ContextManager(x)):
+            raise RuntimeError
+        return f'Normal return {a.value}'
+    except Exception:
+        return f'Except return {a.value}'

--- a/tests/run/extra_walrus_cy.pyx
+++ b/tests/run/extra_walrus_cy.pyx
@@ -1,0 +1,19 @@
+# mode: run
+
+def return_x(x):
+    return x
+
+def for_from_in_try(x):
+    """
+    >>> for_from_in_try(10)
+    'Except return 10'
+    >>> for_from_in_try(0)
+    'Normal return 0'
+    """
+    try:
+        for 0 <= _ < (a := return_x(x)):
+            raise RuntimeError
+        
+        return f'Normal return {a}'
+    except Exception:
+        return f'Except return {a}'


### PR DESCRIPTION
Fixes #7462

If an assignment node is in an exception block, then `mark_assignment` can change `self.flow.block`. This means that `self.flow.block` at the end of evaluation an `if` condition might be different to `self.flow.block` at the start. Therefore, we continue from the state at the end.

Also fix the equivalent thing in match-case guard blocks.

Also add a small print function just because it was useful for debugging this.

------------------------------------------------

Cherry pick of https://github.com/cython/cython/pull/7514.

I'm just going via a PR ranger than pushing directly because there were merge conflicts so I want to run the CI as a sanity check. No need to review though. They're hopefully trivial.