### PR TITLE
Use proper type name cython.bint instead of bint

### DIFF
--- a/Demos/benchmarks/bm_dataclasses.py
+++ b/Demos/benchmarks/bm_dataclasses.py
@@ -56,8 +56,8 @@ def benchmark_repr(points: list[Point]):
 
 
 def benchmark_compare(points: list[Point]):
-    all_results: bint = False
-    result: bint
+    all_results: cython.bint = False
+    result: cython.bint
 
     for p1, p2 in pairwise(points):
         result = False


### PR DESCRIPTION
Fixes following warnings in benchmarks:
```
[76](https://github.com/cython/cython/actions/runs/24637101396/job/72034403979#step:5:377)
warning: /tmp/tmp7gdhwkz_/benchmarks/HEAD/bm_dataclasses.py:59:17: Unknown type declaration 'bint' in annotation, ignoring
warning: /tmp/tmp7gdhwkz_/benchmarks/HEAD/bm_dataclasses.py:60:12: Unknown type declaration 'bint' in annotation, ignoring
```