### PR TITLE
Remove static PyObject* from PyPy/GraalPy __Pyx_dict_iterator

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1089,6 +1089,17 @@ class IterationTransform(Visitor.EnvTransform):
         temps.append(temp)
         pos_temp = temp.ref(node.pos)
 
+        legacy_method = False
+        if method and method.startswith('iter'):
+            assert method in ('iterkeys', 'itervalues', 'iteritems'), method
+            if dict_obj.type.is_pydict_type:
+                method = EncodedString(method[4:])
+            elif dict_obj.type.is_pyfrozendict_type:
+                # Don't apply legacy Python 2 behaviour to Python 3.15 types
+                return node
+            else:
+                legacy_method = True
+
         key_target = value_target = tuple_target = None
         if keys and values:
             if node.target.is_sequence_constructor:
@@ -1131,9 +1142,6 @@ class IterationTransform(Visitor.EnvTransform):
         body.stats[0:0] = [iter_next_node]
 
         if method:
-            if dict_obj.type.is_pyanydict_type and method.startswith('iter'):
-                assert method in ('iterkeys', 'itervalues', 'iteritems'), method
-                method = EncodedString(method[4:])
             method_node = ExprNodes.IdentifierStringNode(dict_obj.pos, value=method)
             dict_obj = dict_obj.as_none_safe_node(
                 "'NoneType' object has no attribute '%{}s'".format('.30' if len(method) <= 30 else ''),
@@ -1156,7 +1164,7 @@ class IterationTransform(Visitor.EnvTransform):
                 lhs = dict_temp,
                 rhs = ExprNodes.PythonCapiCallNode(
                     dict_obj.pos,
-                    "__Pyx_dict_iterator",
+                    f"__Pyx_dict_iterator{'_legacy' if legacy_method else ''}",
                     self.PyDict_Iterator_func_type,
                     utility_code = UtilityCode.load_cached("dict_iter", "Optimize.c"),
                     args = [dict_obj, is_dict, method_node, dict_len_temp_addr, is_dict_temp_addr],

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1131,7 +1131,7 @@ class IterationTransform(Visitor.EnvTransform):
         body.stats[0:0] = [iter_next_node]
 
         if method:
-            if dict_obj.type.is_pydict_type and method.startswith('iter'):
+            if dict_obj.type.is_pyanydict_type and method.startswith('iter'):
                 assert method in ('iterkeys', 'itervalues', 'iteritems'), method
                 method = EncodedString(method[4:])
             method_node = ExprNodes.IdentifierStringNode(dict_obj.pos, value=method)

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1166,7 +1166,9 @@ class IterationTransform(Visitor.EnvTransform):
                     dict_obj.pos,
                     "__Pyx_dict_iterator_legacy" if legacy_method else "__Pyx_dict_iterator",
                     self.PyDict_Iterator_func_type,
-                    utility_code = UtilityCode.load_cached("dict_iter", "Optimize.c"),
+                    utility_code = UtilityCode.load_cached(
+                        "dict_iter_legacy" if legacy_method else "dict_iter",
+                        "Optimize.c"),
                     args = [dict_obj, is_dict, method_node, dict_len_temp_addr, is_dict_temp_addr],
                     is_temp=True,
                 )),

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1164,7 +1164,7 @@ class IterationTransform(Visitor.EnvTransform):
                 lhs = dict_temp,
                 rhs = ExprNodes.PythonCapiCallNode(
                     dict_obj.pos,
-                    f"__Pyx_dict_iterator{'_legacy' if legacy_method else ''}",
+                    "__Pyx_dict_iterator_legacy" if legacy_method else "__Pyx_dict_iterator",
                     self.PyDict_Iterator_func_type,
                     utility_code = UtilityCode.load_cached("dict_iter", "Optimize.c"),
                     args = [dict_obj, is_dict, method_node, dict_len_temp_addr, is_dict_temp_addr],

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1132,6 +1132,7 @@ class IterationTransform(Visitor.EnvTransform):
 
         if method:
             if dict_obj.type.is_pydict_type and method.startswith('iter'):
+                assert method in ('iterkeys', 'itervalues', 'iteritems'), method
                 method = EncodedString(method[4:])
             method_node = ExprNodes.IdentifierStringNode(dict_obj.pos, value=method)
             dict_obj = dict_obj.as_none_safe_node(

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1131,6 +1131,8 @@ class IterationTransform(Visitor.EnvTransform):
         body.stats[0:0] = [iter_next_node]
 
         if method:
+            if dict_obj.type.is_pydict_type and method.startswith('iter'):
+                method = EncodedString(method[4:])
             method_node = ExprNodes.IdentifierStringNode(dict_obj.pos, value=method)
             dict_obj = dict_obj.as_none_safe_node(
                 "'NoneType' object has no attribute '%{}s'".format('.30' if len(method) <= 30 else ''),

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -320,6 +320,7 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
                                                    Py_ssize_t* p_orig_length, int* p_source_is_dict) {
+    int owned_method_name = 0;
     is_dict = is_dict || likely(PyDict_CheckExact(iterable));
     *p_source_is_dict = is_dict;
     if (is_dict) {
@@ -330,20 +331,16 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
 #else
         // On PyPy3/GraalPy, we need to translate manually a few method names.
         // This logic is not needed on CPython thanks to the fast case above.
-        static PyObject *py_items = NULL, *py_keys = NULL, *py_values = NULL;
-        PyObject **pp = NULL;
         if (method_name) {
             const char *name = PyUnicode_AsUTF8(method_name);
-            if (strcmp(name, "iteritems") == 0) pp = &py_items;
-            else if (strcmp(name, "iterkeys") == 0) pp = &py_keys;
-            else if (strcmp(name, "itervalues") == 0) pp = &py_values;
-            if (pp) {
-                if (!*pp) {
-                    *pp = PyUnicode_FromString(name + 4);
-                    if (!*pp)
-                        return NULL;
-                }
-                method_name = *pp;
+            if (strncmp(name, "iter", 4) == 0 && (
+                    strcmp(name+4, "items") == 0 ||
+                    strcmp(name+4, "keys") == 0 ||
+                    strcmp(name+4, "values") == 0)) {
+                method_name = PyUnicode_FromString(name + 4);
+                if (unlikely(!method_name))
+                    return NULL;
+                owned_method_name = 1;
             }
         }
 #endif
@@ -352,6 +349,8 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
     if (method_name) {
         PyObject* iter;
         iterable = __Pyx_PyObject_CallMethod0(iterable, method_name);
+        if (owned_method_name)
+            Py_DECREF(method_name);
         if (!iterable)
             return NULL;
 #if !CYTHON_AVOID_BORROWED_REFS

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -302,25 +302,15 @@ static CYTHON_INLINE int __Pyx_PyDict_Pop_ignore(PyObject *d, PyObject *key, PyO
 }
 
 
-/////////////// dict_iter.proto ///////////////
-
-static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* dict, int is_dict, PyObject* method_name,
-                                                   Py_ssize_t* p_orig_length, int* p_is_dict);
-// "legacy" handles old-style iter* methods
-static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* dict, int is_dict, PyObject* method_name,
-                                                          Py_ssize_t* p_orig_length, int* p_is_dict);
+/////////////// dict_iter_common.proto ///////////////
+static PyObject *__Pyx_dict_call_to_get_iterable(PyObject* iterable, PyObject* method_name); /* proto */
 static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t orig_length, Py_ssize_t* ppos,
                                               PyObject** pkey, PyObject** pvalue, PyObject** pitem, int is_dict);
 
-/////////////// dict_iter ///////////////
+/////////////// dict_iter_common ///////////////
 //@requires: ObjectHandling.c::UnpackTuple2
 //@requires: ObjectHandling.c::IterFinish
 //@requires: ObjectHandling.c::PyObjectCallMethod0
-//@requires: Builtins.c::PyFrozenDict
-
-#if CYTHON_AVOID_BORROWED_REFS
-#include <string.h>
-#endif
 
 static PyObject *__Pyx_dict_call_to_get_iterable(PyObject* iterable, PyObject* method_name) {
     
@@ -336,60 +326,6 @@ static PyObject *__Pyx_dict_call_to_get_iterable(PyObject* iterable, PyObject* m
     Py_DECREF(iterable);
     return iter;
 }
-
-static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
-                                                   Py_ssize_t* p_orig_length, int* p_source_is_dict) {
-    is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable));
-    *p_source_is_dict = is_dict;
-#if !CYTHON_AVOID_BORROWED_REFS
-    if (is_dict) {
-        *p_orig_length = PyDict_Size(iterable);
-        Py_INCREF(iterable);
-        return iterable;
-    }
-#endif
-    *p_orig_length = 0;
-    if (method_name) {
-        return __Pyx_dict_call_to_get_iterable(iterable, method_name);
-    } else {
-        return PyObject_GetIter(iterable);
-    }
-}
-
-static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* iterable, int is_dict, PyObject* method_name,
-                                                          Py_ssize_t* p_orig_length, int* p_source_is_dict) {
-    int owned_method_name = 0;
-    // Don't include frozendict.
-    is_dict = is_dict || likely(PyDict_CheckExact(iterable));
-    *p_source_is_dict = is_dict;
-    if (is_dict) {
-#if !CYTHON_AVOID_BORROWED_REFS
-        *p_orig_length = PyDict_Size(iterable);
-        Py_INCREF(iterable);
-        return iterable;
-#else
-        // On PyPy3/GraalPy, we need to translate manually the method name.
-        // This logic is not needed on CPython thanks to the fast case above.
-        if (method_name) {
-            method_name = PyUnicode_Substring(method_name, 4, 10);  // longest is "itervalues" (len=10)
-            if (unlikely(!method_name))
-                return NULL;
-            owned_method_name = 1;
-        }
-#endif
-    }
-    *p_orig_length = 0;
-    if (method_name) {
-        iterable = __Pyx_dict_call_to_get_iterable(iterable, method_name);
-        if (owned_method_name) {
-            Py_DECREF(method_name);
-        }
-        return iterable;
-} else {
-    return PyObject_GetIter(iterable);
-}
-}
-
 
 #if !CYTHON_AVOID_BORROWED_REFS
 static CYTHON_INLINE int __Pyx_dict_iter_next_source_is_dict(
@@ -500,6 +436,81 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(
         *pvalue = next_item;
     }
     return 1;
+}
+
+/////////////// dict_iter_legacy.proto //////////////
+
+// "legacy" handles old-style iter* methods
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* dict, int is_dict, PyObject* method_name,
+                                                          Py_ssize_t* p_orig_length, int* p_is_dict);
+
+/////////////// dict_iter_legacy //////////////////
+//@requires: dict_iter_common
+
+#if CYTHON_AVOID_BORROWED_REFS
+#include <string.h>
+#endif
+
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* iterable, int is_dict, PyObject* method_name,
+                                                          Py_ssize_t* p_orig_length, int* p_source_is_dict) {
+    int owned_method_name = 0;
+    // Don't include frozendict.
+    is_dict = is_dict || likely(PyDict_CheckExact(iterable));
+    *p_source_is_dict = is_dict;
+    if (is_dict) {
+#if !CYTHON_AVOID_BORROWED_REFS
+        *p_orig_length = PyDict_Size(iterable);
+        Py_INCREF(iterable);
+        return iterable;
+#else
+        // On PyPy3/GraalPy, we need to translate manually the method name.
+        // This logic is not needed on CPython thanks to the fast case above.
+        if (method_name) {
+            method_name = PyUnicode_Substring(method_name, 4, 10);  // longest is "itervalues" (len=10)
+            if (unlikely(!method_name))
+                return NULL;
+            owned_method_name = 1;
+        }
+#endif
+    }
+    *p_orig_length = 0;
+    if (method_name) {
+        iterable = __Pyx_dict_call_to_get_iterable(iterable, method_name);
+        if (owned_method_name) {
+            Py_DECREF(method_name);
+        }
+        return iterable;
+    } else {
+        return PyObject_GetIter(iterable);
+    }
+}
+
+/////////////// dict_iter.proto ///////////////
+
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* dict, int is_dict, PyObject* method_name,
+                                                   Py_ssize_t* p_orig_length, int* p_is_dict);
+
+/////////////// dict_iter ///////////////
+//@requires: Builtins.c::PyFrozenDict
+//@requires: dict_iter_common
+
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
+                                                   Py_ssize_t* p_orig_length, int* p_source_is_dict) {
+    is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable));
+    *p_source_is_dict = is_dict;
+#if !CYTHON_AVOID_BORROWED_REFS
+    if (is_dict) {
+        *p_orig_length = PyDict_Size(iterable);
+        Py_INCREF(iterable);
+        return iterable;
+    }
+#endif
+    *p_orig_length = 0;
+    if (method_name) {
+        return __Pyx_dict_call_to_get_iterable(iterable, method_name);
+    } else {
+        return PyObject_GetIter(iterable);
+    }
 }
 
 

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -306,6 +306,9 @@ static CYTHON_INLINE int __Pyx_PyDict_Pop_ignore(PyObject *d, PyObject *key, PyO
 
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* dict, int is_dict, PyObject* method_name,
                                                    Py_ssize_t* p_orig_length, int* p_is_dict);
