### PR TITLE
Improve __Pyx_PyType_GetFullyQualifiedName error handling

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2260,9 +2260,11 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         def handle_not_supported(op_name):
             code.putln("__Pyx_TypeName o_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(o));")
+            code.putln("if (!__Pyx_Typename_ErrorCheck(o_type_name)) {")
             code.putln("PyErr_Format(PyExc_NotImplementedError,")
             code.putln(f'  "Subscript %.10s not supported by " __Pyx_FMT_TYPENAME, "{op_name}", o_type_name);')
             code.putln("__Pyx_DECREF_TypeName(o_type_name);")
+            code.putln("}")
             code.putln("return -1;")
 
         set_or_del = "likely(v)" if not del_entry else "unlikely(v)" if not set_entry else "v"

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5746,7 +5746,7 @@ class CClassDefNode(ClassDefNode):
                 # trial_type is a heaptype so GetSlot works in all versions of the limited API
                 trial_type_base = "__Pyx_PyType_GetSlot((PyTypeObject*) %s, tp_base, PyTypeObject*)" % trial_type
                 code.putln("__Pyx_TypeName base_name = __Pyx_PyType_GetFullyQualifiedName(%s);" % trial_type_base)
-                code.putln(code.error_goto_if("__Pyx_Typename_ErrorCheck(base_name)"))
+                code.putln(code.error_goto_if("__Pyx_Typename_ErrorCheck(base_name)", self.pos))
                 code.putln("__Pyx_TypeName type_name = __Pyx_PyType_GetFullyQualifiedName(%s);" % first_base)
                 code.putln("if (likely(!__Pyx_Typename_ErrorCheck(type_name))) {")
                 code.putln("PyErr_Format(PyExc_TypeError, "

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -5746,12 +5746,15 @@ class CClassDefNode(ClassDefNode):
                 # trial_type is a heaptype so GetSlot works in all versions of the limited API
                 trial_type_base = "__Pyx_PyType_GetSlot((PyTypeObject*) %s, tp_base, PyTypeObject*)" % trial_type
                 code.putln("__Pyx_TypeName base_name = __Pyx_PyType_GetFullyQualifiedName(%s);" % trial_type_base)
+                code.putln(code.error_goto_if("__Pyx_Typename_ErrorCheck(base_name)"))
                 code.putln("__Pyx_TypeName type_name = __Pyx_PyType_GetFullyQualifiedName(%s);" % first_base)
+                code.putln("if (likely(!__Pyx_Typename_ErrorCheck(type_name))) {")
                 code.putln("PyErr_Format(PyExc_TypeError, "
                     "\"best base '\" __Pyx_FMT_TYPENAME \"' must be equal to first base '\" __Pyx_FMT_TYPENAME \"'\",")
                 code.putln("             base_name, type_name);")
-                code.putln("__Pyx_DECREF_TypeName(base_name);")
                 code.putln("__Pyx_DECREF_TypeName(type_name);")
+                code.putln("}")
+                code.putln("__Pyx_DECREF_TypeName(base_name);")
                 code.putln(code.error_goto(self.pos))
                 code.putln("}")
 

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -59,10 +59,12 @@ static PyObject* __Pyx_PyExec3(PyObject* o, PyObject* globals, PyObject* locals)
     else if (unlikely(!PyDict_Check(globals))) {
         __Pyx_TypeName globals_type_name =
             __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(globals));
-        PyErr_Format(PyExc_TypeError,
-                     "exec() arg 2 must be a dict, not " __Pyx_FMT_TYPENAME,
-                     globals_type_name);
-        __Pyx_DECREF_TypeName(globals_type_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(globals_type_name))) {
+            PyErr_Format(PyExc_TypeError,
+                        "exec() arg 2 must be a dict, not " __Pyx_FMT_TYPENAME,
+                        globals_type_name);
+            __Pyx_DECREF_TypeName(globals_type_name);
+        }
         goto bad;
     }
 #endif
@@ -98,10 +100,12 @@ static PyObject* __Pyx_PyExec3(PyObject* o, PyObject* globals, PyObject* locals)
             o = s;
         } else if (unlikely(!PyBytes_Check(o))) {
             __Pyx_TypeName o_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(o));
