### PR TITLE
Add some amount of 32 bit tests

### DIFF
--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -52,6 +52,14 @@ on:
         required: false
         default: false
         type: boolean
+      architecture:
+        required: false
+        default: ""
+        type: string
+      freethreaded:
+        required: false
+        default: false  # note that specifying a "t" in the version will override this (intentionally)
+        type: boolean
 
 
 permissions:
@@ -112,6 +120,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
+          architecture: ${{ inputs.architecture }}
+          freethreaded: ${{ inputs.freethreaded }}
 
       - name: Compilation Cache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         # testing specifically.
         freethreaded: [false, true]
 
-      exclude:
+        exclude:
           # Windows and free-threading is difficult to build right now
           - os: windows-2022
             freethreaded: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,33 +202,15 @@ jobs:
     needs: [ci-early-success, file-changes]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
 
-    strategy:
-      # Allows for matrix sub-jobs to fail without canceling the rest
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, windows-2022]
-        # Keep the number of extra tests to a minimum (because very few people really use 32 bit)
-        # so only run C++ on the basis that it's usually pickier.
-        backend: [cpp]
-        python-version:
-          - "3.x"  # latest
-        architecture: [x86]
-        # The freethreaded build does fiddly things with reference counting so is probably worth
-        # testing specifically.
-        freethreaded: [false, true]
-
-        exclude:
-          # Windows and free-threading is difficult to build right now
-          - os: windows-2022
-            freethreaded: true
-
     uses: ./.github/workflows/ci-job.yml
     with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      backend: ${{ matrix.backend }}
-      architecture: ${{ matrix.architecture }}
-      freethreaded: ${{ matrix.freethreaded }}
+      # setup-python doesn't provide 32 bit Linux so Windows is our only test
+      os: windows-2022
+      python-version: "3.x"
+      # Keep the number of extra tests to a minimum (because very few people really use 32 bit)
+      # so only run C++ on the basis that it's usually pickie  
+      backend: "cpp"
+      architecture: "x86"
 
 
   ci-typespecs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,39 @@ jobs:
       backend: ${{ matrix.backend }}
 
 
+  ci-32bit:
+    needs: [ci-early-success, file-changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.file-changes.outputs.ci-changes == 'true' }}
+
+    strategy:
+      # Allows for matrix sub-jobs to fail without canceling the rest
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022]
+        # Keep the number of extra tests to a minimum (because very few people really use 32 bit)
+        # so only run C++ on the basis that it's usually pickier.
+        backend: [cpp]
+        python-version:
+          - "3.x"  # latest
+        architecture: [x86]
+        # The freethreaded build does fiddly things with reference counting so is probably worth
+        # testing specifically.
+        freethreaded: [false, true]
+
+      exclude:
+          # Windows and free-threading is difficult to build right now
+          - os: windows-2022
+            freethreaded: true
+
+    uses: ./.github/workflows/ci-job.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      backend: ${{ matrix.backend }}
+      architecture: ${{ matrix.architecture }}
+      freethreaded: ${{ matrix.freethreaded }}
+
+
   ci-typespecs:
     # compile with typespecs
     needs: [ci-early-success, file-changes]
@@ -392,7 +425,7 @@ jobs:
 
 
   ci-success:
-    needs: [ci-early-success, ci-all, ci-arm64, ci-typespecs, ci-sharedmodule, ci-compileall, ci-stdc, ci-lapi, ci-noncpython]
+    needs: [ci-early-success, ci-all, ci-arm64, ci-32bit, ci-typespecs, ci-sharedmodule, ci-compileall, ci-stdc, ci-lapi, ci-noncpython]
     if: always()
     env:
       FAIL: ${{ case(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'), 1, 0) }}


### PR DESCRIPTION
I've tried to keep the number of extra combinations down (e.g. by building C++ only). I've included the freethreaded builds because I know there can be 32-bit bugs with them. I think it's probably worth distinguishing windows and Linux here.

I think it's worth *some* level of testing, not because 32 bit is important itself but it validates some of our assumptions around numbers. But probably not much testing.