### PR TITLE
Inline __pyx_memoryview_slice_memviewslice as C function

### DIFF
--- a/Cython/Compiler/MemoryView.py
+++ b/Cython/Compiler/MemoryView.py
@@ -336,6 +336,7 @@ class MemoryViewSliceBufferEntry(Buffer.BufferEntry):
                     util_name = "SimpleSlice"
                 else:
                     util_name = "ToughSlice"
+                    code.globalstate.use_utility_code(slice_memviewslice_utility)
                     d['error_goto'] = code.error_goto(index.pos)
 
                 new_ndim += 1
@@ -876,6 +877,7 @@ refcount_utility = load_memview_c_utility("MemviewRefcount")
 slice_init_utility = load_memview_c_utility("MemviewSliceInit")
 memviewslice_declare_code = load_memview_c_utility("MemviewSliceStruct", context=template_context)
 copy_contents_new_utility = load_memview_c_utility("MemviewSliceCopy")
+slice_memviewslice_utility = load_memview_c_utility("SliceMemoryviewSlice")
 
 
 @Utils.cached_function
@@ -892,6 +894,7 @@ def _get_memoryview_utility_code():
                     is_contig_utility,
                     overlapping_utility,
                     copy_contents_new_utility,
+                    slice_memviewslice_utility,
                     ],
     )
 

--- a/Cython/Utility/MemoryView.pxd
+++ b/Cython/Utility/MemoryView.pxd
@@ -91,15 +91,6 @@ cdef memoryview_cwrapper(object o, int flags, bint dtype_is_object, const __Pyx_
 cdef inline bint memoryview_check(object o) noexcept:
     return isinstance(o, memoryview)
 
-@cname('__pyx_memoryview_slice_memviewslice')
-cdef int slice_memviewslice(
-        {{memviewslice_name}} *dst,
-        Py_ssize_t shape, Py_ssize_t stride, Py_ssize_t suboffset,
-        int dim, int new_ndim, int *suboffset_dim,
-        Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step,
-        int have_start, int have_stop, int have_step,
-        bint is_slice) except -1 nogil
-
 @cname('__pyx_memslice_transpose')
 cdef int transpose_memslice({{memviewslice_name}} *memslice) except -1 nogil
 

--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -99,6 +99,14 @@ cdef extern from *:
 
     ctypedef int (*to_dtype_func_type "__pyx_memoryview_to_dtype_func_type")(char *, object) except 0
 
+    int slice_memviewslice "__pyx_memoryview_slice_memviewslice" (
+        {{memviewslice_name}} *dst,
+        Py_ssize_t shape, Py_ssize_t stride, Py_ssize_t suboffset,
+        int dim, int new_ndim, int *suboffset_dim,
+        Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step,
+        int have_start, int have_stop, int have_step,
+        bint is_slice) except -1 nogil
+
 
 cdef extern from "<stdlib.h>":
     void *malloc(size_t) nogil
@@ -864,110 +872,6 @@ cdef memoryview memview_slice(memoryview memview, object indices):
         return memoryview_fromslice(dst, new_ndim, NULL, NULL,
                                     memview.dtype_is_object)
 
-
-#
-### Slicing in a single dimension of a memoryviewslice
-#
-
-@cname('__pyx_memoryview_slice_memviewslice')
-cdef int slice_memviewslice(
-        {{memviewslice_name}} *dst,
-        Py_ssize_t shape, Py_ssize_t stride, Py_ssize_t suboffset,
-        int dim, int new_ndim, int *suboffset_dim,
-        Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step,
-        int have_start, int have_stop, int have_step,
-        bint is_slice) except -1 nogil:
-    """
-    Create a new slice dst given slice src.
-
-    dim             - the current src dimension (indexing will make dimensions
-                                                 disappear)
-    new_dim         - the new dst dimension
-    suboffset_dim   - pointer to a single int initialized to -1 to keep track of
-                      where slicing offsets should be added
-    """
-
-    cdef Py_ssize_t new_shape
-    cdef bint negative_step
-
-    if not is_slice:
-        # index is a normal integer-like index
-        if start < 0:
-            start += shape
-        if not 0 <= start < shape:
-            _err_dim(PyExc_IndexError, "Index out of bounds (axis %d)", dim)
-    else:
-        # index is a slice
-        if have_step:
-            negative_step = step < 0
-            if step == 0:
-                _err_dim(PyExc_ValueError, "Step may not be zero (axis %d)", dim)
-        else:
-            negative_step = False
-            step = 1
-
-        # check our bounds and set defaults
-        if have_start:
-            if start < 0:
-                start += shape
-                if start < 0:
-                    start = 0
-            elif start >= shape:
-                if negative_step:
-                    start = shape - 1
-                else:
-                    start = shape
-        else:
-            if negative_step:
-                start = shape - 1
-            else:
-                start = 0
-
-        if have_stop:
-            if stop < 0:
-                stop += shape
-                if stop < 0:
-                    stop = 0
-            elif stop > shape:
-                stop = shape
-        else:
-            if negative_step:
-                stop = -1
-            else:
-                stop = shape
-
-        # len = ceil( (stop - start) / step )
-        with cython.cdivision(True):
-            new_shape = (stop - start) // step
-
-            if (stop - start) - step * new_shape:
-                new_shape += 1
-
-        if new_shape < 0:
-            new_shape = 0
-
-        # shape/strides/suboffsets
-        dst.strides[new_ndim] = stride * step
-        dst.shape[new_ndim] = new_shape
-        dst.suboffsets[new_ndim] = suboffset
-
-    # Add the slicing or indexing offsets to the right suboffset or base data *
-    if suboffset_dim[0] < 0:
-        dst.data += start * stride
-    else:
-        dst.suboffsets[suboffset_dim[0]] += start * stride
-
-    if suboffset >= 0:
-        if not is_slice:
-            if new_ndim == 0:
-                dst.data = (<char **> dst.data)[0] + suboffset
-            else:
-                _err_dim(PyExc_IndexError, "All dimensions preceding dimension %d "
-                                     "must be indexed and not sliced", dim)
-        else:
-            suboffset_dim[0] = new_ndim
-
-    return 0
 
 #
 ### Index a memoryview

--- a/Cython/Utility/MemoryView_C.c
+++ b/Cython/Utility/MemoryView_C.c
@@ -928,3 +928,132 @@ __pyx_fill_slice_{{dtype_name}}({{type_decl}} *p, Py_ssize_t extent, Py_ssize_t 
         p += stride;
     }
 }
