### PR TITLE
Avoid useless incref-decref cycles in the inner listcomp loop

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9552,10 +9552,12 @@ class ComprehensionAppendNode(Node):
         return self
 
     def generate_execution_code(self, code):
+        steal_temp = False
         if self.target.type.is_pylist_type:
+            steal_temp = self.expr.is_temp
             code.globalstate.use_utility_code(
-                UtilityCode.load_cached("ListCompAppend", "Optimize.c"))
-            function = "__Pyx_ListComp_Append"
+                UtilityCode.load_cached("ListCompAppendSteal" if steal_temp else "ListCompAppend", "Optimize.c"))
+            function = "__Pyx_ListComp_AppendSteal" if steal_temp else "__Pyx_ListComp_Append"
         elif self.target.type.is_pyset_type:
             function = "PySet_Add"
         else:
@@ -9563,12 +9565,16 @@ class ComprehensionAppendNode(Node):
                 "Invalid type for comprehension node: %s" % self.target.type)
 
         self.expr.generate_evaluation_code(code)
-        code.putln(code.error_goto_if("%s(%s, (PyObject*)%s)" % (
-            function,
-            self.target.result(),
-            self.expr.result()
-            ), self.pos))
-        self.expr.generate_disposal_code(code)
+        if steal_temp:
+            code.put_giveref(self.expr.result(), self.expr.ctype())
+
+        code.putln(code.error_goto_if(
+            f"{function}({self.target.result()}, {self.expr.py_result()})", self.pos))
+
+        if steal_temp:
+            self.expr.generate_post_assignment_code(code)
+        else:
+            self.expr.generate_disposal_code(code)
         self.expr.free_temps(code)
 
     def generate_function_definitions(self, env, code):
@@ -9786,11 +9792,18 @@ class MergedSequenceNode(ExprNode):
                     helpers.add(("ListCompAppend", "Optimize.c"))
                 for arg in item.args:
                     arg.generate_evaluation_code(code)
+                    can_steal_list_item = not is_set and arg.is_temp
+                    if can_steal_list_item:
+                        helpers.add(("ListCompAppendSteal", "Optimize.c"))
                     code.put_error_if_neg(arg.pos, "%s(%s, %s)" % (
-                        add_func,
+                        "__Pyx_ListComp_AppendSteal" if can_steal_list_item else add_func,
                         self.result(),
                         arg.py_result()))
-                    arg.generate_disposal_code(code)
+                    if can_steal_list_item:
+                        code.put_giveref(arg.result(), arg.ctype())
+                        arg.generate_post_assignment_code(code)
+                    else:
+                        arg.generate_disposal_code(code)
                     arg.free_temps(code)
                 continue
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9556,8 +9556,8 @@ class ComprehensionAppendNode(Node):
         if self.target.type.is_pylist_type:
             steal_temp = self.expr.is_temp
             code.globalstate.use_utility_code(
-                UtilityCode.load_cached("ListCompAppendSteal" if steal_temp else "ListCompAppend", "Optimize.c"))
-            function = "__Pyx_ListComp_AppendSteal" if steal_temp else "__Pyx_ListComp_Append"
+                UtilityCode.load_cached("ListCompAppendAndDecref" if steal_temp else "ListCompAppend", "Optimize.c"))
+            function = "__Pyx_ListComp_AppendAndDecref" if steal_temp else "__Pyx_ListComp_Append"
         elif self.target.type.is_pyset_type:
             function = "PySet_Add"
         else:
@@ -9794,9 +9794,9 @@ class MergedSequenceNode(ExprNode):
                     arg.generate_evaluation_code(code)
                     can_steal_list_item = not is_set and arg.is_temp
                     if can_steal_list_item:
