### PR TITLE
docs: fix incorrect "edit on GitHub" link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ html_theme_options: ThemeOptions = {
     # Set both to enable "Edit page source"
     "edit_page_label": "Edit on GitHub",
     # $FILENAME$ will be replaced by actual source filename
-    "edit_page_url": "https://github.com/cython/cython/edit/master/docs/src/$FILENAME$",
+    "edit_page_url": "https://github.com/cython/cython/edit/master/docs/$FILENAME$",
     "header_title": "Cython Documentation",
     "header_menu": [
         {


### PR DESCRIPTION
Small fix: the "Edit on GitHub" link was an invalid URL.

<img width="1640" height="346" alt="CleanShot 2026-03-24 at 06 40 48@2x" src="https://github.com/user-attachments/assets/5a960be5-ba05-4bce-9f6e-e025db907a7d" />
