### PR TITLE
Clean up a few mixups regarding vectorcall nargs vs. nargsf

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1321,7 +1321,7 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
             } else {
                 // "tb" or even "val" might be NULL
                 PyObject *cargs[4] = {NULL, typ, val, tb};
-                Py_ssize_t nargs = 1 + (val != NULL) + (tb != NULL);
+                size_t nargs = 1 + (val != NULL) + (tb != NULL);
                 ret = __Pyx_PyObject_FastCall(meth, cargs+1, nargs | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET);
             }
             Py_DECREF(meth);

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1321,7 +1321,7 @@ static PyObject *__Pyx__Coroutine_Throw(PyObject *self, PyObject *typ, PyObject 
             } else {
                 // "tb" or even "val" might be NULL
                 PyObject *cargs[4] = {NULL, typ, val, tb};
-                size_t nargs = 1 + (val != NULL) + (tb != NULL);
+                size_t nargs = 1U + (val != NULL) + (tb != NULL);
                 ret = __Pyx_PyObject_FastCall(meth, cargs+1, nargs | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET);
             }
             Py_DECREF(meth);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2239,6 +2239,9 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObj
 
     #if CYTHON_COMPILING_IN_LIMITED_API
     return __Pyx_PyObject_FastCall_fallback(func, args, (size_t)nargs, kwargs);
+    #elif CYTHON_COMPILING_IN_PYPY
+    // PyPy miscalculates nargs if we include PY_VECTORCALL_ARGUMENTS_OFFSET.
+    return PyObject_VectorcallDict(func, args, (size_t) nargs, kwargs);
     #else
     return PyObject_VectorcallDict(func, args, nargsf, kwargs);
     #endif

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2150,7 +2150,7 @@ static PyObject* __Pyx__CallUnboundCMethod2(__Pyx_CachedCFunction* cfunc, PyObje
 /////////////// PyObjectFastCall.proto ///////////////
 
 #define __Pyx_PyObject_FastCall(func, args, nargs)  __Pyx_PyObject_FastCallDict(func, args, (size_t)(nargs), NULL)
-static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObject * const*args, size_t nargs, PyObject *kwargs); /*proto*/
+static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObject * const*args, size_t nargsf, PyObject *kwargs); /*proto*/
 
 /////////////// PyObjectFastCall ///////////////
 //@requires: PyObjectCall
@@ -2203,12 +2203,12 @@ static CYTHON_INLINE vectorcallfunc __Pyx_PyVectorcall_Function(PyObject *callab
   #endif
 #endif
 
-static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObject *const *args, size_t _nargs, PyObject *kwargs) {
+static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObject *const *args, size_t nargsf, PyObject *kwargs) {
     // Special fast paths for 0 and 1 arguments
     // NOTE: in many cases, this is called with a constant value for nargs
     // which is known at compile-time. So the branches below will typically
     // be optimized away.
-    Py_ssize_t nargs = __Pyx_PyVectorcall_NARGS(_nargs);
+    Py_ssize_t nargs = __Pyx_PyVectorcall_NARGS(nargsf);
 #if CYTHON_COMPILING_IN_CPYTHON
     if (nargs == 0 && kwargs == NULL) {
         if (__Pyx_CyOrPyCFunction_Check(func) && likely( __Pyx_CyOrPyCFunction_GET_FLAGS(func) & METH_NOARGS))
@@ -2223,11 +2223,11 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObj
     if (kwargs == NULL) {
         #if CYTHON_VECTORCALL
           #if CYTHON_COMPILING_IN_LIMITED_API || CYTHON_COMPILING_IN_PYPY
-            return PyObject_Vectorcall(func, args, _nargs, NULL);
+            return PyObject_Vectorcall(func, args, nargsf, NULL);
           #else
             vectorcallfunc f = __Pyx_PyVectorcall_Function(func);
             if (f) {
-                return f(func, args, _nargs, NULL);
+                return f(func, args, nargsf, NULL);
             }
           #endif
         #endif
@@ -2240,7 +2240,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_FastCallDict(PyObject *func, PyObj
     #if CYTHON_COMPILING_IN_LIMITED_API
     return __Pyx_PyObject_FastCall_fallback(func, args, (size_t)nargs, kwargs);
     #else
-    return PyObject_VectorcallDict(func, args, (size_t)nargs, kwargs);
+    return PyObject_VectorcallDict(func, args, nargsf, kwargs);
     #endif
 }
 


### PR DESCRIPTION
This is an easy source of bugs, so we should try to be strict about plain size_t/Py_ssize_t `nargs` vs. `size_t nargsf` (which may include the arguments offset flag).