### PR TITLE
Fix cache ignoring `compiler_directives` when fingerprinting compiler options

### DIFF
--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -738,8 +738,9 @@ class CompilationOptions:
                 # hopefully caching has no influence on the compilation result
                 continue
             elif key in ['compiler_directives']:
-                # directives passed on to the C compiler do not influence the generated C code
-                continue
+                # Some compiler directives do not influence the generated C code but others do
+                # (such as linetrace, profiling).
+                data[key] = value
             elif key in ['include_path']:
                 # this path changes which headers are tracked as dependencies,
                 # it has no influence on the generated C code


### PR DESCRIPTION
This PR suggests a conservative approach to fix the problem.

We could later refine it using an ignore list (we ignore a specific set of directives) or using a list of directives we know modify the code while considering the others do not.

Meant to fix #7532.