### PR TITLE
Fix reference leak in Generator_Replace_StopIteration

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -424,6 +424,7 @@ static void __Pyx_Generator_Replace_StopIteration(int in_async_gen) {
     }
     PyException_SetCause(new_exc, val); // steals ref to val
     PyErr_SetObject(PyExc_RuntimeError, new_exc);
+    Py_DECREF(new_exc);
 }
 
 


### PR DESCRIPTION
`PyErr_SetObject` doesn't steal a reference.

Another thing flagged by @devdanzin's analysis.