### PR TITLE
Fix cyfunction annotate setter on Python 3.14

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -255,6 +255,9 @@ Bugs fixed
   ``@functools.wraps`` work in Python 3.14+.
   (Github issue :issue:`7675`)
 
+* Assigning a Python 3.14+ ``.__annotate__`` function to a Cython compiled function no
+  longer evaluates annotations eagerly.
+
 * The ``--embed-positions`` option no longer includes absolute file paths in the C code.
   (Github issue :issue:`6755`)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,10 @@ Features added
 Bugs fixed
 ----------
 
+* Assigning a Python 3.14+ ``.__annotate__`` function to a Cython compiled function no
+  longer evaluates annotations eagerly.
+  (Github issue :issue:`7767`)
+
 * Generated Cython language features like properties, auto-pickle or dataclasses
   now use a critical section (on the object itself) as guard for concurrent access.
   (Github issue :issue:`6621`)
@@ -254,9 +258,6 @@ Bugs fixed
 * A minimal implementation of ``.__annotate__`` was added to Cython compiled functions to make
   ``@functools.wraps`` work in Python 3.14+.
   (Github issue :issue:`7675`)
-
-* Assigning a Python 3.14+ ``.__annotate__`` function to a Cython compiled function no
-  longer evaluates annotations eagerly.
 
 * The ``--embed-positions`` option no longer includes absolute file paths in the C code.
   (Github issue :issue:`6755`)

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -549,6 +549,7 @@ __Pyx_CyFunction_get_kwdefaults(PyObject *op, void *context) {
 }
 
 static PyObject *__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in); /*proto*/
+static int __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value); /*proto*/
 static int __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value); /*proto*/
 
 static int
@@ -566,7 +567,7 @@ __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
     __Pyx_Py_XDECREF_SET(op->func_annotations, value);
     __Pyx_END_CRITICAL_SECTION();
-    if (unlikely(__Pyx_CyFunction_set_annotate_in_dict(op_in, Py_None) < 0)) return -1;
+    if (unlikely(__Pyx_CyFunction_set_annotate_in_dict_if_exists(op_in, Py_None) < 0)) return -1;
     return 0;
 }
 
@@ -584,6 +585,20 @@ __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in) {
     PyObject *annotate = PyDict_GetItemString(dict, "__annotate__");
     Py_XINCREF(annotate);
     return annotate;
+}
+
+static int
+__Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value) {
+    PyObject *dict;
+#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    PyObject **dictptr = _PyObject_GetDictPtr(op_in);
+    if (unlikely(!dictptr)) return 0;
+    dict = *dictptr;
+#else
+    dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
+#endif
+    if (!dict) return 0;
+    return PyDict_SetItemString(dict, "__annotate__", value);
 }
 
 static int

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -631,39 +631,22 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
 }
 
 static PyObject *
