### PR TITLE
Avoid using paths filter for "required" github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         persist-credentials: false
       # Only needed to compare the "base" on push; not needed for PR
-      if: ${{ github.event.name == 'push' }}
+      if: ${{ github.event_name == 'push' }}
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter
       with:
@@ -55,7 +55,7 @@ jobs:
 
   ci-early:
     needs: [file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
       fail-fast: false
@@ -108,7 +108,7 @@ jobs:
 
   ci-all:
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -170,7 +170,7 @@ jobs:
   ci-arm64:
     # ARM builds
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -191,7 +191,7 @@ jobs:
   ci-typespecs:
     # compile with typespecs
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -216,7 +216,7 @@ jobs:
   ci-sharedmodule:
     # compile with shared utility module
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -240,7 +240,7 @@ jobs:
   ci-compileall:
     # compile all modules
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -264,7 +264,7 @@ jobs:
   ci-stdc:
     # GCC/clang with broad language standards
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -310,7 +310,7 @@ jobs:
   ci-lapi:
     # Limited API tests
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -350,7 +350,7 @@ jobs:
   ci-noncpython:
     # PyPy, GraalPython, ...
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   ci-early:
     needs: [file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
       fail-fast: false
@@ -102,7 +102,7 @@ jobs:
 
   ci-all:
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -164,7 +164,7 @@ jobs:
   ci-arm64:
     # ARM builds
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -185,7 +185,7 @@ jobs:
   ci-typespecs:
     # compile with typespecs
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -210,7 +210,7 @@ jobs:
   ci-sharedmodule:
     # compile with shared utility module
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -234,7 +234,7 @@ jobs:
   ci-compileall:
     # compile all modules
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -258,7 +258,7 @@ jobs:
   ci-stdc:
     # GCC/clang with broad language standards
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -304,7 +304,7 @@ jobs:
   ci-lapi:
     # Limited API tests
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -344,7 +344,7 @@ jobs:
   ci-noncpython:
     # PyPy, GraalPython, ...
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
+    if: ${{ github.event.name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           - '**/*.md'
           - '**/*.rst'
           - 'docs/**'
-          positive-docs
+          positive-docs:
           - 'docs/examples/**'
 
   ci-early:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      ci-changes: ${{ steps.filter.outputs.files }}
+      ci-changes: |
+        ${{ steps.filter.outputs.any-files == 'true' }} &&
+        ${{ steps.filter.outputs.negative-files == 'false' || steps.filter.outputs.positive-github == 'true' }} &&
+        ${{ steps.filter.outputs.negative-docs == 'false' || steps.filter.outputs.positive-docs == 'true' }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,14 +46,18 @@ jobs:
       with:
         base: ${{ github.ref }}
         filters: |
-          files:
+          any-files:
           - '**'
-          - '!Demos/benchmarks/**'
-          - '!.github/**'
+          negative-files:
+          - 'Demos/benchmarks/**'
+          - '.github/**'
+          positive-github:
           - '.github/workflows/ci*.yml'
+          negative-docs:
           - '**/*.md'
           - '**/*.rst'
-          - '!docs/**'
+          - 'docs/**'
+          positive-docs
           - 'docs/examples/**'
 
   ci-early:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   ci-early:
     needs: [file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
       fail-fast: false
@@ -102,7 +102,7 @@ jobs:
 
   ci-all:
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -164,7 +164,7 @@ jobs:
   ci-arm64:
     # ARM builds
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -185,7 +185,7 @@ jobs:
   ci-typespecs:
     # compile with typespecs
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -210,7 +210,7 @@ jobs:
   ci-sharedmodule:
     # compile with shared utility module
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -234,7 +234,7 @@ jobs:
   ci-compileall:
     # compile all modules
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -258,7 +258,7 @@ jobs:
   ci-stdc:
     # GCC/clang with broad language standards
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -304,7 +304,7 @@ jobs:
   ci-lapi:
     # Limited API tests
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -344,7 +344,7 @@ jobs:
   ci-noncpython:
     # PyPy, GraalPython, ...
     needs: [ci-early-success, file-changes]
-    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.ci-changes == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
     outputs:
       ci-changes: ${{ steps.filter.outputs.files }}
     steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+      # Only needed to compare the "base" on push; not needed for PR
+      if: ${{ github.event.name == 'push' }}
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    outputs: ci-changes: ${{ steps.filter.outputs.files }}
+    outputs:
+      ci-changes: ${{ steps.filter.outputs.files }}
     steps:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,7 @@ name: CI
 
 on:
   push:
-    paths:
-      - '**'
-      - '!Demos/benchmarks/**'
-      - '!.github/**'
-      - '.github/workflows/ci*.yml'
-      - '**/*.md'
-      - '**/*.rst'
-      - '!docs/**'
-      - 'docs/examples/**'
   pull_request:
-    paths:
-      - '**'
-      - '!Demos/benchmarks/**'
-      - '!.github/**'
-      - '.github/workflows/ci*.yml'
-      - '!**/*.md'
-      - '!**/*.rst'
-      - '!docs/**'
-      - 'docs/examples/**'
   workflow_dispatch:
 
 concurrency:
@@ -43,8 +25,30 @@ env:
 
 
 jobs:
+  file-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs: ci-changes: ${{ steps.filter.outputs.files }}
+    steps:
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          files:
+          - '**'
+          - '!Demos/benchmarks/**'
+          - '!.github/**'
+          - '.github/workflows/ci*.yml'
+          - '**/*.md'
+          - '**/*.rst'
+          - '!docs/**'
+          - 'docs/examples/**'
 
   ci-early:
+    needs: [file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
       fail-fast: false
@@ -96,7 +100,8 @@ jobs:
 
 
   ci-all:
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -157,7 +162,8 @@ jobs:
 
   ci-arm64:
     # ARM builds
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -177,7 +183,8 @@ jobs:
 
   ci-typespecs:
     # compile with typespecs
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -201,7 +208,8 @@ jobs:
 
   ci-sharedmodule:
     # compile with shared utility module
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -224,7 +232,8 @@ jobs:
 
   ci-compileall:
     # compile all modules
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -247,7 +256,8 @@ jobs:
 
   ci-stdc:
     # GCC/clang with broad language standards
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -292,7 +302,8 @@ jobs:
 
   ci-lapi:
     # Limited API tests
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -331,7 +342,8 @@ jobs:
 
   ci-noncpython:
     # PyPy, GraalPython, ...
-    needs: [ci-early-success]
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event.name == "workflow_dispatch" || needs.file-changes.outputs.files == 'true' }}
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      ci-changes: |
-        ${{ steps.filter.outputs.any-files == 'true' }} &&
-        ${{ steps.filter.outputs.negative-files == 'false' || steps.filter.outputs.positive-github == 'true' }} &&
-        ${{ steps.filter.outputs.negative-docs == 'false' || steps.filter.outputs.positive-docs == 'true' }}
+      ci-changes: ${{ steps.filter.outputs.any-files == 'true' && (steps.filter.outputs.negative-files == 'false' || steps.filter.outputs.positive-github == 'true') && (steps.filter.outputs.negative-docs == 'false' || steps.filter.outputs.positive-docs == 'true') }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         persist-credentials: false
       # Only needed to compare the "base" on push; not needed for PR
-      if: ${{ github.event.name == 'push' }}
+      if: ${{ github.event_name == 'push' }}
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -5,20 +5,7 @@ on:
   push:
     branches:
       - master
-    paths:
-      - ".github/workflows/sanitizers.yml"
-      - ".github/workflows/compiled_python.yml"
-      - "Cython/**"
-      - "tests/**"
   pull_request:
-    paths:
-      # Only run these tests on PRs likely to affect code generation
-      - ".github/workflows/sanitizers.yml"
-      - ".github/workflows/compiled_python.yml"
-      - "Cython/Utility/**"
-      - "Cython/Compiler/Nodes.py"
-      - "Cython/Compiler/ExprNodes.py"
-      - "Cython/Compiler/Optimize.py"
   label:
     # Accepted labels (in the 'if' condition below) are:
     # * sanitizers
@@ -33,7 +20,32 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  file-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs: ci-changes: ${{ steps.filter.outputs.files }}
+    steps:
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          push-files:
+          - ".github/workflows/sanitizers.yml"
+          - ".github/workflows/compiled_python.yml"
+          - "Cython/**"
+          - "tests/**"
+          pr-files:
+          - ".github/workflows/sanitizers.yml"
+          - ".github/workflows/compiled_python.yml"
+          - "Cython/Utility/**"
+          - "Cython/Compiler/Nodes.py"
+          - "Cython/Compiler/ExprNodes.py"
+          - "Cython/Compiler/Optimize.py"
+
   sanitizers:
+    needs: [file-changes]
     strategy:
       fail-fast: false
       matrix:
@@ -45,9 +57,11 @@ jobs:
       cpp_compiler: clang++
       sanitize: ${{ matrix.sanitizer }}
       name: ${{ matrix.sanitizer }}
-    if: ${{ github.event_name != 'label' || github.event.label.name == 'sanitizers' || github.event.label.name == 'full_sanitizers' }}
+    if: ${{ case(github.event_name == 'push', needs.file-changes.outputs.push-files == 'true', github.event_name == 'pull_request', needs.file-changes.outputs.pr-files == 'true', github.event_name == 'label', github.event.label.name == 'sanitizers' || github.event.label.name == 'full_sanitizers', 'true') }}
 
   pydebug:
     uses: ./.github/workflows/compiled_python.yml
     with:
       name: pydebug
+    needs: [file-changes]
+    if: ${{ case(github.event_name == 'push', needs.file-changes.outputs.push-files == 'true', github.event_name == 'pull_request', needs.file-changes.outputs.pr-files == 'true', 'true') }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
-    outputs: ci-changes: ${{ steps.filter.outputs.files }}
+    outputs:
+      push-files: ${{ steps.filter.outputs.push-files }}
+      pr-files: ${{ steps.filter.outputs.pr-files }}
     steps:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -28,6 +28,12 @@ jobs:
       push-files: ${{ steps.filter.outputs.push-files }}
       pr-files: ${{ steps.filter.outputs.pr-files }}
     steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+      # Only needed to compare the "base" on push; not needed for PR
+      if: ${{ github.event.name == 'push' }}
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
       id: filter
       with:


### PR DESCRIPTION
The reason being that if jobs are skipped because of it then the PR becomes unmergeable. In contrast if jobs are skipped at job level then it's fine.

Instead move the file filters to job level and skip them there.

I've only done this for "required" jobs and no worried about anything else (e.g. coverage)