### PR TITLE
Adapt array module declarations Python 3.15 changes

### DIFF
--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -104,34 +104,6 @@ cdef extern from *:  # Hard-coded utility code hack.
         cdef inline __data_union data(self) noexcept nogil:
             return __Pyx_PyArray_Data(self)
 
-        def __getbuffer__(self, Py_buffer* info, int flags):
-            # This implementation of getbuffer is geared towards Cython
-            # requirements, and does not yet fulfill the PEP.
-            # In particular strided access is always provided regardless
-            # of flags
-            item_count = Py_SIZE(self)
-
-            info.suboffsets = NULL
-            info.buf = self.data.as_chars
-            info.readonly = 0
-            info.ndim = 1
-            info.itemsize = self.ob_descr.itemsize   # e.g. sizeof(float)
-            info.len = info.itemsize * item_count
-
-            info.shape = <Py_ssize_t*> PyObject_Malloc(sizeof(Py_ssize_t) + 2)
-            if not info.shape:
-                raise MemoryError()
-            info.shape[0] = item_count      # constant regardless of resizing
-            info.strides = &info.itemsize
-
-            info.format = <char*> (info.shape + 1)
-            info.format[0] = self.ob_descr.typecode
-            info.format[1] = 0
-            info.obj = self
-
-        def __releasebuffer__(self, Py_buffer* info):
-            PyObject_Free(info.shape)
-
     array newarrayobject(PyTypeObject* type, Py_ssize_t size, arraydescr *descr)
 
     __data_union __Pyx_PyArray_Data(array self) noexcept nogil

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -70,7 +70,9 @@ cdef extern from *:  # Hard-coded utility code hack.
     ctypedef object GETF(array a, Py_ssize_t ix)
     ctypedef object SETF(array a, Py_ssize_t ix, object o)
     ctypedef struct arraydescr:  # [object arraydescr]:
-        char typecode   # This is untrue in Python 3.15+ but it isn't easy to expose both
+        char typecode "typecode_char"  # backwards compatibility only
+        char typecode_char             # Python <= 3.14
+        char typecode_array[3]         # Python 3.15+
         int itemsize
         GETF getitem    # PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
         SETF setitem    # int (*setitem)(struct arrayobject *, Py_ssize_t, PyObject *);

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -77,9 +77,6 @@ cdef extern from *:  # Hard-coded utility code hack.
         GETF getitem    # PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
         SETF setitem    # int (*setitem)(struct arrayobject *, Py_ssize_t, PyObject *);
 
-    Py_ssize_t _typecode_length "__Pyx_PyArrayDescr_typecode_length"(arraydescr *descr)
-    void _copy_typecode "__Pyx_PyArrayDescr_copy_typecode"(arraydescr *descr, char *dst)
-
     ctypedef union __data_union "__Pyx_data_union":
         # views of ob_item:
         float* as_floats        # direct float pointer access to buffer

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -70,10 +70,13 @@ cdef extern from *:  # Hard-coded utility code hack.
     ctypedef object GETF(array a, Py_ssize_t ix)
     ctypedef object SETF(array a, Py_ssize_t ix, object o)
     ctypedef struct arraydescr:  # [object arraydescr]:
-        char typecode
+        char typecode   # This is untrue in Python 3.15+ but it isn't easy to expose both
         int itemsize
         GETF getitem    # PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
         SETF setitem    # int (*setitem)(struct arrayobject *, Py_ssize_t, PyObject *);
+
+    Py_ssize_t _typecode_length "__Pyx_PyArrayDescr_typecode_length"(arraydescr *descr)
+    void _copy_typecode "__Pyx_PyArrayDescr_copy_typecode"(arraydescr *descr, char *dst)
 
     ctypedef union __data_union "__Pyx_data_union":
         # views of ob_item:
@@ -118,15 +121,14 @@ cdef extern from *:  # Hard-coded utility code hack.
             info.itemsize = self.ob_descr.itemsize   # e.g. sizeof(float)
             info.len = info.itemsize * item_count
 
-            info.shape = <Py_ssize_t*> PyObject_Malloc(sizeof(Py_ssize_t) + 2)
+            info.shape = <Py_ssize_t*> PyObject_Malloc(sizeof(Py_ssize_t) + _typecode_length(self.ob_descr) +  1)
             if not info.shape:
                 raise MemoryError()
             info.shape[0] = item_count      # constant regardless of resizing
             info.strides = &info.itemsize
 
             info.format = <char*> (info.shape + 1)