-__Pyx_CyFunction_get_annotations_locked(PyObject *op_in) {
+__Pyx_CyFunction_get_annotations_or_annotate_locked(PyObject *op_in, PyObject **annotate) {
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    PyObject *annotate = NULL;
     PyObject *result = op->func_annotations;
+    *annotate = NULL;
     if (result) {
         Py_INCREF(result);
         return result;
     }
 
-    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
-    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
-    if (annotate && annotate != Py_None) {
-        PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
-        if (unlikely(!format)) {
-            Py_DECREF(annotate);
-            return NULL;
-        }
-        result = __Pyx_PyObject_CallOneArg(annotate, format);
-        Py_DECREF(format);
-        Py_DECREF(annotate);
-        if (unlikely(!result)) return NULL;
-        if (unlikely(!PyDict_Check(result))) {
-            PyErr_SetString(PyExc_TypeError, "__annotate__ must return a dict");
-            Py_DECREF(result);
-            return NULL;
-        }
-        if (!op->func_annotations) {
-            Py_INCREF(result);
-            op->func_annotations = result;
-        }
-        return result;
+    *annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
+    if (unlikely(!*annotate && PyErr_Occurred())) return NULL;
+    if (*annotate && *annotate != Py_None) {
+        return NULL;
     }
-    Py_XDECREF(annotate);
+    Py_XDECREF(*annotate);
+    *annotate = NULL;
 
     result = op->func_annotations;
     if (unlikely(!result)) {
@@ -677,10 +660,35 @@ __Pyx_CyFunction_get_annotations_locked(PyObject *op_in) {
 
 static PyObject *
 __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
+    PyObject *annotate = NULL;
     PyObject *result = NULL;
+    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     CYTHON_UNUSED_VAR(context);
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    result = __Pyx_CyFunction_get_annotations_locked(op_in);
+    result = __Pyx_CyFunction_get_annotations_or_annotate_locked(op_in, &annotate);
+    __Pyx_END_CRITICAL_SECTION();
+    if (result) return result;
+    if (unlikely(!annotate)) return NULL;
+
+    PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
+    if (unlikely(!format)) {
+        Py_DECREF(annotate);
+        return NULL;
+    }
+    result = __Pyx_PyObject_CallOneArg(annotate, format);
+    Py_DECREF(format);
+    Py_DECREF(annotate);
+    if (unlikely(!result)) return NULL;
+    if (unlikely(!PyDict_Check(result))) {
+        PyErr_SetString(PyExc_TypeError, "__annotate__ must return a dict");
+        Py_DECREF(result);
+        return NULL;
+    }
+    __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+    if (!op->func_annotations) {
+        Py_INCREF(result);
+        op->func_annotations = result;
+    }
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -631,24 +631,8 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
 }
 
 static PyObject *
-__Pyx_CyFunction_get_annotations_or_annotate_locked(PyObject *op_in, PyObject **annotate) {
-    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    PyObject *result = op->func_annotations;
-    *annotate = NULL;
-    if (result) {
-        Py_INCREF(result);
-        return result;
-    }
-
-    *annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
-    if (unlikely(!*annotate && PyErr_Occurred())) return NULL;
-    if (*annotate && *annotate != Py_None) {
-        return NULL;
-    }
-    Py_XDECREF(*annotate);
-    *annotate = NULL;
-
-    result = op->func_annotations;
+__Pyx_CyFunction_get_annotations_locked(__pyx_CyFunctionObject *op) {
+    PyObject* result = op->func_annotations;
     if (unlikely(!result)) {
         result = PyDict_New();
         if (unlikely(!result)) return NULL;
@@ -665,10 +649,21 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     CYTHON_UNUSED_VAR(context);
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    result = __Pyx_CyFunction_get_annotations_or_annotate_locked(op_in, &annotate);
+    if (op->func_annotations) {
+        result = __Pyx_CyFunction_get_annotations_locked(op);
+    }
     __Pyx_END_CRITICAL_SECTION();
     if (result) return result;
-    if (unlikely(!annotate)) return NULL;
+
+    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
+    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (!annotate || annotate == Py_None) {
+        Py_XDECREF(annotate);
+        __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+        result = __Pyx_CyFunction_get_annotations_locked(op);
+        __Pyx_END_CRITICAL_SECTION();
+        return result;
+    }
 
     PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
     if (unlikely(!format)) {

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -548,7 +548,7 @@ __Pyx_CyFunction_get_kwdefaults(PyObject *op, void *context) {
     return result;
 }
 
-static PyObject *__Pyx_CyFunction_get_annotate_from_dict(PyObject *op_in); /*proto*/
+static PyObject *__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in); /*proto*/
 static int __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value); /*proto*/
 
 static int
@@ -571,21 +571,47 @@ __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context
 }
 
 static PyObject *
-__Pyx_CyFunction_get_annotate_from_dict(PyObject *op_in) {
-    PyObject *dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
-    if (unlikely(!dict)) return NULL;
+__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in) {
+    PyObject *dict;
+#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    PyObject **dictptr = _PyObject_GetDictPtr(op_in);
+    if (unlikely(!dictptr)) return NULL;
+    dict = *dictptr;
+#else
+    dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
+#endif
+    if (!dict) return NULL;
     PyObject *annotate = PyDict_GetItemString(dict, "__annotate__");
     Py_XINCREF(annotate);
-    Py_DECREF(dict);
     return annotate;
 }
 
 static int
 __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
-    PyObject *dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
+    PyObject *dict;
+    int result;
+#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
+    dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
     if (unlikely(!dict)) return -1;
-    int result = PyDict_SetItemString(dict, "__annotate__", value);
+    result = PyDict_SetItemString(dict, "__annotate__", value);
     Py_DECREF(dict);
+#else
+    int decref_dict = 0;
+    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
+    dict = op->func_dict;
+    if (!dict) {
+        dict = PyDict_New();
+        if (unlikely(!dict)) return -1;
+        op->func_dict = dict;
+    } else {
+        Py_INCREF(dict);
+        decref_dict = 1;
+    }
+    result = PyDict_SetItemString(dict, "__annotate__", value);
+    if (decref_dict) {
+        Py_DECREF(dict);
+    }
+#endif
     return result;
 }
 
@@ -614,7 +640,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     __Pyx_END_CRITICAL_SECTION();
     if (result) return result;
 
-    annotate = __Pyx_CyFunction_get_annotate_from_dict(op_in);
+    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
     if (unlikely(!annotate && PyErr_Occurred())) return NULL;
     if (!annotate || annotate == Py_None) {
         Py_XDECREF(annotate);
@@ -684,7 +710,7 @@ static PyMethodDef __Pyx_CyFunction_annotate_method = {
 static PyObject *
 __Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
     CYTHON_UNUSED_VAR(context);
-    PyObject *annotate = __Pyx_CyFunction_get_annotate_from_dict(op_in);
+    PyObject *annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
     if (unlikely(!annotate && PyErr_Occurred())) return NULL;
     if (annotate) return annotate;
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -675,13 +675,8 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
         return NULL;
     }
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    if (!op->func_annotations) {
-        Py_INCREF(result);
-        op->func_annotations = result;
-    } else {
-        Py_DECREF(result);
-        result = __Pyx_NewRef(op->func_annotations);
-    }
+    Py_CLEAR(op->func_annotations);
+    op->func_annotations = __Pyx_NewRef(result);
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -610,7 +610,7 @@ static int
 __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
     PyObject *dict;
     int result;
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     dict = op->func_dict;
     if (!dict) {
@@ -622,7 +622,7 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
     result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
     Py_DECREF(dict);
 #else
-    dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
+    dict = PyObject_GenericGetDict(op_in, NULL);
     if (unlikely(!dict)) return -1;
     result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
     Py_DECREF(dict);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -675,8 +675,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
         return NULL;
     }
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    Py_CLEAR(op->func_annotations);
-    op->func_annotations = __Pyx_NewRef(result);
+    __Pyx_Py_XDECREF_SET(op->func_annotations, __Pyx_NewRef(result));
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -254,6 +254,7 @@ static PyObject * __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS_METHOD(PyObject 
 //@requires: Exceptions.c::IgnoreException
 //@requires: ModuleSetupCode.c::IncludeStructmemberH
 //@requires: ObjectHandling.c::PyObjectGetAttrStr
+//@requires: ObjectHandling.c::PyObjectCallOneArg
 //@requires: ExtensionTypes.c::CallTypeTraverse
 //@requires: Synchronization.c::CriticalSections
 //@substitute: naming
@@ -547,6 +548,9 @@ __Pyx_CyFunction_get_kwdefaults(PyObject *op, void *context) {
     return result;
 }
 
+static PyObject *__Pyx_CyFunction_get_annotate_from_dict(PyObject *op_in); /*proto*/
+static int __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value); /*proto*/
+
 static int
 __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context) {
     CYTHON_UNUSED_VAR(context);
@@ -562,7 +566,27 @@ __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
     __Pyx_Py_XDECREF_SET(op->func_annotations, value);
     __Pyx_END_CRITICAL_SECTION();
+    if (unlikely(__Pyx_CyFunction_set_annotate_in_dict(op_in, Py_None) < 0)) return -1;
     return 0;
+}
+
+static PyObject *
+__Pyx_CyFunction_get_annotate_from_dict(PyObject *op_in) {
+    PyObject *dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
+    if (unlikely(!dict)) return NULL;
+    PyObject *annotate = PyDict_GetItemString(dict, "__annotate__");
+    Py_XINCREF(annotate);
+    Py_DECREF(dict);
+    return annotate;
+}
+
+static int
+__Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
+    PyObject *dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
+    if (unlikely(!dict)) return -1;
+    int result = PyDict_SetItemString(dict, "__annotate__", value);
+    Py_DECREF(dict);
+    return result;
 }
 
 static PyObject *
@@ -579,11 +603,46 @@ __Pyx_CyFunction_get_annotations_locked(__pyx_CyFunctionObject *op) {
 
 static PyObject *
 __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
-    PyObject *result;
+    PyObject *annotate = NULL;
+    PyObject *result = NULL;
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     CYTHON_UNUSED_VAR(context);
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    result = __Pyx_CyFunction_get_annotations_locked(op);
+    if (op->func_annotations) {
+        result = __Pyx_CyFunction_get_annotations_locked(op);
+    }
+    __Pyx_END_CRITICAL_SECTION();
+    if (result) return result;
+
+    annotate = __Pyx_CyFunction_get_annotate_from_dict(op_in);
+    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (!annotate || annotate == Py_None) {
+        Py_XDECREF(annotate);
+        __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+        result = __Pyx_CyFunction_get_annotations_locked(op);
+        __Pyx_END_CRITICAL_SECTION();
+        return result;
+    }
+
+    PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
+    if (unlikely(!format)) {
+        Py_DECREF(annotate);
+        return NULL;
+    }
+    result = __Pyx_PyObject_CallOneArg(annotate, format);
+    Py_DECREF(format);
+    Py_DECREF(annotate);
+    if (unlikely(!result)) return NULL;
+    if (unlikely(!PyDict_Check(result))) {
+        PyErr_SetString(PyExc_TypeError, "__annotate__ must return a dict");
+        Py_DECREF(result);
+        return NULL;
+    }
+    __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+    if (!op->func_annotations) {
+        Py_INCREF(result);
+        op->func_annotations = result;
+    }
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }
@@ -622,11 +681,13 @@ static PyMethodDef __Pyx_CyFunction_annotate_method = {
 
 // We don't yet support PEP649 properly, so __annotate__ is
 // implemented in a minimal way, just so that functools.wraps works.
-// Essentially the effect of doing func.__annotate__ = other.__annotate__
-// is to copy the annotations dictionary.
 static PyObject *
 __Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
     CYTHON_UNUSED_VAR(context);
+    PyObject *annotate = __Pyx_CyFunction_get_annotate_from_dict(op_in);
+    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (annotate) return annotate;
+
     PyObject *annotations = __Pyx_CyFunction_get_annotations(op_in, NULL);
     if (unlikely(!annotations)) return NULL;
     PyObject *method = PyCFunction_New(
@@ -643,15 +704,15 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
         PyErr_SetString(PyExc_TypeError, "__annotate__ cannot be deleted");
         return -1;
     }
-    if (value == Py_None) {
-        // PEP 649 says "Setting o.__annotate__ to None has no effect on the cached annotations dict."
-        return 0;
+    if (unlikely(value != Py_None && !PyCallable_Check(value))) {
+        PyErr_SetString(PyExc_TypeError, "__annotate__ must be callable or None");
+        return -1;
     }
-    PyObject *annotations = PyObject_CallObject(value, NULL);
-    if (!annotations) return -1;
-    int result = __Pyx_CyFunction_set_annotations(op_in, annotations, NULL);
-    Py_DECREF(annotations);
-    return result;
+    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
+    __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+    Py_CLEAR(op->func_annotations);
+    __Pyx_END_CRITICAL_SECTION();
+    return __Pyx_CyFunction_set_annotate_in_dict(op_in, value);
 }
 
 #if __PYX_LIMITED_VERSION_HEX < 0x030B0000

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -548,10 +548,7 @@ __Pyx_CyFunction_get_kwdefaults(PyObject *op, void *context) {
     return result;
 }
 
-static int __Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict); /*proto*/
-static int __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in, PyObject **annotate); /*proto*/
 static int __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value); /*proto*/
-static int __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value); /*proto*/
 
 static int
 __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context) {

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -611,21 +611,16 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
     result = PyDict_SetItemString(dict, "__annotate__", value);
     Py_DECREF(dict);
 #else
-    int decref_dict = 0;
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     dict = op->func_dict;
     if (!dict) {
         dict = PyDict_New();
         if (unlikely(!dict)) return -1;
         op->func_dict = dict;
-    } else {
-        Py_INCREF(dict);
-        decref_dict = 1;
     }
+    Py_INCREF(dict);
     result = PyDict_SetItemString(dict, "__annotate__", value);
-    if (decref_dict) {
-        Py_DECREF(dict);
-    }
+    Py_DECREF(dict);
 #endif
     return result;
 }
