### PR TITLE
Improve handling on non-heaptype bases on Py3.9 Limited API

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1744,7 +1744,21 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         tp_new = TypeSlots.get_base_slot_function(scope, tp_slot)
         if tp_new is None:
-            tp_new = f"__Pyx_PyType_GetSlot({base_type_typeptr_cname}, tp_new, newfunc)"
+            code.putln(f"newfunc base_tp_new = __Pyx_PyType_TryGetSlot({base_type_typeptr_cname}, tp_new, newfunc);")
+            tp_new = "base_tp_new"
+            code.putln("#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_VEX < 0x030A0000")
+            code.putln(f"if (unlikely(!base_tp_new)) {{")
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached("RaiseErrorWithObjectTypes", "ObjectHandling.c"))
+            code.putln('__Pyx_RaiseTypeErrorWithTypes('
+                       '"Type " __Pyx_FMT_TYPENAME " cannot be instantiated because it '
+                       'cannot access tp_new of its base " __Pyx_FMT_TYPENAME ". '
+                       'This is probably because the base is not a heap type and is a '
+                       'restriction of the Limited API in Python<=3.9", '
+                       f"t, {base_type_typeptr_cname});")
+            code.putln("o = NULL;")
+            code.putln("} else")
+            code.putln("#endif")
 
         code.putln(f"o = {tp_new}(t, {call_args});")
 

--- a/Cython/Utility/ImportExport.c
+++ b/Cython/Utility/ImportExport.c
@@ -735,7 +735,7 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
         PyTypeObject* base = __Pyx_PyType_GetSlot(type, tp_base, PyTypeObject*);
         while (base) {
             base_depth += 1;
-            base = __Pyx_PyType_GetSlot(base, tp_base, PyTypeObject*);
+            base = __Pyx_PyType_TryGetSlot(base, tp_base, PyTypeObject*);
         }
     }
     base_vtables = (void**) PyMem_Malloc(sizeof(void*) * (size_t)(base_depth + 1));
@@ -780,7 +780,10 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
         } else {
             assert(base_vtable != NULL);
             int j;
-            PyTypeObject* base = __Pyx_PyType_GetSlot(type, tp_base, PyTypeObject*);
+            PyTypeObject* base = __Pyx_PyType_TryGetSlot(type, tp_base, PyTypeObject*);
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
+            if (!base) goto bad;
+#endif
             for (j = 0; j < base_depth; j++) {
                 if (base_vtables[j] == unknown) {
                     switch (__Pyx_GetVtable(base, &base_vtables[j])) {
@@ -799,7 +802,10 @@ static int __Pyx_MergeVtables(PyTypeObject *type) {
                 if (base_vtables[j] == base_vtable) {
                     break;
                 }
-                base = __Pyx_PyType_GetSlot(base, tp_base, PyTypeObject*);
+                base = __Pyx_PyType_TryGetSlot(base, tp_base, PyTypeObject*);
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX <= 0x030A0000
+                if (!base) goto bad;
+#endif
             }
         }
     }


### PR DESCRIPTION
1. Fixes an issue in `__Pyx_MergeVtables` where accessing the final `object` base fails because it isn't a heap-type.
2. Raise an error in the constructor for a type than cannot be instantiated because we can't reach its base.

This will affect inheritance from external types.