-            info.format[0] = self.ob_descr.typecode
-            info.format[1] = 0
+            _copy_typecode(self.ob_descr, info.format)
             info.obj = self
 
         def __releasebuffer__(self, Py_buffer* info):

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -23,12 +23,35 @@
 // below.  That's defined later because the appropriate get and set
 // functions aren't visible yet.
 typedef struct arraydescr {
-    int typecode;
+#if PY_VERSION_HEX <= 0x030F00a8
+    const char* typecode;
+#else
+    char typecode;
+#endif
     int itemsize;
     PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
     int (*setitem)(struct arrayobject *, Py_ssize_t, PyObject *);
+#if PY_VERSION_HEX <= 0x030F00a8
     char *formats;
+#endif
 } arraydescr;
+
+static CYTHON_INLINE Py_ssize_t __Pyx_PyArrayDescr_typecode_length(arraydescr *desc) {
+#if PY_VERSION_HEX <= 0x030F00a8
+    return strlen(desc->typecode);
+#else
+    return 1;
+#endif
+}
+
+static CYTHON_INLINE void __Pyx_PyArrayDescr_copy_typecode(arraydescr *desc, char *dst) {
+#if PY_VERSION_HEX <= 0x030F00a8
+    strcpy(dst, desc->typecode);
+#else
+    dst[0] = arrayarray->typecode;
+    dst[1] = '\0';
+#endif
+}
 
 typedef union {
     char *ob_item;

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -23,11 +23,10 @@
 // below.  That's defined later because the appropriate get and set
 // functions aren't visible yet.
 typedef struct arraydescr {
-#if PY_VERSION_HEX <= 0x030F00a8
-    char typecode;
-#else
-    const char* typecode;
-#endif
+    union {
+        char typecode_char;  // pre-3.15
+        char typecode_array[3]; // post-3.15
+    };
     int itemsize;
     PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
     int (*setitem)(struct arrayobject *, Py_ssize_t, PyObject *);
@@ -35,24 +34,6 @@ typedef struct arraydescr {
     char *formats;
 #endif
 } arraydescr;
-
-static CYTHON_INLINE Py_ssize_t __Pyx_PyArrayDescr_typecode_length(arraydescr *desc) {
-#if PY_VERSION_HEX <= 0x030F00a8
-    (void)desc;
-    return 1;
-#else
-    return strlen(desc->typecode);
-#endif
-}
-
-static CYTHON_INLINE void __Pyx_PyArrayDescr_copy_typecode(arraydescr *desc, char *dst) {
-#if PY_VERSION_HEX <= 0x030F00a8
-    dst[0] = desc->typecode;
-    dst[1] = '\0';
-#else
-    strcpy(dst, desc->typecode);
-#endif
-}
 
 typedef union {
     char *ob_item;

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -24,9 +24,9 @@
 // functions aren't visible yet.
 typedef struct arraydescr {
 #if PY_VERSION_HEX <= 0x030F00a8
-    const char* typecode;
-#else
     char typecode;
+#else
+    const char* typecode;
 #endif
     int itemsize;
     PyObject * (*getitem)(struct arrayobject *, Py_ssize_t);
@@ -38,18 +38,19 @@ typedef struct arraydescr {
 
 static CYTHON_INLINE Py_ssize_t __Pyx_PyArrayDescr_typecode_length(arraydescr *desc) {
 #if PY_VERSION_HEX <= 0x030F00a8
-    return strlen(desc->typecode);
-#else
+    (void)desc;
     return 1;
+#else
+    return strlen(desc->typecode);
 #endif
 }
 
 static CYTHON_INLINE void __Pyx_PyArrayDescr_copy_typecode(arraydescr *desc, char *dst) {
 #if PY_VERSION_HEX <= 0x030F00a8
-    strcpy(dst, desc->typecode);
-#else
     dst[0] = desc->typecode;
     dst[1] = '\0';
+#else
+    strcpy(dst, desc->typecode);
 #endif
 }
 

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -48,7 +48,7 @@ static CYTHON_INLINE void __Pyx_PyArrayDescr_copy_typecode(arraydescr *desc, cha
 #if PY_VERSION_HEX <= 0x030F00a8
     strcpy(dst, desc->typecode);
 #else
-    dst[0] = arrayarray->typecode;
+    dst[0] = desc->typecode;
     dst[1] = '\0';
 #endif
 }


### PR DESCRIPTION
In https://github.com/python/cpython/pull/148676 the format of the `arraydescr` struct get changed, which meant that our representation was outdated and crashed.

It isn't easy to adapt it perfectly for both (if users are manually using the `arraydescr` type anyway) but we can make our `array.array.__getbuffer__` function not crash by hiding some of the details in C code.