### PR TITLE
Avoid unnecessary cpdef fused assignments

### DIFF
--- a/Cython/Compiler/FusedNode.py
+++ b/Cython/Compiler/FusedNode.py
@@ -805,6 +805,13 @@ class FusedCFuncDefNode(StatListNode):
 
         return py_func
 
+    def attach_fused_py_funcs(self):
+        for node in self.nodes:
+            if isinstance(self.node, DefNode):
+                node.fused_py_func = self.py_func
+            else:
+                node.py_func.fused_py_func = self.py_func
+
     def update_fused_defnode_entry(self, env):
         copy_attributes = (
             'name', 'pos', 'cname', 'func_cname', 'pyfunc_cname',
@@ -834,10 +841,8 @@ class FusedCFuncDefNode(StatListNode):
         for node in self.nodes:
             if isinstance(self.node, DefNode):
                 def_nodes.append(node)
-                node.fused_py_func = self.py_func
             else:
                 def_nodes.append(node.py_func)
-                node.py_func.fused_py_func = self.py_func
                 node.entry.as_variable = entry
 
         self.synthesize_defnodes(def_nodes)

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2456,6 +2456,8 @@ if VALUE is not None:
 
         decorators = getattr(node, 'decorators', None)
         node = FusedNode.FusedCFuncDefNode(node, env)
+        if node.py_func:
+            node.attach_fused_py_funcs()
         self.fused_function = node
         self.visitchildren(node)
         self.fused_function = None


### PR DESCRIPTION
We use `node.fused_py_func` to determine whether to skip generating an assignment node for specialized fused implementation functions. For cpdef fused functions, `node.fused_py_func` is assigned too late, so this PR moves it earlier (before the specialized implementation functions are visited).

This generates avoids generating some pointless unused code.

Example file:

```cython
cdef fused FT:
    int
    float

cpdef FT ggg(FT x):
    return x
```

With this PR, the following code (plus a little bit of CyFunction utility code) is removed entirely:

```c
__pyx_t_2 = __Pyx_CyFunction_New(&__pyx_fuse_0__pyx_mdef_8fusedex1_3__pyx_fuse_0ggg, 0, __pyx_mstate_global->__pyx_n_u_pyx_fuse_0ggg, NULL, __pyx_mstate_global->__pyx_n_u_fusedex1, __pyx_mstate_global->__pyx_d, ((PyObject *)__pyx_mstate_global->__pyx_codeobj_tab[0])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 5, __pyx_L1_error)
  __Pyx_GOTREF(__pyx_t_2);
  #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030E0000
  PyUnstable_Object_EnableDeferredRefcount(__pyx_t_2);
  #endif
  if (PyDict_SetItem(__pyx_mstate_global->__pyx_d, __pyx_mstate_global->__pyx_n_u_ggg, __pyx_t_2) < (0)) __PYX_ERR(0, 5, __pyx_L1_error)
  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
  __pyx_t_2 = __Pyx_CyFunction_New(&__pyx_fuse_1__pyx_mdef_8fusedex1_5__pyx_fuse_1ggg, 0, __pyx_mstate_global->__pyx_n_u_pyx_fuse_1ggg, NULL, __pyx_mstate_global->__pyx_n_u_fusedex1, __pyx_mstate_global->__pyx_d, ((PyObject *)__pyx_mstate_global->__pyx_codeobj_tab[1])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 5, __pyx_L1_error)
  __Pyx_GOTREF(__pyx_t_2);
  #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030E0000
  PyUnstable_Object_EnableDeferredRefcount(__pyx_t_2);
  #endif
  if (PyDict_SetItem(__pyx_mstate_global->__pyx_d, __pyx_mstate_global->__pyx_n_u_ggg, __pyx_t_2) < (0)) __PYX_ERR(0, 5, __pyx_L1_error)
  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
```

I believe the generated cyfunctions are pointless, in that they're written into the global dictionary and then immediately overwritten by the fused function.

My interest here is in fixing the remaining issue with https://github.com/cython/cython/pull/7656 (which I think this change will accomplish or at least help with). But it seems cleaner to do it separately.