@@ -688,7 +683,7 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
-static PyObject *__Pyx_CyFunction_annotate_impl(PyObject *self, 
+static PyObject *__Pyx_CyFunction_annotate_impl(PyObject *self,
 #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
     PyObject *args
 #else

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -574,6 +574,8 @@ __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context
 
 static int
 __Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict) {
+    /* Return 1 if the function dict exists, 0 otherwise.  This cannot fail:
+     * _PyObject_GetDictPtr() may clear errors internally, but never reports them. */
     *dict = NULL;
 #if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
     *dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
@@ -591,7 +593,6 @@ __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in, PyObject **an
     int dict_found;
     *annotate = NULL;
     dict_found = __Pyx_CyFunction_get_dict_if_exists(op_in, &dict);
-    if (unlikely(dict_found < 0)) return -1;
     if (!dict_found) return 0;
     return __Pyx_PyDict_GetItemRef(dict, PYIDENT("__annotate__"), annotate);
 }
@@ -601,7 +602,6 @@ __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value
     PyObject *dict;
     int dict_found;
     dict_found = __Pyx_CyFunction_get_dict_if_exists(op_in, &dict);
-    if (unlikely(dict_found < 0)) return -1;
     if (!dict_found) return 0;
     return PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -573,13 +573,17 @@ static int
 __Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict) {
     /* Return 1 if the function dict exists, 0 otherwise.  This cannot fail:
      * _PyObject_GetDictPtr() may clear errors internally, but never reports them. */
-    *dict = NULL;
-#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
+#if CYTHON_COMPILING_IN_PYPY
+    *dict = PyObject_GenericGetDict(op_in, NULL);
+#elif CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
     *dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
 #else
     PyObject **dictptr = _PyObject_GetDictPtr(op_in);
     if (unlikely(!dictptr)) return 0;
     *dict = *dictptr;
+#else
+    PyObject **dictptr = _PyObject_GetDictPtr(op_in);
+    *dict = likely(dictptr) ? *dictptr : NULL;
 #endif
     return *dict ? 1 : 0;
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -742,10 +742,12 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
         PyErr_SetString(PyExc_TypeError, "__annotate__ must be callable or None");
         return -1;
     }
