### PR TITLE
Fix bytearray.append() optimisation

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3177,6 +3177,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             value = value.coerce_to(PyrexTypes.c_char_type, self.current_env())
             utility_code = UtilityCode.load_cached("ByteArrayAppend", "StringTools.c")
         elif value.type.is_pyobject:
+            value = value.as_none_safe_node("'NoneType' object cannot be interpreted as an integer")
             func_name = "__Pyx_PyByteArray_AppendObject"
             func_type = self.PyByteArray_AppendObject_func_type
             utility_code = UtilityCode.load_cached("ByteArrayAppendObject", "StringTools.c")

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3184,9 +3184,14 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
         else:
             return node
 
+        ba_obj = args[0].as_none_safe_node(
+            "'NoneType' object has no attribute '%.30s'",
+            error="PyExc_AttributeError",
+            format_args=['append'])
+
         new_node = ExprNodes.PythonCapiCallNode(
             node.pos, func_name, func_type,
-            args=[args[0], value],
+            args=[ba_obj, value],
             may_return_none=False,
             is_temp=node.is_temp,
             utility_code=utility_code,

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3177,7 +3177,6 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             value = value.coerce_to(PyrexTypes.c_char_type, self.current_env())
             utility_code = UtilityCode.load_cached("ByteArrayAppend", "StringTools.c")
         elif value.type.is_pyobject:
-            value = value.as_none_safe_node("'NoneType' object cannot be interpreted as an integer")
             func_name = "__Pyx_PyByteArray_AppendObject"
             func_type = self.PyByteArray_AppendObject_func_type
             utility_code = UtilityCode.load_cached("ByteArrayAppendObject", "StringTools.c")

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1232,6 +1232,7 @@ static CYTHON_INLINE int __Pyx_PyByteArray_AppendObject(PyObject* bytearray, PyO
         }
     }
     return __Pyx_PyByteArray_Append(bytearray, (int) ival);
+
 bad_range:
     PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
     return -1;
@@ -1244,22 +1245,8 @@ static CYTHON_INLINE int __Pyx_PyByteArray_Append(PyObject* bytearray, int value
 //////////////////// ByteArrayAppend ////////////////////
 //@requires: ObjectHandling.c::PyObjectCallMethod1
 
-static CYTHON_INLINE int __Pyx_PyByteArray_Append(PyObject* bytearray, int value) {
+static int __Pyx_PyByteArray_Append_fallback(PyObject* bytearray, int value) {
     PyObject *pyval, *retval;
-#if CYTHON_COMPILING_IN_CPYTHON
-    if (likely(__Pyx_is_valid_index(value, 256))) {
-        Py_ssize_t n = Py_SIZE(bytearray);
-        if (likely(n != PY_SSIZE_T_MAX)) {
-            if (unlikely(PyByteArray_Resize(bytearray, n + 1) < 0))
-                return -1;
-            PyByteArray_AS_STRING(bytearray)[n] = (char) (unsigned char) value;
-            return 0;
-        }
-    } else {
-        PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
-        return -1;
-    }
-#endif
     pyval = PyLong_FromLong(value);
     if (unlikely(!pyval))
         return -1;
@@ -1269,6 +1256,31 @@ static CYTHON_INLINE int __Pyx_PyByteArray_Append(PyObject* bytearray, int value
         return -1;
     Py_DECREF(retval);
     return 0;
+}
+
+static CYTHON_INLINE int __Pyx_PyByteArray_Append(PyObject* bytearray, int value) {
+#if CYTHON_COMPILING_IN_CPYTHON
+    if (likely(__Pyx_is_valid_index(value, 256))) {
+        int retval = 1;
+        __Pyx_BEGIN_CRITICAL_SECTION(bytearray);
+        Py_ssize_t n = Py_SIZE(bytearray);
+        if (likely(n != PY_SSIZE_T_MAX)) {
+            retval = PyByteArray_Resize(bytearray, n + 1);
+            if (likely(retval == 0)) {
+                PyByteArray_AS_STRING(bytearray)[n] = (char) (unsigned char) value;
+            }
+        }
+        __Pyx_END_CRITICAL_SECTION();
+        if (likely(retval != 1)) {
+            return retval;
+        }
+    } else {
+        PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
+        return -1;
+    }
+#endif
+
+    return __Pyx_PyByteArray_Append_fallback(bytearray, value);
 }
 
 

--- a/tests/run/bytearraymethods.pyx
+++ b/tests/run/bytearraymethods.pyx
@@ -269,6 +269,13 @@ def bytearray_append(bytearray b, signed char c, int i, object o):
     ValueError: ...
     >>> print(b.decode('ascii'))
     abcX@xy
+
+    >>> b = bytearray(b'abc')
+    >>> b = bytearray_append(b, ord('x'), ord('y'), None)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...
+    >>> print(b.decode('ascii'))
+    abcX@xy
     """
     assert b.append('X') is None
     b.append(64)

--- a/tests/run/bytearraymethods.pyx
+++ b/tests/run/bytearraymethods.pyx
@@ -276,6 +276,10 @@ def bytearray_append(bytearray b, signed char c, int i, object o):
     TypeError: ...
     >>> print(b.decode('ascii'))
     abcX@xy
+
+    >>> b = bytearray_append(None, ord('x'), ord('y'), b'x')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    AttributeError: 'NoneType' object has no attribute 'append'
     """
     assert b.append('X') is None
     b.append(64)


### PR DESCRIPTION
It crashed for `(<bytearray>None).append(…)` and was lacking a critical section.