### PR TITLE
Disable some buggy tests from Graal 25.1.3

### DIFF
--- a/tests/graal_bugs.txt
+++ b/tests/graal_bugs.txt
@@ -199,3 +199,8 @@ time_pxd
 # cannot import name '_excepthook' from '_thread' (unknown location)
 
 cython3
+
+# new in 25.1.3
+ext_attr_setter
+# https://github.com/oracle/graalpython/issues/1003 - bug is in pure-Python test. Cython code is fine.
+extra_patma_py


### PR DESCRIPTION
On the positive side, it does look like they're improved the speed a bit.