-    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    Py_CLEAR(op->func_annotations);
-    __Pyx_END_CRITICAL_SECTION();
+    if (value != Py_None) {
+        __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
+        __Pyx_BEGIN_CRITICAL_SECTION(op_in);
+        Py_CLEAR(op->func_annotations);
+        __Pyx_END_CRITICAL_SECTION();
+    }
     return __Pyx_CyFunction_set_annotate_in_dict(op_in, value);
 }
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -548,7 +548,8 @@ __Pyx_CyFunction_get_kwdefaults(PyObject *op, void *context) {
     return result;
 }
 
-static PyObject *__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in); /*proto*/
+static int __Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict); /*proto*/
+static int __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in, PyObject **annotate); /*proto*/
 static int __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value); /*proto*/
 static int __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value); /*proto*/
 
@@ -571,51 +572,45 @@ __Pyx_CyFunction_set_annotations(PyObject *op_in, PyObject* value, void *context
     return 0;
 }
 
-static PyObject *
-__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in) {
-    PyObject *dict;
-#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
+static int
+__Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict) {
+    *dict = NULL;
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
+    *dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
+#else
     PyObject **dictptr = _PyObject_GetDictPtr(op_in);
-    if (unlikely(!dictptr)) return NULL;
-    dict = *dictptr;
-#else
-    dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
+    if (unlikely(!dictptr)) return 0;
+    *dict = *dictptr;
 #endif
-    if (!dict) return NULL;
-#if (defined(Py_LIMITED_API) && Py_LIMITED_API >= 0x030d0000) || (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000)
-    PyObject *annotate = NULL;
-    if (unlikely(PyDict_GetItemStringRef(dict, "__annotate__", &annotate) < 0)) return NULL;
-#else
-    PyObject *annotate = PyDict_GetItemString(dict, "__annotate__");
-    Py_XINCREF(annotate);
-#endif
-    return annotate;
+    return *dict ? 1 : 0;
+}
+
+static int
+__Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in, PyObject **annotate) {
+    PyObject *dict;
+    int dict_found;
+    *annotate = NULL;
+    dict_found = __Pyx_CyFunction_get_dict_if_exists(op_in, &dict);
+    if (unlikely(dict_found < 0)) return -1;
+    if (!dict_found) return 0;
+    return __Pyx_PyDict_GetItemRef(dict, PYIDENT("__annotate__"), annotate);
 }
 
 static int
 __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value) {
     PyObject *dict;
-#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
-    PyObject **dictptr = _PyObject_GetDictPtr(op_in);
-    if (unlikely(!dictptr)) return 0;
-    dict = *dictptr;
-#else
-    dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
-#endif
-    if (!dict) return 0;
-    return PyDict_SetItemString(dict, "__annotate__", value);
+    int dict_found;
+    dict_found = __Pyx_CyFunction_get_dict_if_exists(op_in, &dict);
+    if (unlikely(dict_found < 0)) return -1;
+    if (!dict_found) return 0;
+    return PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
 }
 
 static int
 __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
     PyObject *dict;
     int result;
