### PR TITLE
Implement boxed types allowing cythonize more codebases without changes

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12800,13 +12800,12 @@ class BitwiseOrNode(IntBinopNode):
             ttype = operand_node.analyse_as_type(env)
         if not ttype:
             return None
-        if not ttype.can_be_optional():
-            # If ttype cannot be optional we need to return an equivalent Python type allowing None.
-            # If it cannot be mapped to a Python type, we must error out.
-            if ttype.equivalent_type and not operand_node.as_cython_attribute():
-                return ttype.equivalent_type
-            else:
-                error(operand_node.pos, f"'[...] | None' cannot be applied to type {ttype}")
+        if ttype.can_be_optional():
+            return ttype
+        boxed_type = PyrexTypes.optional_boxed_type(ttype)
+        if boxed_type is not None:
+            return boxed_type
+        error(operand_node.pos, f"'[...] | None' cannot be applied to type {ttype}")
         return ttype
 
     def analyse_as_type(self, env):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -1068,18 +1068,21 @@ class CArgDeclNode(Node):
                 # "x: Optional[...]"  =>  explicitly allow 'None'
                 arg_type = arg_type.resolve()
                 if arg_type and not arg_type.can_be_optional():
-                    # We probably already reported this as "cannot be applied to non-Python type".
-                    # error(annotation.pos, "Only Python type arguments can use typing.Optional[...]")
-                    pass
-                else:
-                    self.or_none = True
+                    boxed_type = PyrexTypes.optional_boxed_type(arg_type)
+                    if boxed_type is not None:
+                        arg_type = boxed_type
+                    else:
+                        # We probably already reported this as "cannot be applied to non-Python type".
+                        # error(annotation.pos, "Only Python type arguments can use typing.Optional[...]")
+                        pass
+                self.or_none = True
             elif arg_type is py_object_type:
                 # exclude ": object" from the None check - None is a generic object.
                 self.or_none = True
-            elif self.default and self.default.is_none and (arg_type.can_be_optional() or arg_type.equivalent_type):
+            elif self.default and self.default.is_none and (arg_type.can_be_optional() or PyrexTypes.optional_boxed_type(arg_type)):
                 # "x: ... = None"  =>  implicitly allow 'None'
                 if not arg_type.can_be_optional():
-                    arg_type = arg_type.equivalent_type
+                    arg_type = PyrexTypes.optional_boxed_type(arg_type)
                 if not self.or_none:
                     warning(self.pos, "PEP-484 recommends 'typing.Optional[...]' for arguments that can be None.")
                     self.or_none = True
@@ -1349,9 +1352,10 @@ class TemplatedTypeNode(CBaseTypeNode):
         for i, ttype in enumerate(template_types):
             if ttype is None:
                 continue