-            PyErr_Format(PyExc_TypeError,
-                "exec: arg 1 must be string, bytes or code object, got " __Pyx_FMT_TYPENAME,
-                o_type_name);
-            __Pyx_DECREF_TypeName(o_type_name);
+            if (likely(!__Pyx_Typename_ErrorCheck(o_type_name))) {
+                PyErr_Format(PyExc_TypeError,
+                    "exec: arg 1 must be string, bytes or code object, got " __Pyx_FMT_TYPENAME,
+                    o_type_name);
+                __Pyx_DECREF_TypeName(o_type_name);
+            }
             goto bad;
         }
         code = PyBytes_AS_STRING(o);
@@ -520,10 +524,12 @@ static long __Pyx__PyObject_Ord(PyObject* c) {
     } else {
         // FIXME: support character buffers - but CPython doesn't support them either
         __Pyx_TypeName c_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(c));
-        PyErr_Format(PyExc_TypeError,
-            "ord() expected string of length 1, but " __Pyx_FMT_TYPENAME " found",
-            c_type_name);
-        __Pyx_DECREF_TypeName(c_type_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(c_type_name))) {
+            PyErr_Format(PyExc_TypeError,
+                "ord() expected string of length 1, but " __Pyx_FMT_TYPENAME " found",
+                c_type_name);
+            __Pyx_DECREF_TypeName(c_type_name);
+        }
         return (long)(Py_UCS4)-1;
     }
     PyErr_Format(PyExc_TypeError,

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -63,9 +63,11 @@ static CYTHON_INLINE __Pyx_PySendResult __Pyx_Generator_Yield_From(__pyx_Corouti
 #if CYTHON_USE_TYPE_SLOTS
 static void __Pyx_PyIter_CheckErrorAndDecref(PyObject *source) {
     __Pyx_TypeName source_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(source));
-    PyErr_Format(PyExc_TypeError,
-        "iter() returned non-iterator of type '" __Pyx_FMT_TYPENAME "'", source_type_name);
-    __Pyx_DECREF_TypeName(source_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(source_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            "iter() returned non-iterator of type '" __Pyx_FMT_TYPENAME "'", source_type_name);
+        __Pyx_DECREF_TypeName(source_type_name);
+    }
     Py_DECREF(source);
 }
 #endif
@@ -214,12 +216,13 @@ static CYTHON_INLINE PyObject *__Pyx_Coroutine_GetAwaitableIter(PyObject *o) {
 static void __Pyx_Coroutine_AwaitableIterError(PyObject *source) {
 #if (PY_VERSION_HEX < 0x030d0000 || defined(_PyErr_FormatFromCause)) && !CYTHON_COMPILING_IN_LIMITED_API
     __Pyx_TypeName source_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(source));
-    _PyErr_FormatFromCause(PyExc_TypeError,
-        "'async for' received an invalid object from __anext__: " __Pyx_FMT_TYPENAME, source_type_name);
-    __Pyx_DECREF_TypeName(source_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(source_type_name))) {
+        _PyErr_FormatFromCause(PyExc_TypeError,
+            "'async for' received an invalid object from __anext__: " __Pyx_FMT_TYPENAME, source_type_name);
+        __Pyx_DECREF_TypeName(source_type_name);
+    }
 #else
     PyObject *exc, *val, *val2, *tb;
-    __Pyx_TypeName source_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(source));
     assert(PyErr_Occurred());
     __Pyx_PyErr_FetchException(&exc, &val, &tb);
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
@@ -231,9 +234,12 @@ static void __Pyx_Coroutine_AwaitableIterError(PyObject *source) {
     Py_DECREF(exc);
 #endif
     assert(!PyErr_Occurred());
-    PyErr_Format(PyExc_TypeError,
-        "'async for' received an invalid object from __anext__: " __Pyx_FMT_TYPENAME, source_type_name);
-    __Pyx_DECREF_TypeName(source_type_name);
+    __Pyx_TypeName source_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(source));
+    if (likely(!__Pyx_Typename_ErrorCheck(source_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            "'async for' received an invalid object from __anext__: " __Pyx_FMT_TYPENAME, source_type_name);
+        __Pyx_DECREF_TypeName(source_type_name);
+    }
 
     __Pyx_PyErr_FetchException(&exc, &val2, &tb);
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
@@ -298,9 +304,11 @@ static PyObject *__Pyx__Coroutine_GetAwaitableIter(PyObject *obj) {
     }
     if (unlikely(!PyIter_Check(res))) {
         __Pyx_TypeName res_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(res));
-        PyErr_Format(PyExc_TypeError,
-            "__await__() returned non-iterator of type '" __Pyx_FMT_TYPENAME "'", res_type_name);
-        __Pyx_DECREF_TypeName(res_type_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(res_type_name))) {
+            PyErr_Format(PyExc_TypeError,
+                "__await__() returned non-iterator of type '" __Pyx_FMT_TYPENAME "'", res_type_name);
+            __Pyx_DECREF_TypeName(res_type_name);
+        }
         Py_CLEAR(res);
     } else {
         int is_coroutine = 0;
@@ -320,9 +328,11 @@ static PyObject *__Pyx__Coroutine_GetAwaitableIter(PyObject *obj) {
 slot_error:
     {
         __Pyx_TypeName obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-        PyErr_Format(PyExc_TypeError,
-            "object " __Pyx_FMT_TYPENAME " can't be used in 'await' expression", obj_type_name);
-        __Pyx_DECREF_TypeName(obj_type_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+            PyErr_Format(PyExc_TypeError,
+                "object " __Pyx_FMT_TYPENAME " can't be used in 'await' expression", obj_type_name);
+            __Pyx_DECREF_TypeName(obj_type_name);
+        }
     }
 bad:
     return NULL;
@@ -339,9 +349,11 @@ static CYTHON_INLINE PyObject *__Pyx_Coroutine_AsyncIterNext(PyObject *o); /*pro
 
 static PyObject *__Pyx_Coroutine_GetAsyncIter_Fail(PyObject *obj) {
     __Pyx_TypeName obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-    PyErr_Format(PyExc_TypeError,
-                 "'async for' requires an object with __aiter__ method, got " __Pyx_FMT_TYPENAME, obj_type_name);
-    __Pyx_DECREF_TypeName(obj_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+                    "'async for' requires an object with __aiter__ method, got " __Pyx_FMT_TYPENAME, obj_type_name);
+        __Pyx_DECREF_TypeName(obj_type_name);
+    }
     return NULL;
 }
 
@@ -364,9 +376,11 @@ static CYTHON_INLINE PyObject *__Pyx_Coroutine_GetAsyncIter(PyObject *obj) {
 
 static PyObject *__Pyx_Coroutine_AsyncIterNext_Fail(PyObject *obj) {
     __Pyx_TypeName obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-    PyErr_Format(PyExc_TypeError,
-        "'async for' requires an object with __anext__ method, got " __Pyx_FMT_TYPENAME, obj_type_name);
-    __Pyx_DECREF_TypeName(obj_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            "'async for' requires an object with __anext__ method, got " __Pyx_FMT_TYPENAME, obj_type_name);
+        __Pyx_DECREF_TypeName(obj_type_name);
+    }
     return NULL;
 }
 
@@ -1729,9 +1743,11 @@ static PyObject *__Pyx_Coroutine_fail_reduce_ex(PyObject *self, PyObject *arg) {
     CYTHON_UNUSED_VAR(arg);
 
     __Pyx_TypeName self_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE((PyObject*)self));
-    PyErr_Format(PyExc_TypeError, "cannot pickle '" __Pyx_FMT_TYPENAME "' object",
-                         self_type_name);
-    __Pyx_DECREF_TypeName(self_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(self_type_name))) {
+        PyErr_Format(PyExc_TypeError, "cannot pickle '" __Pyx_FMT_TYPENAME "' object",
+                            self_type_name);
+        __Pyx_DECREF_TypeName(self_type_name);
+    }
     return NULL;
 }
 // #endif

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -88,13 +88,15 @@ static int __Pyx_validate_bases_tuple(const char *type_name, int has_dictoffset,
             if (b_dictoffset) {
                 {
                     __Pyx_TypeName b_name = __Pyx_PyType_GetFullyQualifiedName(b);
-                    PyErr_Format(PyExc_TypeError,
-                        "extension type '%.200s' has no __dict__ slot, "
-                        "but base type '" __Pyx_FMT_TYPENAME "' has: "
-                        "either add 'cdef dict __dict__' to the extension type "
-                        "or add '__slots__ = [...]' to the base type",
-                        type_name, b_name);
-                    __Pyx_DECREF_TypeName(b_name);
+                    if (likely(!__Pyx_Typename_ErrorCheck(b_name))) {
+                        PyErr_Format(PyExc_TypeError,
+                            "extension type '%.200s' has no __dict__ slot, "
+                            "but base type '" __Pyx_FMT_TYPENAME "' has: "
+                            "either add 'cdef dict __dict__' to the extension type "
+                            "or add '__slots__ = [...]' to the base type",
+                            type_name, b_name);
+                        __Pyx_DECREF_TypeName(b_name);
+                    }
                 }
 #if !CYTHON_USE_TYPE_SLOTS
               dictoffset_return:
@@ -469,9 +471,11 @@ __PYX_BAD:
     if (!PyErr_Occurred()) {
         __Pyx_TypeName type_obj_name =
             __Pyx_PyType_GetFullyQualifiedName((PyTypeObject*)type_obj);
-        PyErr_Format(PyExc_RuntimeError,
-            "Unable to initialize pickling for " __Pyx_FMT_TYPENAME, type_obj_name);
-        __Pyx_DECREF_TypeName(type_obj_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(type_obj_name))) {
+            PyErr_Format(PyExc_RuntimeError,
+                "Unable to initialize pickling for " __Pyx_FMT_TYPENAME, type_obj_name);
+            __Pyx_DECREF_TypeName(type_obj_name);
+        }
     }
     ret = -1;
 __PYX_GOOD:
@@ -686,9 +690,11 @@ static int __Pyx_validate_extern_base(PyTypeObject *base) {
 #endif
     if (itemsize) {
         __Pyx_TypeName b_name = __Pyx_PyType_GetFullyQualifiedName(base);
-        PyErr_Format(PyExc_TypeError,
-                "inheritance from PyVarObject types like '" __Pyx_FMT_TYPENAME "' not currently supported", b_name);
-        __Pyx_DECREF_TypeName(b_name);
+        if (likely(!__Pyx_Typename_ErrorCheck(b_name))) {
+            PyErr_Format(PyExc_TypeError,
+                    "inheritance from PyVarObject types like '" __Pyx_FMT_TYPENAME "' not currently supported", b_name);
+            __Pyx_DECREF_TypeName(b_name);
+        }
         return -1;
     }
     return 0;

--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -34,18 +34,24 @@ static int __Pyx__ArgTypeTest(PyObject *obj, PyTypeObject *type, const char *nam
         }
     }
     type_name = __Pyx_PyType_GetFullyQualifiedName(type);
-    obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-    PyErr_Format(PyExc_TypeError,
-        "Argument '%.200s' has incorrect type (expected " __Pyx_FMT_TYPENAME
-        ", got " __Pyx_FMT_TYPENAME ")"
+    if (likely(!__Pyx_Typename_ErrorCheck(type_name))) {
+        obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
+        if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+            PyErr_Format(PyExc_TypeError,
+                "Argument '%.200s' has incorrect type (expected " __Pyx_FMT_TYPENAME
+                ", got " __Pyx_FMT_TYPENAME ")"
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
-        "%s%U"
+                "%s%U"
 #endif
-        , name, type_name, obj_type_name
+                , name, type_name, obj_type_name
 #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
-        , (from_annotation_subclass ? ". " : ""), extra_info
+                , (from_annotation_subclass ? ". " : ""), extra_info
 #endif
-        );
+                );
+            __Pyx_DECREF_TypeName(obj_type_name);
+        }
+        __Pyx_DECREF_TypeName(type_name);
+    }
 #if __PYX_LIMITED_VERSION_HEX >= 0x030C0000
     // Set the extra_info as a note instead. In principle it'd be possible to do this
     // from Python 3.11 up, but PyErr_GetRaisedException makes it much easier so do it
@@ -60,8 +66,6 @@ static int __Pyx__ArgTypeTest(PyObject *obj, PyTypeObject *type, const char *nam
         PyErr_SetRaisedException(vargs[0]);
     }
 #endif
-    __Pyx_DECREF_TypeName(type_name);
-    __Pyx_DECREF_TypeName(obj_type_name);
     return 0;
 }
 
@@ -139,9 +143,11 @@ static void __Pyx_RaiseMappingExpectedError(PyObject* arg); /*proto*/
 
 static void __Pyx_RaiseMappingExpectedError(PyObject* arg) {
     __Pyx_TypeName arg_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(arg));
-    PyErr_Format(PyExc_TypeError,
-        "'" __Pyx_FMT_TYPENAME "' object is not a mapping", arg_type_name);
-    __Pyx_DECREF_TypeName(arg_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(arg_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            "'" __Pyx_FMT_TYPENAME "' object is not a mapping", arg_type_name);
+        __Pyx_DECREF_TypeName(arg_type_name);
+    }
 }
 
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -789,6 +789,7 @@ bad:
         PyTypeObject* basei = NULL;
         PyTypeObject* tp_base = __Pyx_PyType_GetSlot(type, tp_base, PyTypeObject*);
         tp_base_name = __Pyx_PyType_GetFullyQualifiedName(tp_base);
+        if (unlikely(__Pyx_Typename_ErrorCheck(tp_base_name))) goto really_bad;
 #if CYTHON_AVOID_BORROWED_REFS
         basei = (PyTypeObject*)PySequence_GetItem(bases, i);
         if (unlikely(!basei)) goto really_bad;
@@ -799,15 +800,14 @@ bad:
         basei = (PyTypeObject*)PyTuple_GET_ITEM(bases, i);
 #endif
         base_name = __Pyx_PyType_GetFullyQualifiedName(basei);
+        if (unlikely(__Pyx_Typename_ErrorCheck(base_name))) goto really_bad;
 #if CYTHON_AVOID_BORROWED_REFS
         Py_DECREF(basei);
 #endif
     }
     PyErr_Format(PyExc_TypeError,
         "multiple bases have vtable conflict: '" __Pyx_FMT_TYPENAME "' and '" __Pyx_FMT_TYPENAME "'", tp_base_name, base_name);
