### PR TITLE
Fix call to final method cross module when cimport_from_pyx=True

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -32,6 +32,7 @@ from typing import Optional
 from .Errors import (
     error, warning, InternalError, CompileError, report_error, local_errors,
     CannotSpecialize, performance_hint)
+from . import Options
 from .Code import UtilityCode, TempitaUtilityCode
 from .LineTable import build_line_table
 from . import StringEncoding
@@ -8292,7 +8293,7 @@ class AttributeNode(ExprNode):
         #print "...obj_code =", obj_code ###
         if self.entry and self.entry.is_cmethod:
             if obj.type.is_extension_type and not self.entry.is_builtin_cmethod:
-                if self.entry.final_func_cname:
+                if self.entry.final_func_cname and not Options.cimport_from_pyx:
                     return self.entry.final_func_cname
 
                 if self.type.from_fused:

--- a/tests/run/final_cimport_from_pxd.srctree
+++ b/tests/run/final_cimport_from_pxd.srctree
@@ -1,0 +1,35 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import b; import a"
+
+######## setup.py ########
+from Cython.Build.Dependencies import cythonize
+import Cython.Compiler.Options
+from distutils.core import setup
+
+setup(ext_modules = cythonize("*.pyx"))
+
+######## a.pyx ########
+from b cimport B
+
+cpdef test():
+    b = B()
+    b.mtd()
+
+######## b.pxd ########
+from cython import final
+
+@final
+cdef class B:
+    @final
+    cpdef mtd(self)
+
+######## b.pyx ########
+from cython import cclass, ccall, final
+
+@final
+@cclass
+class B:
+    @final
+    @ccall
+    def mtd(self):
+        pass

--- a/tests/run/final_cimport_from_pyx.srctree
+++ b/tests/run/final_cimport_from_pyx.srctree
@@ -1,0 +1,28 @@
+PYTHON setup.py build_ext --inplace
+PYTHON -c "import b; import a"
+
+######## setup.py ########
+from Cython.Build.Dependencies import cythonize
+import Cython.Compiler.Options
+Cython.Compiler.Options.cimport_from_pyx = True
+from distutils.core import setup
+
+setup(ext_modules = cythonize("*.pyx"))
+
+######## a.pyx ########
+from b cimport B
+
+cpdef test():
+    b = B()
+    b.mtd()
+
+######## b.pyx ########
+from cython import cclass, ccall, final
+
+@final
+@cclass
+class B:
+    @final
+    @ccall
+    def mtd(self):
+        pass


### PR DESCRIPTION
Final methods failed when `cimport_from_pyx=True` on multi module scenarios.
Added two test files that ensure final methods working with and without cimport_from_pyx directive.