### PR TITLE
Simplify codestyle on CI and split off docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
 
   ci-all:
-    needs: [codespell, codestyle, ci-early]
+    needs: [codespell, codestyle, ci-early, build_docs]
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest


### PR DESCRIPTION
A while ago I added a standalone file to just run the code style test (just to make it easier that manually disabling all other tests). Use that on the CI run instead.

Also fix the docs build (by actually building it, rather than just trying to upload it), and split it off into a separate job.