### PR TITLE
Fix AsyncGenerator following CPython

### DIFF
--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -167,6 +167,14 @@ typedef struct __pyx__PyAsyncGenWrappedValue {
                     Py_IS_TYPE(o, CGLOBAL(__pyx__PyAsyncGenWrappedValueType))
 
 
+static void
+__Pyx_async_gen_raise_already_running(const char* context) {
+    PyErr_Format(
+        PyExc_RuntimeError,
+        // context: anext/athrow/aclose
+        "%6s(): asynchronous generator is already running", context);
+}
+
 static int
 __Pyx_async_gen_traverse(__pyx_PyAsyncGenObject *gen, visitproc visit, void *arg)
 {
@@ -532,9 +540,8 @@ __Pyx_async_gen_asend_send_impl(PyObject *g, PyObject *arg, int iternext)
 
     if (o->ags_state == __PYX_AWAITABLE_STATE_INIT) {
         if (unlikely(o->ags_gen->ag_running_async)) {
-            PyErr_SetString(
-                PyExc_RuntimeError,
-                "anext(): asynchronous generator is already running");
+            o->ags_state = __PYX_AWAITABLE_STATE_CLOSED;
+            __Pyx_async_gen_raise_already_running("anext");
             return NULL;
         }
 
@@ -585,6 +592,17 @@ __Pyx_async_gen_asend_throw(__pyx_PyAsyncGenASend *o,
         return NULL;
     }
 
+    if (o->ags_state == __PYX_AWAITABLE_STATE_INIT) {
+        if (unlikely(o->ags_gen->ag_running_async)) {
+            o->ags_state = __PYX_AWAITABLE_STATE_CLOSED;
+            __Pyx_async_gen_raise_already_running("anext");
+            return NULL;
+        }
+
+        o->ags_state = __PYX_AWAITABLE_STATE_ITER;
+        o->ags_gen->ag_running_async = 1;
+    }
+
     result = __Pyx_Coroutine_Throw((PyObject*)o->ags_gen, args
 #if !(CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000)
         , nargs
@@ -605,6 +623,36 @@ __Pyx_async_gen_asend_close(PyObject *g, PyObject *args)
 {
     __pyx_PyAsyncGenASend *o = (__pyx_PyAsyncGenASend*) g;
     CYTHON_UNUSED_VAR(args);
+
+    if (o->ags_state == __PYX_AWAITABLE_STATE_CLOSED) {
+        Py_RETURN_NONE;
+    }
+
+    PyObject *result;
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
+    PyObject *throw_args = PyTuple_Pack(1, PyExc_GeneratorExit);
+    if (unlikely(!throw_args)) return NULL;
+    result = __Pyx_async_gen_asend_throw(o, throw_args);
+    Py_DECREF(throw_args);
+#else
+    result = __Pyx_async_gen_asend_throw(o, &PyExc_GeneratorExit, 1);
+#endif
+
+    if (likely(result == NULL)) {
+        PyObject *exc_type = PyErr_Occurred();
+        if (likely(__Pyx_PyErr_GivenExceptionMatches2(exc_type, PyExc_StopIteration, PyExc_GeneratorExit) ||
+                   __Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopAsyncIteration)))
+        {
+            PyErr_Clear();
+            Py_RETURN_NONE;
+        }
+        return result;
+    } else {
+        Py_DECREF(result);
+        PyErr_SetString(PyExc_RuntimeError, "coroutine ignored GeneratorExit");
+        return NULL;
+    }
+
     o->ags_state = __PYX_AWAITABLE_STATE_CLOSED;
     Py_RETURN_NONE;
 }
@@ -811,15 +859,7 @@ __Pyx_async_gen_athrow_send_impl(__pyx_PyAsyncGenAThrow *o, PyObject *arg, int i
     if (o->agt_state == __PYX_AWAITABLE_STATE_INIT) {
         if (unlikely(o->agt_gen->ag_running_async)) {
             o->agt_state = __PYX_AWAITABLE_STATE_CLOSED;
-            if (o->agt_args == NULL) {
-                PyErr_SetString(
-                    PyExc_RuntimeError,
-                    "aclose(): asynchronous generator is already running");
-            } else {
-                PyErr_SetString(
-                    PyExc_RuntimeError,
-                    "athrow(): asynchronous generator is already running");
-            }
+            __Pyx_async_gen_raise_already_running((o->agt_args == NULL) ? "aclose" : "athrow");
             return NULL;
         }
 
@@ -937,6 +977,17 @@ __Pyx_async_gen_athrow_throw(__pyx_PyAsyncGenAThrow *o,
         return NULL;
     }
 
+    if (o->agt_state == __PYX_AWAITABLE_STATE_INIT) {
+        if (unlikely(o->agt_gen->ag_running_async)) {
+            o->agt_state = __PYX_AWAITABLE_STATE_CLOSED;
+            __Pyx_async_gen_raise_already_running((o->agt_args == NULL) ? "aclose" : "athrow");
+            return NULL;
+        }
+
+        o->agt_state = __PYX_AWAITABLE_STATE_ITER;
+        o->agt_gen->ag_running_async = 1;
+    }
+
     retval = __Pyx_Coroutine_Throw((PyObject*)o->agt_gen, args
 #if !(CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000)
         , nargs
@@ -989,6 +1040,35 @@ __Pyx_async_gen_athrow_close(PyObject *g, PyObject *args)
 {
     __pyx_PyAsyncGenAThrow *o = (__pyx_PyAsyncGenAThrow*) g;
     CYTHON_UNUSED_VAR(args);
+
+    if (o->agt_state == __PYX_AWAITABLE_STATE_CLOSED) {
+        Py_RETURN_NONE;
+    }
+
+    PyObject *result;
+#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
+    PyObject *throw_args = PyTuple_Pack(1, PyExc_GeneratorExit);
+    if (unlikely(!throw_args)) return NULL;
+    result = __Pyx_async_gen_athrow_throw(o, throw_args);
+    Py_DECREF(throw_args);
+#else
+    result = __Pyx_async_gen_athrow_throw(o, &PyExc_GeneratorExit, 1);
+#endif
+    if (likely(result == NULL)) {
+        PyObject *exc_type = PyErr_Occurred();
+        if (likely(__Pyx_PyErr_GivenExceptionMatches2(exc_type, PyExc_StopIteration, PyExc_GeneratorExit) ||
+                   __Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopAsyncIteration)))
+        {
+            PyErr_Clear();
+            Py_RETURN_NONE;
+        }
+        return result;
+    } else {
+        Py_DECREF(result);
+        PyErr_SetString(PyExc_RuntimeError, "coroutine ignored GeneratorExit");
+        return NULL;
+    }
+
     o->agt_state = __PYX_AWAITABLE_STATE_CLOSED;
     Py_RETURN_NONE;
 }

--- a/tests/run/test_asyncgen.py
+++ b/tests/run/test_asyncgen.py
@@ -10,7 +10,7 @@ from Cython.TestUtils import TimedTest
 
 import os
 import sys
-#import inspect
+import inspect
 #import types
 import unittest
 import contextlib
@@ -122,7 +122,7 @@ try:
 except ImportError:
     def inspect_isawaitable(o):
         return hasattr(o, '__await__')
-    
+
 try:
     anext
 except NameError:
@@ -526,12 +526,52 @@ class AsyncGenTest(TimedTest):
         g.__qualname__ = '123'
         self.assertEqual(g.__qualname__, '123')
 
-        #self.assertIsNone(g.ag_await)
+        self.assertIsNone(g.ag_await)
         #self.assertIsInstance(g.ag_frame, types.FrameType)
         self.assertFalse(g.ag_running)
         #self.assertIsInstance(g.ag_code, types.CodeType)
 
-        self.assertTrue(inspect_isawaitable(g.aclose()))
+        aclose = g.aclose()
+        self.assertTrue(inspect.isawaitable(aclose))
+        aclose.close()
+
+    def test_async_gen_api_ag_running(self):
+        async def gen():
+            self.assertTrue(g.ag_running)
+            try:
+                yield 123
+                self.assertTrue(g.ag_running)
+                yield 456
+            finally:
+                self.assertTrue(g.ag_running)
+
+        g = gen()
+
+        ai = g.__aiter__()
+        self.assertFalse(g.ag_running)
+
+        an = anext(ai)
+        self.assertFalse(g.ag_running)
+
+        try:
+            next(an)
+        except StopIteration as ex:
+            self.assertFalse(g.ag_running)
+            self.assertEqual(ex.args[0], 123)
+
+        an = anext(ai)
+        self.assertFalse(g.ag_running)
+
+        try:
+            next(an)
+        except StopIteration as ex:
+            self.assertFalse(g.ag_running)
+            self.assertEqual(ex.args[0], 456)
+
+        aclose = g.aclose()
+        self.assertFalse(g.ag_running)
+        aclose.close()
+        self.assertFalse(g.ag_running)
 
 
 class AsyncGenAsyncioTest(TimedTest):

--- a/tests/run/test_asyncgen.py
+++ b/tests/run/test_asyncgen.py
@@ -512,6 +512,159 @@ class AsyncGenTest(TimedTest):
                 r"cannot reuse already awaited __anext__\(\)/asend\(\)"):
             an.send(None)
 
+    def test_async_gen_asend_throw_concurrent_with_send(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        class MyExc(Exception):
+            pass
+
+        async def agenfn():
+            while True:
+                try:
+                    await _async_yield(None)
+                except MyExc:
+                    pass
+            return
+            yield
+
+
+        agen = agenfn()
+        gen = agen.asend(None)
+        gen.send(None)
+        gen2 = agen.asend(None)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r'anext\(\): asynchronous generator is already running'):
+            gen2.throw(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r"cannot reuse already awaited __anext__\(\)/asend\(\)"):
+            gen2.send(None)
+
+    def test_async_gen_athrow_throw_concurrent_with_send(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        class MyExc(Exception):
+            pass
+
+        async def agenfn():
+            while True:
+                try:
+                    await _async_yield(None)
+                except MyExc:
+                    pass
+            return
+            yield
+
+
+        agen = agenfn()
+        gen = agen.asend(None)
+        gen.send(None)
+        gen2 = agen.athrow(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r'athrow\(\): asynchronous generator is already running'):
+            gen2.throw(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r"cannot reuse already awaited aclose\(\)/athrow\(\)"):
+            gen2.send(None)
+
+    def test_async_gen_asend_throw_concurrent_with_throw(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        class MyExc(Exception):
+            pass
+
+        async def agenfn():
+            try:
+                yield
+            except MyExc:
+                pass
+            while True:
+                try:
+                    await _async_yield(None)
+                except MyExc:
+                    pass
+
+
+        agen = agenfn()
+        with self.assertRaises(StopIteration):
+            agen.asend(None).send(None)
+
+        gen = agen.athrow(MyExc)
+        gen.throw(MyExc)
+        gen2 = agen.asend(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r'anext\(\): asynchronous generator is already running'):
+            gen2.throw(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r"cannot reuse already awaited __anext__\(\)/asend\(\)"):
+            gen2.send(None)
+
+    def test_async_gen_athrow_throw_concurrent_with_throw(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        class MyExc(Exception):
+            pass
+
+        async def agenfn():
+            try:
+                yield
+            except MyExc:
+                pass
+            while True:
+                try:
+                    await _async_yield(None)
+                except MyExc:
+                    pass
+
+        agen = agenfn()
+        with self.assertRaises(StopIteration):
+            agen.asend(None).send(None)
+
+        gen = agen.athrow(MyExc)
+        gen.throw(MyExc)
+        gen2 = agen.athrow(None)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r'athrow\(\): asynchronous generator is already running'):
+            gen2.throw(MyExc)
+
+        with self.assertRaisesRegex(RuntimeError,
+                r"cannot reuse already awaited aclose\(\)/athrow\(\)"):
+            gen2.send(None)
+
+    @unittest.skip("NOT IMPLEMENTED")
+    def test_async_gen_3_arg_deprecation_warning(self):
+        async def gen():
+            yield 123
+
+        with self.assertWarns(DeprecationWarning):
+            x = gen().athrow(GeneratorExit, GeneratorExit(), None)
+        with self.assertRaises(GeneratorExit):
+            x.send(None)
+            del x
+            gc_collect()
+
     def test_async_gen_api_01(self):
         async def gen():
             yield 123
@@ -572,6 +725,55 @@ class AsyncGenTest(TimedTest):
         self.assertFalse(g.ag_running)
         aclose.close()
         self.assertFalse(g.ag_running)
+        gc_collect()
+
+    def test_async_gen_asend_close_runtime_error(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        async def agenfn():
+            try:
+                await _async_yield(None)
+            except GeneratorExit:
+                await _async_yield(None)
+            return
+            yield
+
+        agen = agenfn()
+        gen = agen.asend(None)
+        gen.send(None)
+        with self.assertRaisesRegex(RuntimeError, "coroutine ignored GeneratorExit"):
+            gen.close()
+
+    def test_async_gen_athrow_close_runtime_error(self):
+        import types
+
+        @types.coroutine
+        def _async_yield(v):
+            return (yield v)
+
+        class MyExc(Exception):
+            pass
+
+        async def agenfn():
+            try:
+                yield
+            except MyExc:
+                try:
+                    await _async_yield(None)
+                except GeneratorExit:
+                    await _async_yield(None)
+
+        agen = agenfn()
+        with self.assertRaises(StopIteration):
+            agen.asend(None).send(None)
+        gen = agen.athrow(MyExc)
+        gen.send(None)
+        with self.assertRaisesRegex(RuntimeError, "coroutine ignored GeneratorExit"):
+            gen.close()
 
 
 class AsyncGenAsyncioTest(TimedTest):
@@ -1349,6 +1551,7 @@ class AsyncGenAsyncioTest(TimedTest):
         self.loop.run_until_complete(main())
 
         self.assertEqual([], messages)
+        gc_collect()
 
     def test_async_gen_await_same_anext_coro_twice(self):
         async def async_iterate():


### PR DESCRIPTION
* Fix ".close()" of async generators' asend/athrow to properly raise a GeneratorExit.
* Fix ".close()" and ".throw()" to block access when the generator is running.
* Set ".ag_running" during ".close()".
* Copy the related tests from CPython.
* Add a complete test for the ".ag_running" flag.

Follows https://github.com/python/cpython/issues/117714
Follows https://github.com/python/cpython/issues/117881
