### PR TITLE
Fix use of uninitialized monitoring fields in generator/coroutine objects

### DIFF
--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -1676,6 +1676,10 @@ static __pyx_CoroutineObject *__Pyx__Coroutine_NewInit(
     Py_XINCREF(code);
     gen->gi_code = code;
     gen->gi_frame = NULL;
+#if CYTHON_USE_SYS_MONITORING && (CYTHON_PROFILE || CYTHON_TRACE)
+    memset(gen->$monitoring_states_cname, 0, sizeof(gen->$monitoring_states_cname));
+    gen->$monitoring_version_cname = 0;
+#endif
 
     PyObject_GC_Track(gen);
     return gen;


### PR DESCRIPTION
`__Pyx__Coroutine_NewInit()` does not initialize `monitoring_states` and `monitoring_version` on the generator object. Since `PyObject_GC_New()` does not zero memory, these contain garbage when first read by `PyMonitoring_EnterScope()` via `__Pyx__TraceStartGen()`.

The fix zero-initializes both fields at construction, consistent with how `__Pyx_TraceStartFunc` already handles regular functions.