### PR TITLE
Small cleanup of memoryview assertion

### DIFF
--- a/Cython/Utility/MemoryView.pyx
+++ b/Cython/Utility/MemoryView.pyx
@@ -385,7 +385,8 @@ cdef class memoryview:
         else:
             self.dtype_is_object = dtype_is_object
 
-        assert <uintptr_t><void*>(&self.acquisition_count) % sizeof(__pyx_atomic_int_type) == 0
+        with cython.cdivision(True):
+            assert <uintptr_t>(&self.acquisition_count) % sizeof(__pyx_atomic_int_type) == 0
         self.typeinfo = NULL
 
     def __dealloc__(memoryview self):


### PR DESCRIPTION
Cast via `void*` was unnecessary and caused a warning about casting away atomicness.

C-division directive avoids a divide by 0 check. I'm sure the C compiler would trivially remove it, but it seems worth doing while changing ths anyway.