### PR TITLE
Let vectorcall use cached literal kwnames tuples

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7088,7 +7088,7 @@ class PyMethodCallNode(CallNode):
             code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({kwnames_temp}, {arg_index})")
         code.putln("#else")
         code.putln("{")
-        kwnames.generate_sequence_as_array_code(code, Naming.quick_temp_cname);
+        kwnames.generate_sequence_as_array_code(code, Naming.quick_temp_cname)
         for arg_index in arg_indices_to_check:
             code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({Naming.quick_temp_cname}, {arg_index})")
         code.putln(f"{kwnames_temp} = __Pyx_MakeKwargDict({Naming.quick_temp_cname}, "

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -7082,7 +7082,7 @@ class PyMethodCallNode(CallNode):
 
         code.putln("#if CYTHON_VECTORCALL")
         code.putln(f"{kwnames_temp} = {kwnames.result()};")
-        code.putln(f"{code.error_goto_if_null(kwnames_temp, self.pos)}")
+        code.putln(code.error_goto_if_null(kwnames_temp, self.pos))
         code.put_incref(kwnames_temp, py_object_type)
         for arg_index in arg_indices_to_check:
             code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({kwnames_temp}, {arg_index})")
@@ -7093,7 +7093,7 @@ class PyMethodCallNode(CallNode):
             code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({Naming.quick_temp_cname}, {arg_index})")
         code.putln(f"{kwnames_temp} = __Pyx_MakeKwargDict({Naming.quick_temp_cname}, "
                    f"{Naming.callargs_cname}+{len(args)+1}, {len(kwvalues)});")
-        code.putln(f"{code.error_goto_if_null(kwnames_temp, self.pos)}")
+        code.putln(code.error_goto_if_null(kwnames_temp, self.pos))
         code.put_gotref(kwnames_temp, py_object_type)
         code.putln("}")
         code.putln("#endif")
@@ -7163,11 +7163,7 @@ class PyMethodCallNode(CallNode):
         # To avoid passing an out-of-bounds argument pointer in the no-args case,
         # we need at least two entries, so we pad with NULL and point to that.
         # See https://github.com/cython/cython/issues/5668
-        args_and_kwargs = []
-        if args:
-            args_and_kwargs.extend(args)
-        if kwvalues:
-            args_and_kwargs.extend(kwvalues)
+        args_and_kwargs = args + (kwvalues or [])
         args_list = ', '.join(arg.py_result() for arg in args_and_kwargs) if args_and_kwargs else "NULL"
         code.putln(
             f"PyObject *{Naming.callargs_cname}[{(len(args_and_kwargs) + 1) if args_and_kwargs else 2:d}] = {{{self_arg}, {args_list}}};"
@@ -8784,7 +8780,7 @@ class SequenceNode(ExprNode):
         # Currently only suitable for fixed-size sequences
         assert not self.mult_factor
         code.put(f"PyObject *{target}[{len(self.args)}] = {{")
-        code.put(f"{', '.join(arg.result() for arg in self.args)}")
+        code.put(', '.join(arg.result() for arg in self.args))
         code.putln("};")
 
     def generate_subexpr_disposal_code(self, code):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6903,25 +6903,38 @@ class PyMethodCallNode(CallNode):
     # function    ExprNode      the function/method object to call
     # arg_tuple   TupleNode     the arguments for the args tuple
     # kwdict      ExprNode or None  keyword dictionary (if present)
+    # Arguments to constructor only:
     # kwargs_key_value_pairs  [ExprNode] or None  list of unpacked kwargs key-value pairs, if known
     # function_obj  ExprNode or None  == self.function.obj when using PyObject_VectorcallMethod()
     # unpack      bool
 
-    subexprs = ['function', 'arg_tuple', 'kwdict', 'kwargs_key_value_pairs']
+    subexprs = ['function', 'arg_tuple', 'kwdict', 'kwnames', 'kwvalues']
     is_temp = True
     use_method_vectorcall = False
     kwdict = None
-    kwargs_key_value_pairs = None
+    kwnames = None
+    kwvalues = None
     function_obj = None
 
-    def __init__(self, pos, **kw):
+    def __init__(self, pos, env, **kw):
+        # env is required with keyword args to analyse a newly created tuple
+        # and work out if it's literal.
+        kwdict = kw.get('kwdict', None)
+        kwargs_key_value_pairs = kw.pop('kwargs_key_value_pairs', None)
+        if kwdict and kwdict.is_dict_literal:
+            assert not kwargs_key_value_pairs
+            kwargs_key_value_pairs = kwdict.key_value_pairs
+            del kw['kwdict']
+        if kwargs_key_value_pairs:
+            kwnames = TupleNode(pos, args=[kvp.key for kvp in kwargs_key_value_pairs])
+            kwnames = kwnames.analyse_types(env, skip_children=True)
+            kw['kwnames'] = kwnames
+            kw['kwvalues'] = [kvp.value for kvp in kwargs_key_value_pairs]
+
         super().__init__(pos, **kw)
         if self.can_avoid_attribute_lookup():
             self.use_method_vectorcall = True
             self.function_obj = self.function.obj
-        if self.kwdict and self.kwdict.is_dict_literal:
-            self.kwargs_key_value_pairs = self.kwdict.key_value_pairs
-            self.kwdict = None
 
     def can_avoid_attribute_lookup(self):
         # Essentially, if the signature matches PyObject_VectorcallMethod
@@ -7061,38 +7074,42 @@ class PyMethodCallNode(CallNode):
         code.putln("#endif")  # CYTHON_UNPACK_METHODS
         # TODO may need to deal with unused variables in the #else case
 
-    def generate_keyvalue_args(self, code, args, kwargs_key_value_pairs, kwnames_temp):
-        code.putln(
-            f"{kwnames_temp} = __Pyx_MakeVectorcallBuilderKwds({len(kwargs_key_value_pairs)}); "
-            f"{code.error_goto_if_null(kwnames_temp, self.pos)}"
-        )
-        code.put_gotref(kwnames_temp, py_object_type)
+    def generate_keyvalue_args(self, code, args, kwnames, kwvalues, kwnames_temp):
+        arg_indices_to_check = [
+            n for n, arg in enumerate(kwnames.args)
+            if not arg.type.is_pystr_type or arg.may_be_none()
+        ]
 
-        for n, keyvalue in enumerate(kwargs_key_value_pairs):
-            key_is_str = keyvalue.key.type.is_pystr_type and not keyvalue.key.may_be_none()
-            code.put_error_if_neg(
-                self.pos,
-                f"__Pyx_VectorcallBuilder_AddArg{'' if key_is_str else '_Check'}("
-                f"{keyvalue.key.py_result()}, "
-                f"{keyvalue.value.py_result()}, "
-                f"{kwnames_temp}, "
-                f"{Naming.callargs_cname}+{len(args) + 1}, "
-                f"{n:d}"
-                ")"
-            )
+        code.putln("#if CYTHON_VECTORCALL")
+        code.putln(f"{kwnames_temp} = {kwnames.result()};")
+        code.putln(f"{code.error_goto_if_null(kwnames_temp, self.pos)}")
+        code.put_incref(kwnames_temp, py_object_type)
+        for arg_index in arg_indices_to_check:
+            code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({kwnames_temp}, {arg_index})")
+        code.putln("#else")
+        code.putln("{")
+        kwnames.generate_sequence_as_array_code(code, Naming.quick_temp_cname);
+        for arg_index in arg_indices_to_check:
+            code.put_error_if_neg(kwnames.pos, f"__Pyx_CheckVectorcallKwarg({Naming.quick_temp_cname}, {arg_index})")
+        code.putln(f"{kwnames_temp} = __Pyx_MakeKwargDict({Naming.quick_temp_cname}, "
+                   f"{Naming.callargs_cname}+{len(args)+1}, {len(kwvalues)});")
+        code.putln(f"{code.error_goto_if_null(kwnames_temp, self.pos)}")
+        code.put_gotref(kwnames_temp, py_object_type)
+        code.putln("}")
+        code.putln("#endif")
 
     def select_utility_code(self, code):
         # ... and return the utility function's cname.
         if self.use_method_vectorcall:
-            if self.kwargs_key_value_pairs:
-                name = "PyObjectVectorCallMethodKwBuilder"
-                cfunc = "__Pyx_Object_VectorcallMethod_CallFromBuilder"
+            if self.kwnames:
+                name = "PyObjectVectorcallMethodKwds"
+                cfunc = "__Pyx_Object_VectorcallMethodKwds"
             else:
                 name = "PyObjectFastCallMethod"
                 cfunc = "__Pyx_PyObject_FastCallMethod"
-        elif self.kwargs_key_value_pairs:
-            name = "PyObjectVectorCallKwBuilder"
-            cfunc = "__Pyx_Object_Vectorcall_CallFromBuilder"
+        elif self.kwnames:
+            name = "PyObjectVectorcallKwds"
+            cfunc = "__Pyx_Object_VectorcallKwds"
         elif self.kwdict:
             name = "PyObjectFastCall"
             cfunc = "__Pyx_PyObject_FastCallDict"
@@ -7108,7 +7125,8 @@ class PyMethodCallNode(CallNode):
         code.mark_pos(self.pos)
         self.allocate_temp_result(code)
 
-        kwargs_key_value_pairs = self.kwargs_key_value_pairs
+        kwnames = self.kwnames
+        kwvalues = self.kwvalues
         kwdict = self.kwdict
 
         self_arg = code.funcstate.allocate_temp(py_object_type, manage_ref=True)
@@ -7119,9 +7137,10 @@ class PyMethodCallNode(CallNode):
         for arg in args:
             arg.generate_evaluation_code(code)
 
-        if kwargs_key_value_pairs:
-            for keyvalue in kwargs_key_value_pairs:
-                keyvalue.generate_evaluation_code(code)
+        if kwnames:
+            kwnames.generate_evaluation_code(code)
+            for value in kwvalues:
+                value.generate_evaluation_code(code)
         elif kwdict:
             kwdict.generate_evaluation_code(code)
 
@@ -7144,16 +7163,20 @@ class PyMethodCallNode(CallNode):
         # To avoid passing an out-of-bounds argument pointer in the no-args case,
         # we need at least two entries, so we pad with NULL and point to that.
         # See https://github.com/cython/cython/issues/5668
-        args_list = ', '.join(arg.py_result() for arg in args) if args else "NULL"
-        extra_keyword_args = f" + ((CYTHON_VECTORCALL) ? {len(kwargs_key_value_pairs)} : 0)" if kwargs_key_value_pairs else ""
+        args_and_kwargs = []
+        if args:
+            args_and_kwargs.extend(args)
+        if kwvalues:
+            args_and_kwargs.extend(kwvalues)
+        args_list = ', '.join(arg.py_result() for arg in args_and_kwargs) if args_and_kwargs else "NULL"
         code.putln(
-            f"PyObject *{Naming.callargs_cname}[{(len(args) + 1) if args else 2:d}{extra_keyword_args}] = {{{self_arg}, {args_list}}};"
+            f"PyObject *{Naming.callargs_cname}[{(len(args_and_kwargs) + 1) if args_and_kwargs else 2:d}] = {{{self_arg}, {args_list}}};"
         )
 
         keyword_variable = ""
-        if kwargs_key_value_pairs:
+        if kwnames:
             keyword_variable = code.funcstate.allocate_temp(py_object_type, manage_ref=True)
-            self.generate_keyvalue_args(code, args, kwargs_key_value_pairs, keyword_variable)
+            self.generate_keyvalue_args(code, args, kwnames, kwvalues, keyword_variable)
         elif kwdict:
             keyword_variable = kwdict.result()
 
@@ -7176,10 +7199,12 @@ class PyMethodCallNode(CallNode):
             arg.generate_disposal_code(code)
             arg.free_temps(code)
 
-        if kwargs_key_value_pairs:
-            for kw_node in kwargs_key_value_pairs:
-                kw_node.generate_disposal_code(code)
-                kw_node.free_temps(code)
+        if kwnames:
+            kwnames.generate_disposal_code(code)
+            kwnames.free_temps(code)
+            for value in kwvalues:
+                value.generate_disposal_code(code)
+                value.free_temps(code)
             code.put_decref_clear(keyword_variable, py_object_type)
             code.funcstate.release_temp(keyword_variable)
         elif kwdict:
@@ -8754,6 +8779,13 @@ class SequenceNode(ExprNode):
             code.put_decref(target, py_object_type)
             code.putln('%s = %s;' % (target, Naming.quick_temp_cname))
             code.putln('}')
+
+    def generate_sequence_as_array_code(self, code, target):
+        # Currently only suitable for fixed-size sequences
+        assert not self.mult_factor
+        code.put(f"PyObject *{target}[{len(self.args)}] = {{")
+        code.put(f"{', '.join(arg.result() for arg in self.args)}")
+        code.putln("};")
 
     def generate_subexpr_disposal_code(self, code):
         if self.needs_subexpr_disposal:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6903,8 +6903,9 @@ class PyMethodCallNode(CallNode):
     # function    ExprNode      the function/method object to call
     # arg_tuple   TupleNode     the arguments for the args tuple
     # kwdict      ExprNode or None  keyword dictionary (if present)
+    # kwnames     TupleNode or None   names of keyword arguments
+    # kwvalues    list[ExprNode] | None  values of keyword arguments
     # Arguments to constructor only:
-    # kwargs_key_value_pairs  [ExprNode] or None  list of unpacked kwargs key-value pairs, if known
     # function_obj  ExprNode or None  == self.function.obj when using PyObject_VectorcallMethod()
     # unpack      bool
 
@@ -6916,21 +6917,7 @@ class PyMethodCallNode(CallNode):
     kwvalues = None
     function_obj = None
 
-    def __init__(self, pos, env, **kw):
-        # env is required with keyword args to analyse a newly created tuple
-        # and work out if it's literal.
-        kwdict = kw.get('kwdict', None)
-        kwargs_key_value_pairs = kw.pop('kwargs_key_value_pairs', None)
-        if kwdict and kwdict.is_dict_literal:
-            assert not kwargs_key_value_pairs
-            kwargs_key_value_pairs = kwdict.key_value_pairs
-            del kw['kwdict']
-        if kwargs_key_value_pairs:
-            kwnames = TupleNode(pos, args=[kvp.key for kvp in kwargs_key_value_pairs])
-            kwnames = kwnames.analyse_types(env, skip_children=True)
-            kw['kwnames'] = kwnames
-            kw['kwvalues'] = [kvp.value for kvp in kwargs_key_value_pairs]
-
+    def __init__(self, pos, **kw):
         super().__init__(pos, **kw)
         if self.can_avoid_attribute_lookup():
             self.use_method_vectorcall = True

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5233,7 +5233,8 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
                         # function self object was moved into a CloneNode => undo
                         function.obj = function.obj.arg
                     node = self.replace(node, ExprNodes.PyMethodCallNode.from_node(
-                        node, function=function, arg_tuple=node.arg_tuple, type=node.type,
+                        node, env=self.current_env(),
+                        function=function, arg_tuple=node.arg_tuple, type=node.type,
                         unpack=self._check_optimize_method_calls(node)))
         return node
 
@@ -5252,7 +5253,8 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
             return node
 
         node = self.replace(node, ExprNodes.PyMethodCallNode.from_node(
-            node, function=function, arg_tuple=node.positional_args, kwdict=node.keyword_args,
+            node, env=self.current_env(),
+            function=function, arg_tuple=node.positional_args, kwdict=node.keyword_args,
             type=node.type, unpack=self._check_optimize_method_calls(node)))
         return node
 

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5261,7 +5261,7 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
             kwvalues = [kvp.value for kvp in node.keyword_args.key_value_pairs]
         elif node.keyword_args:
             kwdict = node.keyword_args
-            
+
         node = self.replace(node, ExprNodes.PyMethodCallNode.from_node(
             node,
             function=function, arg_tuple=node.positional_args, kwdict=kwdict,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5252,9 +5252,20 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
         if not ExprNodes.PyMethodCallNode.can_be_used_for_function(function):
             return node
 
+        kwnames = kwvalues = kwdict = None
+        if node.keyword_args and node.keyword_args.is_dict_literal:
+            kwnames = ExprNodes.TupleNode(
+                node.pos,
+                args=[kvp.key for kvp in node.keyword_args.key_value_pairs])
+            kwnames = kwnames.analyse_types(self.current_env(), skip_children=True)
+            kwvalues = [kvp.value for kvp in node.keyword_args.key_value_pairs]
+        elif node.keyword_args:
+            kwdict = node.keyword_args
+            
         node = self.replace(node, ExprNodes.PyMethodCallNode.from_node(
-            node, env=self.current_env(),
-            function=function, arg_tuple=node.positional_args, kwdict=node.keyword_args,
+            node,
+            function=function, arg_tuple=node.positional_args, kwdict=kwdict,
+            kwnames=kwnames, kwvalues=kwvalues,
             type=node.type, unpack=self._check_optimize_method_calls(node)))
         return node
 

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2270,83 +2270,78 @@ static PyObject *__Pyx_PyObject_FastCallMethod(PyObject *name, PyObject *const *
 }
 #endif
 
-/////////////// PyObjectVectorCallKwBuilder.proto ////////////////
+/////////////// PyObjectVectorcallKwds.proto ////////////////////
 //@requires: PyObjectFastCall
-// For versions that define PyObject_Vectorcall, use PyObject_Vectorcall and define functions to build a kwnames tuple and add arguments to args.
-// For versions that don't, use __Pyx_PyObject_FastCallDict and functions to build a keyword dictionary
-
-CYTHON_UNUSED static int __Pyx_VectorcallBuilder_AddArg_Check(PyObject *key, PyObject *value, PyObject *builder, PyObject **args, int n); /* proto */
 
 #if CYTHON_VECTORCALL
-#define __Pyx_Object_Vectorcall_CallFromBuilder PyObject_Vectorcall
-
-#define __Pyx_MakeVectorcallBuilderKwds(n) PyTuple_New(n)
-
-static int __Pyx_VectorcallBuilder_AddArg(PyObject *key, PyObject *value, PyObject *builder, PyObject **args, int n); /* proto */
-static int __Pyx_VectorcallBuilder_AddArgStr(const char *key, PyObject *value, PyObject *builder, PyObject **args, int n); /* proto */
+#define __Pyx_Object_VectorcallKwds PyObject_Vectorcall
+CYTHON_UNUSED static int __Pyx_CheckVectorcallKwarg(PyObject *kwnames, Py_ssize_t i); /* proto */
 #else
-#define __Pyx_Object_Vectorcall_CallFromBuilder __Pyx_PyObject_FastCallDict
-
-#define __Pyx_MakeVectorcallBuilderKwds(n) __Pyx_PyDict_NewPresized(n)
-
-#define __Pyx_VectorcallBuilder_AddArg(key, value, builder, args, n) PyDict_SetItem(builder, key, value)
-#define __Pyx_VectorcallBuilder_AddArgStr(key, value, builder, args, n) PyDict_SetItemString(builder, key, value)
+#define __Pyx_Object_VectorcallKwds __Pyx_PyObject_FastCallDict
+CYTHON_UNUSED static PyObject *__Pyx_MakeKwargDict(PyObject **keys, PyObject **values, Py_ssize_t n); /* proto */
+CYTHON_UNUSED static int __Pyx_CheckVectorcallKwarg(PyObject **kwnames, Py_ssize_t i); /* proto */
 #endif
 
-/////////////// PyObjectVectorCallKwBuilder ////////////////
+/////////////// PyObjectVectorcallKwds ////////////////////
 
 #if CYTHON_VECTORCALL
-static int __Pyx_VectorcallBuilder_AddArg(PyObject *key, PyObject *value, PyObject *builder, PyObject **args, int n) {
-    (void)__Pyx_PyObject_FastCallDict;
+CYTHON_UNUSED static int __Pyx_CheckVectorcallKwarg(PyObject *kwnames, Py_ssize_t i) {
+    PyObject *key = __Pyx_PyTuple_GET_ITEM(kwnames, i);
+#if !CYTHON_ASSUME_SAFE_MACROS
+    if (unlikely(!key)) return -1;
+#endif
 
-    Py_INCREF(key);
-    if (__Pyx_PyTuple_SET_ITEM(builder, n, key) != (0)) return -1;
-    args[n] = value;
+    if (unlikely(!PyUnicode_Check(key))) {
+        PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+        return -1;
+    }
     return 0;
 }
 
-CYTHON_UNUSED static int __Pyx_VectorcallBuilder_AddArg_Check(PyObject *key, PyObject *value, PyObject *builder, PyObject **args, int n) {
-    (void)__Pyx_VectorcallBuilder_AddArgStr;
-    if (unlikely(!PyUnicode_Check(key))) {
-        PyErr_SetString(PyExc_TypeError, "keywords must be strings");
-        return -1;
+#else
+
+CYTHON_UNUSED static PyObject *__Pyx_MakeKwargDict(PyObject **keys, PyObject **values, Py_ssize_t n) {
+    PyObject *out = PyDict_New();
+    if (unlikely(!out)) return NULL;
+    for (Py_ssize_t i=0; i<n; ++i) {
+        if (unlikely(PyDict_SetItem(out, keys[i], values[i]) < 0)) {
+            Py_DECREF(out);
+            return NULL;
+        }
     }
-    return __Pyx_VectorcallBuilder_AddArg(key, value, builder, args, n);
+    return out;
 }
 
-static int __Pyx_VectorcallBuilder_AddArgStr(const char *key, PyObject *value, PyObject *builder, PyObject **args, int n) {
-    PyObject *pyKey = PyUnicode_FromString(key);
-    if (!pyKey) return -1;
-    return __Pyx_VectorcallBuilder_AddArg(pyKey, value, builder, args, n);
-}
-#else // CYTHON_VECTORCALL
-CYTHON_UNUSED static int __Pyx_VectorcallBuilder_AddArg_Check(PyObject *key, PyObject *value, PyObject *builder, CYTHON_UNUSED PyObject **args, CYTHON_UNUSED int n) {
+CYTHON_UNUSED static int __Pyx_CheckVectorcallKwarg(PyObject **kwnames, Py_ssize_t i) {
+    PyObject *key = kwnames[i];
+
     if (unlikely(!PyUnicode_Check(key))) {
         PyErr_SetString(PyExc_TypeError, "keywords must be strings");
         return -1;
     }
-    return PyDict_SetItem(builder, key, value);
+    return 0;
 }
+
 #endif
 
-/////////////// PyObjectVectorCallMethodKwBuilder.proto ////////////////
+/////////////// PyObjectVectorcallMethodKwds.proto /////////////////
+//@requires: PyObjectVectorcallKwds
 
 #if CYTHON_VECTORCALL
-#define __Pyx_Object_VectorcallMethod_CallFromBuilder PyObject_VectorcallMethod
+#define __Pyx_Object_VectorcallMethodKwds PyObject_VectorcallMethod
 #else
-static PyObject *__Pyx_Object_VectorcallMethod_CallFromBuilder(PyObject *name, PyObject *const *args, size_t nargsf, PyObject *kwnames); /* proto */
+static PyObject *__Pyx_Object_VectorcallMethodKwds(PyObject *name, PyObject *const *args, size_t nargsf, PyObject *kwnames); /* proto */
 #endif
 
-/////////////// PyObjectVectorCallMethodKwBuilder ////////////////
-//@requires: PyObjectVectorCallKwBuilder
+/////////////// PyObjectVectorcallMethodKwds ///////////////////
 
 #if !CYTHON_VECTORCALL
-static PyObject *__Pyx_Object_VectorcallMethod_CallFromBuilder(PyObject *name, PyObject *const *args, size_t nargsf, PyObject *kwnames) {
+static PyObject *__Pyx_Object_VectorcallMethodKwds(PyObject *name, PyObject *const *args, size_t nargsf, PyObject *kwnames) {
     PyObject *result;
     PyObject *obj = PyObject_GetAttr(args[0], name);
     if (unlikely(!obj))
         return NULL;
-    result = __Pyx_Object_Vectorcall_CallFromBuilder(obj, args+1, nargsf-1, kwnames);
+    result = __Pyx_Object_VectorcallKwds(obj, args+1, nargsf-1, kwnames);
     Py_DECREF(obj);
     return result;
 }

--- a/Cython/Utility/TString.c
+++ b/Cython/Utility/TString.c
@@ -271,7 +271,6 @@ static PyObject* __Pyx_MakeTemplateLibTemplate(PyObject *strings, PyObject *inte
 
 //////////////////////////// MakeTemplateLibTemplate ////////////////////////
 //@requires: InitializeTemplateLib
-//@requires: ObjectHandling.c::PyObjectVectorCallKwBuilder
 
 #if PY_VERSION_HEX >= 0x030E0000 && CYTHON_COMPILING_IN_CPYTHON
 #ifndef Py_BUILD_CORE
@@ -296,22 +295,29 @@ static PyObject* __Pyx_MakeTemplateLibTemplate(PyObject *strings, PyObject *inte
         // There's a high chance (but not certain) that we're using our internal
         // fallback version of template. In this case we can try to use a better
         // constructor.
-        PyObject *args[] = { NULL, NULL };
-        PyObject *kwargs_builder = __Pyx_MakeVectorcallBuilderKwds(2);
-        if (unlikely(!kwargs_builder)) goto failed_shortcut; 
-        if (unlikely(__Pyx_VectorcallBuilder_AddArg(PYIDENT("strings"), strings, kwargs_builder, args, 0)<0))
-            goto failed_shortcut;
-        if (unlikely(__Pyx_VectorcallBuilder_AddArg(PYIDENT("interpolations"), interpolations, kwargs_builder, args, 1)<0))
-            goto failed_shortcut;
-        result = __Pyx_Object_Vectorcall_CallFromBuilder(tp, args, 0, kwargs_builder);
-        Py_DECREF(kwargs_builder);
+        PyObject *kwds = NULL;
+        {
+#if CYTHON_VECTORCALL
+            PyObject *args[] = { strings, interpolations };
+            kwds = PyTuple_Pack(2, PYIDENT("strings"), PYIDENT("interpolations"));
+            if (unlikely(!kwds)) goto failed_shortcut;
+            result = PyObject_Vectorcall(tp, args, 0, kwds);
+#else
+            kwds = PyDict_New();
+            if (unlikely(!kwds)) goto failed_shortcut;
+            if (unlikely(PyDict_SetItem(kwds, PYIDENT("strings"), strings) < 0)) goto failed_shortcut;
+            if (unlikely(PyDict_SetItem(kwds, PYIDENT("interpolations"), interpolations) < 0)) goto failed_shortcut;
+            result = PyObject_Call(tp, EMPTY(tuple), kwds);
+#endif
+        }
         if (result) {
+            Py_DECREF(kwds);
             Py_DECREF(tp);
             return result;
         }
 
       failed_shortcut:
-        Py_CLEAR(kwargs_builder);
+        Py_XDECREF(kwds);
         if (!__Pyx_IgnoreException(PyExc_Exception)) {
             return NULL; // BaseException
         }

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -881,12 +881,10 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
             return PyLong_FromNativeBytes(bytes, sizeof(value), -1);
         }
 #elif !CYTHON_COMPILING_IN_LIMITED_API && PY_VERSION_HEX < 0x030d0000
-        int one = 1; int little = (int)*(unsigned char *)&one;
         return _PyLong_FromByteArray(bytes, sizeof({{TYPE}}),
-                                     little, !is_unsigned);
+                                     PY_LITTLE_ENDIAN, !is_unsigned);
 #else
         // call int.from_bytes()
-        int one = 1; int little = (int)*(unsigned char *)&one;
         PyObject *result = NULL, *kwds = NULL;
         PyObject *py_bytes = NULL, *order_str = NULL, *from_bytes_str = NULL;;
         py_bytes = PyBytes_FromStringAndSize((char*)bytes, sizeof({{TYPE}}));
@@ -895,7 +893,11 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
         // to ever run so it seems a pessimization mostly.
         from_bytes_str = PyUnicode_FromStringAndSize("from_bytes", 10);
         if (!from_bytes_str) goto limited_bad;
-        order_str = PyUnicode_FromString(little ? "little" : "big");
+#if PY_LITTLE_ENDIAN
+        order_str = PyUnicode_FromStringAndSize("little", 6);
+#else
+        order_str = PyUnicode_FromStringAndSize("big", 3);
+#endif
         if (!order_str) goto limited_bad;
         {
             PyObject *args[] = { (PyObject*)&PyLong_Type, py_bytes, order_str, Py_True };

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -881,10 +881,12 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
             return PyLong_FromNativeBytes(bytes, sizeof(value), -1);
         }
 #elif !CYTHON_COMPILING_IN_LIMITED_API && PY_VERSION_HEX < 0x030d0000
+        int one = 1; int little = (int)*(unsigned char *)&one;
         return _PyLong_FromByteArray(bytes, sizeof({{TYPE}}),
-                                     PY_LITTLE_ENDIAN, !is_unsigned);
+                                     little, !is_unsigned);
 #else
         // call int.from_bytes()
+        int one = 1; int little = (int)*(unsigned char *)&one;
         PyObject *result = NULL, *kwds = NULL;
         PyObject *py_bytes = NULL, *order_str = NULL, *from_bytes_str = NULL;;
         py_bytes = PyBytes_FromStringAndSize((char*)bytes, sizeof({{TYPE}}));
@@ -893,11 +895,7 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
         // to ever run so it seems a pessimization mostly.
         from_bytes_str = PyUnicode_FromStringAndSize("from_bytes", 10);
         if (!from_bytes_str) goto limited_bad;
-#if PY_LITTLE_ENDIAN
-        order_str = PyUnicode_FromStringAndSize("little", 6);
-#else
-        order_str = PyUnicode_FromStringAndSize("big", 3);
-#endif
+        order_str = PyUnicode_FromString(little ? "little" : "big");
         if (!order_str) goto limited_bad;
         {
             PyObject *args[] = { (PyObject*)&PyLong_Type, py_bytes, order_str, Py_True };

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -841,7 +841,7 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value);
 
 /////////////// CIntToPy ///////////////
 //@requires: GCCDiagnostics
-//@requires: ObjectHandling.c::PyObjectVectorCallKwBuilder
+//@requires: ObjectHandling.c::PyObjectVectorcallMethodKwds
 
 static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
 #ifdef __Pyx_HAS_GCC_DIAGNOSTIC
@@ -888,30 +888,41 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
         // call int.from_bytes()
         int one = 1; int little = (int)*(unsigned char *)&one;
         PyObject *from_bytes, *result = NULL, *kwds = NULL;
-        PyObject *py_bytes = NULL, *order_str = NULL;
-        from_bytes = PyObject_GetAttrString((PyObject*)&PyLong_Type, "from_bytes");
+        PyObject *py_bytes = NULL, *order_str = NULL, *from_bytes_str = NULL;;
         if (!from_bytes) return NULL;
         py_bytes = PyBytes_FromStringAndSize((char*)bytes, sizeof({{TYPE}}));
         if (!py_bytes) goto limited_bad;
         // I'm deliberately not using PYIDENT here because this code path is very unlikely
         // to ever run so it seems a pessimization mostly.
+        from_bytes_str = PyUnicode_FromStringAndSize("from_bytes", 10);
+        if (!from_bytes_str) goto limited_bad;
         order_str = PyUnicode_FromString(little ? "little" : "big");
         if (!order_str) goto limited_bad;
         {
-            PyObject *args[3+(CYTHON_VECTORCALL ? 1 : 0)] = { NULL, py_bytes, order_str };
+            PyObject *args[] = { (PyObject*)&PyLong_Type, py_bytes, order_str, Py_True };
             if (!is_unsigned) {
-                kwds = __Pyx_MakeVectorcallBuilderKwds(1);
-                if (!kwds) goto limited_bad;
-                if (__Pyx_VectorcallBuilder_AddArgStr("signed", __Pyx_NewRef(Py_True), kwds, args+3, 0) < 0) goto limited_bad;
+                PyObject *signed_str = PyUnicode_FromStringAndSize("signed", 6);
+                if (!signed_str) goto limited_bad;
+#if CYTHON_VECTORCALL
+                kwds = PyTuple_Pack(1, signed_str);
+#else
+                {
+                    PyObject *keys[] = {signed_str};
+                    PyObject *values[] = {Py_True};
+                    kwds = __Pyx_MakeKwargDict(keys, values, 1);
+                }
+#endif
+                Py_DECREF(signed_str);
+                if (unlikely(!kwds)) goto limited_bad;
             }
-            result = __Pyx_Object_Vectorcall_CallFromBuilder(from_bytes, args+1, 2 | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET, kwds);
+            result = __Pyx_Object_VectorcallMethodKwds(from_bytes_str, args, 3 | __Pyx_PY_VECTORCALL_ARGUMENTS_OFFSET, kwds);
         }
 
         limited_bad:
         Py_XDECREF(kwds);
         Py_XDECREF(order_str);
         Py_XDECREF(py_bytes);
-        Py_XDECREF(from_bytes);
+        Py_XDECREF(from_bytes_str);
         return result;
 #endif
     }

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -887,9 +887,8 @@ static CYTHON_INLINE PyObject* {{TO_PY_FUNCTION}}({{TYPE}} value) {
 #else
         // call int.from_bytes()
         int one = 1; int little = (int)*(unsigned char *)&one;
-        PyObject *from_bytes, *result = NULL, *kwds = NULL;
+        PyObject *result = NULL, *kwds = NULL;
         PyObject *py_bytes = NULL, *order_str = NULL, *from_bytes_str = NULL;;
-        if (!from_bytes) return NULL;
         py_bytes = PyBytes_FromStringAndSize((char*)bytes, sizeof({{TYPE}}));
         if (!py_bytes) goto limited_bad;
         // I'm deliberately not using PYIDENT here because this code path is very unlikely


### PR DESCRIPTION
Most of the time, function/method calls have fixed keyword arguments, and so it's possible to skip building the `kwnames` tuple and instead used a cached literal. This can end up being a significant time saving where used.

As a side-effect of this I've eliminated my "vectorcall builder" "helper". It was a bit confusing to use and a bit hard to read so I don't think this is a great loss. I've removed the two places where it was used in the utility code.