+// "legacy" handles old-style iter* methods
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* dict, int is_dict, PyObject* method_name,
+                                                   Py_ssize_t* p_orig_length, int* p_is_dict);
 static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t orig_length, Py_ssize_t* ppos,
                                               PyObject** pkey, PyObject** pvalue, PyObject** pitem, int is_dict);
 
@@ -319,10 +322,47 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 #include <string.h>
 #endif
 
+static PyObject *__Pyx_dict_call_to_get_iterable(PyObject* iterable, PyObject* method_name) {
+    
+    PyObject* iter;
+    iterable = __Pyx_PyObject_CallMethod0(iterable, method_name);
+    if (!iterable)
+        return NULL;
+#if !CYTHON_AVOID_BORROWED_REFS
+    if (PyTuple_CheckExact(iterable) || PyList_CheckExact(iterable))
+        return iterable;
+#endif
+    iter = PyObject_GetIter(iterable);
+    Py_DECREF(iterable);
+    return iter;
+}
+
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
                                                    Py_ssize_t* p_orig_length, int* p_source_is_dict) {
-    int owned_method_name = 0;
     is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable));
+    *p_source_is_dict = is_dict;
+#if !CYTHON_AVOID_BORROWED_REFS
+    if (is_dict) {
+        *p_orig_length = PyDict_Size(iterable);
+        Py_INCREF(iterable);
+        return iterable;
+    }
+#endif
+    *p_orig_length = 0;
+    if (method_name) {
+        iterable = __Pyx_dict_call_to_get_iterable(iterable, method_name);
+        if (unlikely(!iterable)) {
+            return NULL;
+        }
+    }
+    return PyObject_GetIter(iterable);
+}
+
+static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* iterable, int is_dict, PyObject* method_name,
+                                                          Py_ssize_t* p_orig_length, int* p_source_is_dict) {
+    int owned_method_name = 0;
+    // Don't include frozendict.
+    is_dict = is_dict || likely(PyDict_CheckExact(iterable));
     *p_source_is_dict = is_dict;
     if (is_dict) {
 #if !CYTHON_AVOID_BORROWED_REFS
@@ -330,10 +370,9 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
         Py_INCREF(iterable);
         return iterable;
 #else
-        // On PyPy3/GraalPy, we need to translate manually a few method names.
+        // On PyPy3/GraalPy, we need to translate manually the method name.
         // This logic is not needed on CPython thanks to the fast case above.
-        if (method_name && PyUnicode_GET_LENGTH(method_name) > 6) {
-            // This is enough to distinguish the "iter*" names from "items", "values", "keys".
+        if (method_name) {
             method_name = PyUnicode_Substring(method_name, 4, 10);  // longest is "itervalues" (len=10)
             if (unlikely(!method_name))
                 return NULL;
@@ -343,19 +382,13 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
     }
     *p_orig_length = 0;
     if (method_name) {
-        PyObject* iter;
-        iterable = __Pyx_PyObject_CallMethod0(iterable, method_name);
-        if (owned_method_name)
+        iterable = __Pyx_dict_call_to_get_iterable(iterable, method_name);
+        if (owned_method_name) {
             Py_DECREF(method_name);
-        if (!iterable)
+        }
+        if (unlikely(!iterable)) {
             return NULL;
-#if !CYTHON_AVOID_BORROWED_REFS
-        if (PyTuple_CheckExact(iterable) || PyList_CheckExact(iterable))
-            return iterable;
-#endif
-        iter = PyObject_GetIter(iterable);
-        Py_DECREF(iterable);
-        return iter;
+        }
     }
     return PyObject_GetIter(iterable);
 }

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -308,7 +308,7 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* dict, int is_dict, 
                                                    Py_ssize_t* p_orig_length, int* p_is_dict);
 // "legacy" handles old-style iter* methods
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* dict, int is_dict, PyObject* method_name,
-                                                   Py_ssize_t* p_orig_length, int* p_is_dict);
+                                                          Py_ssize_t* p_orig_length, int* p_is_dict);
 static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t orig_length, Py_ssize_t* ppos,
                                               PyObject** pkey, PyObject** pvalue, PyObject** pitem, int is_dict);
 