+
+/////////////////// SliceMemoryviewSlice.proto //////////////
+//@substitute: naming
+
+// Slicing in a single dimension of a memoryviewslice.
+
+// Relies on being inlined to optimize out unused paths so
+// not a good candidate for the shared library.
+//
+// Create a new slice dst given slice src.
+//
+//    dim             - the current src dimension (indexing will make dimensions
+//                                                 disappear)
+//    new_dim         - the new dst dimension
+//    suboffset_dim   - pointer to a single int initialized to -1 to keep track of
+//                      where slicing offsets should be added
+
+static CYTHON_INLINE int __pyx_memoryview_slice_memviewslice(
+        $memviewslice_cname *dst,
+        Py_ssize_t shape, Py_ssize_t stride, Py_ssize_t suboffset,
+        int dim, int new_ndim, int *suboffset_dim,
+        Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step,
+        int have_start, int have_stop, int have_step,
+        int is_slice); /* proto */
+
+/////////////////// SliceMemoryviewSlice //////////////
+//@substitute: naming
+
+static void __pyx_memoryview_slice_memviewslice_err_dim(PyObject *error, const char* msg, int dim) {
+    PyGILState_STATE gilstate = PyGILState_Ensure();
+    PyErr_Format(error, msg, dim);
+    PyGILState_Release(gilstate);
+}
+
+static CYTHON_INLINE int __pyx_memoryview_slice_memviewslice(
+        $memviewslice_cname *dst,
+        Py_ssize_t shape, Py_ssize_t stride, Py_ssize_t suboffset,
+        int dim, int new_ndim, int *suboffset_dim,
+        Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step,
+        int have_start, int have_stop, int have_step,
+        int is_slice) {
+    if (!is_slice) {
+        // index is a normal integer-like index
+        if (start < 0) {
+            start += shape;
+        }
+        if (unlikely(!(0 <= start && start < shape))) {
+            __pyx_memoryview_slice_memviewslice_err_dim(PyExc_IndexError, "Index out of bounds (axis %d)", dim);
+            return -1;
+        }
+    } else {
+        // index is a slice
+        int negative_step;
+        if (have_step) {
+            negative_step = step < 0;
+            if (unlikely(step == 0)) {
+                __pyx_memoryview_slice_memviewslice_err_dim(PyExc_ValueError, "Step may not be zero (axis %d)", dim);
+                return -1;
+            }
+        } else {
+            negative_step = 0;
+            step = 1;
+        }
+
+        // check our bounds and set defaults
+        if (have_start) {
+            if (start < 0) {
+                start += shape;
+                if (start < 0) {
+                    start = 0;
+                }
+            } else if (start >= shape) {
+                start = negative_step ? (shape - 1) : shape;
+            }
+        } else {
+            start = negative_step ? (shape - 1) : 0;
+        }
+        if (have_stop) {
+            if (stop < 0) {
+                stop += shape;
+                if (stop < 0) {
+                    stop = 0;
+                }
+            } else if (stop > shape) {
+                stop = shape;
+            }
+        } else {
+            stop = negative_step ? -1 : shape;
+        }
+
+        // len = ceil( (stop - start) / step )
+        Py_ssize_t new_shape = (stop - start) / step;
+        if ((stop - start) - step * new_shape) {
+            ++new_shape;
+        }
+        if (new_shape < 0) {
+            new_shape = 0;
+        }
+
+        // shape/strides/suboffsets
+        dst->strides[new_ndim] = stride * step;
+        dst->shape[new_ndim] = new_shape;
+        dst->suboffsets[new_ndim] = suboffset;
+    }
+    
+    // Add the slicing or indexing offsets to the right suboffset or base data *
+    if (suboffset_dim[0] < 0) {
+        dst->data += start * stride;
+    } else {
+        dst->suboffsets[suboffset_dim[0]] += start * stride;
+    }
+
+    if (suboffset >= 0) {
+        if (!is_slice) {
+            if (likely(new_ndim == 0)) {
+                dst->data = ((char **)(dst->data))[0] + suboffset;
+            } else {
+                __pyx_memoryview_slice_memviewslice_err_dim(
+                    PyExc_IndexError,
+                    "All dimensions preceding dimension %d must be indexed and not sliced",
+                    dim);
+                return -1;
+            }
+        } else {
+            suboffset_dim[0] = new_ndim;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Partial fix for #7521.

This came up in a particular scikit-image microbenchmark so almost certainly isn't the only thing. But it looks like this particular function relies heavily on unused branches being eliminated so really wants to be inlined.

On the scikit-image microbenchmark, it's now actually faster with the shared utility code than without. I'm not sure why but possibly just the effect of the inline keyword.

The shared utility module itself doesn't change size at all with this fix (despite moving it to C)

Alternative to https://github.com/cython/cython/pull/7557. I prefer this version because it has less duplication but there's some risk of errors in the translation to C