### PR TITLE
Fix cdef function optional argument captured by closures not moved into the closure scope

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -3074,7 +3074,7 @@ class CFuncDefNode(FuncDefNode):
 
         # Move arguments into closure if required
         def put_into_closure(entry):
-            if entry.in_closure and not arg.default:
+            if entry.in_closure:
                 code.putln('%s = %s;' % (entry.cname, entry.original_cname))
                 if entry.type.is_memoryviewslice:
                     code.putln(entry.type.get_incref_memoryviewslice_code(entry.cname, True))

--- a/tests/run/cdef_optional_arg_closure.pyx
+++ b/tests/run/cdef_optional_arg_closure.pyx
@@ -15,10 +15,12 @@ cdef test(object register=None, object length=None):
     return length, _on_done()
 
 
-cdef test_multi(object device_index, object register=2, object tdi_data=3):
-    def inner():
-        return (device_index, register, tdi_data)
-    return inner()
+def run_default():
+    """
+    >>> run_default()
+    (None, None)
+    """
+    return test(0)
 
 
 def run_passed():
@@ -29,20 +31,40 @@ def run_passed():
     return test(0, 196883)
 
 
-def run_default():
-    """
-    >>> run_default()
-    (None, None)
-    """
-    return test(0)
+cdef test_ctype(int register=7):
+    def inner():
+        return (register)
+    return register, inner()
 
 
-def run_multi_all():
+def run_ctype_default():
     """
-    >>> run_multi_all()
-    (1, 20, 30)
+    >>> run_ctype_default()
+    (7, 7)
     """
-    return test_multi(1, 20, 30)
+    return test_ctype(7)
+
+
+def run_ctype_passed():
+    """
+    >>> run_ctype_passed()
+    (17, 17)
+    """
+    return test_ctype(17)
+
+
+cdef test_multi(object device_index, object register=2, object tdi_data=3):
+    def inner():
+        return (device_index, register, tdi_data)
+    return inner()
+
+
+def run_multi_defaults():
+    """
+    >>> run_multi_defaults()
+    (1, 2, 3)
+    """
+    return test_multi(1)
 
 
 def run_multi_partial():
@@ -53,9 +75,9 @@ def run_multi_partial():
     return test_multi(1, 20)
 
 
-def run_multi_defaults():
+def run_multi_all():
     """
-    >>> run_multi_defaults()
-    (1, 2, 3)
+    >>> run_multi_all()
+    (1, 20, 30)
     """
-    return test_multi(1)
+    return test_multi(1, 20, 30)

--- a/tests/run/cdef_optional_arg_closure.pyx
+++ b/tests/run/cdef_optional_arg_closure.pyx
@@ -1,0 +1,61 @@
+# mode: run
+# tag: closures, optional_args
+
+# An optional (defaulted) argument of a cdef function that is captured by an
+# inner function (closure) must be moved into the closure scope, just like a
+# non-optional argument. Previously it was unpacked only into a C local while
+# the body and the closure read the (uninitialised) scope field, which returned
+# the wrong value or crashed (NULL dereference on the freelist allocation path).
+
+
+cdef test(object register=None, object length=None):
+    # `length` is captured by `_on_done`, so it lives in the closure scope.
+    def _on_done():
+        return length
+    return length, _on_done()
+
+
+cdef test_multi(object device_index, object register=2, object tdi_data=3):
+    def inner():
+        return (device_index, register, tdi_data)
+    return inner()
+
+
+def run_passed():
+    """
+    >>> run_passed()
+    (196883, 196883)
+    """
+    return test(0, 196883)
+
+
+def run_default():
+    """
+    >>> run_default()
+    (None, None)
+    """
+    return test(0)
+
+
+def run_multi_all():
+    """
+    >>> run_multi_all()
+    (1, 20, 30)
+    """
+    return test_multi(1, 20, 30)
+
+
+def run_multi_partial():
+    """
+    >>> run_multi_partial()
+    (1, 20, 3)
+    """
+    return test_multi(1, 20)
+
+
+def run_multi_defaults():
+    """
+    >>> run_multi_defaults()
+    (1, 2, 3)
+    """
+    return test_multi(1)


### PR DESCRIPTION
### Minimal reproducible example

``` Python
cdef _queue_scan_reg(
    object length = None, # int | None
):
    print(f'length: {length}') # Segfault caused by null pointer __pyx_cur_scope->__pyx_v_length
    def _on_done():
        # NameError: free variable 'length' referenced before assignment in enclosing scope
        return length
    return _on_done()

def run():
    res = _queue_scan_reg(196883)
    print(res)
```

When a cdef function is declared with optional argument and has nested function inside that captures this optional argument, the generated code didn't move the parsed argument (`__pyx_v_length` in this case) into the closure scope (`__pyx_cur_scope->__pyx_v_length`). Further uses of this variable through `__pyx_cur_scope->__pyx_v_length`  cause errors as it's a null pointer.

This patch simply fixes this bug by removing the `arg.default` condition when generating the assignment code for the captured variables (and now it's similar to how arguments of [non-cdef functions](https://github.com/cython/cython/blob/0d6e04ce50c2a4c412dc9b58539145b64094558b/Cython/Compiler/Nodes.py#L3749) are processed).
