### PR TITLE
[3.2.x] Shared module: Use `SharedUtilitySourceDescriptor` instead of temporary directory (#7723)

### DIFF
--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -1,13 +1,10 @@
 import os
-import re
-import shutil
-import tempfile
 
 from Cython.Compiler import (
     MemoryView, Code, Options, Pipeline, Errors, Main, Symtab
 )
 from Cython.Compiler.StringEncoding import EncodedString
-from Cython.Compiler.Scanning import FileSourceDescriptor
+from Cython.Compiler.Scanning import SharedUtilitySourceDescriptor
 
 
 def create_shared_library_pipeline(context, scope, options, result):
@@ -72,23 +69,17 @@ def generate_shared_module(options):
     Errors.open_listing_file(None)
 
     dest_c_file = options.shared_c_file_path
+    pyx_file = os.path.splitext(dest_c_file)[0] + '.pyx'
     module_name = os.path.splitext(os.path.basename(dest_c_file))[0]
 
     context = Main.Context.from_options(options)
     scope = Symtab.ModuleScope('MemoryView', parent_module = None, context = context, is_package=False)
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        pyx_file = os.path.join(tmpdirname, f'{module_name}.pyx')
-        c_file = os.path.join(tmpdirname, f'{module_name}.c')
-        with open(pyx_file, 'w'):
-            pass
-        source_desc = FileSourceDescriptor(pyx_file)
-        comp_src = Main.CompilationSource(source_desc, EncodedString(module_name), os.getcwd())
-        result = Main.create_default_resultobj(comp_src, options)
+    source_desc = SharedUtilitySourceDescriptor(pyx_file)
+    comp_src = Main.CompilationSource(source_desc, EncodedString(module_name), os.getcwd())
+    result = Main.create_default_resultobj(comp_src, options)
 
-        pipeline = create_shared_library_pipeline(context, scope, options, result)
-        err, enddata = Pipeline.run_pipeline(pipeline, comp_src)
-        if err is None:
-            shutil.copy(c_file, dest_c_file)
+    pipeline = create_shared_library_pipeline(context, scope, options, result)
+    err, enddata = Pipeline.run_pipeline(pipeline, comp_src)
 
     return err, enddata

--- a/Cython/Compiler/Scanning.py
+++ b/Cython/Compiler/Scanning.py
@@ -281,6 +281,15 @@ class StringSourceDescriptor(SourceDescriptor):
         return "<StringSourceDescriptor:%s>" % self.name
 
 
+class SharedUtilitySourceDescriptor(FileSourceDescriptor):
+    """
+    A specialized source descriptor for shared utility code only. Not part of public API.
+    """
+
+    def get_file_object(self, encoding=None, error_handling=None):
+        from io import StringIO
+        return StringIO('')
+
 #------------------------------------------------------------------
 
 class PyrexScanner(Scanner):


### PR DESCRIPTION
This PR uses `SharedUtilitySourceDescriptor` instead of an empty pyx file in the temp dir. This simplifies the logic and also assures that `__pyx_f` is unchanged across builds.

Backport of https://github.com/cython/cython/pull/7723
Alternative to https://github.com/cython/cython/pull/7634