### PR TITLE
Rewrite VisitorTransform._flatten_list() to avoid list copying when possible

### DIFF
--- a/Cython/Compiler/Tests/TestVisitor.py
+++ b/Cython/Compiler/Tests/TestVisitor.py
@@ -1,7 +1,7 @@
 from Cython.Compiler.ModuleNode import ModuleNode
 from Cython.Compiler.Symtab import ModuleScope
-from Cython.TestUtils import TransformTest
-from Cython.Compiler.Visitor import MethodDispatcherTransform
+from Cython.TestUtils import TransformTest, TimedTest
+from Cython.Compiler.Visitor import MethodDispatcherTransform, _test_flatten_list as test_flatten_list
 from Cython.Compiler.ParseTreeTransforms import (
     NormalizeTree, AnalyseDeclarationsTransform,
     AnalyseExpressionsTransform, InterpretCompilerDirectives)
@@ -59,3 +59,61 @@ class TestMethodDispatcherTransform(TransformTest):
         Test(None)(tree)
         self.assertEqual(1, calls['bytes'])
         self.assertEqual(0, calls['object'])
+
+
+class TestVisitorTransform(TimedTest):
+    def test_flatten_list_unchanged(self):
+        for test_list in [[], [1], [1,2], [0], [0,0]]:
+            self.assertIs(test_flatten_list(test_list), test_list)
+
+    def test_flatten_list_unchanged_sublist(self):
+        for test_list in [
+                [[1]],
+                [[1,2]],
+                [[1,2], 3],
+                [[1,2], None, []],
+            ]:
+            self.assertIs(test_flatten_list(test_list), test_list[0])
+
+        for test_list in [
+                [None, [1]],
+                [[], [1,2]],
+                [[], [1,2], []],
+                [[], [1,2], None],
+                [[], [1,2], 3],
+                [None, [1,2], None, []],
+                [None, [1,2], None, [3]],
+            ]:
+            self.assertIs(test_flatten_list(test_list), test_list[1])
+
+    def test_flatten_list_mixed(self):
+        self.assertListEqual(test_flatten_list([1, []]), [1])
+        self.assertListEqual(test_flatten_list([[], [], []]), [])
+        self.assertListEqual(test_flatten_list([[], None, []]), [])
+        self.assertListEqual(test_flatten_list([None, [], None]), [])
+        self.assertListEqual(test_flatten_list([1, [2]]), [1, 2])
+        self.assertListEqual(test_flatten_list([[1], [2]]), [1, 2])
+        self.assertListEqual(test_flatten_list([[1,2], [3,4]]), [1, 2, 3, 4])
+        self.assertListEqual(test_flatten_list([[1,2], [0], [], 0, [4]]), [1, 2, 0, 0, 4])
+
+    def test_flatten_list_fuzzer(self):
+        def flatten(l):
+            return [
+                item
+                for item_or_list in filter(None, l)
+                for item in (item_or_list if type(item_or_list) is list else [item_or_list])
+            ]
+
+        from itertools import chain, combinations as mixer
+        test_items = [None, [], None, 1, [2], [], 3, None, [4], [5, 6], [], None]
+
+        from collections import defaultdict
+        counter = defaultdict(int)
+
+        for test_list in chain.from_iterable(mixer(test_items, length) for length in range(2, 7)):
+            counter[len(test_list)] += 1
+            test_list = list(test_list)
+            expected = flatten(test_list)
+            self.assertListEqual(test_flatten_list(test_list), expected)
+
+        #print("FUZZER TEST COUNTS:", dict(counter))

--- a/Cython/Compiler/Tests/TestVisitor.py
+++ b/Cython/Compiler/Tests/TestVisitor.py
@@ -72,7 +72,7 @@ class TestVisitorTransform(TimedTest):
                 [[1,2]],
                 [[1,2], 3],
                 [[1,2], None, []],
-            ]:
+                ]:
             self.assertIs(test_flatten_list(test_list), test_list[0])
 
         for test_list in [
@@ -83,7 +83,7 @@ class TestVisitorTransform(TimedTest):
                 [[], [1,2], 3],
                 [None, [1,2], None, []],
                 [None, [1,2], None, [3]],
-            ]:
+                ]:
             self.assertIs(test_flatten_list(test_list), test_list[1])
 
     def test_flatten_list_mixed(self):

--- a/Cython/Compiler/Visitor.pxd
+++ b/Cython/Compiler/Visitor.pxd
@@ -15,7 +15,6 @@ cdef class TreeVisitor:
 cdef class VisitorTransform(TreeVisitor):
     cdef dict _process_children(self, parent, attrs=*, exclude=*)
     cpdef visitchildren(self, parent, attrs=*, exclude=*)
