### PR TITLE
Add missing inputs for ci-job.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,12 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       backend: ${{ matrix.backend }}
+      limited_api: ${{ matrix.limited_api }}
+      # shared_utility - not used in this matrix
+      gcc_version: ${{ matrix.gcc_version }}
+      extra_cflags: ${{ matrix.extra_cflags }}
+      cython_compile_all: ${{ matrix.cython_compile_all }}
+      no_cython_compile: ${{ matrix.no_cython_compile }}
       extra_hash: ${{ matrix.extra_hash }}
 
 


### PR DESCRIPTION
They were in the matrix but weren't being passed to ci-job so weren't doing anything.