### PR TITLE
Try to fix GraalPy CI memory usage

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -2729,14 +2729,12 @@ def main():
             # Make sure subprocesses can print() Unicode text.
             os.environ["PYTHONIOENCODING"] = sys.stdout.encoding or sys.getdefaultencoding()
         from concurrent.futures import ProcessPoolExecutor, as_completed
-        pool = ProcessPoolExecutor(
-            options.shard_count,
-            # GraalPy seems to like using all the memory and crashing the GitHub workflow runner.
-            # This is a shot-in-the dark attempt to keep it down on the assumption that cleanup of
-            # Cython modules is poor. Because of this, always run the GraalPy tests in the executor
-            # even with -j1.
-            max_tasks_per_child=10 if IS_GRAAL else None
-        )
+        # GraalPy seems to like using all the memory and crashing the GitHub workflow runner.
+        # This is a shot-in-the dark attempt to keep it down on the assumption that cleanup of
+        # Cython modules is poor. Because of this, always run the GraalPy tests in the executor
+        # even with -j1.
+        executor_args = {'max_tasks_per_child': 10} if IS_GRAAL else {}
+        pool = ProcessPoolExecutor(options.shard_count, **executor_args)
         tasks = [(options, cmd_args, shard_num) for shard_num in range(options.shard_count)]
         open_shards = list(range(options.shard_count))
         error_shards = []

--- a/runtests.py
+++ b/runtests.py
@@ -1119,6 +1119,8 @@ class CythonCompileTestCase(unittest.TestCase):
         ]
         Options.warning_errors = self.warning_errors
 
+        gc.collect()
+
         os.makedirs(self.workdir, exist_ok=True)
         if self.workdir not in sys.path:
             sys.path.insert(0, self.workdir)
@@ -2722,12 +2724,19 @@ def main():
     else:
         keep_alive_interval = None
     setup_test_directory(options)
-    if options.shard_count > 1 and options.shard_num == -1:
+    if (options.shard_count > 1 or IS_GRAAL) and options.shard_num == -1:
         if "PYTHONIOENCODING" not in os.environ:
             # Make sure subprocesses can print() Unicode text.
             os.environ["PYTHONIOENCODING"] = sys.stdout.encoding or sys.getdefaultencoding()
         from concurrent.futures import ProcessPoolExecutor, as_completed
-        pool = ProcessPoolExecutor(options.shard_count)
+        pool = ProcessPoolExecutor(
+            options.shard_count,
+            # GraalPy seems to like using all the memory and crashing the GitHub workflow runner.
+            # This is a shot-in-the dark attempt to keep it down on the assumption that cleanup of
+            # Cython modules is poor. Because of this, always run the GraalPy tests in the executor
+            # even with -j1.
+            max_tasks_per_child=10 if IS_GRAAL else None
+        )
         tasks = [(options, cmd_args, shard_num) for shard_num in range(options.shard_count)]
         open_shards = list(range(options.shard_count))
         error_shards = []
@@ -2768,7 +2777,7 @@ def main():
             _, stats, merged_pipeline_stats, return_code, _ = runtests(options, cmd_args, coverage)
 
     if coverage:
-        if options.shard_count > 1 and options.shard_num == -1:
+        if (options.shard_count > 1 or IS_GRAAL) and options.shard_num == -1:
             coverage.combine()
         coverage.stop()
 


### PR DESCRIPTION
We're seeing periodic test failures of the GraalPy run with

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

I don't really know what's causing it, but my initial assumption is memory.

The is an uninformed attempt to fix that. To do so I've:
* force the GC to run before each compilation. (We already force it after each "run" test, but let's assume that cleaning up after the Cython compilation might be the problem here).
* Make the `ProcessPoolExecutor` periodically restart the processes (on the assumption that we're gradually accumulating memory leaks somewhere).

I've got no idea if this will work but it at least seems worth a try.