### PR TITLE
Fix dict iteration with CYTHON_AVOID_BORROWED_REFS

### DIFF
--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -314,7 +314,7 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 //@requires: ObjectHandling.c::IterFinish
 //@requires: ObjectHandling.c::PyObjectCallMethod0
 
-#if CYTHON_COMPILING_IN_PYPY
+#if CYTHON_AVOID_BORROWED_REFS
 #include <string.h>
 #endif
 
@@ -323,12 +323,12 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
     is_dict = is_dict || likely(PyDict_CheckExact(iterable));
     *p_source_is_dict = is_dict;
     if (is_dict) {
-#if !CYTHON_COMPILING_IN_PYPY
+#if !CYTHON_AVOID_BORROWED_REFS
         *p_orig_length = PyDict_Size(iterable);
         Py_INCREF(iterable);
         return iterable;
 #else
-        // On PyPy3, we need to translate manually a few method names.
+        // On PyPy3/GraalPy, we need to translate manually a few method names.
         // This logic is not needed on CPython thanks to the fast case above.
         static PyObject *py_items = NULL, *py_keys = NULL, *py_values = NULL;
         PyObject **pp = NULL;
@@ -354,7 +354,7 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
         iterable = __Pyx_PyObject_CallMethod0(iterable, method_name);
         if (!iterable)
             return NULL;
-#if !CYTHON_COMPILING_IN_PYPY
+#if !CYTHON_AVOID_BORROWED_REFS
         if (PyTuple_CheckExact(iterable) || PyList_CheckExact(iterable))
             return iterable;
 #endif


### PR DESCRIPTION
In the dict iteration code, some of the code paths used `CYTHON_AVOID_BORROWED_REFS` and some used `CYTHON_COMPILING_IN_PYPY`, resulting in broken state on GraalPy where one part of the exact-dict fast-path was active and one was not. It would end up calling `PyIter_Next` with a dict object instead of an iterator.

The existing test `iterdict` tests this AFAICS. Unfortunately, it's currently disabled on GraalPy. I had to fix one more thing on our side to make it pass. So I'm not adding any new test right now with the plan that after we release, we can enable the existing test.