### PR TITLE
Warn about instability in array.array docs

### DIFF
--- a/docs/src/tutorial/array.rst
+++ b/docs/src/tutorial/array.rst
@@ -7,6 +7,20 @@ Working with Python arrays
 .. include::
     ../two-syntax-variants-used
 
+.. caution::
+
+    The developers of Python are keen to emphasize that the Python
+    ``array.array`` type is an *internal* structure and can change at
+    any time, including between patch releases of Python. If you use it
+    through the ``cpython.array`` cimport then you are accepting the risk
+    of that happening and will not complain to either them or us (the
+    developers of Cython). It is exposed mostly for historical reasons
+    from a time when there was no other way to provide fast element access.
+
+    The compatible way to use this type to use it through the Python
+    interface without specifying a type to Cython, and to use
+    :ref:`typed memoryviews<memoryviews>` for fast element element access.
+
 Python has a builtin array module supporting dynamic 1-dimensional arrays of
 primitive types. It is possible to access the underlying C array of a Python
 array from within Cython. At the same time they are ordinary Python objects

--- a/docs/src/tutorial/array.rst
+++ b/docs/src/tutorial/array.rst
@@ -9,17 +9,17 @@ Working with Python arrays
 
 .. caution::
 
-    The developers of Python are keen to emphasize that the Python
-    ``array.array`` type is an *internal* structure and can change at
-    any time, including between patch releases of Python. If you use it
+    The developers of CPython are keen to emphasize that the implementation of
+    the ``array.array`` type is an *internal* structure and can change at any time,
+    potentially even between patch releases of Python. If you use it
     through the ``cpython.array`` cimport then you are accepting the risk
     of that happening and will not complain to either them or us (the
     developers of Cython). It is exposed mostly for historical reasons
     from a time when there was no other way to provide fast element access.
 
-    The compatible way to use this type is to use it through the Python
-    interface without specifying a type to Cython, and to use
-    :ref:`typed memoryviews<memoryviews>` for fast element element access.
+    The compatible ways to use this type are to use it through the Python
+    interface without specifying a type to Cython at all, and to use
+    :ref:`typed memoryviews<memoryviews>` for fast element access.
 
 Python has a builtin array module supporting dynamic 1-dimensional arrays of
 primitive types. It is possible to access the underlying C array of a Python

--- a/docs/src/tutorial/array.rst
+++ b/docs/src/tutorial/array.rst
@@ -17,7 +17,7 @@ Working with Python arrays
     developers of Cython). It is exposed mostly for historical reasons
     from a time when there was no other way to provide fast element access.
 
-    The compatible way to use this type to use it through the Python
+    The compatible way to use this type is to use it through the Python
     interface without specifying a type to Cython, and to use
     :ref:`typed memoryviews<memoryviews>` for fast element element access.
 

--- a/docs/src/userguide/memoryviews.rst
+++ b/docs/src/userguide/memoryviews.rst
@@ -852,11 +852,7 @@ CPython array module
 An alternative to ``cython.view.array`` is the ``array`` module in the
 Python standard library.  In Python 3, the ``array.array`` type supports
 the buffer interface natively, so memoryviews work on top of it without
-additional setup.
-
-Starting with Cython 0.17, however, it is possible to use these arrays
-as buffer providers also in Python 2.  This is done through explicitly
-cimporting the ``cpython.array`` module as follows:
+additional setup:
 
 .. tabs::
 
@@ -868,7 +864,7 @@ cimporting the ``cpython.array`` module as follows:
 
         .. literalinclude:: ../../examples/userguide/memoryviews/cpython_array.pyx
 
-Note that the cimport also enables the old buffer syntax for the array
+Cimporting ``cpython.array`` also enables the old buffer syntax for the array
 type.  Therefore, the following also works:
 
 .. tabs::


### PR DESCRIPTION
and also adjust some old documentation which was only really relevant to Python 2 (and for which the examples no longer quite matched the text).

See https://github.com/python/cpython/issues/148675#issuecomment-4389160366 - I'm not convinced we want to go as far as adding compile-time warnings for people using `array.array` but I think it's reasonable to generally discourage it.