### PR TITLE
Emit compile-time error for 'not None' parameters with None default

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3419,6 +3419,9 @@ class DefNode(FuncDefNode):
                     arg.accept_none = True
                 elif arg.not_none:
                     arg.accept_none = False
+                    if arg.default and arg.default.constant_result is None:
+                        error(arg.pos,
+                              "Parameter '%s' is declared 'not None' but has a default value of None" % arg.name)
                 elif (arg.type.is_extension_type or arg.type.is_builtin_type
                         or arg.type.is_buffer or arg.type.is_memoryviewslice):
                     if arg.default and arg.default.constant_result is None:

--- a/tests/errors/e_notnone_default.pyx
+++ b/tests/errors/e_notnone_default.pyx
@@ -1,0 +1,35 @@
+# mode: error
+
+cdef class Foo:
+    pass
+
+def ext_type(Foo x not None = None):
+    pass
+
+def builtin_type(str s not None = None):
+    pass
+
+def untyped(x not None = None):
+    pass
+
+def object_type(object o not None = None):
+    pass
+
+# This should remain valid (no not None)
+def valid_default(Foo x = None):
+    pass
+
+# This should remain valid (not None without default)
+def valid_not_none(Foo x not None):
+    pass
+
+# This should remain valid (or None with default)
+def valid_or_none(Foo x or None = None):
+    pass
+
+_ERRORS = u"""
+6:13: Parameter 'x' is declared 'not None' but has a default value of None
+9:17: Parameter 's' is declared 'not None' but has a default value of None
+12:12: Parameter 'x' is declared 'not None' but has a default value of None
+15:16: Parameter 'o' is declared 'not None' but has a default value of None
+"""


### PR DESCRIPTION
Adds a compile-time check that rejects parameters declared with `not None` that also have a default value of `None`, since the default can never be used without raising `TypeError` at runtime.

Fixes #7762