### PR TITLE
cpython: Define few function from the ABI 3.14

### DIFF
--- a/Cython/Includes/cpython/float.pxd
+++ b/Cython/Includes/cpython/float.pxd
@@ -36,3 +36,21 @@ cdef extern from "Python.h":
     double PyFloat_AS_DOUBLE(object pyfloat)
     # Return a C double representation of the contents of pyfloat, but
     # without error checking.
+
+    int PyFloat_Pack2(double x, unsigned char *p, int le) except -1
+    # Pack a C double as the IEEE 754 binary16 half-precision format.
+
+    int PyFloat_Pack4(double x, unsigned char *p, int le) except -1
+    # Pack a C double as the IEEE 754 binary32 single precision format.
+
+    int PyFloat_Pack8(double x, unsigned char *p, int le) except -1
+    # Pack a C double as the IEEE 754 binary64 double precision format.
+
+    double PyFloat_Unpack2(const unsigned char *p, int le) except? -1.0
+    # Unpack the IEEE 754 binary16 half-precision format as a C double.
+
+    double PyFloat_Unpack4(const unsigned char *p, int le) except? -1.0
+    # Unpack the IEEE 754 binary32 single precision format as a C double.
+
+    double PyFloat_Unpack8(const unsigned char *p, int le) except? -1.0
+    # Unpack the IEEE 754 binary64 double precision format as a C double.

--- a/Cython/Includes/cpython/long.pxd
+++ b/Cython/Includes/cpython/long.pxd
@@ -1,3 +1,4 @@
+from libc.stdint cimport uint32_t, uint64_t, int32_t, int64_t
 
 cdef extern from "Python.h":
     ctypedef long long PY_LONG_LONG
@@ -15,6 +16,15 @@ cdef extern from "Python.h":
     #
     # This instance of PyTypeObject represents the Python long integer
     # type. This is the same object as long and types.LongType.
+
+    cdef enum:
+        Py_ASNATIVEBYTES_DEFAULTS,
+        Py_ASNATIVEBYTES_BIG_ENDIAN,
+        Py_ASNATIVEBYTES_LITTLE_ENDIAN,
+        Py_ASNATIVEBYTES_NATIVE_ENDIAN,
+        Py_ASNATIVEBYTES_UNSIGNED_BUFFER,
+        Py_ASNATIVEBYTES_REJECT_NEGATIVE,
+        Py_ASNATIVEBYTES_ALLOW_INDEX
 
     bint PyLong_Check(object p)
     # Return true if its argument is a PyLongObject or a subtype of PyLongObject.
@@ -147,3 +157,24 @@ cdef extern from "Python.h":
     # raised. This is only assured to produce a usable void pointer
     # for values created with PyLong_FromVoidPtr(). For values outside
     # 0..LONG_MAX, both signed and unsigned integers are accepted.
+
+    object PyLong_FromNativeBytes(const void *buffer, size_t n_bytes, int flags)
+    # Create a Python integer from the value contained in the firstn_bytes
+    # of buffer, interpreted as a two’s-complement signed number.
+
+    object PyLong_FromUnsignedNativeBytes(const void *buffer, size_t n_bytes, int flags)
+    # Create a Python integer from the value contained in the first n_bytes of
+    # buffer, interpreted as an unsigned number.
+
+    Py_ssize_t PyLong_AsNativeBytes(object pylong, void *buffer, Py_ssize_t n_bytes, int flags) except -1
+    # Copy the Python integer value pylong to a native buffer of size n_bytes.
+    # The flags can be set to -1 to behave similarly to a C cast, or to values
+    # to control the behavior.
+
+    int PyLong_AsInt32(object obj, int32_t *value) except -1
+    int PyLong_AsInt64(object obj, int64_t *value) except -1
+    # Set *value to a signed C int32_t or int64_t representation of obj.
+
+    int PyLong_AsUInt32(object obj, uint32_t *value) except -1
+    int PyLong_AsUInt64(object obj, uint64_t *value) except -1
+    # Set *value to an unsigned C uint32_t or uint64_t representation of obj.


### PR DESCRIPTION
Hi,

Here is few functions related to `long` (3.14)  and `float` (sounds like it's there for long time)  that i  would like to use at some point.

- https://docs.python.org/3.14/c-api/long.html
- https://docs.python.org/3.11/c-api/float.html

Would you like such contribution?

Tell me if there is more to do.

Thanks a lot.