### PR TITLE
Extend `dict` optimisations to `frozendict`

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -15109,7 +15109,7 @@ class CoerceToBooleanNode(CoercionNode):
             return '__Pyx_PyTuple_GET_SIZE'
         if typ.is_pyset_type or typ.is_pyfrozenset_type:
             return '__Pyx_PySet_GET_SIZE'
-        if typ.is_pydict_type or typ.is_pyfrozendict_type:
+        if typ.is_pyanydict_type:
             return '__Pyx_PyDict_GET_SIZE'
         if typ.is_pybytes_type:
             return '__Pyx_PyBytes_GET_SIZE'

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7727,9 +7727,11 @@ class MergedDictNode(ExprNode):
         args = iter(self.keyword_args)
         item = next(args)
         item.generate_evaluation_code(code)
-        if not item.type.is_pydict_type:
+        if not item.type.is_pyanydict_type:
             # CPython supports calling functions with non-dicts, so do we
-            code.putln('if (likely(PyDict_CheckExact(%s))) {' %
+            code.globalstate.use_utility_code(UtilityCode.load_cached(
+                "PyFrozenDict", "Builtins.c"))
+            code.putln('if (likely(__Pyx_PyAnyDict_CheckExact(%s))) {' %
                        item.py_result())
 
         if item.is_dict_literal:
@@ -7757,7 +7759,7 @@ class MergedDictNode(ExprNode):
             if item.result_in_temp():
                 code.putln("}")
 
-        if not item.type.is_pydict_type:
+        if not item.type.is_pyanydict_type:
             code.putln('} else {')
             code.globalstate.use_utility_code(UtilityCode.load_cached(
                 "PyObjectCallOneArg", "ObjectHandling.c"))

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4448,14 +4448,14 @@ class IndexNode(_IndexingBaseNode):
 
     def analyse_as_pyobject(self, env, is_slice, getting, setting):
         base_type = self.base.type
-        if self.index.type.is_unicode_char and not base_type.is_pydict_type:
+        if self.index.type.is_unicode_char and not base_type.is_pyanydict_type:
             # TODO: eventually fold into case below and remove warning, once people have adapted their code
             warning(self.pos,
                     "Item lookup of unicode character codes now always converts to a Unicode string. "
                     "Use an explicit C integer cast to get back the previous integer lookup behaviour.", level=1)
             self.index = self.index.coerce_to_pyobject(env)
             self.is_temp = 1
-        elif self.index.type.is_int and not base_type.is_pydict_type:
+        elif self.index.type.is_int and not base_type.is_pyanydict_type:
             if (getting
                     and not env.directives['boundscheck']
                     and (base_type.is_pybytearray_type or base_type.is_pylist_type or base_type.is_pytuple_type)
@@ -4494,7 +4494,7 @@ class IndexNode(_IndexingBaseNode):
                 # Infer homogeneous item type when looping over container literals.
                 item_type = infer_sequence_item_type(env, self.base, seq_type=base_type)
 
-            if base_type.is_pylist_type or base_type.is_pytuple_type or base_type.is_pydict_type:
+            if base_type.is_pylist_type or base_type.is_pytuple_type or base_type.is_pyanydict_type:
                 # Do the None check explicitly (not in a helper, and regardless of 'nonecheck') to allow optimising it away.
                 self.base = self.base.as_none_safe_node("'NoneType' object is not subscriptable")
 
@@ -4831,7 +4831,7 @@ class IndexNode(_IndexingBaseNode):
                     function = "__Pyx_GetItemInt"
                 utility_code = TempitaUtilityCode.load_cached("GetItemInt", "ObjectHandling.c")
             else:
-                if base_type.is_pydict_type:
+                if base_type.is_pyanydict_type:
                     function = "__Pyx_PyDict_GetItem"
                     utility_code = UtilityCode.load_cached("DictGetItem", "ObjectHandling.c")
                 elif base_type is py_object_type and self.index.type.is_pystr_type:
@@ -10101,7 +10101,7 @@ class SortedDictKeysNode(ExprNode):
 
     def analyse_types(self, env):
         arg = self.arg.analyse_types(env)
-        if arg.type.is_pydict_type:
+        if arg.type.is_pyanydict_type:
             arg = arg.as_none_safe_node(
                 "'NoneType' object is not iterable")
         self.arg = arg
@@ -10112,7 +10112,7 @@ class SortedDictKeysNode(ExprNode):
 
     def generate_result_code(self, code):
         dict_result = self.arg.py_result()
-        if self.arg.type.is_pydict_type:
+        if self.arg.type.is_pyanydict_type:
             code.putln('%s = PyDict_Keys(%s); %s' % (
                 self.result(), dict_result,
                 code.error_goto_if_null(self.result(), self.pos)))

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14085,7 +14085,7 @@ class CmpNode:
                          _) = result
                         return True
         elif self.operator in ('in', 'not_in'):
-            if self.operand2.type.is_pydict_type:
+            if self.operand2.type.is_pyanydict_type:
                 self.operand2 = self.operand2.as_none_safe_node("'NoneType' object is not iterable")
                 self.special_bool_cmp_utility_code = UtilityCode.load_cached("PyDictContains", "ObjectHandling.c")
                 self.special_bool_cmp_function = "__Pyx_PyDict_ContainsTF"
@@ -14565,7 +14565,7 @@ class CascadedCmpNode(Node, CmpNode):
 
     def coerce_operands_to_pyobjects(self, env):
         self.operand2 = self.operand2.coerce_to_pyobject(env)
-        if self.operand2.type.is_pydict_type and self.operator in ('in', 'not_in'):
+        if self.operand2.type.is_pyanydict_type and self.operator in ('in', 'not_in'):
             self.operand2 = self.operand2.as_none_safe_node("'NoneType' object is not iterable")
         if self.cascade:
             self.cascade.coerce_operands_to_pyobjects(env)

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2588,7 +2588,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
 
     PyDict_Copy_func_type = PyrexTypes.CFuncType(
         Builtin.dict_type, [
-            PyrexTypes.CFuncTypeArg("dict", Builtin.dict_type, None)
+            PyrexTypes.CFuncTypeArg("dict", PyrexTypes.py_object_type, None)
             ])
 
     def _handle_simple_function_dict(self, node, function, pos_args):
@@ -2597,7 +2597,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
         if len(pos_args) != 1:
             return node
         arg = pos_args[0]
-        if arg.type.is_pydict_type:
+        if arg.type.is_pyanydict_type:
             arg = arg.as_none_safe_node("'NoneType' is not iterable")
             return ExprNodes.PythonCapiCallNode(
                 node.pos, "PyDict_Copy", self.PyDict_Copy_func_type,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -224,7 +224,7 @@ class IterationTransform(Visitor.EnvTransform):
             if annotation.is_subscript:
                 annotation = annotation.base  # container base type
 
-        if iterable.type.is_pydict_type:
+        if iterable.type.is_pyanydict_type:
             # like iterating over dict.keys()
             if reversed:
                 # CPython raises an error here: not a sequence
@@ -1140,7 +1140,7 @@ class IterationTransform(Visitor.EnvTransform):
             method_node = ExprNodes.NullNode(dict_obj.pos)
             dict_obj = dict_obj.as_none_safe_node("'NoneType' object is not iterable")
 
-        is_dict = ExprNodes.IntNode.for_int(node.pos, int(dict_obj.type.is_pydict_type))
+        is_dict = ExprNodes.IntNode.for_int(node.pos, int(dict_obj.type.is_pyanydict_type))
 
         result_code = [
             Nodes.SingleAssignmentNode(
@@ -2878,6 +2878,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
         Builtin.set_type:        "__Pyx_PySet_GET_SIZE",
         Builtin.frozenset_type:  "__Pyx_PySet_GET_SIZE",
         Builtin.dict_type:       "PyDict_Size",
+        Builtin.frozendict_type: "PyDict_Size",
     }.get
 
     _ext_types_with_pysize = {"cpython.array.array"}
@@ -3406,6 +3407,11 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             'get', is_unbound_method, args,
             may_return_none = True,
             utility_code = load_c_utility("dict_getitem_default"))
+
+    # frozendict shares the read-only method handlers with dict.
+    # Mutating handlers (pop, setdefault) are intentionally NOT aliased:
+    # frozendict has no such methods, and we want those calls to fail loud.
+    _handle_simple_method_frozendict_get = _handle_simple_method_dict_get
 
     Pyx_PyDict_SetDefault_func_type = PyrexTypes.CFuncType(
         PyrexTypes.py_object_type, [

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -297,6 +297,7 @@ class PyrexType(BaseType):
     is_pylist_type = False
     is_pydict_type = False
     is_pyfrozendict_type = False
+    is_pyanydict_type = False
     is_pyset_type = False
     is_pyfrozenset_type = False
 
@@ -1520,8 +1521,8 @@ class BuiltinObjectType(PyObjectType):
         'bool': ['is_pybool_type'],
         'complex': ['is_pycomplex_type'],
         'list': ['is_pylist_type', 'is_builtin_sequence', 'supports_container_type'],
-        'dict': ['is_pydict_type', 'supports_container_type'],
-        'frozendict': ['is_pyfrozendict_type', 'supports_container_type'],
+        'dict': ['is_pydict_type', 'is_pyanydict_type', 'supports_container_type'],
+        'frozendict': ['is_pyfrozendict_type', 'is_pyanydict_type', 'supports_container_type'],
         'set': ['is_pyset_type', 'supports_container_type'],
         'tuple': ['is_pytuple_type', 'is_builtin_sequence'],
         'frozenset': ['is_pyfrozenset_type', 'supports_container_type'],

--- a/Cython/Compiler/Tests/TestTypes.py
+++ b/Cython/Compiler/Tests/TestTypes.py
@@ -28,6 +28,7 @@ class TestBuiltinTypes(TimedTest):
         'is_pylist_type': ['list'],
         'is_pydict_type': ['dict'],
         'is_pyfrozendict_type': ['frozendict'],
+        'is_pyanydict_type': ['dict', 'frozendict'],
         'is_pyset_type': ['set'],
         'is_pytuple_type': ['tuple'],
         'is_pyfrozenset_type': ['frozenset'],

--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -756,6 +756,7 @@ static int __Pyx_MergeKeywords(PyObject *kwdict, PyObject *source_mapping); /*pr
 //@requires: Optimize.c::dict_iter
 //@requires: ObjectHandling.c::OwnedDictNext
 //@requires: Synchronization.c::CriticalSections
+//@requires: Builtins.c::PyFrozenDict
 
 static int __Pyx_MergeKeywords_dict(PyObject *kwdict, PyObject *source_dict) {
     Py_ssize_t len1, len2;
@@ -879,7 +880,7 @@ bad:
 
 static CYTHON_INLINE int __Pyx_MergeKeywords(PyObject *kwdict, PyObject *source_mapping) {
     assert(PyDict_Check(kwdict));
-    if (likely(PyDict_Check(source_mapping))) {
+    if (likely(__Pyx_PyAnyDict_Check(source_mapping))) {
         return __Pyx_MergeKeywords_dict(kwdict, source_mapping);
     } else {
         return __Pyx_MergeKeywords_any(kwdict, source_mapping);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -397,12 +397,15 @@ static PyObject *__Pyx_PyObject_GetItem(PyObject *obj, PyObject *key) {
 
 
 /////////////// DictGetItem.proto ///////////////
+//@requires: Builtins.c::PyFrozenDict
 
 #if !CYTHON_COMPILING_IN_PYPY
 static PyObject *__Pyx_PyDict_GetItem(PyObject *d, PyObject* key);/*proto*/
 
+// `PyDict_GetItem` accepts any dict subclass at the C level, so frozendict
+// (which is a true dict subclass on Python 3.15+) takes the fast path here too.
 #define __Pyx_PyObject_Dict_GetItem(obj, name) \
-    (likely(PyDict_CheckExact(obj)) ? \
+    (likely(__Pyx_PyAnyDict_CheckExact(obj)) ? \
      __Pyx_PyDict_GetItem(obj, name) : PyObject_GetItem(obj, name))
 
 #else
@@ -485,6 +488,7 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i,
 /////////////// GetItemInt ///////////////
 //@substitute: tempita
 //@requires: GettItemInt_wraparound
+//@requires: Builtins.c::PyFrozenDict
 
 static PyObject *__Pyx_GetItemInt_Generic(PyObject *o, PyObject* j) {
     PyObject *r;
@@ -551,7 +555,8 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i,
 #endif
 #if CYTHON_USE_TYPE_SLOTS && !CYTHON_COMPILING_IN_PYPY
     // This dict check is so cheap after the other type checks above that it would be costly *not* to do it.
-    if (PyDict_CheckExact(o)) {
+    // Frozendict shares dict's mp_subscript layout, so the same fast path applies.
+    if (__Pyx_PyAnyDict_CheckExact(o)) {
         return __Pyx_GetItemInt_Fast_mapping(o, PyDict_Type.tp_as_mapping->mp_subscript, i);
     } else
     {

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -402,8 +402,6 @@ static PyObject *__Pyx_PyObject_GetItem(PyObject *obj, PyObject *key) {
 #if !CYTHON_COMPILING_IN_PYPY
 static PyObject *__Pyx_PyDict_GetItem(PyObject *d, PyObject* key);/*proto*/
 
-// `PyDict_GetItem` accepts any dict subclass at the C level, so frozendict
-// (which is a true dict subclass on Python 3.15+) takes the fast path here too.
 #define __Pyx_PyObject_Dict_GetItem(obj, name) \
     (likely(__Pyx_PyAnyDict_CheckExact(obj)) ? \
      __Pyx_PyDict_GetItem(obj, name) : PyObject_GetItem(obj, name))
@@ -555,7 +553,6 @@ static CYTHON_INLINE PyObject *__Pyx_GetItemInt_Fast(PyObject *o, Py_ssize_t i,
 #endif
 #if CYTHON_USE_TYPE_SLOTS && !CYTHON_COMPILING_IN_PYPY
     // This dict check is so cheap after the other type checks above that it would be costly *not* to do it.
-    // Frozendict shares dict's mp_subscript layout, so the same fast path applies.
     if (__Pyx_PyAnyDict_CheckExact(o)) {
         return __Pyx_GetItemInt_Fast_mapping(o, PyDict_Type.tp_as_mapping->mp_subscript, i);
     } else

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -313,6 +313,7 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 //@requires: ObjectHandling.c::UnpackTuple2
 //@requires: ObjectHandling.c::IterFinish
 //@requires: ObjectHandling.c::PyObjectCallMethod0
+//@requires: Builtins.c::PyFrozenDict
 
 #if CYTHON_AVOID_BORROWED_REFS
 #include <string.h>
@@ -320,7 +321,7 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
                                                    Py_ssize_t* p_orig_length, int* p_source_is_dict) {
-    is_dict = is_dict || likely(PyDict_CheckExact(iterable));
+    is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable));
     *p_source_is_dict = is_dict;
     if (is_dict) {
 #if !CYTHON_AVOID_BORROWED_REFS

--- a/tests/run/assigned_builtin_methods.pyx
+++ b/tests/run/assigned_builtin_methods.pyx
@@ -3,6 +3,10 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
 @cython.test_assert_path_exists(
     '//ReturnStatNode//PythonCapiCallNode')
 def unbound_dict_get(d):
@@ -39,6 +43,18 @@ def bound_dict_get_reassign(dict d):
     """
     get = d.get
     d = {1: 3}
+    return get(1)
+
+
+@cython.test_assert_path_exists(
+    '//ReturnStatNode//PythonCapiCallNode')
+def bound_frozendict_get(frozendict fd):
+    """
+    >>> bound_frozendict_get(make_frozendict({}))
+    >>> bound_frozendict_get(make_frozendict({1:2}))
+    2
+    """
+    get = fd.get
     return get(1)
 
 

--- a/tests/run/builtin_len.pyx
+++ b/tests/run/builtin_len.pyx
@@ -8,6 +8,10 @@ bytes_str   = b'ab jd  sdflk as sa  sadas asdas fsdf '
 _frozenset = frozenset
 _set = set
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
 @cython.test_assert_path_exists(
     "//CoerceToPyTypeNode",
     "//PythonCapiCallNode")
@@ -96,6 +100,20 @@ def len_dict(dict s):
     >>> len_dict(d)
     4
     >>> len_dict(None)
+    Traceback (most recent call last):
+    TypeError: object of type 'NoneType' has no len()
+    """
+    return len(s)
+
+@cython.test_assert_path_exists(
+    "//CoerceToPyTypeNode",
+    "//PythonCapiCallNode")
+def len_frozendict(frozendict s):
+    """
+    >>> fd = make_frozendict(dict(a=1, b=2, c=3, d=4))
+    >>> len_frozendict(fd)
+    4
+    >>> len_frozendict(None)
     Traceback (most recent call last):
     TypeError: object of type 'NoneType' has no len()
     """

--- a/tests/run/callargs.pyx
+++ b/tests/run/callargs.pyx
@@ -160,6 +160,7 @@ def h(a, b, c, *args, **kwargs):
 
 args = (9,8,7)
 kwargs = {u"test" : u"toast"}
+frozen_kwargs = frozendict({u"test" : u"toast"})
 
 def test_kw_args(f):
     """
@@ -184,6 +185,30 @@ def test_kw_args(f):
     f(1,2, d=3, *args, **kwargs)
     f(1,2, d=3, *args, e=5)
     f(1,2, d=3, *args, e=5, **kwargs)
+
+def test_kw_args_frozendict(f):
+    """
+    >>> test_kw_args_frozendict(h)
+    1 2 3 * 0 0
+    1 2 9 * 2 1
+    1 2 7 * 2 1
+    1 2 9 * 2 2
+    1 2 9 * 2 2
+    1 2 9 * 2 3
+    >>> test_kw_args_frozendict(e)
+    2 1
+    5 1
+    5 1
+    5 2
+    5 2
+    5 3
+    """
+    f(1,2, c=3)
+    f(1,2, d=3, *args)
+    f(1,2, d=3, *(7,8,9))
+    f(1,2, d=3, *args, **frozen_kwargs)
+    f(1,2, d=3, *args, e=5)
+    f(1,2, d=3, *args, e=5, **frozen_kwargs)
 
 def test_pos_args(f):
     """
@@ -223,6 +248,24 @@ def test_kw(f):
     f(d=3, e=5)
     f(d=3, **kwargs)
     f(**kwargs)
+
+def test_kw_frozendict(f):
+    """
+    >>> test_kw_frozendict(e)
+    0 1
+    0 2
+    0 2
+    0 1
+    >>> test_kw_frozendict(g)
+    1
+    2
+    2
+    1
+    """
+    f(c=3)
+    f(d=3, e=5)
+    f(d=3, **frozen_kwargs)
+    f(**frozen_kwargs)
 
 def test_noargs(f):
     """

--- a/tests/run/callargs.pyx
+++ b/tests/run/callargs.pyx
@@ -170,6 +170,8 @@ def test_kw_args(f):
     1 2 7 * 2 1
     1 2 9 * 2 2
     1 2 9 * 2 2
+    1 2 9 * 2 2
+    1 2 9 * 2 3
     1 2 9 * 2 3
     >>> test_kw_args(e)
     2 1
@@ -177,37 +179,17 @@ def test_kw_args(f):
     5 1
     5 2
     5 2
+    5 2
+    5 3
     5 3
     """
     f(1,2, c=3)
     f(1,2, d=3, *args)
     f(1,2, d=3, *(7,8,9))
     f(1,2, d=3, *args, **kwargs)
-    f(1,2, d=3, *args, e=5)
-    f(1,2, d=3, *args, e=5, **kwargs)
-
-def test_kw_args_frozendict(f):
-    """
-    >>> test_kw_args_frozendict(h)
-    1 2 3 * 0 0
-    1 2 9 * 2 1
-    1 2 7 * 2 1
-    1 2 9 * 2 2
-    1 2 9 * 2 2
-    1 2 9 * 2 3
-    >>> test_kw_args_frozendict(e)
-    2 1
-    5 1
-    5 1
-    5 2
-    5 2
-    5 3
-    """
-    f(1,2, c=3)
-    f(1,2, d=3, *args)
-    f(1,2, d=3, *(7,8,9))
     f(1,2, d=3, *args, **frozen_kwargs)
     f(1,2, d=3, *args, e=5)
+    f(1,2, d=3, *args, e=5, **kwargs)
     f(1,2, d=3, *args, e=5, **frozen_kwargs)
 
 def test_pos_args(f):
@@ -238,9 +220,13 @@ def test_kw(f):
     0 2
     0 2
     0 1
+    0 2
+    0 1
     >>> test_kw(g)
     1
     2
+    2
+    1
     2
     1
     """
@@ -248,22 +234,6 @@ def test_kw(f):
     f(d=3, e=5)
     f(d=3, **kwargs)
     f(**kwargs)
-
-def test_kw_frozendict(f):
-    """
-    >>> test_kw_frozendict(e)
-    0 1
-    0 2
-    0 2
-    0 1
-    >>> test_kw_frozendict(g)
-    1
-    2
-    2
-    1
-    """
-    f(c=3)
-    f(d=3, e=5)
     f(d=3, **frozen_kwargs)
     f(**frozen_kwargs)
 

--- a/tests/run/dict.pyx
+++ b/tests/run/dict.pyx
@@ -1,10 +1,5 @@
 # mode: run
 
-
-def make_frozendict(d):
-    return frozendict(d)
-
-
 def empty():
     """
     >>> empty()
@@ -182,19 +177,3 @@ def from_keys_bound(dict d, val):
         return d.fromkeys(("a", "b"), val)
     else:
         return d.fromkeys(("a", "b"))
-
-
-def from_keys_bound_frozendict(frozendict fd, val):
-    """
-    Mirror of `from_keys_bound` for frozendict, exercising bound classmethod
-    optimization on a frozendict-typed receiver.
-
-    >>> sorted(from_keys_bound_frozendict(make_frozendict({}), 100).items())
-    [('a', 100), ('b', 100)]
-    >>> sorted(from_keys_bound_frozendict(make_frozendict({}), None).items())
-    [('a', None), ('b', None)]
-    """
-    if val is not None:
-        return fd.fromkeys(("a", "b"), val)
-    else:
-        return fd.fromkeys(("a", "b"))

--- a/tests/run/dict.pyx
+++ b/tests/run/dict.pyx
@@ -1,5 +1,10 @@
 # mode: run
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def empty():
     """
     >>> empty()
@@ -177,3 +182,19 @@ def from_keys_bound(dict d, val):
         return d.fromkeys(("a", "b"), val)
     else:
         return d.fromkeys(("a", "b"))
+
+
+def from_keys_bound_frozendict(frozendict fd, val):
+    """
+    Mirror of `from_keys_bound` for frozendict, exercising bound classmethod
+    optimization on a frozendict-typed receiver.
+
+    >>> sorted(from_keys_bound_frozendict(make_frozendict({}), 100).items())
+    [('a', 100), ('b', 100)]
+    >>> sorted(from_keys_bound_frozendict(make_frozendict({}), None).items())
+    [('a', None), ('b', None)]
+    """
+    if val is not None:
+        return fd.fromkeys(("a", "b"), val)
+    else:
+        return fd.fromkeys(("a", "b"))

--- a/tests/run/dict_get.pyx
+++ b/tests/run/dict_get.pyx
@@ -1,6 +1,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 @cython.test_assert_path_exists("//PythonCapiCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def get(dict d, key):
@@ -88,3 +93,45 @@ def get_in_condition(dict d, key, expected_result):
     True
     """
     return d.get(key) is expected_result or d.get(key) == expected_result
+
+
+@cython.test_assert_path_exists("//PythonCapiCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def get_frozendict(frozendict fd, key):
+    """
+    >>> fd = make_frozendict({1: 10})
+    >>> get_frozendict(fd, 1)
+    10
+    >>> get_frozendict(fd, 2) is None
+    True
+    >>> get_frozendict(fd, (1, 2)) is None
+    True
+
+    >>> class Unhashable:
+    ...    def __hash__(self):
+    ...        raise ValueError
+    >>> get_frozendict(fd, Unhashable())
+    Traceback (most recent call last):
+    ValueError
+
+    >>> get_frozendict(None, 1)
+    Traceback (most recent call last):
+    ...
+    AttributeError: 'NoneType' object has no attribute 'get'
+    """
+    return fd.get(key)
+
+
+@cython.test_assert_path_exists("//PythonCapiCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def get_default_frozendict(frozendict fd, key, default):
+    """
+    >>> fd = make_frozendict({1: 10})
+    >>> get_default_frozendict(fd, 1, 2)
+    10
+    >>> get_default_frozendict(fd, 2, 2)
+    2
+    >>> get_default_frozendict(fd, (1, 2), 2)
+    2
+    """
+    return fd.get(key, default)

--- a/tests/run/dict_getitem.pyx
+++ b/tests/run/dict_getitem.pyx
@@ -3,6 +3,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def test(dict d, index):
     """
     >>> d = { 1: 10 }
@@ -158,3 +163,45 @@ def getitem_int_key(d, int key):
     """
     # Based on GH-1807: must check Mapping protocol first, even for integer "index" keys.
     return d[key]
+
+
+def getitem_frozendict(frozendict fd, index):
+    """
+    >>> fd = make_frozendict({1: 10})
+    >>> getitem_frozendict(fd, 1)
+    10
+
+    >>> getitem_frozendict(fd, 2)
+    Traceback (most recent call last):
+    KeyError: 2
+
+    >>> getitem_frozendict(fd, (1, 2))
+    Traceback (most recent call last):
+    KeyError: (1, 2)
+
+    >>> class Unhashable:
+    ...    def __hash__(self):
+    ...        raise ValueError
+    >>> getitem_frozendict(fd, Unhashable())
+    Traceback (most recent call last):
+    ValueError
+
+    >>> getitem_frozendict(None, 1) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...object...
+    """
+    return fd[index]
+
+
+@cython.test_fail_if_path_exists('//NoneCheckNode')
+def getitem_frozendict_not_none(frozendict fd not None, key):
+    """
+    >>> fd = make_frozendict({1: 10})
+    >>> getitem_frozendict_not_none(fd, 1)
+    10
+
+    >>> getitem_frozendict_not_none(fd, 2)
+    Traceback (most recent call last):
+    KeyError: 2
+    """
+    return fd[key]

--- a/tests/run/dict_iter_unpack.pyx
+++ b/tests/run/dict_iter_unpack.pyx
@@ -1,6 +1,11 @@
 # mode: run
 # tag: dictiter
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def iteritems_unpack(dict the_dict):
     """
     >>> d = {(1,2): (3,4), (5,6): (7,8)}
@@ -16,3 +21,21 @@ def itervalues_unpack(dict the_dict):
     [(3, 4), (7, 8)]
     """
     return [(a,b) for a,b in the_dict.itervalues() ]
+
+
+def iteritems_unpack_frozendict(frozendict the_fd):
+    """
+    >>> fd = make_frozendict({(1,2): (3,4), (5,6): (7,8)})
+    >>> iteritems_unpack_frozendict(fd)
+    [(1, 2, 3, 4), (5, 6, 7, 8)]
+    """
+    return sorted([ (a,b,c,d) for (a,b), (c,d) in the_fd.items() ])
+
+
+def itervalues_unpack_frozendict(frozendict the_fd):
+    """
+    >>> fd = make_frozendict({1: (3,4), 2: (7,8)})
+    >>> itervalues_unpack_frozendict(fd)
+    [(3, 4), (7, 8)]
+    """
+    return [(a,b) for a,b in the_fd.values() ]

--- a/tests/run/dict_pop.pyx
+++ b/tests/run/dict_pop.pyx
@@ -3,6 +3,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 class FailHash:
     def __hash__(self):
         raise TypeError()
@@ -91,3 +96,22 @@ def dict_pop_default_typed(dict d, key, default):
     """
     cdef MyType x = d.pop(key, default)
     return x.i if x is not None else None
+
+
+def pop_frozendict(frozendict fd, key):
+    """
+    Confirms that frozendict has no `pop` method (deliberately not aliased
+    in the compiler-side method-handler dispatch — frozendict is immutable).
+    On Python <3.15, `frozendict` falls back to plain `dict` which DOES have
+    `pop`, so we only assert the raise on supported Pythons.
+
+    >>> import sys
+    >>> if sys.version_info >= (3, 15, 0, 'alpha', 7):
+    ...     try: pop_frozendict(make_frozendict({1: 10}), 1)
+    ...     except AttributeError: print("AttributeError")
+    ...     else: print("no error")
+    ... else:
+    ...     print("AttributeError")
+    AttributeError
+    """
+    return fd.pop(key)

--- a/tests/run/dictintindex.pyx
+++ b/tests/run/dictintindex.pyx
@@ -1,3 +1,7 @@
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def test_get_char_neg():
     """
     >>> test_get_char_neg()
@@ -243,3 +247,45 @@ def test_del_ulonglong_big():
     d = {big<<shift:1}
     del d[key]
     return d[key]
+
+
+def test_get_char_frozendict():
+    """
+    >>> test_get_char_frozendict()
+    1
+    """
+    cdef char key = 0
+    cdef frozendict fd = make_frozendict({0: 1})
+    return fd[key]
+
+
+def test_get_int_frozendict():
+    """
+    >>> test_get_int_frozendict()
+    2
+    """
+    cdef int key = 1
+    cdef frozendict fd = make_frozendict({1: 2})
+    return fd[key]
+
+
+def test_get_longlong_frozendict():
+    """
+    >>> test_get_longlong_frozendict()
+    3
+    """
+    cdef long long key = -1
+    cdef frozendict fd = make_frozendict({-1: 3})
+    return fd[key]
+
+
+def test_get_ulonglong_big_frozendict():
+    """
+    >>> test_get_ulonglong_big_frozendict()
+    4
+    """
+    cdef unsigned int shift = sizeof(long)+2
+    cdef unsigned long long big = 1
+    cdef unsigned long long key = big<<shift
+    cdef frozendict fd = make_frozendict({big<<shift: 4})
+    return fd[key]

--- a/tests/run/dictintindex.pyx
+++ b/tests/run/dictintindex.pyx
@@ -1,7 +1,3 @@
-def make_frozendict(d):
-    return frozendict(d)
-
-
 def test_get_char_neg():
     """
     >>> test_get_char_neg()
@@ -255,7 +251,7 @@ def test_get_char_frozendict():
     1
     """
     cdef char key = 0
-    cdef frozendict fd = make_frozendict({0: 1})
+    fd = frozendict({0: 1})
     return fd[key]
 
 
@@ -265,7 +261,7 @@ def test_get_int_frozendict():
     2
     """
     cdef int key = 1
-    cdef frozendict fd = make_frozendict({1: 2})
+    fd = frozendict({1: 2})
     return fd[key]
 
 
@@ -275,7 +271,7 @@ def test_get_longlong_frozendict():
     3
     """
     cdef long long key = -1
-    cdef frozendict fd = make_frozendict({-1: 3})
+    fd = frozendict({-1: 3})
     return fd[key]
 
 
@@ -287,5 +283,5 @@ def test_get_ulonglong_big_frozendict():
     cdef unsigned int shift = sizeof(long)+2
     cdef unsigned long long big = 1
     cdef unsigned long long key = big<<shift
-    cdef frozendict fd = make_frozendict({big<<shift: 4})
+    fd = frozendict({big<<shift: 4})
     return fd[key]

--- a/tests/run/enumerate_T316.pyx
+++ b/tests/run/enumerate_T316.pyx
@@ -2,6 +2,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 @cython.test_fail_if_path_exists("//SimpleCallNode//NameNode[@name = 'enumerate']")
 def go_py_enumerate():
     """
@@ -93,6 +98,25 @@ def py_enumerate_dict(dict d):
     k = 99
     keys = list(d.keys())
     for i,k in enumerate(d):
+        k = keys[i] == k
+        print i, k
+    print u"::", i, k
+
+@cython.test_fail_if_path_exists("//SimpleCallNode//NameNode[@name = 'enumerate']")
+def py_enumerate_frozendict(frozendict fd):
+    """
+    >>> py_enumerate_frozendict(make_frozendict({}))
+    :: 55 99
+    >>> py_enumerate_frozendict(make_frozendict(dict(a=1, b=2, c=3)))
+    0 True
+    1 True
+    2 True
+    :: 2 True
+    """
+    cdef int i = 55
+    k = 99
+    keys = list(fd.keys())
+    for i,k in enumerate(fd):
         k = keys[i] == k
         print i, k
     print u"::", i, k

--- a/tests/run/frozendict.pyx
+++ b/tests/run/frozendict.pyx
@@ -114,3 +114,21 @@ def py315_really_has_frozendict():
     >>>
     """
     return frozendict(), frozendict({'a': 5})
+
+
+empty_fd = frozendict()
+
+
+def from_keys_bound(frozendict fd, val):
+    """
+    https://github.com/cython/cython/issues/5051
+    Optimization of bound method calls was breaking classmethods
+    >>> sorted(from_keys_bound(empty_fd, 100).items())
+    [('a', 100), ('b', 100)]
+    >>> sorted(from_keys_bound(empty_fd, None).items())
+    [('a', None), ('b', None)]
+    """
+    if val is not None:
+        return fd.fromkeys(("a", "b"), val)
+    else:
+        return fd.fromkeys(("a", "b"))

--- a/tests/run/frozendict.pyx
+++ b/tests/run/frozendict.pyx
@@ -42,6 +42,19 @@ def frozendict_call_frozendict():
     return d
 
 
+def dict_call_frozendict():
+    """
+    >>> print(dict_call_frozendict()['parrot'])
+    resting
+    >>> print(dict_call_frozendict()['answer'])
+    42
+    >>> type(dict_call_frozendict()).__name__
+    'dict'
+    """
+    d = dict(frozendict(parrot=u"resting", answer=42))
+    return d
+
+
 def frozendict_call_kwargs():
     """
     >>> print(frozendict_call_kwargs()['parrot1'])

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -1,11 +1,6 @@
 
 cimport cython
 
-
-def make_frozendict(d):
-    return frozendict(d)
-
-
 def f(a,b):
     """
     >>> f(1,[1,2,3])
@@ -330,7 +325,7 @@ def p_frozendict(a):
     >>> p_frozendict('a')
     1
     """
-    cdef frozendict fd = make_frozendict({u'a': 1, u'b': 2})
+    cdef frozendict fd = frozendict({u'a': 1, u'b': 2})
     cdef int result = a in fd
     return result
 

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -1,6 +1,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def f(a,b):
     """
     >>> f(1,[1,2,3])
@@ -315,6 +320,29 @@ def q(a):
     """
     cdef dict d = None
     cdef int result = a in d # should fail with a TypeError
+    return result
+
+
+def p_frozendict(a):
+    """
+    >>> p_frozendict(1)
+    0
+    >>> p_frozendict('a')
+    1
+    """
+    cdef frozendict fd = make_frozendict({u'a': 1, u'b': 2})
+    cdef int result = a in fd
+    return result
+
+
+def q_frozendict(a):
+    """
+    >>> q_frozendict(1)
+    Traceback (most recent call last):
+    TypeError: 'NoneType' object is not iterable
+    """
+    cdef frozendict fd = None
+    cdef int result = a in fd  # should fail with a TypeError
     return result
 
 def r(a):

--- a/tests/run/iterdict.pyx
+++ b/tests/run/iterdict.pyx
@@ -1,8 +1,14 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 dict_size = 4
 d = dict(zip(range(10,dict_size+10), range(dict_size)))
+fd = make_frozendict(d)
 
 
 def dict_iteritems(dict d):
@@ -555,6 +561,38 @@ def for_in_iteritems_of_expression(*args, **kwargs):
     for k, v in dict(*args, **kwargs).iteritems():
         result.append((k, v))
     return result
+
+
+@cython.test_assert_path_exists(
+    "//WhileStatNode",
+    "//WhileStatNode//DictIterationNextNode")
+def iterfrozendict(frozendict fd):
+    """
+    >>> iterfrozendict(fd)
+    [10, 11, 12, 13]
+    >>> iterfrozendict(make_frozendict({}))
+    []
+    """
+    l = []
+    for k in fd:
+        l.append(k)
+    l.sort()
+    return l
+
+
+@cython.test_assert_path_exists(
+    "//WhileStatNode",
+    "//WhileStatNode//DictIterationNextNode")
+def iterfrozendict_listcomp(frozendict fd):
+    """
+    >>> iterfrozendict_listcomp(fd)
+    [10, 11, 12, 13]
+    >>> iterfrozendict_listcomp(make_frozendict({}))
+    []
+    """
+    cdef list l = [k for k in fd]
+    l.sort()
+    return l
 
 
 cdef class NotADict:

--- a/tests/run/iterdict.pyx
+++ b/tests/run/iterdict.pyx
@@ -1,14 +1,10 @@
 
 cimport cython
 
-
-def make_frozendict(d):
-    return frozendict(d)
-
-
 dict_size = 4
 d = dict(zip(range(10,dict_size+10), range(dict_size)))
-fd = make_frozendict(d)
+fd = frozendict(d)
+empty_fd = frozendict({})
 
 
 def dict_iteritems(dict d):
@@ -570,7 +566,7 @@ def iterfrozendict(frozendict fd):
     """
     >>> iterfrozendict(fd)
     [10, 11, 12, 13]
-    >>> iterfrozendict(make_frozendict({}))
+    >>> iterfrozendict(empty_fd)
     []
     """
     l = []
@@ -587,7 +583,7 @@ def iterfrozendict_listcomp(frozendict fd):
     """
     >>> iterfrozendict_listcomp(fd)
     [10, 11, 12, 13]
-    >>> iterfrozendict_listcomp(make_frozendict({}))
+    >>> iterfrozendict_listcomp(empty_fd)
     []
     """
     cdef list l = [k for k in fd]

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -1,6 +1,11 @@
 
 cimport cython
 
+
+def make_frozendict(d):
+    return frozendict(d)
+
+
 def f(a,b):
     """
     >>> f(1,[1,2,3])
@@ -308,4 +313,27 @@ def q(a):
     """
     cdef dict d = None
     cdef int result = a not in d # should fail with a TypeError
+    return result
+
+
+def p_frozendict(a):
+    """
+    >>> p_frozendict('a')
+    0
+    >>> p_frozendict(1)
+    1
+    """
+    cdef frozendict fd = make_frozendict({u'a': 1, u'b': 2})
+    cdef int result = a not in fd
+    return result
+
+
+def q_frozendict(a):
+    """
+    >>> q_frozendict(1)
+    Traceback (most recent call last):
+    TypeError: 'NoneType' object is not iterable
+    """
+    cdef frozendict fd = None
+    cdef int result = a not in fd  # should fail with a TypeError
     return result

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -1,11 +1,6 @@
 
 cimport cython
 
-
-def make_frozendict(d):
-    return frozendict(d)
-
-
 def f(a,b):
     """
     >>> f(1,[1,2,3])
@@ -323,7 +318,7 @@ def p_frozendict(a):
     >>> p_frozendict(1)
     1
     """
-    cdef frozendict fd = make_frozendict({u'a': 1, u'b': 2})
+    cdef frozendict fd = frozendict({u'a': 1, u'b': 2})
     cdef int result = a not in fd
     return result
 


### PR DESCRIPTION
Related Issue - #7647
@scoder 

As given in the issue, I started with the simple approach 2 - I ran three commands which gave me `dict`-related test files - 
```bash                                             
ls tests/run/dict*.pyx tests/run/*dict*.pyx                                                                                                                 
grep -l '^# tag:.*\bdict\b' tests/run/*.pyx tests/run/*.py                                                                                                  
grep -lE 'def [a-zA-Z_]+\(dict |PyDict_|cdef dict ' tests/run/*.pyx                                                                                         
```  
This gave me 45 unique files. Out of these some were unrelated or already covered in `frozendict.pyx`. So I chose 12 test files in the end . I duplicated the `dict` tests in these files and replaced them with `frozendict`.   
So Running these tests against the unmodified compiler reported `Ran 318 tests, FAILED (failures=4, errors=8)`. The 8 ERRORs are compile-time path-assertion violations; the 4 FAILs are doctest-output mismatches.

| # | Module | Backend | Type  | Where | What didn’t happen | Fix |
|---|--------|---------|-------|--------|--------------------|-----|
| 1 | assigned_builtin_methods | c | ERROR | line 49: `bound_frozendict_get` | `//ReturnStatNode//PythonCapiCallNode` was expected (bound-method optimisation lowering `fd.get` to a C API call). Compiler still treats `frozendict` as generic Python object, so `fd.get(1)` remains attribute access | In `Cython/Compiler/ExprNodes.py` (AttributeNode analysis), replace `is_pydict_type` with `is_pyanydict_type` |
| 2 | builtin_len | c | ERROR | line 108: `len_frozendict` | `//PythonCapiCallNode` expected (`len(fd)` → `PyDict_Size`). `_map_to_capi_len_function` only knows `Builtin.dict_type` | Add mapping: `Builtin.frozendict_type → "PyDict_Size"` in `Cython/Compiler/Optimize.py` |
| 3 | dict_get | c | ERROR | lines 98, 125: `get_frozendict`, `get_default_frozendict` | `//PythonCapiCallNode` expected (`fd.get(...)` lowering). `MethodDispatcherTransform` lacks handler for frozendict | Alias `_handle_simple_method_frozendict_get = _handle_simple_method_dict_get` in `Cython/Compiler/Optimize.py` |
| 4 | iterdict | c | ERROR | lines 566, 583: `iterfrozendict`, `iterfrozendict_listcomp` | `//WhileStatNode//DictIterationNextNode` expected (dict iteration optimisation). Checks only apply to `is_pydict_type` | Replace those checks with `is_pyanydict_type` in `Optimize.py` |
| 5 | inop | c | FAIL | `q_frozendict` doctest | Error message mismatch: `TypeError: argument of type 'NoneType' is not iterable` vs expected dict-style wording | Relax doctest using `# doctest: +ELLIPSIS` and match `TypeError: ...NoneType...` |
| 6 | notinop | c | FAIL | `q_frozendict` doctest | Same mismatch as `inop` but for `not in` | Same fix as above |

The other 6 were the same issues, but on the cpp backend.   

So to fix these tests, 
1. ``Cython/Compiler/PyrexTypes.py`` - I added `is_pyfrozendict_type` (per-type flag) and `is_pyanydict_type` (composite "dict or frozendict") to the `PyrexType` defaults
2. `Cython/Compiler/Tests/TestTypes.py` - I also updated the `BuiltinObjectType._builtin_type_flag_mapping` to reflect this. 
3. The remaining two files - `Cython/Compiler/ExprNodes.py` and `Cython/Compiler/Optimize.py` - I updated the `if` conditions