### PR TITLE
Fix __dealloc__ refcount guard resurrecting dying objects on free-threading (GH-7769)

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -2196,14 +2196,17 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         if not entry or not entry.is_special:
             return
 
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("DeallocKeepAlive", "ExtensionTypes.c"))
         code.putln("{")
         code.putln("PyObject *etype, *eval, *etb;")
         code.putln("__Pyx_PyErr_FetchException(&etype, &eval, &etb);")
-        # increase the refcount while we are calling into user code
-        # to prevent recursive deallocation
-        code.putln("Py_SET_REFCNT(o, Py_REFCNT(o) + 1);")
+        # Keep the object alive while we are calling into user code, to prevent
+        # the user code from triggering recursive deallocation.  On free-threading
+        # this must not use Py_SET_REFCNT() (see DeallocKeepAlive in ExtensionTypes.c).
+        code.putln("__Pyx_DeallocKeepAliveBegin(o);")
         code.putln("%s(o);" % entry.func_cname)
-        code.putln("Py_SET_REFCNT(o, Py_REFCNT(o) - 1);")
+        code.putln("__Pyx_DeallocKeepAliveEnd(o);")
         code.putln("__Pyx_PyErr_RestoreException(etype, eval, etb);")
         code.putln("}")
 

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -295,6 +295,34 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
 #define __Pyx_TRASHCAN_END
 #endif
 
+/////////////// DeallocKeepAlive.proto ///////////////
+
+// Keep `o` alive across a call into user __dealloc__ code, to prevent the user
+// code from triggering recursive deallocation, then drop the temporary reference.
+//
+// On the GIL build this is a plain refcount bump.  On free-threading we must NOT
+// use Py_SET_REFCNT(o, 1): the object reaching tp_dealloc is unowned and merged
+// (ob_ref_shared == _Py_REF_MERGED), so Py_SET_REFCNT takes the unowned branch and
+// writes ob_ref_shared = _Py_REF_SHARED(1, _Py_REF_MERGED), i.e. "merged, shared
+// count 1" -- indistinguishable from a live object.  A concurrent
+// PyUnstable_TryIncRef() would then succeed and resurrect the dying object
+// (use-after-free).  Instead we mirror CPython's _PyObject_ResurrectStart/End:
+// re-take ownership and keep the *shared* refcount at the refuse sentinel (0), so
+// the bump is invisible to other threads and TryIncRef keeps refusing.
+
+#if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING
+#define __Pyx_DeallocKeepAliveBegin(o) do {                                  \
+        _Py_atomic_store_uintptr_relaxed(&(o)->ob_tid, _Py_ThreadId());      \
+        _Py_atomic_store_uint32_relaxed(&(o)->ob_ref_local, 1);              \
+        _Py_atomic_store_ssize_relaxed(&(o)->ob_ref_shared, 0);             \
+    } while (0)
+#define __Pyx_DeallocKeepAliveEnd(o) \
+        _Py_atomic_store_uint32_relaxed(&(o)->ob_ref_local, 0)
+#else
+#define __Pyx_DeallocKeepAliveBegin(o) Py_SET_REFCNT(o, Py_REFCNT(o) + 1)
+#define __Pyx_DeallocKeepAliveEnd(o)   Py_SET_REFCNT(o, Py_REFCNT(o) - 1)
+#endif
+
 /////////////// CallNextTpDealloc.proto ///////////////
 
 static void __Pyx_call_next_tp_dealloc(PyObject* obj, destructor current_tp_dealloc);

--- a/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
+++ b/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
@@ -13,45 +13,93 @@
 # has already started.  The fix keeps the object alive owner-locally, leaving the
 # shared refcount at the refuse sentinel so cross-thread TryIncRef keeps failing.
 #
