### PR TITLE
Fully specify CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-latest]
         backend: [c, cpp]
+        extra_hash: ['']
 
         include:
           # Limited API
@@ -112,6 +113,7 @@ jobs:
           - "3.14t"
           - "3.15-dev"
           - "3.15t-dev"
+        extra_hash: ['']
 
         exclude:
           # Windows and free-threading is difficult to build right now

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,12 +135,6 @@ jobs:
           # ================
           # GCC 13 (with broad language standards)
           - os: ubuntu-24.04
-            python-version: "3.9"
-            backend: c
-            gcc_version: 13
-            extra_cflags: "-std=c99"
-            extra_hash: "-c99"
-          - os: ubuntu-24.04
             python-version: "3.10"
             backend: c
             gcc_version: 13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,12 @@ jobs:
           # ================
           # GCC 13 (with broad language standards)
           - os: ubuntu-24.04
+            python-version: "3.9"
+            backend: c
+            gcc_version: 13
+            extra_cflags: "-std=c99"
+            extra_hash: "-c99"
+          - os: ubuntu-24.04
             python-version: "3.10"
             backend: c
             gcc_version: 13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       backend: ${{ matrix.backend }}
       limited_api: ${{ matrix.limited_api }}
-      # shared_utility - not used in this matrix
+      shared_utility: ${{ matrix.shared_utility }}
       gcc_version: ${{ matrix.gcc_version }}
       extra_cflags: ${{ matrix.extra_cflags }}
       cython_compile_all: ${{ matrix.cython_compile_all }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,18 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-latest]
+        os: [ubuntu-24.04, windows-2022, macos-latest]
         backend: [c, cpp]
         extra_hash: ['']
 
         include:
           # Limited API
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             backend: "c,cpp"
             limited_api: "--limited-api --abi3audit"
             extra_hash: "-limited_api"
           # Cython Shared Module
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             backend: "c,cpp"
             shared_utility: "--shared-utility"
             extra_hash: "--shared-utility"
@@ -100,7 +100,7 @@ jobs:
       matrix:
         # Tests [amd64]
         #
-        os: [ubuntu-22.04, windows-2022, macos-latest]
+        os: [ubuntu-24.04, windows-2022, macos-latest]
         backend: [c, cpp]
         python-version:
           - "3.9"
@@ -134,35 +134,35 @@ jobs:
           # Ubuntu sub-jobs:
           # ================
           # GCC 13 (with broad language standards)
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             backend: c
             gcc_version: 13
             extra_cflags: "-std=c99"
             extra_hash: "-c99"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.10"
             backend: c
             gcc_version: 13
             extra_cflags: "-std=c17"
             extra_hash: "-c17"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             backend: c
             gcc_version: 13
             extra_cflags: "-std=c17"
             extra_hash: "-c17"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.13"
             backend: cpp
             gcc_version: 13
             extra_cflags: "-std=c++20"
             extra_hash: "-cpp20"
           # Arm64
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             python-version: "3.13"
             backend: c
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             python-version: "3.13"
             backend: cpp
           - os:  windows-11-arm
@@ -172,84 +172,84 @@ jobs:
             python-version: "3.13"
             backend: "cpp"
           # compile all modules
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             backend: c
             cython_compile_all: 1
             extra_hash: "-all"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             backend: cpp
             cython_compile_all: 1
             extra_hash: "-all"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.11"
             backend: c
             cython_compile_all: 1
             extra_hash: "-all"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.11"
             backend: cpp
             cython_compile_all: 1
             extra_hash: "-all"
           # Limited API
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             backend: "c,cpp"
             limited_api: "--limited-api --abi3audit"
             extra_hash: "-limited_api"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.11"
             backend: "c,cpp"
             limited_api: "--limited-api --abi3audit"
             extra_hash: "-limited_api"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             backend: "c,cpp"
             limited_api: "--limited-api --abi3audit"
             extra_hash: "-limited_api"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.15-dev"
             backend: "c,cpp"
             limited_api: "--limited-api"
             extra_hash: "-limited_api"
           # Cython Shared Module
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             backend: "c,cpp"
             shared_utility: "--shared-utility"
             extra_hash: "--shared-utility"
           # Type specs
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.14"
             backend: c
             extra_cflags: "-DCYTHON_USE_TYPE_SPECS=1"
             extra_hash: "-typespecs"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.12"
             backend: c
             extra_cflags: "-DCYTHON_USE_TYPE_SPECS=1"
             extra_hash: "-typespecs"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.9"
             backend: c
             extra_cflags: "-DCYTHON_USE_TYPE_SPECS=1"
             extra_hash: "-typespecs"
           # Pypy
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: pypy-3.9
             backend: c
             no_cython_compile: 1
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: pypy-3.10
             backend: c
             no_cython_compile: 1
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: pypy-3.11
             backend: c
             no_cython_compile: 1
           # GraalPy
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: graalpy25
             backend: c
             no_cython_compile: 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   pycoverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       # deploy HTML to GitHub pages
