### PR TITLE
Don't trigger full CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,20 @@ on:
       - '!Demos/benchmarks/**'
       - '!.github/**'
       - '.github/workflows/ci.yml'
+      - '**/*.md'
+      - '**/*.rst'
+      - '!docs/**'
+      - 'docs/examples/**'
   pull_request:
     paths:
       - '**'
       - '!Demos/benchmarks/**'
       - '!.github/**'
       - '.github/workflows/ci.yml'
+      - '!**/*.md'
+      - '!**/*.rst'
+      - '!docs/**'
+      - 'docs/examples/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Exclude all markdown and rst files. Exclude the docs directory (but not docs/examples).