-#if CYTHON_AVOID_BORROWED_REFS || !CYTHON_ASSUME_SAFE_MACROS
 really_bad: // bad has failed!
-#endif
     __Pyx_DECREF_TypeName(tp_base_name);
     __Pyx_DECREF_TypeName(base_name);
 #if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_AVOID_BORROWED_REFS || !CYTHON_ASSUME_SAFE_MACROS

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -255,9 +255,11 @@ static PyObject *__Pyx_PyIter_Next2Default(PyObject* defval) {
 
 static void __Pyx_PyIter_Next_ErrorNoIterator(PyObject *iterator) {
     __Pyx_TypeName iterator_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(iterator));
-    PyErr_Format(PyExc_TypeError,
-        __Pyx_FMT_TYPENAME " object is not an iterator", iterator_type_name);
-    __Pyx_DECREF_TypeName(iterator_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(iterator_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            __Pyx_FMT_TYPENAME " object is not an iterator", iterator_type_name);
+        __Pyx_DECREF_TypeName(iterator_type_name);
+    }
 }
 
 // originally copied from Py3's builtin_next()
@@ -348,11 +350,13 @@ static PyObject *__Pyx_PyObject_GetIndex(PyObject *obj, PyObject *index) {
 
     // Error handling code -- only manage OverflowError differently.
     if (PyErr_GivenExceptionMatches(runerr, PyExc_OverflowError)) {
-        __Pyx_TypeName index_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(index));
         PyErr_Clear();
-        PyErr_Format(PyExc_IndexError,
-            "cannot fit '" __Pyx_FMT_TYPENAME "' into an index-sized integer", index_type_name);
-        __Pyx_DECREF_TypeName(index_type_name);
+        __Pyx_TypeName index_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(index));
+        if (likely(__Pyx_Typename_ErrorCheck(index_type_name))) {
+            PyErr_Format(PyExc_IndexError,
+                "cannot fit '" __Pyx_FMT_TYPENAME "' into an index-sized integer", index_type_name);
+            __Pyx_DECREF_TypeName(index_type_name);
+        }
     }
     return NULL;
 }