-# This test publishes each instance to a borrowed slot and, from another thread,
-# repeatedly upgrades that borrowed pointer with the documented
-# PyUnstable_EnableTryIncRef/PyUnstable_TryIncRef protocol.  If a TryIncRef ever
-# succeeds on an object that is already in __dealloc__, the run is buggy (and an
-# unfixed free-threaded build also aborts with
-# "Py_SET_REFCNT: Assertion `refcnt >= 0' failed").  The PyUnstable_TryIncRef API
-# exists only on CPython 3.14+, and the race only exists on free-threaded builds,
-# so the consumer is a no-op elsewhere and the test then trivially passes.
+# To detect this deterministically (rather than relying on timing luck), a
+# dedicated probe thread does a single cross-thread PyUnstable_TryIncRef each time
+# an object enters __dealloc__: __dealloc__ hands "self" to the probe thread and
+# blocks until the probe reports back.  A separate thread is required -- a
+# same-thread TryIncRef would take the owner fast path and succeed even with the
+# fix, so it could not tell buggy from fixed.  If the probe ever acquires a strong
+# reference to an object that is mid-__dealloc__, the guard resurrected it.
+#
+# PyUnstable_TryIncRef exists only on CPython 3.14+ and the race only exists on
+# free-threaded builds, so on every other build the helpers are no-ops and the
+# test passes trivially.
 
 cdef extern from *:
     """
     #if PY_VERSION_HEX >= 0x030E0000 && defined(Py_GIL_DISABLED)
     #include <stdatomic.h>
-    static _Atomic(PyObject*) _ka_slot = NULL;
-    static atomic_long _ka_caught = 0;
-    static void _ka_publish(PyObject *o) { atomic_store(&_ka_slot, o); }
-    static void _ka_enable(PyObject *o) { PyUnstable_EnableTryIncRef(o); }
-    static void _ka_consume(int (*dying)(PyObject *)) {
-        PyObject *o = atomic_load(&_ka_slot);
-        if (o && PyUnstable_TryIncRef(o)) {       /* borrowed -> strong upgrade */
-            if (dying(o)) atomic_fetch_add(&_ka_caught, 1);
-            Py_DECREF(o);
+    #include <threads.h>
+
+    typedef int (*_ka_dyingfn)(PyObject *);
+
+    static _Atomic(PyObject *) _ka_slot = NULL;   /* object currently in __dealloc__ */
+    static _ka_dyingfn         _ka_dying = NULL;   /* reads the per-object "dying" flag */
+    static atomic_int  _ka_request = 0;            /* __dealloc__ -> probe: probe now */
+    static atomic_int  _ka_answered = 0;           /* probe -> __dealloc__: done */
+    static atomic_int  _ka_quit = 0;               /* shut the probe thread down */
+    static atomic_long _ka_caught = 0;             /* # of TryIncRefs that hit a dying object */
+    static thrd_t      _ka_thread;
+
+    static int _ka_probe_main(void *unused) {
+        (void) unused;
+        for (;;) {
+            while (!atomic_load(&_ka_request)) {
+                if (atomic_load(&_ka_quit))
+                    return 0;
+                thrd_yield();
+            }
+            PyObject *o = atomic_load(&_ka_slot);
+            /* The object is alive (we are inside its __dealloc__, which is blocked
+               in the handshake below), so reading it here is safe.  A correct build
+               must refuse this cross-thread upgrade; a buggy one accepts it. */
+            if (o && PyUnstable_TryIncRef(o)) {
+                if (_ka_dying(o))
+                    atomic_fetch_add(&_ka_caught, 1);
+                Py_DECREF(o);
+            }
+            atomic_store(&_ka_request, 0);
+            atomic_store(&_ka_answered, 1);
         }
     }
+
+    static void _ka_start(_ka_dyingfn dying) {
+        _ka_dying = dying;
+        atomic_store(&_ka_quit, 0);
+        thrd_create(&_ka_thread, _ka_probe_main, NULL);
+    }
+    static void _ka_stop(void) {
+        atomic_store(&_ka_quit, 1);
+        thrd_join(_ka_thread, NULL);
+    }
+    static void _ka_enable(PyObject *o) { PyUnstable_EnableTryIncRef(o); }
+
+    /* Called from inside __dealloc__: ask the probe thread to TryIncRef "self"
+       right now, and block until it has answered. */
+    static void _ka_handshake(PyObject *o) {
+        atomic_store(&_ka_slot, o);
+        atomic_store(&_ka_answered, 0);
+        atomic_store(&_ka_request, 1);
+        while (!atomic_load(&_ka_answered))
+            thrd_yield();
+    }
     static long _ka_caught_count(void) { return atomic_load(&_ka_caught); }
+
     #else
-    static void _ka_publish(PyObject *o) { (void)o; }
-    static void _ka_enable(PyObject *o) { (void)o; }
-    static void _ka_consume(int (*dying)(PyObject *)) { (void)dying; }
+    typedef int (*_ka_dyingfn)(PyObject *);
+    static void _ka_start(_ka_dyingfn dying) { (void) dying; }
+    static void _ka_stop(void) { }
+    static void _ka_enable(PyObject *o) { (void) o; }
+    static void _ka_handshake(PyObject *o) { (void) o; }
     static long _ka_caught_count(void) { return 0; }
     #endif
     """
