### PR TITLE
Improve behaviour of cclass properties in auto-complete

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -2413,6 +2413,12 @@ class FuncDefNode(StatNode, BlockNode):
                         "int %s = 0; /* StopIteration */" % Naming.error_without_exception_cname
                     )
                     code.putln("if (!%s) {" % Naming.error_without_exception_cname)
+                if (self.entry.scope.is_property_scope and
+                        self.entry.name == "__get__" and
+                        self.local_scope.directives['safe_property_autocomplete']):
+                    code.globalstate.use_utility_code(
+                        UtilityCode.load_cached("GuardPropertyAutocomplete", "Exceptions.c"))
+                    code.putln("__Pyx_GuardPropertyAutocomplete();")
                 code.put_add_traceback(self.entry.qualified_name)
                 if code.funcstate.error_without_exception:
                     code.putln("}")

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -237,6 +237,7 @@ _directive_defaults = {
     'cpp_locals': False,  # uses std::optional for C++ locals, so that they work more like Python locals
     'legacy_implicit_noexcept': False,
     'c_compile_guard': '',
+    'safe_property_autocomplete': False,
 
     # set __file__ and/or __path__ to known source/target path at import time (instead of not having them available)
     'set_initial_path' : None,  # SOURCEFILE or "/full/path/to/module"

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -160,7 +160,7 @@ annotation_typing = returns = wraparound = boundscheck = initializedcheck = \
     freelist = auto_pickle = cpow = trashcan = auto_cpdef = \
     allow_none_for_extension_args = callspec = show_performance_hints = \
     py2_import = iterable_coroutine = remove_unreachable = \
-    test_body_needs_exception_handling = \
+    test_body_needs_exception_handling = safe_property_autocomplete = \
         lambda _: _EmptyDecoratorAndManager()
 
 binding = embedsignature = always_allow_keywords = unraisable_tracebacks = \

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -1036,3 +1036,114 @@ static CYTHON_INLINE int __Pyx_IgnoreGivenException(PyObject *given_exception, P
     }
     return 0;
 }
