### PR TITLE
Fix a couple of cyfunction ref-counting errors

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -906,7 +906,9 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->func_doc);
     Py_CLEAR(m->func_globals);
     Py_CLEAR(m->func_code);
-#if !CYTHON_COMPILING_IN_LIMITED_API
+#if CYTHON_COMPILING_IN_LIMITED_API
+    Py_CLEAR(m->func_classobj);
+#else
     {
         PyObject *cls = (PyObject*) ((PyCMethodObject *) (m))->mm_class;
         ((PyCMethodObject *) (m))->mm_class = NULL;
@@ -977,11 +979,10 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->func_globals);
     // The code objects that we generate only contain plain constants and can never participate in reference cycles.
     __Pyx_VISIT_CONST(m->func_code);
-#if !CYTHON_COMPILING_IN_LIMITED_API
     Py_VISIT(__Pyx__CyFunction_GetClassObj(m));
-#endif
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
+    Py_VISIT(m->func_annotations);
     Py_VISIT(m->func_is_coroutine);
     Py_VISIT(m->defaults);
 


### PR DESCRIPTION
1. The annotations dict wasn't visited. Normally it's just strings, so this shouldn't matter. However, it is modifiable so it can participate in reference cycles if people try hard.
2. Classobj wasn't freed in the Limited API.
3. Classobj wasn't visited in the Limited API.

@devdanzin sent me an automated analysis (I think parsing the C code to find potentially suspicious bits and then putting them into AI to try to identify problems, but I could be misrepresenting it) that pointed these out. More fixes to follow based on that...