@@ -33,7 +33,7 @@ jobs:
 
     env:
       BACKEND: c,cpp
-      OS_NAME: ubuntu-22.04
+      OS_NAME: ubuntu-24.04
       PYTHON_VERSION: "3.12"
       HEAD: "${{ github.head_ref || github.ref_name }}"
 
@@ -86,12 +86,12 @@ jobs:
           if [ -f coverage-report.md ]; then { echo; cat coverage-report.md ; } >> $GITHUB_STEP_SUMMARY; fi
 
   cycoverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [ pycoverage ]  # order summary report output
 
     env:
       BACKEND: c,cpp
-      OS_NAME: ubuntu-22.04
+      OS_NAME: ubuntu-24.04
       PYTHON_VERSION: "3.12"
 
     steps:

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -10,7 +10,7 @@ if [[ $OSTYPE == "linux-gnu"* && ! "$EXTERNAL_OVERRIDE_CC" ]]; then
   echo "Installing requirements [apt]"
   #sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
   sudo apt-get update -y -q
-  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION || exit 1
+  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas || exit 1
 
   ALTERNATIVE_ARGS=""
   if [[ $BACKEND == *"cpp"* ]]; then

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -8,7 +8,7 @@ GCC_VERSION=${GCC_VERSION:=10}
 if [[ $OSTYPE == "linux-gnu"* && ! "$EXTERNAL_OVERRIDE_CC" ]]; then
   echo "Setting up linux compiler"
   echo "Installing requirements [apt]"
-  sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+  #sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
   sudo apt-get update -y -q
   sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION || exit 1
 

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -10,7 +10,7 @@ if [[ $OSTYPE == "linux-gnu"* && ! "$EXTERNAL_OVERRIDE_CC" ]]; then
   echo "Installing requirements [apt]"
   #sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
   sudo apt-get update -y -q
-  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas || exit 1
+  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas0 || exit 1
 
   ALTERNATIVE_ARGS=""
   if [[ $BACKEND == *"cpp"* ]]; then

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -10,7 +10,7 @@ if [[ $OSTYPE == "linux-gnu"* && ! "$EXTERNAL_OVERRIDE_CC" ]]; then
   echo "Installing requirements [apt]"
   #sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
   sudo apt-get update -y -q
-  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas0-dev || exit 1
+  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas-dev || exit 1
 
   ALTERNATIVE_ARGS=""
   if [[ $BACKEND == *"cpp"* ]]; then

--- a/Tools/ci-run.sh
+++ b/Tools/ci-run.sh
@@ -10,7 +10,7 @@ if [[ $OSTYPE == "linux-gnu"* && ! "$EXTERNAL_OVERRIDE_CC" ]]; then
   echo "Installing requirements [apt]"
   #sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
   sudo apt-get update -y -q
-  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas0 || exit 1
+  sudo apt-get install -y -q gdb python3-dbg gcc-$GCC_VERSION libopenblas0-dev || exit 1
 
   ALTERNATIVE_ARGS=""
   if [[ $BACKEND == *"cpp"* ]]; then


### PR DESCRIPTION
According to https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations it doesn't look like the matrix looks quite like we've been assuming it does.

Essentially anything extra in "include" that doesn't contradict something existing is added everywhere. So the `gcc_version: 13` aren't being added as extra subjobs but are being applied to everything that the other fields match.

I think the gist is that we at least need to specify `extra_hash` to the original matrix so that they definitely contradict that and get added as as extra job.