-    void _ka_publish(object)
+    ctypedef int (*_ka_dyingfn)(object) noexcept
+    void _ka_start(_ka_dyingfn)
+    void _ka_stop()
     void _ka_enable(object)
-    void _ka_consume(int (*)(object) noexcept)
+    void _ka_handshake(object)
     long _ka_caught_count()
-
-
-from threading import Thread
 
 
 cdef int _is_dying(object o) noexcept:
@@ -63,34 +111,22 @@ cdef class Dying:
 
     def __cinit__(self):
         _ka_enable(self)
-        _ka_publish(self)
 
     def __dealloc__(self):
-        # Mark the object as mid-deallocation, then widen the window a little so
-        # the consumer thread has a chance to race the guard.
         self.dying = 1
-        cdef int i
-        for i in range(200):
-            pass
+        _ka_handshake(self)
 
 
-def _consume_loop(long iterations):
-    cdef long i
-    for i in range(iterations):
-        _ka_consume(_is_dying)
-
-
-def run(long producer_loops=100000, long consumer_iterations=2000000):
+def run(int n=1000):
     """
     >>> run()
     0
     """
-    t = Thread(target=_consume_loop, args=(consumer_iterations,))
-    t.start()
+    _ka_start(_is_dying)
     try:
-        for _ in range(producer_loops):
+        for _ in range(n):
             obj = Dying()
             obj = None
     finally:
-        t.join()
+        _ka_stop()
     return _ka_caught_count()

