### PR TITLE
Escape github label name

### DIFF
--- a/.github/workflows/compiled_python.yml
+++ b/.github/workflows/compiled_python.yml
@@ -88,7 +88,7 @@ jobs:
             else
               TSAN_SUPPRESSIONS="${GITHUB_WORKSPACE}/cpython_main/Tools/tsan/suppressions.txt"
             fi
-            if [[ "${{github.event.label.name}}" != "full_sanitizers" ]]; then
+            if [[ "${GITHUB_LABEL_NAME}" != "full_sanitizers" ]]; then
               # For thread sanitizer run on a much smaller list of tests
               EXCLUDE="tag:threads"
             fi
@@ -105,6 +105,8 @@ jobs:
           echo "CONFIGURE_ARGS=$CONFIGURE_ARGS" >> $GITHUB_ENV
           echo "SANITIZER_CFLAGS=$SANITIZER_CFLAGS" >> $GITHUB_ENV
           echo "EXTRA_CONFIGURE_CFLAGS=$EXTRA_CONFIGURE_CFLAGS" >> $GITHUB_ENV
+        env:
+          GITHUB_LABEL_NAME: ${{ github.event.label.name }}
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
... by sending it through the environment.

This is a potential "code injection via template expansion" that zizmor (zizmor.sh) identifies.  It does identify a few others too however they're all from input variables that we directly control (e.g. `${{ inputs.compiler }}`) so I believe are genuinely fine, while this one is from something somewhat external. I don't think it's a real issue
but it seemed like it might be worth fixing while I was looking at it