### PR TITLE
Fix duplicate C++ conversion utility emission

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -4248,8 +4248,12 @@ class CppClassType(CType):
                 'type': self.cname,
             })
             # Override directives that should not be inherited from user code.
+            # Use the module-level (global scope) directives to ensure that the same
+            # conversion utility is not emitted twice when it is requested from two
+            # different local scopes that carry different directive values for settings
+            # that are irrelevant to the generated C helper (e.g. 'binding').
             from .UtilityCode import CythonUtilityCode
-            directives = CythonUtilityCode.filter_inherited_directives(env.directives)
+            directives = CythonUtilityCode.filter_inherited_directives(env.global_scope().directives)
             env.use_utility_code(CythonUtilityCode.load(
                 cls.replace('unordered_', '') + ".from_py", "CppConvert.pyx",
                 context=context, compiler_directives=directives))
@@ -4294,8 +4298,11 @@ class CppClassType(CType):
                 'type': self.cname,
             })
             from .UtilityCode import CythonUtilityCode
-            # Override directives that should not be inherited from user code.
-            directives = CythonUtilityCode.filter_inherited_directives(env.directives)
+            # Use the module-level (global scope) directives to ensure that the same
+            # conversion utility is not emitted twice when it is requested from two
+            # different local scopes that carry different directive values for settings
+            # that are irrelevant to the generated C helper (e.g. 'binding').
+            directives = CythonUtilityCode.filter_inherited_directives(env.global_scope().directives)
             env.use_utility_code(CythonUtilityCode.load(
                 cls.replace('unordered_', '') + ".to_py", "CppConvert.pyx",
                 context=context, compiler_directives=directives))

--- a/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
+++ b/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
@@ -1,5 +1,5 @@
 # mode: compile
-# tag: cpp no-cpp-locals
+# tag: cpp, no-cpp-locals
 
 # Regression test for gh-6981: duplicate __pyx_convert_vector_to_py_double in generated C++.
 # Trigger requires both:

--- a/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
+++ b/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
@@ -1,5 +1,5 @@
 # mode: compile
-# tag: cpp
+# tag: cpp no-cpp-locals
 
 # Regression test for gh-6981: duplicate __pyx_convert_vector_to_py_double in generated C++.
 # Trigger requires both:

--- a/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
+++ b/tests/compile/cpp_vector_to_py_dedup_T6981.pyx
@@ -1,0 +1,26 @@
+# mode: compile
+# tag: cpp
+
+# Regression test for gh-6981: duplicate __pyx_convert_vector_to_py_double in generated C++.
+# Trigger requires both:
+#   (a) an extension-type property returning a vector[T] member of a template cppclass, and
+#   (b) a module-level def with a vector[T] default argument.
+
+from libcpp.vector cimport vector
+
+cdef extern from *:
+    """
+    #include <vector>
+    template<class T> struct RD { std::vector<T> v; };
+    """
+    cdef cppclass RD[T]:
+        vector[T] v
+
+cdef class C:
+    cdef RD[double] *p
+    property v:
+        def __get__(self):
+            return self.p.v
+
+def f(vector[double] x=[]):
+    pass


### PR DESCRIPTION
**AI Disclosure**: This PR is the result of me steering LLMs to try to come up with a fix for gh-6981. Please feel free to close this PR if you deem this wasteful of your time.

I put LLMs to create a MWE for the issue I reported earlier (#6981), eventually they produced a small reproducer:

```cython
# Trigger: template cppclass with vector[T] member returned from a property
# + module-level function taking vector[double] with default [] arg.
from libcpp.vector cimport vector
cdef extern from *:
    """
    #include <vector>
    template<class T> struct RD { std::vector<T> v; };
    """
    cdef cppclass RD[T]:
        vector[T] v
cdef class C:
    cdef RD[double] *p
    property v:
        def __get__(self): return self.p.v
def f(vector[double] x=[]):
    pass
```
which could be used to bisect a (potentially) offending commit: ed2b40be6cad

With a small reproducer and a git bisected commit I thought I could ask the LLM to write a potential fix to Cython as well (which is this PR). I must admit that I have no idea if this fix is sensible or not.