### PR TITLE
Separate wheel check step from wheel build step

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -241,7 +241,7 @@ jobs:
           cd ./wheel_check
           for filename in *.whl; do
             twine check "$filename"
-            if [[ "$filename" == *"abi3"*]]; then
+            if [[ "$filename" == *"abi3"* ]]; then
               abi3audit --strict --report "$filename"
             fi
           done

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -123,11 +123,6 @@ jobs:
         with:
           only: ${{ matrix.only }}
 
-      - name: Check wheel
-        run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
-
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.only }}
@@ -177,11 +172,6 @@ jobs:
                 matrix.os == 'windows-11-arm' && '*win_arm64' ||
             '' }}
 
-      - name: Check wheel
-        run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
-
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Stable-ABI-${{ matrix.os }}-${{ strategy.job-index }}
@@ -211,10 +201,9 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install --upgrade wheel setuptools twine
+          pip install --upgrade wheel setuptools
           python setup.py sdist
           python setup.py bdist_wheel --no-cython-compile
-          twine check ./dist/*.whl
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -226,9 +215,40 @@ jobs:
           name: pure-wheel
           path: ./dist/*.whl
 
+  # Keep abi3audit and twine checks out of the the wheel build step
+  # to minimize the dependencies that need to be installed (ideally to
+  # steptools, cibuildwheel and cibuildwheel's dependencies only).
+  inspect_wheels:
+    name: Inspect Release Assets
+    needs: [ build_sdist_pure_wheel, build_wheels, build_limited_api_wheels ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ./wheel_check
+          merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: ls -la ./wheel_check
+
+      - name: Install tools
+        run: python -m pip install twine abi3audit
+
+      - name: Run tools on wheels
+        run: |
+          cd ./wheel_check
+          for filename in *.whl; do
+            twine check "$filename"
+            if [[ "$filename" == *"abi3"*]]; then
+              abi3audit --strict --report "$filename"
+            fi
+          done
+
   upload_release_assets:
     name: Upload Release Assets
-    needs: [ build_sdist_pure_wheel, build_wheels, build_limited_api_wheels ]
+    needs: [ inspect_wheels ]
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -216,8 +216,7 @@ jobs:
           path: ./dist/*.whl
 
   # Keep abi3audit and twine checks out of the the wheel build step
-  # to minimize the dependencies that need to be installed (ideally to
-  # steptools, cibuildwheel and cibuildwheel's dependencies only).
+  # to minimize the dependencies that need to be installed.
   inspect_wheels:
     name: Inspect Release Assets
     needs: [ build_sdist_pure_wheel, build_wheels, build_limited_api_wheels ]
@@ -239,12 +238,14 @@ jobs:
       - name: Run tools on wheels
         run: |
           cd ./wheel_check
+          ERRORS=0
           for filename in *.whl; do
-            twine check "$filename"
+            twine check "$filename" || ERRORS=$((ERRORS + 1))
             if [[ "$filename" == *"abi3"* ]]; then
-              abi3audit --strict --report "$filename"
+              abi3audit --strict --report "$filename" || ERRORS=$((ERRORS + 1))
             fi
           done
+          exit $ERRORS
 
   upload_release_assets:
     name: Upload Release Assets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ environment.CFLAGS = "-O3 -g0 -pipe -fPIC"
 select = "*i686 *musllinux* *win32 *win_arm64 *macosx_x86_64 *armv7l"
 inherit.environment = "append"
 environment.CYTHON_LIMITED_API = "true"
-inherit.test-requires = "append"
-test-requires = ["abi3audit>=0.0.25"]
-inherit.test-command = "append"
-test-command = ["abi3audit --strict --report {wheel}"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64", "x86", "ARM64"]


### PR DESCRIPTION
Thinking about trying to improve supply chain security and pinning our build dependencies.

The dependencies that we use during the wheel build step are:
* cibuildwheel (which is pinned through the github action, so is hopefully relative secure)
* setuptools (which has no dependencies)
* abi3audit and its dependencies
* twine and its dependencies.

This PR moves abi3audit and twine to a separate step so there's no way they can influence the built wheels.

That leaves us with only setuptools, and managing a single pinned dependency seems pretty reasonable.

It's probably more paranoid than it needs to be (and no-one else seems to really be worried about test dependencies like this). However it's also fairly simple to do given Cython's limited dependencies.

`twine` may be a lost cause though because I suspect it's ultimately used to upload to PyPI. But I can't see that so I'm ignoring it.