--- a/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
+++ b/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
@@ -1,0 +1,96 @@
+# mode: run
+# tag: c11, no-cpp, threads
+
+# cython: freethreading_compatible=True
+
+# Regression test for a free-threading __dealloc__ resurrection race.
+#
+# The reference-count guard that Cython emits around a user __dealloc__ must not
+# make the dying object acquirable by other threads.  On a free-threaded build,
+# using Py_SET_REFCNT(o, 1) on the (unowned, merged) dying object writes the
+# "live, shared count 1" encoding into ob_ref_shared, which a concurrent
+# PyUnstable_TryIncRef() would accept -- resurrecting an object whose __dealloc__
+# has already started.  The fix keeps the object alive owner-locally, leaving the
+# shared refcount at the refuse sentinel so cross-thread TryIncRef keeps failing.
+#
+# This test publishes each instance to a borrowed slot and, from another thread,
+# repeatedly upgrades that borrowed pointer with the documented
+# PyUnstable_EnableTryIncRef/PyUnstable_TryIncRef protocol.  If a TryIncRef ever
+# succeeds on an object that is already in __dealloc__, the run is buggy (and an
+# unfixed free-threaded build also aborts with
+# "Py_SET_REFCNT: Assertion `refcnt >= 0' failed").  The PyUnstable_TryIncRef API
+# exists only on CPython 3.14+, and the race only exists on free-threaded builds,
+# so the consumer is a no-op elsewhere and the test then trivially passes.
+
+cdef extern from *:
+    """
+    #if PY_VERSION_HEX >= 0x030E0000 && defined(Py_GIL_DISABLED)
+    #include <stdatomic.h>
+    static _Atomic(PyObject*) _ka_slot = NULL;
+    static atomic_long _ka_caught = 0;
+    static void _ka_publish(PyObject *o) { atomic_store(&_ka_slot, o); }
+    static void _ka_enable(PyObject *o) { PyUnstable_EnableTryIncRef(o); }
+    static void _ka_consume(int (*dying)(PyObject *)) {
+        PyObject *o = atomic_load(&_ka_slot);
+        if (o && PyUnstable_TryIncRef(o)) {       /* borrowed -> strong upgrade */
+            if (dying(o)) atomic_fetch_add(&_ka_caught, 1);
+            Py_DECREF(o);
+        }
+    }
+    static long _ka_caught_count(void) { return atomic_load(&_ka_caught); }
+    #else
+    static void _ka_publish(PyObject *o) { (void)o; }
+    static void _ka_enable(PyObject *o) { (void)o; }
+    static void _ka_consume(int (*dying)(PyObject *)) { (void)dying; }
+    static long _ka_caught_count(void) { return 0; }
+    #endif
+    """
+    void _ka_publish(object)
+    void _ka_enable(object)
+    void _ka_consume(int (*)(object) noexcept)
+    long _ka_caught_count()
+
+
+from threading import Thread
+
+
+cdef int _is_dying(object o) noexcept:
+    return (<Dying>o).dying
+
+
+cdef class Dying:
+    cdef public int dying
+
+    def __cinit__(self):
+        _ka_enable(self)
+        _ka_publish(self)
+
+    def __dealloc__(self):
+        # Mark the object as mid-deallocation, then widen the window a little so
+        # the consumer thread has a chance to race the guard.
+        self.dying = 1
+        cdef int i
+        for i in range(200):
+            pass
+
+
+def _consume_loop(long iterations):
+    cdef long i
+    for i in range(iterations):
+        _ka_consume(_is_dying)
+
+
+def run(long producer_loops=100000, long consumer_iterations=2000000):
+    """
+    >>> run()
+    0
+    """
+    t = Thread(target=_consume_loop, args=(consumer_iterations,))
+    t.start()
+    try:
+        for _ in range(producer_loops):
+            obj = Dying()
+            obj = None
+    finally:
+        t.join()
+    return _ka_caught_count()

--- a/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
+++ b/tests/run/freethreaded_dealloc_resurrect_T7769.pyx
@@ -3,118 +3,79 @@
 
 # cython: freethreading_compatible=True
 
-# Regression test for a free-threading __dealloc__ resurrection race.
+# Regression test for a free-threading __dealloc__ resurrection race (GH #7769).
 #
-# The reference-count guard that Cython emits around a user __dealloc__ must not
-# make the dying object acquirable by other threads.  On a free-threaded build,
-# using Py_SET_REFCNT(o, 1) on the (unowned, merged) dying object writes the
-# "live, shared count 1" encoding into ob_ref_shared, which a concurrent
-# PyUnstable_TryIncRef() would accept -- resurrecting an object whose __dealloc__
-# has already started.  The fix keeps the object alive owner-locally, leaving the
-# shared refcount at the refuse sentinel so cross-thread TryIncRef keeps failing.
+# Cython's keep-alive guard around a user __dealloc__ must not make the dying
+# object acquirable by other threads.  The old Py_SET_REFCNT(o, 1) wrote a "live,
+# shared count 1" encoding that a concurrent PyUnstable_TryIncRef() would accept,
+# resurrecting an object already in __dealloc__.
 #
