### PR TITLE
Tests: Read current builtins from a fresh Python process in TestBuiltin.py

### DIFF
--- a/Cython/Compiler/Tests/TestBuiltin.py
+++ b/Cython/Compiler/Tests/TestBuiltin.py
@@ -1,4 +1,6 @@
 import builtins
+import json
+import subprocess
 import sys
 
 from ..Builtin import (
@@ -43,9 +45,17 @@ class TestBuiltinCompatibility(TimedTest):
         expected_builtins = set(KNOWN_PYTHON_BUILTINS)
         if sys.platform != 'win32':
             expected_builtins.discard("WindowsError")
+
+        # Read builtins from fresh Python process to prevent modifications by test dependencies.
+        output = subprocess.run(
+            [sys.executable, '-c', 'import builtins, json, sys; sys.stdout.write(json.dumps(dir(builtins)))'],
+            capture_output=True,
+            encoding='utf8',
+        )
         runtime_builtins = frozenset(
-            name for name in dir(builtins)
+            name for name in json.loads(output.stdout)
             if name not in ('__doc__', '__loader__', '__name__', '__package__', '__spec__'))
+
         if sys.version_info < KNOWN_PYTHON_BUILTINS_VERSION:
             missing_builtins = expected_builtins - runtime_builtins
             if missing_builtins:


### PR DESCRIPTION
We compare the expected (known) set of builtins against what Python provides at runtime, but that risks depending on the installed third-party packages, specifically IPython and potentially others.

Thus, we start a fresh Python process and read the builtins from that, to avoid any interference with the imported test dependencies of the test runner.