-#if PY_VERSION_HEX >= 0x030C0000 && !CYTHON_COMPILING_IN_LIMITED_API
-    dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
-    if (unlikely(!dict)) return -1;
-    result = PyDict_SetItemString(dict, "__annotate__", value);
-    Py_DECREF(dict);
-#else
+#if CYTHON_COMPILING_IN_LIMITED_API || PY_VERSION_HEX < 0x030C0000
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     dict = op->func_dict;
     if (!dict) {
@@ -624,7 +619,12 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
         op->func_dict = dict;
     }
     Py_INCREF(dict);
-    result = PyDict_SetItemString(dict, "__annotate__", value);
+    result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
+    Py_DECREF(dict);
+#else
+    dict = __Pyx_PyObject_GetAttrStr(op_in, PYIDENT("__dict__"));
+    if (unlikely(!dict)) return -1;
+    result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
     Py_DECREF(dict);
 #endif
     return result;
@@ -649,14 +649,11 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     CYTHON_UNUSED_VAR(context);
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    if (op->func_annotations) {
-        result = __Pyx_CyFunction_get_annotations_locked(op);
-    }
+    result = __Pyx_XNewRef(op->func_annotations);
     __Pyx_END_CRITICAL_SECTION();
     if (result) return result;
 
-    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
-    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (unlikely(__Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in, &annotate) < 0)) return NULL;
     if (!annotate || annotate == Py_None) {
         Py_XDECREF(annotate);
         __Pyx_BEGIN_CRITICAL_SECTION(op_in);
@@ -666,12 +663,10 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     }
 
     PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