-    cdef list _flatten_list(self, list orig_list)
     cpdef visitchild(self, parent, str attr, idx=*)
 
 cdef class CythonTransform(VisitorTransform):

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -223,6 +223,60 @@ class TreeVisitor:
         return result
 
 
+@cython.cfunc
+def _flatten_list(orig_list: list) -> list:
+    """
+    Flatten the list one level and remove any None.
+
+    Assumes input lists to be reusable and mutable.
+    May return the original list if it remains unchanged.
+    """
+    # Start lazy until we know that we really have to construct a different list.
+    newlist = None
+    i: cython.Py_ssize_t
+    use_before: cython.Py_ssize_t = 0
+
+    for i, x in enumerate(orig_list):
+        if x is None:
+            # Exclude x by not appending it to 'newlist' and not increasing 'use_before'.
+            pass
+        elif type(x) is list:
+            if x:
+                # Replace list object x by its content.
+                if newlist is not None:
+                    newlist.extend(x)
+                elif use_before == 0:
+                    # Stop being lazy and start newlist from x.
+                    newlist = x  # May mutate the input list in x.
+                else:
+                    # Stop being lazy and build newlist up to the last used item.
+                    newlist = orig_list[:use_before]
+                    newlist.extend(x)
+        elif newlist is not None:
+            newlist.append(x)
+        elif use_before == i:
+            # Keep counting items lazily.
+            use_before = i + 1
+        else:
+            # Stop being lazy and close the gap.
+            newlist = orig_list[:use_before]
+            newlist.append(x)
+
+    if newlist is not None:
+        return newlist
+    elif use_before < len(orig_list):
+        return orig_list[:use_before]
+    else:
+        return orig_list  # Original input list, no copy.
+
+
+def _test_flatten_list(orig_list: list) -> list:
+    """
+    Test entry point when compiled.
+    """
+    return _flatten_list(orig_list)
+
+
 class VisitorTransform(TreeVisitor):
     """
     A tree transform is a base class for visitors that wants to do stream
@@ -253,21 +307,9 @@ class VisitorTransform(TreeVisitor):
         result = self._visitchildren(parent, attrs, exclude)
         for attr, newnode in result.items():
             if type(newnode) is list:
-                newnode = self._flatten_list(newnode)
+                newnode = _flatten_list(newnode)
             setattr(parent, attr, newnode)
         return result
-
-    @cython.final
-    def _flatten_list(self, orig_list):
-        # Flatten the list one level and remove any None
-        newlist = []
-        for x in orig_list:
-            if x is not None:
-                if type(x) is list:
-                    newlist.extend(x)
-                else:
-                    newlist.append(x)
-        return newlist
 
     def visitchild(self, parent, attr, idx=0):
         # Helper to visit specific children from Python subclasses

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -239,23 +239,28 @@ def _flatten_list(orig_list: list) -> list:
     for i, x in enumerate(orig_list):
         if x is None:
             # Exclude x by not appending it to 'newlist' and not increasing 'use_before'.
-            pass
-        elif type(x) is list:
-            if x:
-                # Replace list object x by its content.
-                if newlist is not None:
-                    newlist.extend(x)
-                elif use_before == 0:
-                    # Stop being lazy and start newlist from x.
-                    newlist = x  # May mutate the input list in x.
-                else:
-                    # Stop being lazy and build newlist up to the last used item.
-                    newlist = orig_list[:use_before]
-                    newlist.extend(x)
-        elif newlist is not None:
-            newlist.append(x)
+            continue
+        x_is_list: bool = type(x) is list
+        if x_is_list and not x:
+            continue
+
+        if newlist is not None:
+            # Non-lazy list building.
+            if x_is_list:
+                newlist.extend(x)
+            else:
+                newlist.append(x)
+        elif x_is_list:
+            # Stop being lazy and replace list object x by its content.
+            if use_before == 0:
+                # Start newlist from x.
+                newlist = x  # May mutate the input list in x.
+            else:
+                # Build newlist up to the last used item.
+                newlist = orig_list[:use_before]
+                newlist.extend(x)
         elif use_before == i:
-            # Keep counting items lazily.
+            # Keep counting single items lazily.
             use_before = i + 1
         else:
             # Stop being lazy and close the gap.


### PR DESCRIPTION
Reuses lists and sublists in many if not most cases to save time while traversing the tree under transformation.
As an anecdotal data point, Callgrind counts about 60% less instructions spent in this function when translating Parsing.py.