### PR TITLE
Fix ambiguous unique_ptr(NULL) comparison in C++ mode

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14270,6 +14270,30 @@ class CmpNode:
                 operand1.result(),
                 operand2.result()))
 
+        elif self.is_cpp_comparison():
+            # C++ comparisons already had operands coerced in
+            # analyse_cpp_comparison(). Don't re-cast them to a
+            # common_type, as casting NULL to a C++ class type
+            # (e.g. unique_ptr) generates ambiguous code with GCC 14.
+            code1 = operand1.result()
+            code2 = operand2.result()
+            statement = "%s = %s(%s %s %s);" % (
+                result_code,
+                coerce_result,
+                code1,
+                self.c_operator(op),
+                code2)
+            if self.exception_check == '+':
+                translate_cpp_exception(
+                    code,
+                    self.pos,
+                    statement,
+                    result_code if self.type.is_pyobject else None,
+                    self.exception_value,
+                    self.in_nogil_context)
+            else:
+                code.putln(statement)
+
         else:
             type1 = operand1.type
             type2 = operand2.type
@@ -14282,22 +14306,12 @@ class CmpNode:
                 common_type = type1
             code1 = operand1.result_as(common_type)
             code2 = operand2.result_as(common_type)
-            statement = "%s = %s(%s %s %s);" % (
+            code.putln("%s = %s(%s %s %s);" % (
                 result_code,
                 coerce_result,
                 code1,
                 self.c_operator(op),
-                code2)
-            if self.is_cpp_comparison() and self.exception_check == '+':
-                translate_cpp_exception(
-                    code,
-                    self.pos,
-                    statement,
-                    result_code if self.type.is_pyobject else None,
-                    self.exception_value,
-                    self.in_nogil_context)
-            else:
-                code.putln(statement)
+                code2))
 
     def c_operator(self, op):
         if op == 'is':

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14275,14 +14275,7 @@ class CmpNode:
             # analyse_cpp_comparison(). Don't re-cast them to a
             # common_type, as casting NULL to a C++ class type
             # (e.g. unique_ptr) generates ambiguous code with GCC 14.
-            code1 = operand1.result()
-            code2 = operand2.result()
-            statement = "%s = %s(%s %s %s);" % (
-                result_code,
-                coerce_result,
-                code1,
-                self.c_operator(op),
-                code2)
+            statement = f"{result_code} = {coerce_result}({operand1.result()} {self.c_operator(op)} {operand2.result()});"
             if self.exception_check == '+':
                 translate_cpp_exception(
                     code,
@@ -14306,12 +14299,7 @@ class CmpNode:
                 common_type = type1
             code1 = operand1.result_as(common_type)
             code2 = operand2.result_as(common_type)
-            code.putln("%s = %s(%s %s %s);" % (
-                result_code,
-                coerce_result,
-                code1,
-                self.c_operator(op),
-                code2))
+            code.putln(f"{result_code} = {coerce_result}({code1} {self.c_operator(op)} {code2});")
 
     def c_operator(self, op):
         if op == 'is':

--- a/tests/run/cpp_smart_ptr.pyx
+++ b/tests/run/cpp_smart_ptr.pyx
@@ -114,3 +114,66 @@ def test_dynamic_pointer_cast():
     a = shared_ptr[A](new A())
     b = dynamic_pointer_cast[B, A](a)
     assert b.get() == NULL
+
+
+cdef extern from *:
+    """
+    struct MyStruct {
+        int value;
+    };
+    """
+    cdef cppclass MyStruct:
+        int value
+
+
+cdef class Wrapper:
+    cdef unique_ptr[MyStruct] c_obj
+
+    def set_obj(self):
+        self.c_obj.reset(new MyStruct())
+
+
+def test_unique_ptr_null_comparison():
+    """
+    >>> test_unique_ptr_null_comparison()
+    True
+    False
+    True
+    """
+    cdef Wrapper w = Wrapper()
+    print(w.c_obj == NULL)
+    print(w.c_obj != NULL)
+    w.set_obj()
+    print(w.c_obj != NULL)
+
+
+def test_unique_ptr_nullptr_comparison():
+    """
+    >>> test_unique_ptr_nullptr_comparison()
+    True
+    False
+    True
+    """
+    cdef Wrapper w = Wrapper()
+    print(w.c_obj == nullptr)
+    print(w.c_obj != nullptr)
+    w.set_obj()
+    print(w.c_obj != nullptr)
+
+
+def test_unique_ptr_bool_context():
+    """
+    >>> test_unique_ptr_bool_context()
+    False
+    True
+    """
+    cdef Wrapper w = Wrapper()
+    if w.c_obj:
+        print(True)
+    else:
+        print(False)
+    w.set_obj()
+    if w.c_obj:
+        print(True)
+    else:
+        print(False)


### PR DESCRIPTION
## Summary

AI disclosure: I provided an example of some code that was previously working under older Cython versions that was failing under Cython 3.3.0a1 to an agent, and it wrote up issue #7765 and came up with the fix in this PR. I verified that its tests are a faithful representation of the issue I observed, and the fix looks reasonable to me, but there may be a more concise fix here.

Fixes #7765.

Cython 3.3.0a1 introduced a regression where C++ comparisons (e.g. `unique_ptr != NULL`) generate ambiguous C++ code that fails to compile with GCC 14.

## Root Cause

Commit 23581d608 ("Always evaluate comparisons as bint if that is the expected result") changed `coerce_to_boolean` to unconditionally set `is_temp = True`. This routes C++ comparison codegen through `generate_operation_code()`, which casts both operands to a `common_type` via `result_as()`. For C++ types like `unique_ptr`, this generates:

```cpp
(__pyx_v_w->c_obj != ((std::unique_ptr<MyStruct> )NULL));
```

GCC 14 reports this as ambiguous because `NULL` (`__null`) matches both the `pointer` and `nullptr_t` constructors of `unique_ptr`.

## Fix

Since `analyse_cpp_comparison()` already coerces operands to the resolved operator's argument types, the subsequent `result_as(common_type)` cast is redundant for C++ comparisons. This PR skips it and uses the operands' `result()` directly when `is_cpp_comparison()` is true.

## Test

Added `tests/run/cpp_unique_ptr_null_comparison.pyx` covering:
- `unique_ptr == NULL` / `!= NULL`
- `unique_ptr == nullptr` / `!= nullptr`
- `unique_ptr` in boolean context (`if ptr:`)