@@ -372,9 +376,11 @@ static PyObject *__Pyx_PyObject_GetItem_Slow(PyObject *obj, PyObject *key) {
     }
 
     obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-    PyErr_Format(PyExc_TypeError,
-        "'" __Pyx_FMT_TYPENAME "' object is not subscriptable", obj_type_name);
-    __Pyx_DECREF_TypeName(obj_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+        PyErr_Format(PyExc_TypeError,
+            "'" __Pyx_FMT_TYPENAME "' object is not subscriptable", obj_type_name);
+        __Pyx_DECREF_TypeName(obj_type_name);
+    }
     return NULL;
 }
 
@@ -859,14 +865,16 @@ static CYTHON_INLINE int __Pyx_PyObject_SetSlice(PyObject* obj, PyObject* value,
         return result;
     } else {
         obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-        PyErr_Format(PyExc_TypeError,
+        if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+            PyErr_Format(PyExc_TypeError,
 {{if access == 'Get'}}
-            "'" __Pyx_FMT_TYPENAME "' object is unsliceable", obj_type_name);
+                "'" __Pyx_FMT_TYPENAME "' object is unsliceable", obj_type_name);
 {{else}}
-            "'" __Pyx_FMT_TYPENAME "' object does not support slice %.10s",
-            obj_type_name, value ? "assignment" : "deletion");
+                "'" __Pyx_FMT_TYPENAME "' object does not support slice %.10s",
+                obj_type_name, value ? "assignment" : "deletion");
 {{endif}}
