### PR TITLE
Remove redundant check in __Pyx_MergeKeywords_any

### DIFF
--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -840,7 +840,7 @@ static int __Pyx_MergeKeywords_any(PyObject *kwdict, PyObject *source_mapping) {
                 return result;
             }
         }
-        if (unlikely(!iter)) goto bad;
+        goto bad;
     }
 
     while (1) {


### PR DESCRIPTION
It's not doing any harm, but it's always true (even if marked unlikely)