### PR TITLE
pypy fails test_nocopy_star_args

### DIFF
--- a/tests/pypy_implementation_detail_bugs.txt
+++ b/tests/pypy_implementation_detail_bugs.txt
@@ -4,6 +4,7 @@
 # that should be tested on PyPy?)
 
 run.starargs
+run.extstarargs
 
 # refcounting-specific tests
 double_dealloc_T796


### PR DESCRIPTION
PyPy does not pass through starargs, it creates a new tuple:

```
def f(*args):
    return args
```

See issue pypy/pypy#5486. For the meantime, let's skip the test on PyPy as an implementation detail.