-        __Pyx_DECREF_TypeName(obj_type_name);
+            __Pyx_DECREF_TypeName(obj_type_name);
+        }
     }
 
 bad:
@@ -1372,12 +1380,15 @@ static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
     if (likely(__Pyx_TypeCheck(obj, type)))
         return 1;
     obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
+    if (unlikely(__Pyx_Typename_ErrorCheck(obj_type_name))) return 0;
     type_name = __Pyx_PyType_GetFullyQualifiedName(type);
-    PyErr_Format(PyExc_TypeError,
-                 "Cannot convert " __Pyx_FMT_TYPENAME " to " __Pyx_FMT_TYPENAME,
-                 obj_type_name, type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(type_name))) {
+        PyErr_Format(PyExc_TypeError,
+                    "Cannot convert " __Pyx_FMT_TYPENAME " to " __Pyx_FMT_TYPENAME,
+                    obj_type_name, type_name);
+        __Pyx_DECREF_TypeName(type_name);
+    }
     __Pyx_DECREF_TypeName(obj_type_name);
-    __Pyx_DECREF_TypeName(type_name);
     return 0;
 }
 
@@ -1836,10 +1847,12 @@ static int __Pyx_PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **me
     }
 
     type_name = __Pyx_PyType_GetFullyQualifiedName(tp);
