### PR TITLE
Apply some simpler `distutils` migration advice

### DIFF
--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -49,7 +49,7 @@ import re
 import sys
 import time
 import copy
-import distutils.log
+import logging
 import textwrap
 
 IO_ENCODING = sys.getfilesystemencoding()
@@ -434,11 +434,11 @@ class CythonMagics(Magics):
         old_threshold = None
         try:
             if not quiet:
-                old_threshold = distutils.log.set_threshold(distutils.log.DEBUG)
+                old_threshold = logging.set_threshold(logging.DEBUG)
             build_extension.run()
         finally:
             if not quiet and old_threshold is not None:
-                distutils.log.set_threshold(old_threshold)
+                logging.set_threshold(old_threshold)
 
     def _add_pgo_flags(self, build_extension, step_name, temp_dir):
         compiler_type = build_extension.compiler.compiler_type

--- a/Cython/Build/Tests/TestIpythonMagic.py
+++ b/Cython/Build/Tests/TestIpythonMagic.py
@@ -255,12 +255,12 @@ x = sin(0.0)
 
 
             new_log = MockLog()
-            old_log = IpythonMagic.distutils.log
+            old_log = IpythonMagic.logging
             try:
-                IpythonMagic.distutils.log = new_log
+                IpythonMagic.logging = new_log
                 yield new_log
             finally:
-                IpythonMagic.distutils.log = old_log
+                IpythonMagic.logging = old_log
 
         ip = self._ip
         with mock_distutils() as verbose_log:

--- a/Cython/Debugger/Tests/TestLibCython.py
+++ b/Cython/Debugger/Tests/TestLibCython.py
@@ -8,7 +8,7 @@ import unittest
 import tempfile
 import subprocess
 #import distutils.core
-#from distutils import sysconfig
+#import sysconfig
 from distutils import ccompiler
 
 import runtests

--- a/Cython/Distutils/old_build_ext.py
+++ b/Cython/Distutils/old_build_ext.py
@@ -8,13 +8,14 @@ Note that this module is deprecated.  Use cythonize() instead.
 
 __revision__ = "$Id:$"
 
-import sys
+import logging
 import os
+import sys
+import sysconfig
+
 from distutils.errors import DistutilsPlatformError
 from distutils.dep_util import newer, newer_group
-from distutils import log
 from distutils.command import build_ext as _build_ext
-from distutils import sysconfig
 
 
 # FIXME: the below does not work as intended since importing 'Cython.Distutils' already

--- a/Demos/benchmarks/run_benchmarks.py
+++ b/Demos/benchmarks/run_benchmarks.py
@@ -33,7 +33,7 @@ if hasattr(sys, '_is_gil_enabled') and not sys._is_gil_enabled():
 
 
 try:
-    from distutils import sysconfig
+    import sysconfig
     DISTUTILS_CFLAGS = sysconfig.get_config_var('CFLAGS')
 except ImportError:
     DISTUTILS_CFLAGS = ''

--- a/Demos/embed/Makefile
+++ b/Demos/embed/Makefile
@@ -3,17 +3,17 @@ PYTHON := python
 PYVERSION := $(shell $(PYTHON) -c "import sys; print(sys.version[:3])")
 PYPREFIX := $(shell $(PYTHON) -c "import sys; print(sys.prefix)")
 
-INCDIR := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc())")
-PLATINCDIR := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True))")
-LIBDIR1 := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-LIBDIR2 := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBPL'))")
-PYLIB := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBRARY')[3:-2])")
+INCDIR := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_python_inc())")
+PLATINCDIR := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_python_inc(plat_specific=True))")
+LIBDIR1 := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+LIBDIR2 := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBPL'))")
+PYLIB := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBRARY')[3:-2])")
 
-CC := $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('CC'))")
-LINKCC := $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LINKCC'))")
-LINKFORSHARED := $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LINKFORSHARED'))")
-LIBS := $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LIBS'))")
-SYSLIBS :=  $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('SYSLIBS'))")
+CC := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('CC'))")
+LINKCC := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LINKCC'))")
+LINKFORSHARED := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LINKFORSHARED'))")
+LIBS := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBS'))")
+SYSLIBS :=  $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('SYSLIBS'))")
 
 .PHONY: paths all clean test
 

