### PR TITLE
copy CYTHON_VECTORCALL_TPNEW stanza to pypy and graalpy

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -101,6 +101,13 @@
   #define CYTHON_FAST_THREAD_STATE 0
   #undef CYTHON_FAST_GIL
   #define CYTHON_FAST_GIL 0
+  #if CYTHON_USE_TYPE_SPECS && PY_VERSION_HEX < 0x030E0000
+    // Py_tp_vectorcall slot unavailable
+    #undef CYTHON_VECTORCALL_TPNEW
+    #define CYTHON_VECTORCALL_TPNEW 0
+  #elif !defined(CYTHON_VECTORCALL_TPNEW)
+    #define CYTHON_VECTORCALL_TPNEW CYTHON_VECTORCALL
+  #endif
   #ifndef CYTHON_VECTORCALL
     #define CYTHON_VECTORCALL 1
   #endif
@@ -172,6 +179,13 @@
   #define CYTHON_FAST_THREAD_STATE 0
   #undef CYTHON_FAST_GIL
   #define CYTHON_FAST_GIL 0
+  #if CYTHON_USE_TYPE_SPECS && PY_VERSION_HEX < 0x030E0000
+    // Py_tp_vectorcall slot unavailable
+    #undef CYTHON_VECTORCALL_TPNEW
+    #define CYTHON_VECTORCALL_TPNEW 0
+  #elif !defined(CYTHON_VECTORCALL_TPNEW)
+    #define CYTHON_VECTORCALL_TPNEW CYTHON_VECTORCALL
+  #endif
   #ifndef CYTHON_VECTORCALL
     #define CYTHON_VECTORCALL 1
   #endif


### PR DESCRIPTION
A follow up to #7698. Without this, `CYTHON_USE_TYPE_SPECS=1` on PyPy is broken. I tested with
```
export CFLAGS="-O0 -g3 -DCYTHON_USE_TYPE_SPECS=1"
<home>pypy3.11/bin/pypy runtests.py casttoexttype
```

Without the fix it fails to compile, with the fix the test passes.