### PR TITLE
Infer some concrete Python types in "safe" inference mode

### DIFF
--- a/Cython/Compiler/TypeInference.py
+++ b/Cython/Compiler/TypeInference.py
@@ -584,6 +584,26 @@ def safe_spanning_type(types, might_overflow, scope):
     elif (not result_type.can_coerce_to_pyobject(scope)
             and not result_type.is_error):
         return result_type
+
+    # We'll treat it as a Python object from this point on, but may be able to infer
+    # something more concrete than 'object'.
+
+    equivalent_type = result_type.equivalent_type
+    if equivalent_type and equivalent_type.is_pyobject:
+        # This is mostly covered by the cases above but still worth a first try
+        # to give the type a chance to speak up.
+        return equivalent_type
+    elif result_type.is_unicode_char:
+        # Unicode characters are ints but are not safe to infer for all operations,
+        # e.g. '+' should probably concatenate and not add the code unit numbers.
+        return Builtin.unicode_type
+    elif result_type.is_int:
+        return Builtin.int_type
+    elif result_type.is_float:
+        return Builtin.float_type
+    elif result_type.is_complex:
+        return Builtin.complex_type
+
     return py_object_type
 
 

--- a/tests/run/py_ucs4_type.pyx
+++ b/tests/run/py_ucs4_type.pyx
@@ -443,6 +443,48 @@ def const_str_index(int n):
     return str(n)[0]
 
 
+def concat(Py_UCS4 a, Py_UCS4 b):
+    """
+    >>> concat('a', 'b')
+    'ab'
+    """
+    return a + b
+
+
+def plus_int(Py_UCS4 a, int b):
+    """
+    >>> plus_int('a', ord('b'))  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: can only concatenate str (not "int") to str
+    """
+    return a + b
+
+
+def plus_int_const(Py_UCS4 a):
+    """
+    >>> plus_int_const('a')  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    TypeError: can only concatenate str (not "int") to str
+    """
+    return a + 1
+
+
+def multiply(Py_UCS4 a, int m):
+    """
+    >>> multiply('a', 5)
+    'aaaaa'
+    """
+    return a * m
+
+
+def multiply_const(Py_UCS4 a):
+    """
+    >>> multiply_const('a')
+    'aaa'
+    """
+    return a * 3
+
+
 _WARNINGS = """
 373:16: Item lookup of unicode character codes now always converts to a Unicode string. Use an explicit C integer cast to get back the previous integer lookup behaviour.
 """

--- a/tests/run/seq_mul.py
+++ b/tests/run/seq_mul.py
@@ -109,17 +109,18 @@ def tuple_times_cint(n: cython.int):
     print(d)
 
 
-# TODO: enable in Cython 3.1 when we can infer unsafe C int operations as PyLong
-#@cython.test_fail_if_path_exists("//MulNode")
+@cython.test_fail_if_path_exists("//MulNode")
 def list_times_pyint(n: cython.longlong):
     """
-    >>> list_times_cint(3)
+    >>> list_times_pyint(3)
     []
     [None, None, None]
     [3, 3, 3]
     [1, 2, 3, 1, 2, 3, 1, 2, 3]
     """
     py_n = n + 1  # might overflow => should be inferred as Python long!
+    py_n -= 1
+    assert cython.typeof(py_n) == ('int object' if cython.compiled else 'int'), cython.typeof(py_n)
 
     a = [] * py_n
     b = [None] * py_n

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -763,19 +763,19 @@ def safe_only():
     # potentially overflowing arithmetic
     e = 1
     e += 1
-    assert typeof(e) == "Python object", typeof(e)
+    assert typeof(e) == "int object", typeof(e)
     f = 1
     res = f * 10
-    assert typeof(f) == "Python object", typeof(f)
+    assert typeof(f) == "int object", typeof(f)
     g = 1
     res = 10*(~g)
-    assert typeof(g) == "Python object", typeof(g)
+    assert typeof(g) == "int object", typeof(g)
     for j in range(10):
         res = -j
-    assert typeof(j) == "Python object", typeof(j)
+    assert typeof(j) == "int object", typeof(j)
     h = 1
     res = abs(h)
-    assert typeof(h) == "Python object", typeof(h)
+    assert typeof(h) == "int object", typeof(h)
     cdef int c_int = 1
     assert typeof(abs(c_int)) == "int", typeof(abs(c_int))
 

--- a/tests/run/type_inference_new.pyx
+++ b/tests/run/type_inference_new.pyx
@@ -139,6 +139,6 @@ def test_integer_overflow():
     a = 1
     b = 2
     c = a + b
-    assert typeof(a) == "Python object", typeof(a)
-    assert typeof(b) == "Python object", typeof(b)
-    assert typeof(c) == "Python object", typeof(c)
+    assert typeof(a) == "int object", typeof(a)
+    assert typeof(b) == "int object", typeof(b)
+    assert typeof(c) == "int object", typeof(c)


### PR DESCRIPTION
We previously just inferred `object` for historical reasons.