### PR TITLE
Allow C property setters to explicitly propagate exceptions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8150,10 +8150,11 @@ class AttributeNode(ExprNode):
         elif target and self.obj.type.is_builtin_type:
             error(self.pos, "Assignment to an immutable object field")
         elif self.entry and self.entry.is_cproperty:
-            if not target:
-                return SimpleCallNode.for_cproperty_get(self.pos, self.obj, self.entry).analyse_types(env)
+            if target:
+                call_node = SimpleCallNode.for_cproperty_set(self.pos, self.obj, self.entry)
             else:
-                return SimpleCallNode.for_cproperty_set(self.pos, self.obj, self.entry).analyse_types(env)
+                call_node = SimpleCallNode.for_cproperty_get(self.pos, self.obj, self.entry)
+            return call_node.analyse_types(env) if call_node is not None else None
         #elif self.type.is_memoryviewslice and not target:
         #    self.is_temp = True
         return self

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -3055,12 +3055,19 @@ class PropertyScope(Scope):
                 error(pos, "C property getter must have a single (self) argument")
 
         if name=="__set__":
-            if not (type.return_type.is_void or type.return_type.is_int):
+            # Allow only 'void noexcept' and 'int except(?) -1'.
+            if type.return_type.is_void:
+                if type.exception_check or type.exception_value is not None:
+                    error(pos, "C property setter needs 'noexcept' if declared 'void'")
+            elif type.return_type in (PyrexTypes.c_int_type, PyrexTypes.c_returncode_type):
+                if type.exception_value is not None and type.exception_value.python_value != -1:
+                    error(pos, f"C property setter with 'int' return needs explicit 'except -1' or 'except? -1'")
+            else:
                 error(pos, "C property setter must return void or an 'int' error code, -1 (error) or 0 (ok)")
             if len(type.args) != 2:
                 error(pos, "C property setter must have two arguments (self and value)")
 
-        if not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
+        if type.args and not (type.args[0].type.is_pyobject or type.args[0].type is self.parent_scope.parent_type):
             error(pos, "self argument of C property method must be an object")
         if type.args and type.args[0].type is py_object_type:
             # Set 'self' argument type to extension type.

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -2756,13 +2756,15 @@ class CClassScope(ClassScope):
         self.property_entries.append(entry)
         return entry
 
-    def declare_cproperty(self, name, type, cfunc_name, doc=None, pos=None, visibility='extern',
-                          nogil=False, with_gil=False, exception_value=None, exception_check=False,
-                          utility_code=None):
+    def declare_cproperty(self, name, type, cfunc_name, setter_cfunc_name=None,
+                          doc=None, pos=None, visibility='extern',
+                          nogil=False, with_gil=False,
+                          exception_value=None, exception_check=False, setter_raises=True,
+                          utility_code=None, setter_utility_code=None):
         """Internal convenience method to declare a C property function in one go.
         """
         property_entry = self.declare_property(name, doc=doc, ctype=type, pos=pos)
