### PR TITLE
Fix issue with profiling and non-convertable ctuple

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4689,6 +4689,8 @@ class CTupleType(CType):
 
     _convert_to_py_code = None
     _convert_from_py_code = None
+    to_py_function = None
+    from_py_function = None
 
     def __init__(self, cname, components):
         from .Builtin import tuple_type
@@ -4696,8 +4698,6 @@ class CTupleType(CType):
         self.components = components
         self.equivalent_type = tuple_type
         self.size = len(components)
-        self.to_py_function = None
-        self.from_py_function = None
 
     def __str__(self):
         return "(%s)" % ", ".join(str(c) for c in self.components)

--- a/tests/run/sys_monitoring.py
+++ b/tests/run/sys_monitoring.py
@@ -346,8 +346,7 @@ else:
     ...     # monitored
     ...     trace_return_neg_1()
     ...     trace_return_charptr()
-    ...     if COMPILED:
-    ...         trace_return_ctuple()
+    ...     trace_return_ctuple()
     ... finally:
     ...     _ = smon.register_callback(TOOL_ID, E.PY_RETURN, None)
     ...     smon.free_tool_id(TOOL_ID)
@@ -713,5 +712,8 @@ def c_return_ctuple() -> tuple[cython.pointer[cython.int]]:
     return (cython.NULL,)
 
 def trace_return_ctuple():
-    result = c_return_ctuple()
-    return result[0] is cython.NULL
+    if COMPILED:
+        result = c_return_ctuple()
+        return result[0] is cython.NULL
+    # Otherwise pure-py test complains about how Cython.PointerType is unhashable.
+    return True


### PR DESCRIPTION
`CCodeWriter.put_trace_return` used the presence of a `to_py_function` to work out if something could be converted to Python. This means that setting it in the constructor of `CTupleType` was misleading it and was the wrong thing to do. Instead, only create the name when asked to.