-                        helpers.add(("ListCompAppendSteal", "Optimize.c"))
+                        helpers.add(("ListCompAppendAndDecref", "Optimize.c"))
                     code.put_error_if_neg(arg.pos, "%s(%s, %s)" % (
-                        "__Pyx_ListComp_AppendSteal" if can_steal_list_item else add_func,
+                        "__Pyx_ListComp_AppendAndDecref" if can_steal_list_item else add_func,
                         self.result(),
                         arg.py_result()))
                     if can_steal_list_item:

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -26,55 +26,107 @@ static CYTHON_INLINE int __Pyx_PyObject_Append(PyObject* L, PyObject* x) {
     return 0;
 }
 
+
+/////////////// ListAppendStealInternal ///////////////
+
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE void __Pyx__ListComp_AppendSteal(PyObject* list, Py_ssize_t len, PyObject* x) {
+    PyListObject* L = (PyListObject*) list;
+    #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000
+    // In Py3.13a1, PyList_SET_ITEM() checks that the end index is lower than the current size.
+    // However, extending the size *before* setting the value would not be correct,
+    // so we cannot call PyList_SET_ITEM().
+    L->ob_item[len] = x;
+    #else
+    PyList_SET_ITEM(list, len, x);
+    #endif
+    Py_SET_SIZE(list, len + 1);
+}
+#endif
+
+
 /////////////// ListAppend.proto ///////////////
 
-#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS
-static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x) {
-    PyListObject* L = (PyListObject*) list;
-    Py_ssize_t len = Py_SIZE(list);
-    if (likely(L->allocated > len) & likely(len > (L->allocated >> 1))) {
-        Py_INCREF(x);
-        #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000
-        // In Py3.13a1, PyList_SET_ITEM() checks that the end index is lower than the current size.
-        // However, extending the size *before* setting the value would not be correct,
-        // so we cannot call PyList_SET_ITEM().
-        L->ob_item[len] = x;
-        #else
-        PyList_SET_ITEM(list, len, x);
-        #endif
-        Py_SET_SIZE(list, len + 1);
-        return 0;
-    }
-    return PyList_Append(list, x);
-}
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x); /*proto*/
 #else
 #define __Pyx_PyList_Append(L,x) PyList_Append(L,x)
 #endif
 
-/////////////// ListCompAppend.proto ///////////////
+/////////////// ListAppend ///////////////
+//@requires: ListAppendStealInternal
 
-#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS
-static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x) {
     PyListObject* L = (PyListObject*) list;
     Py_ssize_t len = Py_SIZE(list);
-    if (likely(L->allocated > len)) {
+
+    if (likely(L->allocated > len) & likely(len > (L->allocated >> 1))) {
         Py_INCREF(x);
-        #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000
-        // In Py3.13a1, PyList_SET_ITEM() checks that the end index is lower than the current size.
-        // However, extending the size *before* setting the value would not be correct,
-        // so we cannot call PyList_SET_ITEM().
-        L->ob_item[len] = x;
-        #else
-        PyList_SET_ITEM(list, len, x);
-        #endif
-        Py_SET_SIZE(list, len + 1);
+        __Pyx__ListComp_AppendSteal(list, len, x);
         return 0;
     }
     return PyList_Append(list, x);
 }
+#endif
+
+
+/////////////// ListCompAppend.proto ///////////////
+
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x); /*proto*/
 #else
 #define __Pyx_ListComp_Append(L,x) PyList_Append(L,x)
 #endif
+
+/////////////// ListCompAppend ///////////////
+//@requires: ListAppendStealInternal
+
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
+    PyListObject* L = (PyListObject*) list;
+    Py_ssize_t len = Py_SIZE(list);
+
+    if (likely(L->allocated > len)) {
+        Py_INCREF(x);
+        __Pyx__ListComp_AppendSteal(list, len, x);
+        return 0;
+    }
+    return PyList_Append(list, x);
+}
+#endif
+
+
+/////////////// ListCompAppendSteal.proto ///////////////
+
+static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x); /*proto*/
+
+/////////////// ListCompAppendSteal ///////////////
+//@requires: ListAppendStealInternal
+
+#if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
+static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x) {
+    PyListObject* L = (PyListObject*) list;
+    Py_ssize_t len = Py_SIZE(list);
+
+    if (likely(L->allocated > len)) {
+        __Pyx__ListComp_AppendSteal(list, len, x);
+        return 0;
+    }
+
+    int result = PyList_Append(list, x);
+    Py_DECREF(x);
+    return result;
+}
+
+#else
+static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x) {
+    int result = PyList_Append(list, x);
+    Py_DECREF(x);
+    return result;
+}
+#endif
+
 
 //////////////////// ListExtend.proto ////////////////////
 