-    if (unlikely(!format)) {
-        Py_DECREF(annotate);
-        return NULL;
+    if (likely(format)) {
+        result = __Pyx_PyObject_CallOneArg(annotate, format);
+        Py_DECREF(format);
     }
-    result = __Pyx_PyObject_CallOneArg(annotate, format);
-    Py_DECREF(format);
     Py_DECREF(annotate);
     if (unlikely(!result)) return NULL;
     if (unlikely(!PyDict_Check(result))) {
@@ -683,6 +678,9 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     if (!op->func_annotations) {
         Py_INCREF(result);
         op->func_annotations = result;
+    } else {
+        Py_DECREF(result);
+        result = __Pyx_NewRef(op->func_annotations);
     }
     __Pyx_END_CRITICAL_SECTION();
     return result;
@@ -724,9 +722,9 @@ static PyMethodDef __Pyx_CyFunction_annotate_method = {
 // implemented in a minimal way, just so that functools.wraps works.
 static PyObject *
 __Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
+    PyObject *annotate = NULL;
     CYTHON_UNUSED_VAR(context);
-    PyObject *annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
-    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (unlikely(__Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in, &annotate) < 0)) return NULL;
     if (annotate) return annotate;
 
     PyObject *annotations = __Pyx_CyFunction_get_annotations(op_in, NULL);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -582,8 +582,13 @@ __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in) {
     dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
 #endif
     if (!dict) return NULL;
+#if (defined(Py_LIMITED_API) && Py_LIMITED_API >= 0x030d0000) || (!defined(Py_LIMITED_API) && PY_VERSION_HEX >= 0x030d0000)
+    PyObject *annotate = NULL;
+    if (unlikely(PyDict_GetItemStringRef(dict, "__annotate__", &annotate) < 0)) return NULL;
+#else
     PyObject *annotate = PyDict_GetItemString(dict, "__annotate__");
     Py_XINCREF(annotate);
+#endif
     return annotate;
 }
 
@@ -626,8 +631,41 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
 }
 
 static PyObject *