-# To detect this deterministically (rather than relying on timing luck), a
-# dedicated probe thread does a single cross-thread PyUnstable_TryIncRef each time
-# an object enters __dealloc__: __dealloc__ hands "self" to the probe thread and
-# blocks until the probe reports back.  A separate thread is required -- a
-# same-thread TryIncRef would take the owner fast path and succeed even with the
-# fix, so it could not tell buggy from fixed.  If the probe ever acquires a strong
-# reference to an object that is mid-__dealloc__, the guard resurrected it.
-#
-# PyUnstable_TryIncRef exists only on CPython 3.14+ and the race only exists on
-# free-threaded builds, so on every other build the helpers are no-ops and the
-# test passes trivially.
+# Each time an object enters __dealloc__ it publishes "self" and blocks until a
+# probe thread answers, so it is provably mid-__dealloc__ (alive, before tp_free)
+# when the probe attempts one cross-thread TryIncRef -- which a fixed build must
+# refuse.  A separate thread is required (a same-thread TryIncRef takes the owner
+# fast path and succeeds even when fixed).  The probe is a threading.Thread so it
+# holds a PyThreadState and needs no C11 <threads.h> (absent on macOS).  Outside
+# free-threaded CPython 3.14+ the helpers are no-ops and the test is trivial.
+
+from threading import Thread, Event
 
 cdef extern from *:
     """
     #if PY_VERSION_HEX >= 0x030E0000 && defined(Py_GIL_DISABLED)
     #include <stdatomic.h>
-    #include <threads.h>
-
-    typedef int (*_ka_dyingfn)(PyObject *);
-
-    static _Atomic(PyObject *) _ka_slot = NULL;   /* object currently in __dealloc__ */
-    static _ka_dyingfn         _ka_dying = NULL;   /* reads the per-object "dying" flag */
-    static atomic_int  _ka_request = 0;            /* __dealloc__ -> probe: probe now */
-    static atomic_int  _ka_answered = 0;           /* probe -> __dealloc__: done */
-    static atomic_int  _ka_quit = 0;               /* shut the probe thread down */
-    static atomic_long _ka_caught = 0;             /* # of TryIncRefs that hit a dying object */
-    static thrd_t      _ka_thread;
-
-    static int _ka_probe_main(void *unused) {
-        (void) unused;
-        for (;;) {
-            while (!atomic_load(&_ka_request)) {
-                if (atomic_load(&_ka_quit))
-                    return 0;
-                thrd_yield();
-            }
-            PyObject *o = atomic_load(&_ka_slot);
-            /* The object is alive (we are inside its __dealloc__, which is blocked
-               in the handshake below), so reading it here is safe.  A correct build
-               must refuse this cross-thread upgrade; a buggy one accepts it. */
-            if (o && PyUnstable_TryIncRef(o)) {
-                if (_ka_dying(o))
-                    atomic_fetch_add(&_ka_caught, 1);
-                Py_DECREF(o);
-            }
-            atomic_store(&_ka_request, 0);
-            atomic_store(&_ka_answered, 1);
-        }
-    }
-
-    static void _ka_start(_ka_dyingfn dying) {
-        _ka_dying = dying;
-        atomic_store(&_ka_quit, 0);
-        thrd_create(&_ka_thread, _ka_probe_main, NULL);
-    }
-    static void _ka_stop(void) {
-        atomic_store(&_ka_quit, 1);
-        thrd_join(_ka_thread, NULL);
-    }
+    static _Atomic(PyObject *) _ka_slot = NULL;    /* borrowed: object now in __dealloc__ */
+    static atomic_long _ka_caught = 0;             /* # of dying objects acquired cross-thread */
+    static int  _ka_enabled(void) { return 1; }
     static void _ka_enable(PyObject *o) { PyUnstable_EnableTryIncRef(o); }
-
-    /* Called from inside __dealloc__: ask the probe thread to TryIncRef "self"
-       right now, and block until it has answered. */
-    static void _ka_handshake(PyObject *o) {
-        atomic_store(&_ka_slot, o);
-        atomic_store(&_ka_answered, 0);
-        atomic_store(&_ka_request, 1);
-        while (!atomic_load(&_ka_answered))
-            thrd_yield();
+    static void _ka_publish(PyObject *o) { atomic_store(&_ka_slot, o); }
+    /* One cross-thread upgrade of the mid-__dealloc__ object; success == resurrection. */
+    static void _ka_probe(void) {
+        PyObject *o = atomic_load(&_ka_slot);
+        if (o && PyUnstable_TryIncRef(o)) { atomic_fetch_add(&_ka_caught, 1); Py_DECREF(o); }
     }
     static long _ka_caught_count(void) { return atomic_load(&_ka_caught); }
-
     #else
-    typedef int (*_ka_dyingfn)(PyObject *);
-    static void _ka_start(_ka_dyingfn dying) { (void) dying; }
-    static void _ka_stop(void) { }
+    static int  _ka_enabled(void) { return 0; }
     static void _ka_enable(PyObject *o) { (void) o; }
-    static void _ka_handshake(PyObject *o) { (void) o; }
+    static void _ka_publish(PyObject *o) { (void) o; }
+    static void _ka_probe(void) { }
     static long _ka_caught_count(void) { return 0; }
     #endif
     """