+
+/////////////////// GuardPropertyAutocomplete.init /////////////////////////
+
+#if !(__PYX_LIMITED_VERSION_HEX >= 0x030F0000 && PY_VERSION_HEX > 0x030F00B2)
+if (__pyx_interpreter_is_interactive == -1) {
+    __pyx_interpreter_is_interactive = __Pyx_GetInterpreterIsInteractive();
+}
+#endif
+
+/////////////////// GuardPropertyAutocomplete.proto ////////////////////////
+
+#if __PYX_LIMITED_VERSION_HEX >= 0x030F0000 && PY_VERSION_HEX > 0x030F00B2
+// In 3.15, we no longer need the guard
+#define __Pyx_GetInterpreterIsInteractive() (0)
+#define __Pyx_GuardPropertyAutocomplete()
+#else
+static int __pyx_interpreter_is_interactive = -1;
+
+static int __Pyx_GetInterpreterIsInteractive(void);
+static void __Pyx_GuardPropertyAutocomplete(void);
+#endif
+
+/////////////////// GuardPropertyAutocomplete //////////////////////////////
+
+#if !(__PYX_LIMITED_VERSION_HEX >= 0x030F0000 && PY_VERSION_HEX > 0x030F00B2)
+static int __Pyx_GetInterpreterIsInteractive(void) {
+#if CYTHON_COMPILING_IN_LIMITED_API || (CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000)
+    // Depending on the runtime version we may not need to do the guard.
+    // In this case, detect it early and mark the interpreter as "non-interactive".
+    unsigned long rt_version = __Pyx_get_runtime_version();
+    if (rt_version > 0x030d0d00 && rt_version < 0x030E0000) {
+        return 0;
+    }
+    if (rt_version > 0x030E0600 && rt_version < 0x030F0000) {
+        return 0;
+    }
+    // We can't handle beta versions in get_runtime_version so
+    // don't handle them for the Limited API
+    if (rt_version > 0x030F0000) {
+        return 0;
+    }
+#endif
+    return (PySys_GetObject("ps1") != NULL);
+}
+
+static void __Pyx_GuardPropertyAutocomplete(void) {
+    if (likely(!__pyx_interpreter_is_interactive)) {
+        return;
+    }
+    if (PyErr_ExceptionMatches(PyExc_AttributeError) || !PyErr_ExceptionMatches(PyExc_Exception)) {
+        // AttributeError is fine and doesn't need wrapping.
+        // Avoid changing BaseException on moral grounds.
+        return;
+    }
+    PyObject *typ, *val, *tb;
+    __Pyx_PyErr_FetchException(&typ, &val, &tb);
+
+    int is_attr_matches, is_rlcompleter;
+    PyObject *getframe, *frame, *f_code=NULL, *co_name, *co_filename;
+    getframe = PySys_GetObject("_getframe");
+    if (unlikely(!getframe)) goto fail;
+    frame = PyObject_CallObject(getframe, NULL);
+    if (unlikely(!frame)) goto fail;
+    f_code = PyObject_GetAttr(frame, PYIDENT("f_code"));
+    Py_CLEAR(frame);
+    if (unlikely(!f_code)) goto fail;
+    co_name = PyObject_GetAttr(f_code, PYIDENT("co_name"));
+    if (unlikely(!co_name)) goto fail;
+    is_attr_matches = (PyUnicode_CompareWithASCIIString(co_name, "attr_matches") == 0);
+    Py_DECREF(co_name);
+    if (!is_attr_matches) goto fail;
+    co_filename = PyObject_GetAttr(f_code, PYIDENT("co_filename"));
+    if (unlikely(!co_filename)) goto fail;
+    is_rlcompleter = PyUnicode_Tailmatch(
+        co_filename, PYUNICODE("rlcompleter.py"),
+        0, PY_SSIZE_T_MAX, 1);
+    Py_DECREF(co_filename);
+    Py_CLEAR(f_code);
+    if (unlikely(is_rlcompleter != 1)) goto fail;
+
+    // If we're here we've raised an exception while auto-completing.
+#if __PYX_LIMITED_VERSION_HEX < 0x030b0000
+    PyErr_SetExcInfo(typ, val, tb);
+#else
+    PyErr_SetHandledException(val);
+    Py_DECREF(val);
+#endif
+    // This exception should typically be swallowed inside the auto-completer.
+    // However, set a semi-useful message and keep the original exception around
+    // in "During handling of the above exception, another exception occurred"
+    // just in case it isn't. 
+    PyErr_SetString(
+        PyExc_AttributeError,
+        "Exception occurred in Cython property while attempting auto-complete");
+#if __PYX_LIMITED_VERSION_HEX < 0x030b0000
+    PyErr_SetExcInfo(NULL, NULL, NULL);
+#else
+    PyErr_SetHandledException(NULL);
+#endif
+    return;
+
+  fail:
+    Py_XDECREF(f_code);
+    if (!PyErr_Occurred() || PyErr_ExceptionMatches(PyExc_Exception)) {
+        __Pyx_PyErr_RestoreException(typ, val, tb);
+    } else {
+        // Don't swallow BaseException.
+        Py_XDECREF(typ); Py_XDECREF(val); Py_XDECREF(tb);
+    }
+}
+#endif

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -641,6 +641,15 @@ Cython code.  Here is the list of currently supported directives:
     appropriate exception is raised. This is off by default for
     performance reasons.
 
+``safe_property_autocomplete``  (True / False), *default=False*
+    If set to True, Cython will add extra exception handling code
+    to properties of cdef classes to try to make them work better
+    in an interactive Python terminal.  Exceptions raised from
+    within Python's auto-complete handler are translated to
+    AttributeError (which the handler will safely ignore).
+    This has a runtime cost, and some chance of false positives
+    or false negatives.
+
 ``freethreading_compatible``  (True / False), *default=False*
     If set to True, Cython sets the ``Py_mod_gil`` slot to
     ``Py_MOD_GIL_NOT_USED`` to signal that the module is safe to run

