### PR TITLE
Relax libc_math sin doctest

### DIFF
--- a/tests/run/libc_math.pyx
+++ b/tests/run/libc_math.pyx
@@ -30,9 +30,12 @@ def test_sin(x):
     """
     >>> test_sin(0)
     0.0
-    >>> from math import sin
-    >>> [sin(k) == test_sin(k) for k in range(10)]
-    [True, True, True, True, True, True, True, True, True, True]
+    >>> import math
+    >>> all(
+    ...     math.isclose(math.sin(k), test_sin(k), rel_tol=0.0, abs_tol=1e-12)
+    ...     for k in range(10)
+    ... )
+    True
     """
     return sin(x)
 


### PR DESCRIPTION
We're running Cython's tests in GraalPy's CI and this test fails on darwin-aarch64 because on that platform `java.Math.sin` (and even `java.StrictMath.sin`)  is one bit off from `libm`'s `sin`. From what I've gathered, these tiny platform differences are normal, so I've modified the test to be a bit (pun intended) more permissive.