--- a/Demos/freeze/Makefile
+++ b/Demos/freeze/Makefile
@@ -4,12 +4,12 @@ CYTHON_FREEZE = ../../bin/cython_freeze
 PYTHON = python
 RST2HTML = rst2html
 
-PY_LDFLAGS = $(shell $(PYTHON) -c 'from distutils.sysconfig import get_config_var as g; import sys; sys.stdout.write(" ".join([g("LINKFORSHARED"), "-L"+g("LIBPL")]) + "\n")')
-PY_CPPFLAGS = $(shell $(PYTHON) -c 'from distutils.sysconfig import *; import sys; sys.stdout.write("-I"+get_python_inc() + "\n")')
-LIBDIR1 := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-LIBDIR2 := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBPL'))")
-PYLIB := $(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('LIBRARY')[3:-2])")
-LIBS := $(shell $(PYTHON) -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_var('LIBS'))")
+PY_LDFLAGS = $(shell $(PYTHON) -c 'from sysconfig import get_config_var as g; import sys; sys.stdout.write(" ".join([g("LINKFORSHARED"), "-L"+g("LIBPL")]) + "\n")')
+PY_CPPFLAGS = $(shell $(PYTHON) -c 'from sysconfig import *; import sys; sys.stdout.write("-I"+get_python_inc() + "\n")')
+LIBDIR1 := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+LIBDIR2 := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBPL'))")
+PYLIB := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBRARY')[3:-2])")
+LIBS := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('LIBS'))")
 
 CFLAGS = -fPIC -fno-strict-aliasing -g -O2 -Wall -Wextra
 CPPFLAGS = $(PY_CPPFLAGS)

--- a/Tools/site_scons/site_tools/pyext.py
+++ b/Tools/site_scons/site_tools/pyext.py
@@ -186,7 +186,7 @@ def set_configuration(env, use_distutils):
                 'PYEXTINCPATH': ("sysconfig.get_python_inc()", False),
                 'PYEXTSUFFIX': ("sysconfig.get_config_var('SO')", False)}
 
-    from distutils import sysconfig
+    import sysconfig
 
     # We set the python path even when not using distutils, because we rarely
     # want to change this, even if not using distutils
@@ -230,7 +230,7 @@ def exists(env):
     try:
         # This is not quite right: if someone defines all variables by himself,
         # it would work without distutils
-        from distutils import sysconfig
+        import sysconfig
         return True
     except ImportError:
         return False

--- a/docs/src/userguide/faq.rst
+++ b/docs/src/userguide/faq.rst
@@ -729,7 +729,7 @@ This is the most sane (if not the only) way to fix it:
 
 ::
 
-    >>> from distutils import sysconfig
+    >>> import sysconfig
     >>> sysconfig.get_makefile_filename()
 
 That should output the full path of a 'Makefile'... Open that file

--- a/pyximport/test/test_reload.py
+++ b/pyximport/test/test_reload.py
@@ -5,7 +5,7 @@ from . import test_pyximport
 
 
 if 1:
-    import sysconfig
+    from distutils import sysconfig
     try:
         sysconfig.set_python_build()
     except AttributeError:

--- a/pyximport/test/test_reload.py
+++ b/pyximport/test/test_reload.py
@@ -5,7 +5,7 @@ from . import test_pyximport
 
 
 if 1:
-    from distutils import sysconfig
+    import sysconfig
     try:
         sysconfig.set_python_build()
     except AttributeError:

--- a/tests/compile/buildenv.pyx
+++ b/tests/compile/buildenv.pyx
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import os
 import sys
-from distutils import sysconfig
+import sysconfig
 
 
 cdef extern from *:


### PR DESCRIPTION
Related to issue: https://github.com/cython/cython/issues/5751

Cleanup some of the simpler `distutils` usage cases with [their recommended replacements]( https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools ).

There is still much more work to do here, but at least this starts moving in the right direction incrementally.