-__Pyx_CyFunction_get_annotations_locked(__pyx_CyFunctionObject *op) {
-    PyObject* result = op->func_annotations;
+__Pyx_CyFunction_get_annotations_locked(PyObject *op_in) {
+    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
+    PyObject *annotate = NULL;
+    PyObject *result = op->func_annotations;
+    if (result) {
+        Py_INCREF(result);
+        return result;
+    }
+
+    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
+    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
+    if (annotate && annotate != Py_None) {
+        PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
+        if (unlikely(!format)) {
+            Py_DECREF(annotate);
+            return NULL;
+        }
+        result = __Pyx_PyObject_CallOneArg(annotate, format);
+        Py_DECREF(format);
+        Py_DECREF(annotate);
+        if (unlikely(!result)) return NULL;
+        if (unlikely(!PyDict_Check(result))) {
+            PyErr_SetString(PyExc_TypeError, "__annotate__ must return a dict");
+            Py_DECREF(result);
+            return NULL;
+        }
+        if (!op->func_annotations) {
+            Py_INCREF(result);
+            op->func_annotations = result;
+        }
+        return result;
+    }
+    Py_XDECREF(annotate);
+
+    result = op->func_annotations;
     if (unlikely(!result)) {
         result = PyDict_New();
         if (unlikely(!result)) return NULL;
@@ -639,46 +677,10 @@ __Pyx_CyFunction_get_annotations_locked(__pyx_CyFunctionObject *op) {
 
 static PyObject *
 __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
-    PyObject *annotate = NULL;
     PyObject *result = NULL;
-    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
     CYTHON_UNUSED_VAR(context);
     __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    if (op->func_annotations) {
-        result = __Pyx_CyFunction_get_annotations_locked(op);
-    }
-    __Pyx_END_CRITICAL_SECTION();
-    if (result) return result;
-
-    annotate = __Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in);
-    if (unlikely(!annotate && PyErr_Occurred())) return NULL;
-    if (!annotate || annotate == Py_None) {
-        Py_XDECREF(annotate);
-        __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-        result = __Pyx_CyFunction_get_annotations_locked(op);
-        __Pyx_END_CRITICAL_SECTION();
-        return result;
-    }
-
-    PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
-    if (unlikely(!format)) {
-        Py_DECREF(annotate);
-        return NULL;
-    }
-    result = __Pyx_PyObject_CallOneArg(annotate, format);
-    Py_DECREF(format);
-    Py_DECREF(annotate);
-    if (unlikely(!result)) return NULL;
-    if (unlikely(!PyDict_Check(result))) {
-        PyErr_SetString(PyExc_TypeError, "__annotate__ must return a dict");
-        Py_DECREF(result);
-        return NULL;
-    }
-    __Pyx_BEGIN_CRITICAL_SECTION(op_in);
-    if (!op->func_annotations) {
-        Py_INCREF(result);
-        op->func_annotations = result;
-    }
+    result = __Pyx_CyFunction_get_annotations_locked(op_in);
     __Pyx_END_CRITICAL_SECTION();
     return result;
 }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -611,22 +611,13 @@ __Pyx_CyFunction_set_annotate_in_dict(PyObject *op_in, PyObject *value) {
     PyObject *dict;
     int result;
 #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
-    __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
-    dict = op->func_dict;
-    if (!dict) {
-        dict = PyDict_New();
-        if (unlikely(!dict)) return -1;
-        op->func_dict = dict;
-    }
-    Py_INCREF(dict);
-    result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
-    Py_DECREF(dict);
+    dict = __Pyx_CyFunction_get_dict(__Pyx_as_CyFunctionObject(op_in), NULL);
 #else
     dict = PyObject_GenericGetDict(op_in, NULL);
+#endif
     if (unlikely(!dict)) return -1;
     result = PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
     Py_DECREF(dict);
-#endif
     return result;
 }
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -579,10 +579,6 @@ __Pyx_CyFunction_get_dict_if_exists(PyObject *op_in, PyObject **dict) {
     *dict = __Pyx_as_CyFunctionObject(op_in)->func_dict;
 #else
     PyObject **dictptr = _PyObject_GetDictPtr(op_in);
-    if (unlikely(!dictptr)) return 0;
-    *dict = *dictptr;
-#else
-    PyObject **dictptr = _PyObject_GetDictPtr(op_in);
     *dict = likely(dictptr) ? *dictptr : NULL;
 #endif
     return *dict ? 1 : 0;

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -519,6 +519,15 @@ def test_annotate():
     >>> f.__annotations__
     {}
 
+    Setting __annotations__ should clear any assigned lazy annotation function.
+    >>> f = test_annotate()
+    >>> f.__annotate__ = lambda arg=0: {'different_argument': 5}
+    >>> f.__annotations__ = {'manual': str}
+    >>> f.__annotate__ is None
+    True
+    >>> f.__annotations__
+    {'manual': <class 'str'>}
+
     Deleting is banned
     >>> f = test_annotate()
     >>> del f.__annotate__

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -477,12 +477,47 @@ def test_annotate():
     >>> f.__annotate__ = lambda arg=0: {'different_argument': 5}
     >>> f.__annotations__
     {'different_argument': 5}
-    
-    Assigning to None shouldn't change the annotations
+    >>> f.__annotate__(1)
+    {'different_argument': 5}
+
+    Assigning a Python 3.14 annotation function should pass the required
+    annotation format argument when annotations are evaluated.
+    >>> import sys
+    >>> if sys.version_info >= (3, 14):
+    ...     def py_function() -> int:
+    ...         pass
+    ...     f.__annotate__ = py_function.__annotate__
+    ...     f.__annotations__ == {'return': int}
+    ... else:
+    ...     True
+    True
+
+    Assignment itself should not evaluate the annotation function, since
+    evaluating annotations may fail normally when they contain forward
+    references.
+    >>> if sys.version_info >= (3, 14):
+    ...     def py_function_with_forward_ref(arg: MissingType) -> int:
+    ...         pass
+    ...     f.__annotate__ = py_function_with_forward_ref.__annotate__
+    ...     assigned = True
+    ...     try:
+    ...         f.__annotations__
+    ...     except NameError:
+    ...         failed_later = True
+    ...     else:
+    ...         failed_later = False
+    ... else:
+    ...     assigned = failed_later = True
+    >>> assigned, failed_later
+    (True, True)
+     
+    Assigning to None should clear the lazy annotation function.
     >>> f = test_annotate()
     >>> f.__annotate__ = None
-    >>> list(f.__annotate__().keys())
-    ['a', 'b']
+    >>> f.__annotate__ is None
+    True
+    >>> f.__annotations__
+    {}
 
     Deleting is banned
     >>> f = test_annotate()

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -447,7 +447,8 @@ def test_wraps(f):
     'to_be_wrapped'
     >>> wrapped_func.__qualname__
     'to_be_wrapped'
-    >>> wrapped_func.__annotations__ == to_be_wrapped.__annotations__
+    >>> wrapped_func.__annotations__ == to_be_wrapped.__annotations__  or  (
+    ...     wrapped_func.__annotations__, to_be_wrapped.__annotations__)
     True
     >>> wrapped_func.__doc__
     "\\n    Hello from to_be_wrapped's docstring\\n    "
@@ -460,7 +461,8 @@ def test_wraps(f):
     'other_python_module'
     >>> wrapped_py_func.__name__
     'py_to_be_wrapped'
-    >>> wrapped_py_func.__annotations__ == py_to_be_wrapped.__annotations__
+    >>> wrapped_py_func.__annotations__ == py_to_be_wrapped.__annotations__  or  (
+    ...     wrapped_py_func.__annotations__, py_to_be_wrapped.__annotations__)
     True
 
     >>> def py_wraps(f):
@@ -473,7 +475,8 @@ def test_wraps(f):
     'other_module'
     >>> py_wrapped_func.__name__
     'to_be_wrapped'
-    >>> py_wrapped_func.__annotations__ == to_be_wrapped.__annotations__
+    >>> py_wrapped_func.__annotations__ == to_be_wrapped.__annotations__  or  (
+    ...     py_wrapped_func.__annotations__, to_be_wrapped.__annotations__)
     True
 
     # __type_params__ should also be copied, but Cython doesn't support this at all
@@ -499,7 +502,7 @@ def test_annotate():
 
     Assigning should work
     >>> f.__annotate__ = lambda arg=0: {'different_argument': 5}
-    >>> f.__annotations__
+    >>> f.__annotations__  # f.__annotate__ = lambda ...
     {'different_argument': 5}
     >>> f.__annotate__(1)
     {'different_argument': 5}
@@ -511,7 +514,7 @@ def test_annotate():
     ...     def py_function() -> int:
     ...         pass
     ...     f.__annotate__ = py_function.__annotate__
-    ...     f.__annotations__ == {'return': int}
+    ...     f.__annotations__ == {'return': int}  or  f.__annotations__
     ... else:
     ...     True
     True
@@ -538,7 +541,7 @@ def test_annotate():
     Setting __annotate__ to None should clear the lazy annotation function.
     >>> f = test_annotate()
     >>> f.__annotate__ = None
-    >>> f.__annotate__ is None
+    >>> f.__annotate__ is None  or  f.__annotate__
     True
     >>> f.__annotations__
     {'a': 'int', 'b': 'str'}
@@ -548,7 +551,7 @@ def test_annotate():
     >>> f.__annotations__
     {'a': 'int', 'b': 'str'}
     >>> f.__annotate__ = None
-    >>> f.__annotate__ is None
+    >>> f.__annotate__ is None  or  f.__annotate__
     True
     >>> f.__annotations__
     {'a': 'int', 'b': 'str'}
@@ -557,7 +560,7 @@ def test_annotate():
     >>> f = test_annotate()
     >>> f.__annotate__ = lambda arg=0: {'different_argument': 5}
     >>> f.__annotations__ = {'manual': str}
-    >>> f.__annotate__ is None
+    >>> f.__annotate__ is None  or  f.__annotate__
     True
     >>> f.__annotations__
     {'manual': <class 'str'>}

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -452,6 +452,30 @@ def test_wraps(f):
     >>> wrapped_func.__doc__
     "\\n    Hello from to_be_wrapped's docstring\\n    "
 
+    >>> def py_to_be_wrapped(a: int, b: float):
+    ...     return None
+    >>> py_to_be_wrapped.__module__ = "other_python_module"
+    >>> wrapped_py_func = test_wraps(py_to_be_wrapped)
+    >>> wrapped_py_func.__module__
+    'other_python_module'
+    >>> wrapped_py_func.__name__
+    'py_to_be_wrapped'
+    >>> wrapped_py_func.__annotations__ == py_to_be_wrapped.__annotations__
+    True
+
+    >>> def py_wraps(f):
+    ...     @wraps(f)
+    ...     def wrapper(*args, **kwds):
+    ...         return f(*args, **kwds)
+    ...     return wrapper
+    >>> py_wrapped_func = py_wraps(to_be_wrapped)
+    >>> py_wrapped_func.__module__
+    'other_module'
+    >>> py_wrapped_func.__name__
+    'to_be_wrapped'
+    >>> py_wrapped_func.__annotations__ == to_be_wrapped.__annotations__
+    True
+
     # __type_params__ should also be copied, but Cython doesn't support this at all
     """
     @wraps(f)

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -534,14 +534,24 @@ def test_annotate():
     ...     assigned = failed_later = True
     >>> assigned, failed_later
     (True, True)
-     
-    Assigning to None should clear the lazy annotation function.
+
+    Setting __annotate__ to None should clear the lazy annotation function.
     >>> f = test_annotate()
     >>> f.__annotate__ = None
     >>> f.__annotate__ is None
     True
     >>> f.__annotations__
-    {}
+    {'a': 'int', 'b': 'str'}
+
+    Setting __annotate__ to None should not discard already materialized annotations.
+    >>> f = test_annotate()
+    >>> f.__annotations__
+    {'a': 'int', 'b': 'str'}
+    >>> f.__annotate__ = None
+    >>> f.__annotate__ is None
+    True
+    >>> f.__annotations__
+    {'a': 'int', 'b': 'str'}
 
     Setting __annotations__ should clear any assigned lazy annotation function.
     >>> f = test_annotate()


### PR DESCRIPTION
Fixes #7767.

There were a few issues:
- Cython assumed it could call `__annotate__` with no arguments, which is not true for the functions CPython generates
- Calling it eagerly is the wrong thing to do anyway: it loses lazy evaluation of annotations. This PR adds lazy evaluation similar to what CPython does.