@@ -350,12 +350,10 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
 #endif
     *p_orig_length = 0;
     if (method_name) {
-        iterable = __Pyx_dict_call_to_get_iterable(iterable, method_name);
-        if (unlikely(!iterable)) {
-            return NULL;
-        }
+        return __Pyx_dict_call_to_get_iterable(iterable, method_name);
+    } else {
+        return PyObject_GetIter(iterable);
     }
-    return PyObject_GetIter(iterable);
 }
 
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* iterable, int is_dict, PyObject* method_name,
@@ -386,11 +384,10 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator_legacy(PyObject* iterable, in
         if (owned_method_name) {
             Py_DECREF(method_name);
         }
-        if (unlikely(!iterable)) {
-            return NULL;
-        }
-    }
+        return iterable;
+} else {
     return PyObject_GetIter(iterable);
+}
 }
 
 

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -331,17 +331,12 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_di
 #else
         // On PyPy3/GraalPy, we need to translate manually a few method names.
         // This logic is not needed on CPython thanks to the fast case above.
-        if (method_name) {
-            const char *name = PyUnicode_AsUTF8(method_name);
-            if (strncmp(name, "iter", 4) == 0 && (
-                    strcmp(name+4, "items") == 0 ||
-                    strcmp(name+4, "keys") == 0 ||
-                    strcmp(name+4, "values") == 0)) {
-                method_name = PyUnicode_FromString(name + 4);
-                if (unlikely(!method_name))
-                    return NULL;
-                owned_method_name = 1;
-            }
+        if (method_name && PyUnicode_GET_LENGTH(method_name) > 6) {
+            // This is enough to distinguish the "iter*" names from "items", "values", "keys".
+            method_name = PyUnicode_Substring(method_name, 4, 10);  // longest is "itervalues" (len=10)
+            if (unlikely(!method_name))
+                return NULL;
+            owned_method_name = 1;
         }
 #endif
     }

