### PR TITLE
Improve ci-yml file filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,10 @@ jobs:
       pull-requests: read
     outputs:
       ci-changes: |-
-        ${{
-          steps.positive-github == 'true' || steps.positive-docs == 'true' || 
+        ${{ steps.positive-github == 'true' || steps.positive-docs == 'true' || 
             (steps.filter.outputs.any-files == 'true' &&
               (steps.filter.outputs.negative-files_count + steps.filter.outputs.negative-docs_count) <
-                steps.filter.outputs.any-files_count)
-        }}
+                steps.filter.outputs.any-files_count) }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      ci-changes: ${{ steps.positive-files == 'true' || (steps.filter.outputs.any-files == 'true' && (steps.filter.outputs.negative-files_count < steps.filter.outputs.any-files_count)) }}
+      ci-changes: ${{ steps.filter.outputs.positive-files == 'true' || 
+            (steps.filter.outputs.any-files == 'true' &&
+              (steps.filter.outputs.negative-files_count < steps.filter.outputs.any-files_count)) }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,9 @@ jobs:
       pull-requests: read
     outputs:
       ci-changes: |-
-        ${{ steps.positive-github == 'true' || steps.positive-docs == 'true' || 
+        ${{ steps.positive-files == 'true' || 
             (steps.filter.outputs.any-files == 'true' &&
-              (steps.filter.outputs.negative-files_count + steps.filter.outputs.negative-docs_count) <
-                steps.filter.outputs.any-files_count) }}
+              (steps.filter.outputs.negative-files_count < steps.filter.outputs.any-files_count)) }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,13 +51,11 @@ jobs:
           negative-files:
           - 'Demos/benchmarks/**'
           - '.github/**'
-          positive-github:
-          - '.github/workflows/ci*.yml'
-          negative-docs:
           - '**/*.md'
           - '**/*.rst'
           - 'docs/**'
-          positive-docs:
+          positive-files:
+          - '.github/workflows/ci*.yml'
           - 'docs/examples/**'
 
   ci-early:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      ci-changes: |-
-        ${{ steps.positive-files == 'true' || 
-            (steps.filter.outputs.any-files == 'true' &&
-              (steps.filter.outputs.negative-files_count < steps.filter.outputs.any-files_count)) }}
+      ci-changes: ${{ steps.positive-files == 'true' || (steps.filter.outputs.any-files == 'true' && (steps.filter.outputs.negative-files_count < steps.filter.outputs.any-files_count)) }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      ci-changes: ${{ steps.filter.outputs.any-files == 'true' && (steps.filter.outputs.negative-files == 'false' || steps.filter.outputs.positive-github == 'true') && (steps.filter.outputs.negative-docs == 'false' || steps.filter.outputs.positive-docs == 'true') }}
+      ci-changes: |-
+        ${{
+          steps.positive-github == 'true' || steps.positive-docs == 'true' || 
+            (steps.filter.outputs.any-files == 'true' &&
+              (steps.filter.outputs.negative-files_count + steps.filter.outputs.negative-docs_count) <
+                steps.filter.outputs.any-files_count)
+        }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The issue was that if anything matched `negative-docs` then it ended up overriding `any-files` even if there were other files changed.

The solution I've come up with isn't particularly general. It should work for this particular set of path filters but it doesn't solve the problem well.

I quite like the "applied in order" aspect of the regular github actions path filter, but it doesn't combine well with required actions.