### PR TITLE
Remove PyPy pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
         python-version:
           - pypy-3.9
           - pypy-3.10
-          - pypy-3.11-v7.3.21  # TODO remove pin when https://github.com/pypy/pypy/issues/5472 is fixed in a release
+          - pypy-3.11
           - graalpy25
         os: [ubuntu-24.04]
         backend: [c]


### PR DESCRIPTION
I think the fixed version (7.3.23) should now be available