### PR TITLE
Remove legacy uses of iteritems

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7670,7 +7670,7 @@ class MergedDictNode(ExprNode):
                 items = ((key.constant_result, value.constant_result)
                          for key, value in item.key_value_pairs)
             else:
-                items = item.constant_result.iteritems()
+                items = item.constant_result.items()
 
             for key, value in items:
                 if reject_duplicates and key in result:
@@ -7688,7 +7688,7 @@ class MergedDictNode(ExprNode):
                 items = [(key.compile_time_value(denv), value.compile_time_value(denv))
                          for key, value in item.key_value_pairs]
             else:
-                items = item.compile_time_value(denv).iteritems()
+                items = item.compile_time_value(denv).items()
 
             try:
                 for key, value in items:


### PR DESCRIPTION
I can get hit one of these in a debugger with
`return {**{'a': 1}, **({'b': 2} | {'c': 3})}` although fixing it doesn't seem to make any difference to the code generation here.

But either way, we should definitely update to Python 3 methods.