### PR TITLE
Avoid cleanup of unused temp in function call

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7136,7 +7136,8 @@ class PyMethodCallNode(CallNode):
 
         # Clean up.
 
-        code.put_xdecref_clear(self_arg, py_object_type)
+        if self.unpack:
+            code.put_xdecref_clear(self_arg, py_object_type)
         for tmp in [self_arg, space_for_selfarg]:
             code.funcstate.release_temp(tmp)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7136,7 +7136,7 @@ class PyMethodCallNode(CallNode):
 
         # Clean up.
 
-        if self.unpack:
+        if self.unpack or self.use_method_vectorcall:
             code.put_xdecref_clear(self_arg, py_object_type)
         for tmp in [self_arg, space_for_selfarg]:
             code.funcstate.release_temp(tmp)


### PR DESCRIPTION
At the moment this only really affects calls to builtin functions (since for most other cases Cython does generate unpacking code). Practically it probably only makes a difference in the Limited API (where DECREF is opaque).

Before

```
  __pyx_t_2 = NULL;
  __pyx_t_3 = 1;
  {
    PyObject *__pyx_callargs[2] = {__pyx_t_2, __pyx_v_a};
    __pyx_t_1 = __Pyx_PyObject_FastCall((PyObject*)__pyx_builtin_property, __pyx_callargs+__pyx_t_3, (2-__pyx_t_3) | (__pyx_t_3*__Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET));
    __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 4, __pyx_L1_error)
    __Pyx_GOTREF(__pyx_t_1);
  }
```

After

```
__pyx_t_2 = NULL;
  __pyx_t_3 = 1;
  {
    PyObject *__pyx_callargs[2] = {__pyx_t_2, __pyx_v_a};
    __pyx_t_1 = __Pyx_PyObject_FastCall((PyObject*)__pyx_builtin_property, __pyx_callargs+__pyx_t_3, (2-__pyx_t_3) | (__pyx_t_3*__Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET));
    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 4, __pyx_L1_error)
    __Pyx_GOTREF(__pyx_t_1);
  }
```

The difference is to `__pyx_t_2`