--- a/tests/run/iterdict.pyx
+++ b/tests/run/iterdict.pyx
@@ -1,6 +1,16 @@
 
 cimport cython
 
+import sys
+
+def skip_if_no_frozendict(f):
+    if sys.version_info >= (3, 15):
+        return f
+    return None
+
+
+__doc__ = ""
+
 dict_size = 4
 d = dict(zip(range(10,dict_size+10), range(dict_size)))
 fd = frozendict(d)
@@ -589,6 +599,60 @@ def iterfrozendict_listcomp(frozendict fd):
     cdef list l = [k for k in fd]
     l.sort()
     return l
+
+
+@skip_if_no_frozendict
+def frozendict_iteritems(frozendict fd):
+    """
+    >>> frozendict_iteritems(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: type object 'frozendict' has no attribute 'iteritems'
+    """
+    for k, v in fd.iteritems():
+        print(f"This really shouldn't happen: {k}, {v}")
+
+
+@skip_if_no_frozendict
+def frozendict_iterkeys(frozendict fd):
+    """
+    >>> frozendict_iterkeys(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: type object 'frozendict' has no attribute 'iterkeys'
+    """
+    for k, v in fd.iterkeys():
+        print(f"This really shouldn't happen: {k}, {v}")
+
+
+@skip_if_no_frozendict
+def frozendict_itervalues(frozendict fd):
+    """
+    >>> frozendict_itervalues(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: type object 'frozendict' has no attribute 'itervalues'
+    """
+    for k, v in fd.itervalues():
+        print(f"This really shouldn't happen: {k}, {v}")
+
+
+if sys.version_info >= (3, 15):
+    from textwrap import dedent
+    __doc__ += dedent("""
+    >>> optimistic_iteritems(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: 'frozendict' object has no attribute 'iteritems'
+    >>> optimistic_iterkeys(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: 'frozendict' object has no attribute 'iterkeys'
+    >>> optimistic_itervalues(fd)
+    Traceback (most recent call last):
+        ...
+    AttributeError: 'frozendict' object has no attribute 'itervalues'
+    """)
 
 
 cdef class NotADict:


### PR DESCRIPTION
My reasoning is: with module-state / freethreading, static storage in functions makes me increasingly unhappy. Neither of those apply to PyPy or GraalPy yet so it's more future-proofing. I also think the number of people using the Python 2 iteritems/iterkeys/itervalues is increasingly low, so I don't really care about caching a string for their speed.

Also refactor the string comparison a bit to try to skip the common chunks.