-            if require_python_types and not ttype.is_pyobject or require_optional_types and not ttype.can_be_optional():
-                if ttype.equivalent_type and not template_node.as_cython_attribute():
-                    template_types[i] = ttype.equivalent_type
+            if require_python_types and not ttype.is_pyobject or require_optional_types and not (ttype.can_be_optional() or PyrexTypes.optional_boxed_type(ttype)):
+                boxed_type = PyrexTypes.optional_boxed_type(ttype)
+                if boxed_type is not None and not template_node.as_cython_attribute():
+                    template_types[i] = boxed_type
                 else:
                     error(template_node.pos, "%s[...] cannot be applied to type %s" % (
                         base_type.python_type_constructor_name,

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -403,6 +403,10 @@ class PyrexType(BaseType):
         """Returns True if type can be used with typing.Optional[]."""
         return False
 
+    def boxed_type(self):
+        """Return the Python type used when this value type is boxed, or None."""
+        return None
+
     def struct_nesting_depth(self):
         # Returns the number levels of nested structs. This is
         # used for constructing a stack for walking the run-time
@@ -470,6 +474,16 @@ class PyrexType(BaseType):
 
     def needs_explicit_destruction(self, scope):
         return False
+
+
+def optional_boxed_type(tp):
+    tp = tp.resolve()
+    if tp.can_be_optional():
+        return tp
+    boxed = tp.boxed_type()
+    if boxed is not None:
+        return boxed.resolve()
+    return None
 
 
 def public_decl(base_code, dll_linkage):
@@ -703,6 +717,9 @@ class CTypedefType(BaseType):
 
     def can_coerce_from_pyobject(self, env):
         return self.typedef_base_type.can_coerce_from_pyobject(env)
+
+    def boxed_type(self):
+        return self.typedef_base_type.boxed_type()
 
     def can_coerce_to_pystring(self, env, format_spec=None):
         return self.typedef_base_type.can_coerce_to_pystring(env, format_spec)
@@ -1356,6 +1373,9 @@ class PyObjectType(PyrexType):
         """Returns True if type can be used with typing.Optional[]."""
         return True
 
+    def boxed_type(self):
+        return self
+
     def default_coerced_ctype(self):
         """The default C type that this Python type coerces to, or None."""
         return None
@@ -1984,6 +2004,9 @@ class CConstOrVolatileType(BaseType):
     def can_coerce_from_pyobject(self, env):
         return self.cv_base_type.can_coerce_from_pyobject(env)
 
+    def boxed_type(self):
+        return self.cv_base_type.boxed_type()
+
     def create_to_py_utility_code(self, env):
         if self.cv_base_type.create_to_py_utility_code(env):
             self.to_py_function = self.cv_base_type.to_py_function
@@ -2212,6 +2235,10 @@ class CIntLike:
     def can_coerce_from_pyobject(self, env):
         return True
 
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.int_type
+
     def create_to_py_utility_code(self, env):
         if type(self).to_py_function is None:
             self.to_py_function = "__Pyx_PyLong_From_" + self.specialization_name()
@@ -2305,6 +2332,10 @@ class CIntType(CIntLike, CNumericType):
 
     def assignable_from_resolved_type(self, src_type):
         return src_type.is_int or src_type.is_enum or src_type is error_type
+
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.int_type
 
     def overflow_check_binop(self, binop, env, const_rhs=False):
         env.use_utility_code(UtilityCode.load("Common", "Overflow.c"))
@@ -2432,6 +2463,10 @@ class CBIntType(CIntType):
     def py_type_name(self):
         return "bool"
 
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.bool_type
+
 
 class CPyUCS4IntType(CIntType):
     # Py_UCS4
@@ -2535,6 +2570,10 @@ class CFloatType(CNumericType):
 
     def assignable_from_resolved_type(self, src_type):
         return (src_type.is_numeric and not src_type.is_complex) or src_type is error_type
+
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.float_type
 
 
 class CComplexType(CNumericType):
@@ -2644,6 +2683,10 @@ class CComplexType(CNumericType):
                     cname="__Pyx_c_conj%s" % self.funcsuffix)
 
         return True
+
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.complex_type
 
     def _utility_code_context(self):
         return {
@@ -4645,6 +4688,10 @@ class CppScopedEnumType(CType, EnumMixin):
 
         env.use_utility_code(rst)
 
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.int_type
+
 
 class TemplatePlaceholderType(CType):
 
@@ -4767,6 +4814,10 @@ class CEnumType(CIntLike, CType, EnumMixin):
         self.create_enum_to_py_utility_code(env)
         return True
 
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.int_type
+
 
 class CTupleType(CType):
     # components [PyrexType]
@@ -4866,6 +4917,10 @@ class CTupleType(CType):
         components = [c.specialize(values) for c in self.components]
         new_entry = self.entry.scope.declare_tuple_type(self.entry.pos, components)
         return new_entry.type
+
+    def boxed_type(self):
+        from . import Builtin
+        return Builtin.tuple_type
 
 
 def c_tuple_type(components):

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -834,6 +834,10 @@ class Scope:
                 cname = self.mangle(Naming.var_prefix, name)
         entry = self.declare(name, cname, type, pos, visibility)
         entry.is_variable = 1
+        if pytyping_modifiers and "typing.Optional" in pytyping_modifiers and not type.can_be_optional():
+            boxed_type = PyrexTypes.optional_boxed_type(type)
+            if boxed_type is not None:
+                type = entry.type = boxed_type
         if type.is_cpp_class and visibility != 'extern':
             if self.directives['cpp_locals']:
                 entry.make_cpp_optional()
@@ -2534,11 +2538,12 @@ class CClassScope(ClassScope):
             if "typing.ClassVar" in pytyping_modifiers:
                 is_cdef = 0
                 if not type.is_pyobject:
-                    if not type.equivalent_type:
+                    boxed_type = PyrexTypes.optional_boxed_type(type)
+                    if not boxed_type:
                         warning(pos, "ClassVar[] requires the type to be a Python object type. Found '%s', using object instead." % type)
                         type = py_object_type
                     else:
-                        type = type.equivalent_type
+                        type = boxed_type
             if  "dataclasses.InitVar" in pytyping_modifiers and not self.is_c_dataclass_scope:
                 error(pos, "Use of cython.dataclasses.InitVar does not make sense outside a dataclass")
 

--- a/tests/errors/e_typing_errors.pyx
+++ b/tests/errors/e_typing_errors.pyx
@@ -10,11 +10,6 @@ except ImportError:
 
 # not OK
 
-def optional_cython_types(Optional[cython.int] i, Optional[cython.double] d, Optional[cython.float] f,
-                          Optional[cython.complex] c, Optional[cython.long] l, Optional[cython.longlong] ll):
-    pass
-
-
 MyStruct = cython.struct(a=cython.int, b=cython.double)
 
 def optional_cstruct(Optional[MyStruct] x):
@@ -62,26 +57,7 @@ def bitwise_or_pytypes(i: int | None, f: None | float , c: complex | None):
 
 
 _ERRORS = """
-13:42: typing.Optional[...] cannot be applied to type int
-13:66: typing.Optional[...] cannot be applied to type double
-13:93: typing.Optional[...] cannot be applied to type float
-14:42: typing.Optional[...] cannot be applied to type double complex
-14:70: typing.Optional[...] cannot be applied to type long
-14:95: typing.Optional[...] cannot be applied to type long long
-24:30: typing.Optional[...] cannot be applied to type int
-24:47: typing.Optional[...] cannot be applied to type float
-24:87: typing.Optional[...] cannot be applied to type long
+15:30: typing.Optional[...] cannot be applied to type MyStruct
 
-20:30: typing.Optional[...] cannot be applied to type MyStruct
-
-28:20: Modifier 'typing.ClassVar' is not allowed here.
-
-30:29: typing.Union[...] cannot be applied to type int
-30:50: typing.Union[...] cannot be applied to type float
-30:96: typing.Union[...] cannot be applied to type long
-
-33:31: '[...] | None' cannot be applied to type int
-33:60: '[...] | None' cannot be applied to type float
-33:78: '[...] | None' cannot be applied to type double complex
-33:104: '[...] | None' cannot be applied to type long
+23:20: Modifier 'typing.ClassVar' is not allowed here.
 """

--- a/tests/errors/e_typing_optional.py
+++ b/tests/errors/e_typing_optional.py
@@ -28,5 +28,5 @@ def optional_memoryview(d: double[:], o: Optional[double[:]]):
 
 _ERRORS = """
 
-20:33: typing.Optional[...] cannot be applied to type MyStruct
+15:33: typing.Optional[...] cannot be applied to type MyStruct
 """

--- a/tests/errors/e_typing_optional.py
+++ b/tests/errors/e_typing_optional.py
@@ -10,11 +10,6 @@ except ImportError:
 
 # not OK
 
-def optional_cython_types(i: Optional[cython.int], d: Optional[cython.double], f: Optional[cython.float],
-                          c: Optional[cython.complex], l: Optional[cython.long], ll: Optional[cython.longlong]):
-    pass
-
-
 MyStruct = cython.struct(a=cython.int, b=cython.double)
 
 def optional_cstruct(x: Optional[MyStruct]):
@@ -32,12 +27,6 @@ def optional_memoryview(d: double[:], o: Optional[double[:]]):
 
 
 _ERRORS = """
-13:44: typing.Optional[...] cannot be applied to type int
-13:69: typing.Optional[...] cannot be applied to type double
-13:97: typing.Optional[...] cannot be applied to type float
-14:44: typing.Optional[...] cannot be applied to type double complex
-14:73: typing.Optional[...] cannot be applied to type long
-14:100: typing.Optional[...] cannot be applied to type long long
 
 20:33: typing.Optional[...] cannot be applied to type MyStruct
 """

--- a/tests/run/annotation_typing.pyx
+++ b/tests/run/annotation_typing.pyx
@@ -537,6 +537,78 @@ def def_none_as_type(a: None) -> None:
     """
     return c_none_as_type(a)
 
+# Boxed c value types
+
+@cython.ccall
+def use_nullable_c_float(a: Optional[cython.float]): return a is None
+@cython.ccall
+def use_nullable_c_bool(a: Optional[cython.bint]): return a is None
+@cython.ccall
+def use_nullable_c_int(a: Optional[cython.int]): return a is None
+@cython.ccall
+def use_nullable_c_long(a: Optional[cython.long]): return a is None
+@cython.ccall
+def use_nullable_c_longlong(a: Optional[cython.longlong]): return a is None
+@cython.ccall
+def use_nullable_c_tuple(a: Optional[tuple[cython.int, cython.bint]]): return a is None
+
+cpdef test_boxed_values():
+    """
+    >>> test_boxed_values()
+    """
+    assert not use_nullable_c_float(0.0)
+    assert not use_nullable_c_float(0.1)
+    assert use_nullable_c_float(None)
+
+    assert not use_nullable_c_bool(True)
+    assert not use_nullable_c_bool(False)
+    assert use_nullable_c_bool(None)
+
+    assert not use_nullable_c_int(0)
+    assert not use_nullable_c_int(1)
+    assert not use_nullable_c_int(-100)
+    assert use_nullable_c_int(None)
+
+    assert not use_nullable_c_long(0)
+    assert not use_nullable_c_long(1)
+    assert not use_nullable_c_long(-100)
+    assert use_nullable_c_long(None)
+
+    assert not use_nullable_c_longlong(0)
+    assert not use_nullable_c_longlong(1)
+    assert not use_nullable_c_longlong(-100)
+    assert use_nullable_c_longlong(None)
+
+    assert not use_nullable_c_tuple((1, False))
+    assert not use_nullable_c_tuple((0, 0))
+    assert use_nullable_c_tuple(None)
+
+    # test boxed values as variables
+    cdef Optional[cython.int] maybe_int = 1
+    assert maybe_int == 1
+    maybe_int = None
+    assert maybe_int is None
+
+    cdef Optional[cython.float] maybe_float = 0.1
+    assert maybe_float == 0.1
+    maybe_float = None
+    assert maybe_float is None
+
+    cdef Optional[cython.bint] maybe_bool = True
+    assert maybe_bool is True
+    maybe_bool = None
+    assert maybe_bool is None
+
+cdef class ClassWithBoxedValues:
+    cdef Optional[cython.long] b_long
+    cdef Optional[cython.float] b_float
+    cdef Optional[cython.bint] b_bint
+
+    cpdef fn(self):
+        self.b_long = 1
+        self.b_float = 1.0
+        self.b_int = True
+
 _WARNINGS = """
 15:32: Strings should no longer be used for type declarations. Use 'cython.int' etc. directly.
 15:47: Dicts should no longer be used as type annotations. Use 'cython.int' etc. directly.
@@ -579,4 +651,12 @@ _WARNINGS = """
 272:0: 'exception_default_uint' redeclared
 502:0: 'unknown_pyclass' redeclared
 510:0: 'none_as_type' redeclared
+542:0: 'use_nullable_c_float' redeclared
+544:0: 'use_nullable_c_bool' redeclared
+546:0: 'use_nullable_c_int' redeclared
+548:0: 'use_nullable_c_long' redeclared
+550:0: 'use_nullable_c_longlong' redeclared
+552:0: 'use_nullable_c_tuple' redeclared
+555:0: 'test_boxed_values' redeclared
+607:4: 'fn' redeclared
 """


### PR DESCRIPTION
This change introduces Boxed Types.

Boxed types make Cython’s annotation system more practical for real-world APIs by allowing value types to be used where None is a valid state. This extends Cython’s type representation beyond plain native storage and Python objects, so declarations like `int | None`, `float | None`, `bint | None`, ctuples, and enum-like value types can be expressed naturally and used consistently in both function signatures and variable declarations.

This is important because allows to Cythonize **larger code bases** without requiring code changes and potentialized when used with **auto_cpdef**. Even writing interfaces with cython becomes easier with this feature even in py or pyx modes.  
Introducing boxed types keeps the native type information intact while giving Cython a clean, generalized way to support nullable value semantics.