### PR TITLE
Deprecate generate_pxi

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -353,8 +353,14 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code_main = globalstate.parts['type_declarations']
             h_code_end = globalstate.parts['end']
             if options.generate_pxi:
-                result.i_file = replace_suffix_encoded(result.c_file, ".pxi")
-                i_code = Code.PyrexCodeWriter(result.i_file)
+                from .. import __version__
+                if __version__.startswith('3.3.'):
+                    warning(self.pos, "'generate_pxi' is deprecated and will be removed in Cython 3.4.", 2)
+                    result.i_file = replace_suffix_encoded(result.c_file, ".pxi")
+                    i_code = Code.PyrexCodeWriter(result.i_file)
+                else:
+                    error(self.pos, "'generate_pxd' is no longer supported")
+                    i_code = None
             else:
                 i_code = None
 


### PR DESCRIPTION
Eventually closes #5047

It's completely untested, and undocumented. I didn't manage to find any obvious users of it by searching github (but maybe I've missed some...).
Deprecating it is a fairly gentle approach but it may help us discover if there are any legitimate uses of it.

I'm made it self-disabling, just on the off-chance that we forget to chase it up. Although I think we will want to remove it properly.