-    PyErr_Format(PyExc_AttributeError,
-                 "'" __Pyx_FMT_TYPENAME "' object has no attribute '%U'",
-                 type_name, name);
-    __Pyx_DECREF_TypeName(type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(type_name))) {
+        PyErr_Format(PyExc_AttributeError,
+                    "'" __Pyx_FMT_TYPENAME "' object has no attribute '%U'",
+                    type_name, name);
+        __Pyx_DECREF_TypeName(type_name);
+    }
     return 0;
 
 // Generic fallback implementation using normal attribute lookup.
@@ -3075,21 +3088,28 @@ static CYTHON_INLINE PyObject* __Pyx_{{typeobj}}_Multiply(PyObject *seq, Py_ssiz
 
 /////////////// FormatTypeName.proto ///////////////
 
-#if CYTHON_COMPILING_IN_LIMITED_API
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX >= 0x030d0000
+// For these versions we can just pass the type, use the %N format code and
+// Python handles the whole thing internally
+typedef PyObject *__Pyx_TypeName;
+#define __Pyx_FMT_TYPENAME "%N"
+#define __Pyx_DECREF_TypeName(obj) Py_XDECREF(obj)
+#define __Pyx_PyType_GetFullyQualifiedName(tp) Py_NewRef((PyObject*)tp)
+#define __Pyx_Typename_ErrorCheck(obj) (0)
+
+#elif CYTHON_COMPILING_IN_LIMITED_API
 typedef PyObject *__Pyx_TypeName;
 #define __Pyx_FMT_TYPENAME "%U"
 #define __Pyx_DECREF_TypeName(obj) Py_XDECREF(obj)
-
-#if __PYX_LIMITED_VERSION_HEX >= 0x030d0000
-#define __Pyx_PyType_GetFullyQualifiedName PyType_GetFullyQualifiedName
-#else
 static __Pyx_TypeName __Pyx_PyType_GetFullyQualifiedName(PyTypeObject* tp); /*proto*/
-#endif
+#define __Pyx_Typename_ErrorCheck(obj) (obj == NULL)
+
 #else  // !LIMITED_API
 typedef const char *__Pyx_TypeName;
 #define __Pyx_FMT_TYPENAME "%.200s"
 #define __Pyx_PyType_GetFullyQualifiedName(tp) ((tp)->tp_name)
 #define __Pyx_DECREF_TypeName(obj)
+#define __Pyx_Typename_ErrorCheck(obj) (0)
 #endif
 
 /////////////// FormatTypeName ///////////////
@@ -3099,6 +3119,8 @@ static __Pyx_TypeName
 __Pyx_PyType_GetFullyQualifiedName(PyTypeObject* tp)
 {
     PyObject *module = NULL, *name = NULL, *result = NULL;
+    PyObject *current_exc_tp, *current_exc, *current_tb;
+    __Pyx_PyErr_FetchException(&current_exc_tp, &current_exc, &current_tb);
 
     #if __PYX_LIMITED_VERSION_HEX < 0x030b0000
     name = __Pyx_PyObject_GetAttrStr((PyObject *)tp,
@@ -3120,19 +3142,25 @@ __Pyx_PyType_GetFullyQualifiedName(PyTypeObject* tp)
     result = PyUnicode_FromFormat("%U.%U", module, name);
     if (unlikely(result == NULL)) goto bad;
 
-  done:
+  done:       
+    __Pyx_PyErr_RestoreException(current_exc_tp, current_exc, current_tb);
+  done_no_restore:
     Py_XDECREF(name);
     Py_XDECREF(module);
     return result;
 
   bad:
+    if (unlikely(!PyErr_ExceptionMatches(PyExc_Exception))) {
+        goto done_no_restore; // BaseException, fail and raise this
+    }
     PyErr_Clear();
     if (name) {
         // Use this as second-best fallback
         result = name;
         name = NULL;
     } else {
-        result = __Pyx_NewRef(PYUNICODE("?"));
+        result = PyUnicode_FromString("?");
+        if (unlikely(!result)) goto done_no_restore; 
     }
     goto done;
 }
@@ -3149,9 +3177,11 @@ static int
 __Pyx_RaiseUnexpectedTypeError(const char *expected, PyObject *obj)
 {
     __Pyx_TypeName obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
-    PyErr_Format(PyExc_TypeError, "Expected %s, got " __Pyx_FMT_TYPENAME,
-                 expected, obj_type_name);
-    __Pyx_DECREF_TypeName(obj_type_name);
+    if (likely(!__Pyx_Typename_ErrorCheck(obj_type_name))) {
+        PyErr_Format(PyExc_TypeError, "Expected %s, got " __Pyx_FMT_TYPENAME,
+                    expected, obj_type_name);
+        __Pyx_DECREF_TypeName(obj_type_name);
+    }
     return 0;
 }
 

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -678,10 +678,12 @@ static double __Pyx__PyObject_AsDouble(PyObject* obj) {
             float_value = nb->nb_float(obj);
             if (likely(float_value) && unlikely(!PyFloat_Check(float_value))) {
                 __Pyx_TypeName float_value_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(float_value));
-                PyErr_Format(PyExc_TypeError,
-                    "__float__ returned non-float (type " __Pyx_FMT_TYPENAME ")",
-                    float_value_type_name);
-                __Pyx_DECREF_TypeName(float_value_type_name);
+                if (likely(!__Pyx_Typename_ErrorCheck(float_value_type_name))) {
+                    PyErr_Format(PyExc_TypeError,
+                        "__float__ returned non-float (type " __Pyx_FMT_TYPENAME ")",
+                        float_value_type_name);
+                    __Pyx_DECREF_TypeName(float_value_type_name);
+                }
                 Py_DECREF(float_value);
                 goto bad;
             }
@@ -1123,15 +1125,18 @@ def is_type(operand, expected, type1=type1, type2=type2):
 static void __Pyx_BinopTypeError(PyObject *op1, PyObject *op2, const char* op, int inplace) {
     // op1 is either 'int' or 'float', op2 is unknown.
     __Pyx_TypeName type_name_op1 = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(op1));
+    if (unlikely(__Pyx_Typename_ErrorCheck(type_name_op1))) return;
     __Pyx_TypeName type_name_op2 = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(op2));
-    PyErr_Format(PyExc_TypeError,
-        "unsupported operand type(s) for %.2s%.1s: '%.5s' and '%.200s'",
-        op,
-        inplace ? "=" : "",
-        type_name_op1,
-        type_name_op2);
+    if (likely(!__Pyx_Typename_ErrorCheck(type_name_op2))) {
+        PyErr_Format(PyExc_TypeError,
+            "unsupported operand type(s) for %.2s%.1s: '%.5s' and '%.200s'",
+            op,
+            inplace ? "=" : "",
+            type_name_op1,
+            type_name_op2);
+        __Pyx_DECREF_TypeName(type_name_op2);
+    }
     __Pyx_DECREF_TypeName(type_name_op1);
-    __Pyx_DECREF_TypeName(type_name_op2);
 }
 #endif
 #endif

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -346,6 +346,10 @@ static CYTHON_INLINE int __Pyx_PyObject_IsTrueAndDecref(PyObject* x) {
 
 static PyObject* __Pyx_PyNumber_LongWrongResultType(PyObject* result) {
     __Pyx_TypeName result_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(result));
+    if (unlikely(__Pyx_Typename_ErrorCheck(result_type_name))) {
+        Py_DECREF(result);
+        return NULL;
+    }
     if (PyLong_Check(result)) {
         // CPython issue #17576: warn if 'result' not of exact type int.
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
@@ -468,6 +472,7 @@ static CYTHON_INLINE PyObject * __Pyx_PyLong_FromSize_t(size_t ival) {
 
 static void __Pyx_PyBuiltin_Invalid(PyObject *obj, const char *type_name, const char *argname) {
     __Pyx_TypeName obj_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(obj));
+    if (unlikely(__Pyx_Typename_ErrorCheck(obj_type_name))) return;
     if (argname) {
         PyErr_Format(PyExc_TypeError,
             "Argument '%.200s' has incorrect type (expected %.200s, got " __Pyx_FMT_TYPENAME ")",
@@ -689,6 +694,7 @@ bad:
 static void __Pyx_seq_{{funcname}}(PyObject * o, {{struct_type_decl}} *result) {
     if (unlikely(!PySequence_Check(o))) {
         __Pyx_TypeName o_type_name = __Pyx_PyType_GetFullyQualifiedName(Py_TYPE(o));
+        if (unlikely(__Pyx_Typename_ErrorCheck(o_type_name))) goto bad;
         PyErr_Format(PyExc_TypeError,
                      "Expected a sequence of size %zd, got " __Pyx_FMT_TYPENAME, (Py_ssize_t) {{size}}, o_type_name);
         __Pyx_DECREF_TypeName(o_type_name);


### PR DESCRIPTION
1. On newer Limited API we can move all the logic into PyErr_Format by using the `N` format code. This is unlikely to be worse than whatever we do.
2. Allow `__Pyx_PyType_GetFullyQualifiedName` to fail on older Limited API (although only do that if no other options are available or a BaseException is raised).
3. Preserve exceptions inside `__Pyx_PyType_GetFullyQualifiedName`. Since it's usually used in exception handlers so it's quite reasonable that something might already be raised.
4. Don't cache an obscure 3rd-tier string just for a fallback.
5. Adapt other code for the possibility it might fail.

Follow up to #7600