### PR TITLE
Fix tests with asyncio.iscoroutinefunction on Python 3.16

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -93,8 +93,13 @@ typedef struct {
     PyObject *(*defaults_getter)(PyObject *);
     PyObject *func_annotations; /* function annotations dict */
 
-    // Coroutine marker
+    // Coroutine marker (inspect and asyncio versions)
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000  
     PyObject *func_is_coroutine;
+#endif
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+    PyObject *func_is_coroutine_marker;
+#endif
 } __pyx_CyFunctionObject;
 
 #undef __Pyx_CyOrPyCFunction_Check
@@ -586,11 +591,12 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
+// shared between get_is_coroutine and get_is_coroutine_marker
 static PyObject *
-__Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
+__Pyx_CyFunction_get_is_coroutine_attribute_value(__pyx_CyFunctionObject *op, PyObject *module_name, PyObject *marker) {
     int is_coroutine = op->flags & __Pyx_CYFUNCTION_COROUTINE;
     if (is_coroutine) {
-        PyObject *is_coroutine_value, *module, *fromlist, *marker = PYIDENT("_is_coroutine");
+        PyObject *is_coroutine_value, *module, *fromlist;
         fromlist = PyList_New(1);
         if (unlikely(!fromlist)) return NULL;
         Py_INCREF(marker);
@@ -602,7 +608,7 @@ __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
             return NULL;
         }
 #endif
-        module = PyImport_ImportModuleLevelObject(PYIDENT("asyncio.coroutines"), NULL, NULL, fromlist, 0);
+        module = PyImport_ImportModuleLevelObject(module_name, NULL, NULL, fromlist, 0);
         Py_DECREF(fromlist);
         if (unlikely(!module)) {
             goto ignore_or_error;
@@ -621,30 +627,53 @@ ignore_or_error:
     return __Pyx_PyBool_FromLong(is_coroutine);
 }
 
+// shared between get_is_coroutine and get_is_coroutine_marker
 static PyObject *
-__Pyx_CyFunction_get_is_coroutine(PyObject *op_in, void *context) {
+__Pyx_CyFunction_get_is_coroutine_attribute(PyObject *op_in, size_t field_offset, PyObject *module, PyObject *marker) {
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    PyObject *result;
-    CYTHON_UNUSED_VAR(context);
-    if (op->func_is_coroutine) {
-        return __Pyx_NewRef(op->func_is_coroutine);
+    PyObject **field = (PyObject**)((char*)op + field_offset); 
+
+    if (*field) {
+        return __Pyx_NewRef(*field);
     }
 
-    result = __Pyx_CyFunction_get_is_coroutine_value(op);
+    PyObject *result = __Pyx_CyFunction_get_is_coroutine_attribute_value(op, module, marker);
     if (unlikely(!result))
         return NULL;
 
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
     // Guard against concurrent initialisation.
-    if (op->func_is_coroutine) {
+    if (*field) {
         Py_DECREF(result);
-        result = __Pyx_NewRef(op->func_is_coroutine);
+        result = __Pyx_NewRef(*field);
     } else {
-        op->func_is_coroutine = __Pyx_NewRef(result);
+        *field = __Pyx_NewRef(result);
     }
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }
+
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+static PyObject *
+__Pyx_CyFunction_get_is_coroutine(PyObject *op_in, void *context) {
+    CYTHON_UNUSED_VAR(context);
+    return __Pyx_CyFunction_get_is_coroutine_attribute(
+        op_in, offsetof(__pyx_CyFunctionObject, func_is_coroutine),
+        PYIDENT("asyncio.coroutines"), PYIDENT("_is_coroutine")
+    );
+}
+#endif
+
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+static PyObject *
+__Pyx_CyFunction_get_is_coroutine_marker(PyObject *op_in, void *context) {
+   CYTHON_UNUSED_VAR(context);
+    return __Pyx_CyFunction_get_is_coroutine_attribute(
+        op_in, offsetof(__pyx_CyFunctionObject, func_is_coroutine_marker),
+        PYIDENT("inspect"), PYIDENT("_is_coroutine_mark")
+    );
+}
+#endif
 
 //static PyObject *
 //__Pyx_CyFunction_get_signature(__pyx_CyFunctionObject *op, void *context) {
@@ -753,7 +782,12 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
     {"__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
     {"__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
     {"__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     {"_is_coroutine", (getter)__Pyx_CyFunction_get_is_coroutine, 0, 0, 0},
+#endif
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+    {"_is_coroutine_marker", __Pyx_CyFunction_get_is_coroutine_marker, 0, 0, 0},
+#endif
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
 #if CYTHON_COMPILING_IN_LIMITED_API
     {"__module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
@@ -861,7 +895,12 @@ static PyObject *__Pyx_CyFunction_Init(PyObject *op_in,
     op->defaults_kwdict = NULL;
     op->defaults_getter = NULL;
     op->func_annotations = NULL;
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     op->func_is_coroutine = NULL;
+#endif
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+    op->func_is_coroutine_marker = NULL;
+#endif
 #if CYTHON_VECTORCALL
     switch (ml->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O | METH_KEYWORDS | METH_METHOD)) {
     case METH_NOARGS:
@@ -922,7 +961,12 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->defaults_tuple);
     Py_CLEAR(m->defaults_kwdict);
     Py_CLEAR(m->func_annotations);
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_CLEAR(m->func_is_coroutine);
+#endif
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+    Py_CLEAR(m->func_is_coroutine_marker);
+#endif
 
     Py_CLEAR(m->defaults);
 
@@ -987,7 +1031,12 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
     Py_VISIT(m->func_annotations);
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_VISIT(m->func_is_coroutine);
+#endif
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
+    Py_VISIT(m->func_is_coroutine_marker);
+#endif
     Py_VISIT(m->defaults);
 
     return 0;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -93,7 +93,7 @@ typedef struct {
     PyObject *(*defaults_getter)(PyObject *);
     PyObject *func_annotations; /* function annotations dict */
 
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
     // Coroutine marker
     PyObject *func_is_coroutine;
 #endif
@@ -588,7 +588,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
 static PyObject *
 __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
     int is_coroutine = op->flags & __Pyx_CYFUNCTION_COROUTINE;
@@ -757,7 +757,7 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
     {"__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
     {"__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
     {"__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
     {"_is_coroutine", (getter)__Pyx_CyFunction_get_is_coroutine, 0, 0, 0},
 #endif
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
@@ -867,7 +867,7 @@ static PyObject *__Pyx_CyFunction_Init(PyObject *op_in,
     op->defaults_kwdict = NULL;
     op->defaults_getter = NULL;
     op->func_annotations = NULL;
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
     op->func_is_coroutine = NULL;
 #endif
 #if CYTHON_VECTORCALL
@@ -930,7 +930,7 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->defaults_tuple);
     Py_CLEAR(m->defaults_kwdict);
     Py_CLEAR(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
     Py_CLEAR(m->func_is_coroutine);
 #endif
 
@@ -997,7 +997,7 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
     Py_VISIT(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
+#if __PYX_LIMITED_VERSION_HEX < 0x030B0000
     Py_VISIT(m->func_is_coroutine);
 #endif
     Py_VISIT(m->defaults);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -93,13 +93,8 @@ typedef struct {
     PyObject *(*defaults_getter)(PyObject *);
     PyObject *func_annotations; /* function annotations dict */
 
-    // Coroutine marker (inspect and asyncio versions)
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000  
+    // Coroutine marker
     PyObject *func_is_coroutine;
-#endif
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-    PyObject *func_is_coroutine_marker;
-#endif
 } __pyx_CyFunctionObject;
 
 #undef __Pyx_CyOrPyCFunction_Check
@@ -591,12 +586,11 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
-// shared between get_is_coroutine and get_is_coroutine_marker
 static PyObject *
-__Pyx_CyFunction_get_is_coroutine_attribute_value(__pyx_CyFunctionObject *op, PyObject *module_name, PyObject *marker) {
+__Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
     int is_coroutine = op->flags & __Pyx_CYFUNCTION_COROUTINE;
     if (is_coroutine) {
-        PyObject *is_coroutine_value, *module, *fromlist;
+        PyObject *is_coroutine_value, *module, *fromlist, *marker = PYIDENT("_is_coroutine");
         fromlist = PyList_New(1);
         if (unlikely(!fromlist)) return NULL;
         Py_INCREF(marker);
@@ -608,7 +602,7 @@ __Pyx_CyFunction_get_is_coroutine_attribute_value(__pyx_CyFunctionObject *op, Py
             return NULL;
         }
 #endif
-        module = PyImport_ImportModuleLevelObject(module_name, NULL, NULL, fromlist, 0);
+        module = PyImport_ImportModuleLevelObject(PYIDENT("asyncio.coroutines"), NULL, NULL, fromlist, 0);
         Py_DECREF(fromlist);
         if (unlikely(!module)) {
             goto ignore_or_error;
@@ -627,53 +621,30 @@ ignore_or_error:
     return __Pyx_PyBool_FromLong(is_coroutine);
 }
 
-// shared between get_is_coroutine and get_is_coroutine_marker
 static PyObject *
-__Pyx_CyFunction_get_is_coroutine_attribute(PyObject *op_in, size_t field_offset, PyObject *module, PyObject *marker) {
+__Pyx_CyFunction_get_is_coroutine(PyObject *op_in, void *context) {
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    PyObject **field = (PyObject**)((char*)op + field_offset); 
-
-    if (*field) {
-        return __Pyx_NewRef(*field);
+    PyObject *result;
+    CYTHON_UNUSED_VAR(context);
+    if (op->func_is_coroutine) {
+        return __Pyx_NewRef(op->func_is_coroutine);
     }
 
-    PyObject *result = __Pyx_CyFunction_get_is_coroutine_attribute_value(op, module, marker);
+    result = __Pyx_CyFunction_get_is_coroutine_value(op);
     if (unlikely(!result))
         return NULL;
 
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
     // Guard against concurrent initialisation.
-    if (*field) {
+    if (op->func_is_coroutine) {
         Py_DECREF(result);
-        result = __Pyx_NewRef(*field);
+        result = __Pyx_NewRef(op->func_is_coroutine);
     } else {
-        *field = __Pyx_NewRef(result);
+        op->func_is_coroutine = __Pyx_NewRef(result);
     }
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }
-
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
-static PyObject *
-__Pyx_CyFunction_get_is_coroutine(PyObject *op_in, void *context) {
-    CYTHON_UNUSED_VAR(context);
-    return __Pyx_CyFunction_get_is_coroutine_attribute(
-        op_in, offsetof(__pyx_CyFunctionObject, func_is_coroutine),
-        PYIDENT("asyncio.coroutines"), PYIDENT("_is_coroutine")
-    );
-}
-#endif
-
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-static PyObject *
-__Pyx_CyFunction_get_is_coroutine_marker(PyObject *op_in, void *context) {
-   CYTHON_UNUSED_VAR(context);
-    return __Pyx_CyFunction_get_is_coroutine_attribute(
-        op_in, offsetof(__pyx_CyFunctionObject, func_is_coroutine_marker),
-        PYIDENT("inspect"), PYIDENT("_is_coroutine_mark")
-    );
-}
-#endif
 
 //static PyObject *
 //__Pyx_CyFunction_get_signature(__pyx_CyFunctionObject *op, void *context) {
@@ -782,12 +753,7 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
     {"__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
     {"__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
     {"__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     {"_is_coroutine", (getter)__Pyx_CyFunction_get_is_coroutine, 0, 0, 0},
-#endif
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-    {"_is_coroutine_marker", __Pyx_CyFunction_get_is_coroutine_marker, 0, 0, 0},
-#endif
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
 #if CYTHON_COMPILING_IN_LIMITED_API
     {"__module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
@@ -895,12 +861,7 @@ static PyObject *__Pyx_CyFunction_Init(PyObject *op_in,
     op->defaults_kwdict = NULL;
     op->defaults_getter = NULL;
     op->func_annotations = NULL;
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     op->func_is_coroutine = NULL;
-#endif
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-    op->func_is_coroutine_marker = NULL;
-#endif
 #if CYTHON_VECTORCALL
     switch (ml->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O | METH_KEYWORDS | METH_METHOD)) {
     case METH_NOARGS:
@@ -961,12 +922,7 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->defaults_tuple);
     Py_CLEAR(m->defaults_kwdict);
     Py_CLEAR(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_CLEAR(m->func_is_coroutine);
-#endif
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-    Py_CLEAR(m->func_is_coroutine_marker);
-#endif
 
     Py_CLEAR(m->defaults);
 
@@ -1031,12 +987,7 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
     Py_VISIT(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_VISIT(m->func_is_coroutine);
-#endif
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX > 0x030C0000
-    Py_VISIT(m->func_is_coroutine_marker);
-#endif
     Py_VISIT(m->defaults);
 
     return 0;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -93,7 +93,7 @@ typedef struct {
     PyObject *(*defaults_getter)(PyObject *);
     PyObject *func_annotations; /* function annotations dict */
 
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
     // Coroutine marker
     PyObject *func_is_coroutine;
 #endif
@@ -588,7 +588,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
 static PyObject *
 __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
     int is_coroutine = op->flags & __Pyx_CYFUNCTION_COROUTINE;
@@ -757,7 +757,7 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
     {"__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
     {"__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
     {"__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
     {"_is_coroutine", (getter)__Pyx_CyFunction_get_is_coroutine, 0, 0, 0},
 #endif
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
@@ -867,7 +867,7 @@ static PyObject *__Pyx_CyFunction_Init(PyObject *op_in,
     op->defaults_kwdict = NULL;
     op->defaults_getter = NULL;
     op->func_annotations = NULL;
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
     op->func_is_coroutine = NULL;
 #endif
 #if CYTHON_VECTORCALL
@@ -930,7 +930,7 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->defaults_tuple);
     Py_CLEAR(m->defaults_kwdict);
     Py_CLEAR(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
     Py_CLEAR(m->func_is_coroutine);
 #endif
 
@@ -997,7 +997,7 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
     Py_VISIT(m->func_annotations);
-#if __PYX_LIMITED_VERSION_HEX < 0x03100000
+#if __PYX_LIMITED_VERSION_HEX < 0x030A0000
     Py_VISIT(m->func_is_coroutine);
 #endif
     Py_VISIT(m->defaults);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -93,8 +93,10 @@ typedef struct {
     PyObject *(*defaults_getter)(PyObject *);
     PyObject *func_annotations; /* function annotations dict */
 
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     // Coroutine marker
     PyObject *func_is_coroutine;
+#endif
 } __pyx_CyFunctionObject;
 
 #undef __Pyx_CyOrPyCFunction_Check
@@ -586,6 +588,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
 static PyObject *
 __Pyx_CyFunction_get_is_coroutine_value(__pyx_CyFunctionObject *op) {
     int is_coroutine = op->flags & __Pyx_CYFUNCTION_COROUTINE;
@@ -645,6 +648,7 @@ __Pyx_CyFunction_get_is_coroutine(PyObject *op_in, void *context) {
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }
+#endif
 
 //static PyObject *
 //__Pyx_CyFunction_get_signature(__pyx_CyFunctionObject *op, void *context) {
@@ -753,7 +757,9 @@ static PyGetSetDef __pyx_CyFunction_getsets[] = {
     {"__defaults__", (getter)__Pyx_CyFunction_get_defaults, (setter)__Pyx_CyFunction_set_defaults, 0, 0},
     {"__kwdefaults__", (getter)__Pyx_CyFunction_get_kwdefaults, (setter)__Pyx_CyFunction_set_kwdefaults, 0, 0},
     {"__annotations__", (getter)__Pyx_CyFunction_get_annotations, (setter)__Pyx_CyFunction_set_annotations, 0, 0},
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     {"_is_coroutine", (getter)__Pyx_CyFunction_get_is_coroutine, 0, 0, 0},
+#endif
 //    {"__signature__", (getter)__Pyx_CyFunction_get_signature, 0, 0, 0},
 #if CYTHON_COMPILING_IN_LIMITED_API
     {"__module__", (getter)__Pyx_CyFunction_get_module, (setter)__Pyx_CyFunction_set_module, 0, 0},
@@ -861,7 +867,9 @@ static PyObject *__Pyx_CyFunction_Init(PyObject *op_in,
     op->defaults_kwdict = NULL;
     op->defaults_getter = NULL;
     op->func_annotations = NULL;
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     op->func_is_coroutine = NULL;
+#endif
 #if CYTHON_VECTORCALL
     switch (ml->ml_flags & (METH_VARARGS | METH_FASTCALL | METH_NOARGS | METH_O | METH_KEYWORDS | METH_METHOD)) {
     case METH_NOARGS:
@@ -922,7 +930,9 @@ static int __Pyx__CyFunction_clear(__pyx_CyFunctionObject *m)
     Py_CLEAR(m->defaults_tuple);
     Py_CLEAR(m->defaults_kwdict);
     Py_CLEAR(m->func_annotations);
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_CLEAR(m->func_is_coroutine);
+#endif
 
     Py_CLEAR(m->defaults);
 
@@ -987,7 +997,9 @@ static int __Pyx_CyFunction_traverse(PyObject *m_in, visitproc visit, void *arg)
     Py_VISIT(m->defaults_tuple);
     Py_VISIT(m->defaults_kwdict);
     Py_VISIT(m->func_annotations);
+#if __PYX_LIMITED_VERSION_HEX < 0x03100000
     Py_VISIT(m->func_is_coroutine);
+#endif
     Py_VISIT(m->defaults);
 
     return 0;

--- a/tests/run/py35_asyncio_async_def.srctree
+++ b/tests/run/py35_asyncio_async_def.srctree
@@ -21,6 +21,7 @@ import asyncio
 import cy_test
 import py_test
 from contextlib import closing
+from inspect import iscoroutinefunction
 
 async def main():
     await cy_test.say()
@@ -32,12 +33,12 @@ with closing(asyncio.new_event_loop()) as loop:
     print("Running Cython coroutine ...")
     loop.run_until_complete(cy_test.say())
 
-assert asyncio.iscoroutinefunction(cy_test.cy_async_def_example) == True
-assert asyncio.iscoroutinefunction(cy_test.cy_async_def_example) == True
-assert asyncio.iscoroutinefunction(py_test.py_async_def_example) == True
-assert asyncio.iscoroutinefunction(py_test.py_async_def_example) == True
-assert asyncio.iscoroutinefunction(cy_test.cy_def_example) == False
-assert asyncio.iscoroutinefunction(py_test.py_def_example) == False
+assert iscoroutinefunction(cy_test.cy_async_def_example) == True
+assert iscoroutinefunction(cy_test.cy_async_def_example) == True
+assert iscoroutinefunction(py_test.py_async_def_example) == True
+assert iscoroutinefunction(py_test.py_async_def_example) == True
+assert iscoroutinefunction(cy_test.cy_def_example) == False
+assert iscoroutinefunction(py_test.py_def_example) == False
 
 ######## cy_test.pyx ########
 

--- a/tests/run/py35_asyncio_async_def.srctree
+++ b/tests/run/py35_asyncio_async_def.srctree
@@ -21,7 +21,12 @@ import asyncio
 import cy_test
 import py_test
 from contextlib import closing
-from inspect import iscoroutinefunction
+import sys
+if sys.version_info > (3,10,6)
+    from inspect import iscoroutinefunction
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction
+
 
 async def main():
     await cy_test.say()

--- a/tests/run/py35_asyncio_async_def.srctree
+++ b/tests/run/py35_asyncio_async_def.srctree
@@ -22,7 +22,12 @@ import cy_test
 import py_test
 from contextlib import closing
 import sys
-if sys.version_info > (3,10,6)
+if sys.version_info > (3, 10, 6) and sys.version_info < (3, 16):
+    import inspect
+    def iscoroutinefunction(f):
+        # check both
+        return inspect.iscoroutinefunction(f) and asyncio.iscoroutinefunction(f)
+elif sys.version_info >= (3, 16):
     from inspect import iscoroutinefunction
 else:
     iscoroutinefunction = asyncio.iscoroutinefunction


### PR DESCRIPTION
It was deprecated on Python 3.14 and removed in Python 3.16.

`inspect.iscoroutinefunction` looks to be available on all versions we care about, so just use that.

It looks like we only need `cyfunction._is_coroutine` on Python 3.9 and some early Python 3.10 builds. After that `inspect.iscoroutinefunction` will correctly identify cyfunctions without any help. Therefore I've disabled it on versions where I believe it's useless.  This isn't strictly necessary to fix the 3.16 test failures though