### PR TITLE
[3.2.x] Fix potential double-free in tstring code

### DIFF
--- a/Cython/Utility/TString.c
+++ b/Cython/Utility/TString.c
@@ -301,8 +301,8 @@ static PyObject* __Pyx_MakeTemplateLibTemplate(PyObject *strings, PyObject *inte
         if (unlikely(__Pyx_VectorcallBuilder_AddArg(PYIDENT("interpolations"), interpolations, kwargs_builder, args, 1)<0))
             goto failed_shortcut;
         result = __Pyx_Object_Vectorcall_CallFromBuilder(tp, args, 0, kwargs_builder);
-        Py_DECREF(kwargs_builder);
         if (result) {
+            Py_DECREF(kwargs_builder);
             Py_DECREF(tp);
             return result;
         }


### PR DESCRIPTION
This is most likely to happen if someone else using someone else's tstring backport. In this case the call with keyword arguments can fail (because it's something that's only expected to pass on our backport).