-        cfunc_entry = property_entry.scope.declare_cfunction(
+        getter_cfunc_entry = property_entry.scope.declare_cfunction(
             name="__get__",
             type=PyrexTypes.CFuncType(
                 type,
@@ -2777,7 +2779,25 @@ class CClassScope(ClassScope):
             visibility=visibility,
             pos=pos,
         )
-        return property_entry, cfunc_entry
+        setter_cfunc_entry = None
+        if setter_cfunc_name:
+            setter_cfunc_entry = property_entry.scope.declare_cfunction(
+                name="__set__",
+                type=PyrexTypes.CFuncType(
+                    PyrexTypes.c_returncode_type if setter_raises else PyrexTypes.c_void_type,
+                    [PyrexTypes.CFuncTypeArg("self", self.parent_type, pos=None),
+                     PyrexTypes.CFuncTypeArg("value", type, pos=None)],
+                    nogil=nogil,
+                    with_gil=with_gil,
+                    exception_value=-1 if setter_raises else None,
+                ),
+                cname=setter_cfunc_name,
+                # Allow getter+setter in one utility code section.
+                utility_code=setter_utility_code or utility_code,
+                visibility=visibility,
+                pos=pos,
+            )
+        return property_entry, getter_cfunc_entry, setter_cfunc_entry
 
     def declare_inherited_c_attributes(self, base_scope):
         # Declare entries for all the C attributes of an

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -3035,8 +3035,8 @@ class PropertyScope(Scope):
                 error(pos, "C property getter must have a single (self) argument")
 
         if name=="__set__":
-            if not type.return_type.is_int:
-                error(pos, "C property setter must return an 'int' error code, -1 (error) or 0 (ok)")
+            if not (type.return_type.is_void or type.return_type.is_int):
+                error(pos, "C property setter must return void or an 'int' error code, -1 (error) or 0 (ok)")
             if len(type.args) != 2:
                 error(pos, "C property setter must have two arguments (self and value)")
 

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -3035,8 +3035,8 @@ class PropertyScope(Scope):
                 error(pos, "C property getter must have a single (self) argument")
 
         if name=="__set__":
-            if not type.return_type.is_void:
-                error(pos, "C property setter must return 'void'")
+            if not type.return_type.is_int:
+                error(pos, "C property setter must return an 'int' error code, -1 (error) or 0 (ok)")
             if len(type.args) != 2:
                 error(pos, "C property setter must have two arguments (self and value)")
 

--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -408,6 +408,9 @@ class CPropertySetNode(ExprNodes.ExprNode):
         self.arg1.set_cname(rhs.result())
 
         self.call_node.generate_evaluation_code(code)
+        if not self.call_node.is_temp:
+            assert self.call_node.type.is_void, self.call_node.type
+            code.putln(f"{self.call_node.result()};")  # actually call the (void) setter
         self.call_node.generate_disposal_code(code)
         self.call_node.free_temps(code)
 

--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -408,6 +408,8 @@ class CPropertySetNode(ExprNodes.ExprNode):
         self.arg1.set_cname(rhs.result())
 
         self.call_node.generate_evaluation_code(code)
+        self.call_node.generate_disposal_code(code)
+        self.call_node.free_temps(code)
 
         rhs.generate_disposal_code(code)
         rhs.free_temps(code)

--- a/tests/errors/cdef_class_cdef_properties.pyx
+++ b/tests/errors/cdef_class_cdef_properties.pyx
@@ -23,7 +23,7 @@ cdef extern from *:
             pass
 
         @property
-        cdef inline double wrong_return(self):
+        cdef inline void wrong_return(self):
             pass
 
         @wrong_return.setter

--- a/tests/errors/cdef_class_cdef_properties.pyx
+++ b/tests/errors/cdef_class_cdef_properties.pyx
@@ -23,7 +23,7 @@ cdef extern from *:
             pass
 
         @property
-        cdef inline void wrong_return(self):
+        cdef inline double wrong_return(self):
             pass
 
         @wrong_return.setter
@@ -80,7 +80,7 @@ _ERRORS = """
 17:8: C property getter must have a single (self) argument
 21:8: C property setter must have two arguments (self and value)
 25:8: C property getter cannot return 'void'
-29:8: C property setter must return an 'int' error code, -1 (error) or 0 (ok)
+29:8: C property setter must return void or an 'int' error code, -1 (error) or 0 (ok)
 37:8: C property redeclared
 45:8: C property redeclared
 57:8: C property redeclared

--- a/tests/errors/cdef_class_cdef_properties.pyx
+++ b/tests/errors/cdef_class_cdef_properties.pyx
@@ -11,24 +11,24 @@ cdef extern from *:
             return 1
 
         @no_inline2.setter
-        cdef void no_inline2(self, arg):
-            pass
+        cdef int no_inline2(self, arg):
+            return 0
 
         @property
         cdef inline wrong_args(self, arg):
             return 1
 
         @wrong_args.setter
-        cdef inline void wrong_args(self):
+        cdef inline int wrong_args(self):
             pass
-        
+
         @property
         cdef inline void wrong_return(self):
             pass
 
         @wrong_return.setter
-        cdef inline int wrong_return(self, arg):
-            return 0
+        cdef inline float wrong_return(self, arg):
+            return .0
 
         @property
         cdef inline multiple_defs1(self):
@@ -51,9 +51,9 @@ cdef extern from *:
             return 1
 
         @multiple_defs3.setter
-        cdef inline void multiple_defs3(self, arg):
-            pass
-        
+        cdef inline int multiple_defs3(self, arg):
+            return 0
+
         @multiple_defs3.setter
         cdef inline multiple_defs3(self, arg):
             pass
@@ -80,7 +80,7 @@ _ERRORS = """
 17:8: C property getter must have a single (self) argument
 21:8: C property setter must have two arguments (self and value)
 25:8: C property getter cannot return 'void'
-29:8: C property setter must return 'void'
+29:8: C property setter must return an 'int' error code, -1 (error) or 0 (ok)
 37:8: C property redeclared
 45:8: C property redeclared
 57:8: C property redeclared
@@ -91,4 +91,4 @@ _ERRORS = """
 69:8: Previous declaration is here
 73:8: 'has_deleter' redeclared
 """
-            
+

--- a/tests/errors/cdef_class_cdef_properties.pyx
+++ b/tests/errors/cdef_class_cdef_properties.pyx
@@ -74,6 +74,23 @@ cdef extern from *:
         cdef inline void has_deleter(self):
             pass
 
+        @property
+        cdef inline wrong_setter_exceptval(self):
+            return 1
+
+        @wrong_setter_exceptval.setter
+        cdef inline int wrong_setter_exceptval(self, value) except 0:
+            return 1
+
+        @property
+        cdef inline void_setter_lacks_noexcept(self):
+            return 1
+
+        @void_setter_lacks_noexcept.setter
+        cdef inline void void_setter_lacks_noexcept(self, value):
+            pass
+
+
 _ERRORS = """
 5:8: C property method must be declared 'inline'
 13:8: C property method must be declared 'inline'
@@ -86,6 +103,8 @@ _ERRORS = """
 57:8: C property redeclared
 65:8: Mismatching C property names, expected 'mismatched_name', got 'hmmmmm'
 73:8: Cannot have deleter for C property
+81:8: C property setter with 'int' return needs explicit 'except -1' or 'except? -1'
+89:8: C property setter needs 'noexcept' if declared 'void'
 
 # Spurious
 69:8: Previous declaration is here

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -49,7 +49,7 @@ cdef extern from *:
             return PyException_GetArgs(self)
 
         @args_obj.setter
-        cdef inline void args_obj(self, obj):
+        cdef inline void args_obj(self, obj) noexcept:
             PyException_SetArgs(self, obj)
 
         @property
@@ -57,7 +57,7 @@ cdef extern from *:
             return PyException_GetArgs(self)
 
         @args_raising.setter
-        cdef inline int args_raising(self, obj):
+        cdef inline int args_raising(self, obj) except -1:
             PyException_SetArgs_Raising(self, obj)
             return 0
 
@@ -67,7 +67,7 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_int.setter
-        cdef inline void arg0_int(self, int value):
+        cdef inline void arg0_int(self, int value) noexcept:
             PyException_SetArgs(self, (value,))
 
         # This property returns the first arg whatever it is,
@@ -78,7 +78,7 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_str.setter
-        cdef inline void arg0_mixed_str(self, const char* value):
+        cdef inline void arg0_mixed_str(self, const char* value) noexcept:
             PyException_SetArgs(self, (value,))
 
         # This property returns the first argument as a double,
@@ -89,8 +89,19 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_double.setter
-        cdef inline void arg0_mixed_double(self, value):
+        cdef inline void arg0_mixed_double(self, value) noexcept:
             PyException_SetArgs(self, (value,))
+
+        @property
+        cdef inline maybe_raising(self):
+            return 1
+
+        @maybe_raising.setter
+        cdef inline int maybe_raising(self, value) except? -1:
+            if value == 1:
+                raise TypeError()
+            PyException_SetArgs(self, (value,))
+            return -1
 
 
 @cython.test_assert_path_exists("//SimpleCallNode")
@@ -104,6 +115,7 @@ def test_get_obj(Exception e):
     """
     return e.args_obj
 
+
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def test_get_obj_temp(*args):
@@ -114,6 +126,7 @@ def test_get_obj_temp(*args):
     ()
     """
     return Exception(*args).args_obj
+
 
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -127,6 +140,7 @@ def test_set_obj(o):
     e = Exception()
     e.args_obj = o
     return e
+
 
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -142,6 +156,7 @@ def test_set_raising(o):
     e = Exception()
     e.args_raising = o
     return e
+
 
 def forward(o):
     return o
@@ -159,6 +174,7 @@ def test_set_obj_from_temp(o):
     e.args_obj = forward(o)
     return e
 
+
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def test_set_obj_temp(*args):
@@ -170,6 +186,7 @@ def test_set_obj_temp(*args):
     """
     Exception().args_obj = args
 
+
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def test_get_int(Exception e):
@@ -178,14 +195,13 @@ def test_get_int(Exception e):
     10
     >>> test_get_int(Exception())  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-        ...
     IndexError: ...
     >>> test_get_int(Exception(None))  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-        ...
     TypeError: ...
     """
     return e.arg0_int
+
 
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -195,12 +211,12 @@ def test_set_int(value):
     Exception(10)
     >>> test_set_int(None)  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-        ...
     TypeError: ...
     """
     e = Exception()
     e.arg0_int = value
     return e
+
 
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -213,16 +229,17 @@ def test_mixed_str(const char* s):
     e.arg0_mixed_str = s
     return e.arg0_mixed_str
 
+
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def test_fail_mixed_str(v):
     """
     >>> test_fail_mixed_str([1, 2, 3])  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-        ...
     TypeError: ...
     """
     Exception().arg0_mixed_str = v
+
 
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
@@ -235,13 +252,25 @@ def test_mixed_double(v):
     e.arg0_mixed_double = v
     return e.arg0_mixed_double
 
+
 @cython.test_assert_path_exists("//SimpleCallNode")
 @cython.test_fail_if_path_exists("//AttributeNode")
 def test_fail_mixed_double(Exception e):
     """
     >>> test_fail_mixed_double(Exception("not a double"))  # doctest: +ELLIPSIS
     Traceback (most recent call last):
-        ...
     TypeError: ...
     """
     return e.arg0_mixed_double
+
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_setter_maybe_raising(x):
+    """
+    >>> test_setter_maybe_raising(0)
+    >>> test_setter_maybe_raising(1)
+    Traceback (most recent call last):
+    TypeError
+    """
+    Exception().maybe_raising = x

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -13,11 +13,11 @@ cdef extern from *:
         return PyObject_GetAttrString(ex, "args");
     }
 
-    static void PyException_SetArgs(PyObject *ex, PyObject *value) {
+    static int PyException_SetArgs(PyObject *ex, PyObject *value) {
         if (PyObject_SetAttrString(ex, "args", value) < 0) {
-            PyErr_WriteUnraisable(NULL);
-            PyErr_Clear();
+            return -1;
         }
+        return 0;
     }
     #endif
     """
@@ -33,8 +33,9 @@ cdef extern from *:
             return PyException_GetArgs(self)
 
         @args_obj.setter
-        cdef inline void args_obj(self, obj):
+        cdef inline int args_obj(self, obj):
             PyException_SetArgs(self, obj)
+            return 0
 
         @property
         cdef inline int arg0_int(self):
@@ -42,8 +43,9 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_int.setter
-        cdef inline void arg0_int(self, int value):
+        cdef inline int arg0_int(self, int value):
             PyException_SetArgs(self, (value,))
+            return 0
 
         # This property returns the first arg whatever it is,
         # but only accepts a C string.
@@ -53,8 +55,9 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_str.setter
-        cdef inline void arg0_mixed_str(self, const char* value):
+        cdef inline int arg0_mixed_str(self, const char* value):
             PyException_SetArgs(self, (value,))
+            return 0
 
         # This property returns the first argument as a double,
         # but accepts any Python object
@@ -64,8 +67,9 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_double.setter
-        cdef inline void arg0_mixed_double(self, value):
+        cdef inline int arg0_mixed_double(self, value):
             PyException_SetArgs(self, (value,))
+            return 0
 
 
 @cython.test_assert_path_exists("//SimpleCallNode")

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -13,17 +13,33 @@ cdef extern from *:
         return PyObject_GetAttrString(ex, "args");
     }
 
-    static int PyException_SetArgs(PyObject *ex, PyObject *value) {
+    static void PyException_SetArgs(PyObject *ex, PyObject *value) {
+        if (PyObject_SetAttrString(ex, "args", value) < 0) {
+            PyErr_WriteUnraisable(NULL);
+            PyErr_Clear();
+        }
+    }
+    #endif
+
+    static int PyException_SetArgs_Raising(PyObject *ex, PyObject *value) {
+        if (PyTuple_Check(value) && PyTuple_Size(value) == 0) {
+            PyErr_SetString(PyExc_RuntimeError, "expected failure");
+            return -1;
+        }
+        #if __PYX_LIMITED_VERSION_HEX < 0x030C0000
+        PyException_SetArgs(ex, value);
+        #else
         if (PyObject_SetAttrString(ex, "args", value) < 0) {
             return -1;
         }
+        #endif
         return 0;
     }
-    #endif
     """
 
     object PyException_GetArgs(object)
     void PyException_SetArgs(object, object) noexcept
+    int PyException_SetArgs_Raising(object, object) except -1
 
     # Exception is just an easy class to use to test arbitrary getters/setters
     # without needing to define our own class.
@@ -33,8 +49,16 @@ cdef extern from *:
             return PyException_GetArgs(self)
 
         @args_obj.setter
-        cdef inline int args_obj(self, obj):
+        cdef inline void args_obj(self, obj):
             PyException_SetArgs(self, obj)
+
+        @property
+        cdef inline args_raising(self):
+            return PyException_GetArgs(self)
+
+        @args_raising.setter
+        cdef inline int args_raising(self, obj):
+            PyException_SetArgs_Raising(self, obj)
             return 0
 
         @property
@@ -43,9 +67,8 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_int.setter
-        cdef inline int arg0_int(self, int value):
+        cdef inline void arg0_int(self, int value):
             PyException_SetArgs(self, (value,))
-            return 0
 
         # This property returns the first arg whatever it is,
         # but only accepts a C string.
@@ -55,9 +78,8 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_str.setter
-        cdef inline int arg0_mixed_str(self, const char* value):
+        cdef inline void arg0_mixed_str(self, const char* value):
             PyException_SetArgs(self, (value,))
-            return 0
 
         # This property returns the first argument as a double,
         # but accepts any Python object
@@ -67,9 +89,8 @@ cdef extern from *:
             return PyException_GetArgs(self)[0]
 
         @arg0_mixed_double.setter
-        cdef inline int arg0_mixed_double(self, value):
+        cdef inline void arg0_mixed_double(self, value):
             PyException_SetArgs(self, (value,))
-            return 0
 
 
 @cython.test_assert_path_exists("//SimpleCallNode")
@@ -105,6 +126,21 @@ def test_set_obj(o):
     """
     e = Exception()
     e.args_obj = o
+    return e
+
+@cython.test_assert_path_exists("//SimpleCallNode")
+@cython.test_fail_if_path_exists("//AttributeNode")
+def test_set_raising(o):
+    """
+    >>> test_set_raising((1, 2))
+    Exception(1, 2)
+    >>> test_set_raising(())
+    Traceback (most recent call last):
+        ...
+    RuntimeError: expected failure
+    """
+    e = Exception()
+    e.args_raising = o
     return e
 
 def forward(o):


### PR DESCRIPTION
They previously called `PyErr_Occurred()` after each call to the `void` setter, which seems needlessly inefficient.