@@ -313,7 +365,7 @@ static CYTHON_INLINE int __Pyx_dict_iter_next(PyObject* dict_or_iter, Py_ssize_t
 //@requires: ObjectHandling.c::PyObjectCallMethod0
 
 static PyObject *__Pyx_dict_call_to_get_iterable(PyObject* iterable, PyObject* method_name) {
-    
+
     PyObject* iter;
     iterable = __Pyx_PyObject_CallMethod0(iterable, method_name);
     if (!iterable)

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -27,10 +27,10 @@ static CYTHON_INLINE int __Pyx_PyObject_Append(PyObject* L, PyObject* x) {
 }
 
 
-/////////////// ListAppendStealInternal ///////////////
+/////////////// ListAppendAndDecrefInternal ///////////////
 
 #if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
-static CYTHON_INLINE void __Pyx__ListComp_AppendSteal(PyObject* list, Py_ssize_t len, PyObject* x) {
+static CYTHON_INLINE void __Pyx__ListComp_AppendAndDecref(PyObject* list, Py_ssize_t len, PyObject* x) {
     PyListObject* L = (PyListObject*) list;
     #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000
     // In Py3.13a1, PyList_SET_ITEM() checks that the end index is lower than the current size.
@@ -54,7 +54,7 @@ static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x); /*pro
 #endif
 
 /////////////// ListAppend ///////////////
-//@requires: ListAppendStealInternal
+//@requires: ListAppendAndDecrefInternal
 
 #if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
 static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x) {
@@ -63,7 +63,7 @@ static CYTHON_INLINE int __Pyx_PyList_Append(PyObject* list, PyObject* x) {
 
     if (likely(L->allocated > len) & likely(len > (L->allocated >> 1))) {
         Py_INCREF(x);
-        __Pyx__ListComp_AppendSteal(list, len, x);
+        __Pyx__ListComp_AppendAndDecref(list, len, x);
         return 0;
     }
     return PyList_Append(list, x);
@@ -80,7 +80,7 @@ static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x); /*p
 #endif
 
 /////////////// ListCompAppend ///////////////
-//@requires: ListAppendStealInternal
+//@requires: ListAppendAndDecrefInternal
 
 #if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
 static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
@@ -89,7 +89,7 @@ static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
 
     if (likely(L->allocated > len)) {
         Py_INCREF(x);
-        __Pyx__ListComp_AppendSteal(list, len, x);
+        __Pyx__ListComp_AppendAndDecref(list, len, x);
         return 0;
     }
     return PyList_Append(list, x);
@@ -97,20 +97,20 @@ static CYTHON_INLINE int __Pyx_ListComp_Append(PyObject* list, PyObject* x) {
 #endif
 
 
-/////////////// ListCompAppendSteal.proto ///////////////
+/////////////// ListCompAppendAndDecref.proto ///////////////
 
-static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x); /*proto*/
+static CYTHON_INLINE int __Pyx_ListComp_AppendAndDecref(PyObject* list, PyObject* x); /*proto*/
 
-/////////////// ListCompAppendSteal ///////////////
-//@requires: ListAppendStealInternal
+/////////////// ListCompAppendAndDecref ///////////////
+//@requires: ListAppendAndDecrefInternal
 
 #if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
-static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x) {
+static CYTHON_INLINE int __Pyx_ListComp_AppendAndDecref(PyObject* list, PyObject* x) {
     PyListObject* L = (PyListObject*) list;
     Py_ssize_t len = Py_SIZE(list);
 
     if (likely(L->allocated > len)) {
-        __Pyx__ListComp_AppendSteal(list, len, x);
+        __Pyx__ListComp_AppendAndDecref(list, len, x);
         return 0;
     }
 
@@ -120,7 +120,7 @@ static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x)
 }
 
 #else
-static CYTHON_INLINE int __Pyx_ListComp_AppendSteal(PyObject* list, PyObject* x) {
+static CYTHON_INLINE int __Pyx_ListComp_AppendAndDecref(PyObject* list, PyObject* x) {
     int result = PyList_Append(list, x);
     Py_DECREF(x);
     return result;

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -31,11 +31,11 @@ static CYTHON_INLINE int __Pyx_PyObject_Append(PyObject* L, PyObject* x) {
 
 #if CYTHON_USE_PYLIST_INTERNALS && CYTHON_ASSUME_SAFE_MACROS && CYTHON_ASSUME_SAFE_SIZE
 static CYTHON_INLINE void __Pyx__ListComp_AppendAndDecref(PyObject* list, Py_ssize_t len, PyObject* x) {
-    PyListObject* L = (PyListObject*) list;
     #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030d0000
     // In Py3.13a1, PyList_SET_ITEM() checks that the end index is lower than the current size.
     // However, extending the size *before* setting the value would not be correct,
     // so we cannot call PyList_SET_ITEM().
+    PyListObject* L = (PyListObject*) list;
     L->ob_item[len] = x;
     #else
     PyList_SET_ITEM(list, len, x);

--- a/tests/run/listcomp.pyx
+++ b/tests/run/listcomp.pyx
@@ -1,6 +1,9 @@
 # mode: run
 # tag: listcomp, comprehension
 
+# cython: test_assert_c_code_has = __Pyx_ListComp_Append\(
+# cython: test_assert_c_code_has = __Pyx_ListComp_AppendSteal\(
+
 cimport cython
 
 

--- a/tests/run/listcomp.pyx
+++ b/tests/run/listcomp.pyx
@@ -2,7 +2,7 @@
 # tag: listcomp, comprehension
 
 # cython: test_assert_c_code_has = __Pyx_ListComp_Append\(
-# cython: test_assert_c_code_has = __Pyx_ListComp_AppendSteal\(
+# cython: test_assert_c_code_has = __Pyx_ListComp_AppendAndDecref\(
 
 cimport cython
 

--- a/tests/run/pep448_extended_unpacking.pyx
+++ b/tests/run/pep448_extended_unpacking.pyx
@@ -2,7 +2,7 @@
 # tag: all_language_levels
 
 # cython: test_assert_c_code_has = __Pyx_ListComp_Append\(
-# cython: test_assert_c_code_has = __Pyx_ListComp_AppendSteal\(
+# cython: test_assert_c_code_has = __Pyx_ListComp_AppendAndDecref\(
 
 cimport cython
 

--- a/tests/run/pep448_extended_unpacking.pyx
+++ b/tests/run/pep448_extended_unpacking.pyx
@@ -1,6 +1,9 @@
 # mode: run
 # tag: all_language_levels
 
+# cython: test_assert_c_code_has = __Pyx_ListComp_Append\(
+# cython: test_assert_c_code_has = __Pyx_ListComp_AppendSteal\(
+
 cimport cython
 
 
@@ -237,6 +240,17 @@ def unpack_list_simple(it):
     [2, 1]
     """
     return [*it]
+
+
+@cython.test_assert_path_exists(
+    "//MergedSequenceNode",
+)
+def unpack_list_temps(it, x):
+    """
+    >>> unpack_list_temps([1, 2, 3], 4)
+    [1, 2, 3, 4, 5, 6, 1, 2, 3, 7, 8, 9]
+    """
+    return [*it, *[x, x+1, x+2], *it, *[x+3, x+4], *[x+5]]
 
 
 def unpack_list_from_iterable(it):


### PR DESCRIPTION
Instead, steal the item reference if we own it.