--- a/tests/run/autocomplete_properties.pyx
+++ b/tests/run/autocomplete_properties.pyx
@@ -1,0 +1,182 @@
+# cython: safe_property_autocomplete=True
+
+cimport cython
+import sys
+
+# For testing purposes we need to make it so Cython believes the interpreter
+# is interactive.
+cdef extern from *:
+    """
+    #if __PYX_LIMITED_VERSION_HEX >= 0x030F0000 && PY_VERSION_HEX > 0x030F00B2
+    static int __pyx_interpreter_is_interactive;
+    #endif
+    """
+    int __pyx_interpreter_is_interactive
+
+cdef int trick_cython_into_believing_interpreter_is_interactive():
+   global __pyx_interpreter_is_interactive
+   value, __pyx_interpreter_is_interactive = __pyx_interpreter_is_interactive, 1
+   return value;
+
+# Test access through cython call
+def get_guarded_fail_cy(inst):
+    return inst.p_guarded_fail
+
+def get_unguarded_fail_cy(inst):
+    return inst.q_unguarded_fail
+
+# Test access through Python call
+exec("""
+def get_guarded_fail_py(inst):
+    return inst.p_guarded_fail
+
+def get_unguarded_fail_py(inst):
+    return inst.q_unguarded_fail
+""", globals())
+
+assert not trick_cython_into_believing_interpreter_is_interactive()
+
+cdef class FailableProperties:
+    """
+    >>> import rlcompleter
+
+    >>> inst = FailableProperties()
+    >>> inst.set_fail(KeyError)
+    >>> inst.p_guarded_fail
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+    >>> get_guarded_fail_cy(inst)
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+    >>> get_guarded_fail_py(inst)
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+    >>> get_unguarded_fail_cy(inst)
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+    >>> get_unguarded_fail_py(inst)
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+    >>> completer = rlcompleter.Completer(dict(inst=inst))
+    >>> completer.attr_matches("inst.p_")
+    ['inst.p_aardvark', 'inst.p_guarded_fail', 'inst.p_zebra']
+
+    # Note that on AttributeErrors Python sometimes adds "did you mean". This is fine.
+    >>> inst.set_fail(AttributeError)
+    >>> inst.p_guarded_fail  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+       ...
+    AttributeError: Something bad happened...
+    >>> get_guarded_fail_cy(inst)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+       ...
+    AttributeError: Something bad happened...
+    >>> get_guarded_fail_py(inst)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+       ...
+    AttributeError: Something bad happened...
+    >>> get_unguarded_fail_cy(inst)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+       ...
+    AttributeError: Something bad happened...
+    >>> get_unguarded_fail_py(inst)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+       ...
+    AttributeError: Something bad happened...
+    >>> completer = rlcompleter.Completer(dict(inst=inst))
+    >>> completer.attr_matches("inst.p_")
+    ['inst.p_aardvark', 'inst.p_guarded_fail', 'inst.p_zebra']
+    """
+    cdef fail_with_type
+
+    def set_fail(self, tp):
+        self.fail_with_type = tp
+
+    @property
+    def p_aardvark(self):
+        return 1
+    
+    @property
+    def p_guarded_fail(self):
+        if self.fail_with_type is not None:
+            raise self.fail_with_type("Something bad happened")
+
+    @property
+    def p_zebra(self):
+        return 1
+    
+    @property
+    def q_aardvark(self):
+        return 1
+
+    @cython.safe_property_autocomplete(False)
+    @property
+    def q_unguarded_fail(self):
+        if self.fail_with_type is not None:
+            raise self.fail_with_type("Something bad happened")
+
+    @property
+    def q_zebra(self):
+        return 1
+
+class MyBaseException(BaseException):
+    pass
+
+__doc__ = ""
+
+if (sys.version_info < (3, 13, 14) or
+        (sys.version_info[:2] == (3, 14) and sys.version_info < (3, 14, 7))):
+    # On these versions we can check the behaviour of unguarded fails
+    # and BaseExceptions because we implement the guard rather than it
+    # being in rlcompleter.
+    __doc__ += """
+    >>> import rlcompleter
+
+    >>> inst = FailableProperties()
+    >>> completer = rlcompleter.Completer(dict(inst=inst))
+
+    >>> inst.set_fail(KeyError)
+
+    # No catching from unguarded property
+    >>> completer.attr_matches("inst.q_")
+    Traceback (most recent call last):
+       ...
+    KeyError: 'Something bad happened'
+
+    >>> inst.set_fail(MyBaseException)  # BaseException
+    >>> inst.p_guarded_fail
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    >>> get_guarded_fail_cy(inst)
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    >>> get_guarded_fail_py(inst)
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    >>> get_unguarded_fail_cy(inst)
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    >>> get_unguarded_fail_py(inst)
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+
+    # Our guards don't handle base exceptions
+    >>> completer.attr_matches("inst.p_")
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    >>> completer.attr_matches("inst.q_")
+    Traceback (most recent call last):
+       ...
+    autocomplete_properties.MyBaseException: Something bad happened
+    """

--- a/tests/run/autocomplete_properties.pyx
+++ b/tests/run/autocomplete_properties.pyx
@@ -2,6 +2,7 @@
 
 cimport cython
 import sys
+import platform
 
 # For testing purposes we need to make it so Cython believes the interpreter
 # is interactive.
@@ -34,7 +35,8 @@ def get_unguarded_fail_py(inst):
     return inst.q_unguarded_fail
 """, globals())
 
-assert not trick_cython_into_believing_interpreter_is_interactive()
+# At the moment, Graal always believes it's in an interactive terminal.
+assert not trick_cython_into_believing_interpreter_is_interactive() or platform.python_implementation() == "GraalVM"
 
 cdef class FailableProperties:
     """


### PR DESCRIPTION
Add an opt-in way of translating exceptions to AttributeError when called from within Python's auto-complete handler. This should be fairly low cost if called outside an interactive interpreter (because it can be turned off once at module import).

Closes #6471

I'm slight unsure if this:
* should be on by default,
* should be off by default,
* or if it's just too fiddly for a minor problem so shouldn't exist at all.