### PR TITLE
Improve gathering of CI results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,12 @@ jobs:
 
   ci-early-success:
     needs: [codespell, codestyle, ci-early, build_docs]
-    if: success()
+    if: always()
+    env:
+      FAIL: ${{ case(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'), 1, 0) }}
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: exit $FAIL
 
 
   ci-all:
@@ -377,11 +379,13 @@ jobs:
 
 
   ci-success:
-    needs: [ci-all, ci-arm64, ci-typespecs, ci-sharedmodule, ci-compileall, ci-stdc, ci-lapi, ci-noncpython]
-    if: success()
+    needs: [ci-early-success, ci-all, ci-arm64, ci-typespecs, ci-sharedmodule, ci-compileall, ci-stdc, ci-lapi, ci-noncpython]
+    if: always()
+    env:
+      FAIL: ${{ case(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'), 1, 0) }}
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: exit $FAIL
 
 
   codespell:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -73,3 +73,12 @@ jobs:
       name: pydebug
     needs: [file-changes]
     if: ${{ case(github.event_name == 'push', needs.file-changes.outputs.push-files == 'true', github.event_name == 'pull_request', needs.file-changes.outputs.pr-files == 'true', 'true') }}
+
+  sanitizers-success:
+    needs: [sanitizers, pydebug]
+    if: always()
+    env:
+      FAIL: ${{ case(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'), 1, 0) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit $FAIL


### PR DESCRIPTION
1. Skipping a job counts as success from the point of view of mergeability. This means `ci-success` isn't actually doing its job because it gets skipped if any bits of the CI fail.  This version will always run `ci-success` but with a result that tells you if all previous jobs have passed.
2. The `if` clause for a job is done before the matrix is expanded. This means that if the sanitizers job is skipped, then you still can't merge (because it doesn't work out which matrix jobs have been skipped). Add a `sanitizers-success` job to use as the new required job.