-    ctypedef int (*_ka_dyingfn)(object) noexcept
-    void _ka_start(_ka_dyingfn)
-    void _ka_stop()
+    bint _ka_enabled()
     void _ka_enable(object)
-    void _ka_handshake(object)
+    void _ka_publish(object)
+    void _ka_probe()
     long _ka_caught_count()
 
 
-cdef int _is_dying(object o) noexcept:
-    return (<Dying>o).dying
+_request = Event()   # __dealloc__ -> probe: probe now
+_answer = Event()    # probe -> __dealloc__: done
+_active = False      # False also tells the probe to exit
 
 
 cdef class Dying:
-    cdef public int dying
-
     def __cinit__(self):
         _ka_enable(self)
 
     def __dealloc__(self):
-        self.dying = 1
-        _ka_handshake(self)
+        if not _active:
+            return
+        _ka_publish(self)
+        _answer.clear()
+        _request.set()
+        _answer.wait()   # block in __dealloc__ until the probe has answered
+
+
+def _probe_main():
+    while True:
+        _request.wait()
+        _request.clear()
+        if not _active:
+            return
+        _ka_probe()
+        _answer.set()
 
 
 def run(int n=1000):
@@ -122,11 +83,18 @@ def run(int n=1000):
     >>> run()
     0
     """
-    _ka_start(_is_dying)
+    global _active
+    if not _ka_enabled():
+        return 0
+    t = Thread(target=_probe_main)
+    t.start()
+    _active = True
     try:
         for _ in range(n):
             obj = Dying()
             obj = None
     finally:
-        _ka_stop()
+        _active = False
+        _request.set()   # wake the probe so it observes _active and exits
+        t.join()
     return _ka_caught_count()


### PR DESCRIPTION
Fixes #7769.

On free-threaded builds the reference-count guard Cython emits around a user `__dealloc__` (`Py_SET_REFCNT(o, Py_REFCNT(o) + 1)`) marks the dying object as live to other threads: on the unowned, merged object this writes `ob_ref_shared = _Py_REF_SHARED(1, _Py_REF_MERGED)` ("merged, shared count 1"), so a concurrent `PyUnstable_TryIncRef()` succeeds and resurrects an object already in `__dealloc__` (use-after-free; aborts with `Py_SET_REFCNT: Assertion 'refcnt >= 0' failed`).

The fix keeps the object alive owner-locally — re-take ownership and leave the shared refcount at the refuse sentinel (`ob_ref_shared = 0`), mirroring CPython's `_PyObject_ResurrectStart/End` — so the keep-alive is invisible to other threads and `TryIncRef` keeps refusing. The recursion guard still holds via `ob_ref_local`. The GIL build is unchanged.

Only the non-limited free-threaded build is addressed (the only free-threaded build that currently exists). abi3t (PEP 803) cannot express this with the current stable ABI and is left for when CPython provides a stable in-dealloc resurrection primitive.

The added test reproduces the race: a `cdef class` with `__dealloc__` is published to a borrowed slot and another thread upgrades it via `PyUnstable_EnableTryIncRef`/`TryIncRef` while it is mid-`__dealloc__`. It aborts on an unfixed free-threaded build and passes with the fix; on non-free-threaded / pre-3.14 builds the consumer is a no-op so it passes trivially.
