### PR TITLE
[3.2.x] Fix fastcall nargs in coroutine throw

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1311,9 +1311,10 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
             if (likely(args)) {
                 ret = __Pyx_PyObject_Call(meth, args, NULL);
             } else {
-                // "tb" or even "val" might be NULL, but that also correctly terminates the argument list
+                // "tb" or even "val" might be NULL.
                 PyObject *cargs[4] = {NULL, typ, val, tb};
-                ret = __Pyx_PyObject_FastCall(meth, cargs+1, 3 | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET);
+                Py_ssize_t nargs = 1 + (val != NULL) + (tb != NULL);
+                ret = __Pyx_PyObject_FastCall(meth, cargs+1, nargs | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET);
             }
             Py_DECREF(meth);
         }


### PR DESCRIPTION
I believe nargs to vectorcall is taken as fact, and it doesn't generally handle `NULL` values as part of the array.

Targeted at 3.2.x because I have a slightly bigger change aimed at 3.3 which includes the same fix.