### PR TITLE
Optimise bytearray.extend(bytes)

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3324,12 +3324,15 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
         if len(args) != 2:
             return node
 
+        func_type = self.PyByteArray_Extend_func_type
+        utility_code = UtilityCode.load_cached("ByteArrayExtendBytes", "StringTools.c")
+
         value = unwrap_coerced_node(args[1])
         arg_type = value.type
         if arg_type.is_pybytes_type:
-            utility_code = UtilityCode.load_cached("ByteArrayExtendBytes", "StringTools.c")
             func_name = "__Pyx_PyByteArray_ExtendBytes"
-            func_type = self.PyByteArray_Extend_func_type
+        elif arg_type.may_be_pybytes_type:
+            func_name = "__Pyx_PyByteArray_ExtendObject"
         else:
             return node
 

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3313,6 +3313,39 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             new_node = new_node.coerce_to(node.type, self.current_env())
         return new_node
 
+    PyByteArray_Extend_func_type = PyrexTypes.CFuncType(
+        PyrexTypes.c_returncode_type, [
+            PyrexTypes.CFuncTypeArg("bytearray", PyrexTypes.py_object_type, None),
+            PyrexTypes.CFuncTypeArg("value", PyrexTypes.py_object_type, None),
+            ],
+        exception_value=-1)
+
+    def _handle_simple_method_bytearray_extend(self, node, function, args, is_unbound_method):
+        if len(args) != 2:
+            return node
+
+        value = unwrap_coerced_node(args[1])
+        arg_type = value.type
+        if arg_type.is_pybytes_type:
+            utility_code = UtilityCode.load_cached("ByteArrayExtendBytes", "StringTools.c")
+            func_name = "__Pyx_PyByteArray_ExtendBytes"
+            func_type = self.PyByteArray_Extend_func_type
+        else:
+            return node
+
+        value = value.as_none_safe_node("can't extend bytearray with NoneType")
+
+        new_node = ExprNodes.PythonCapiCallNode(
+            node.pos, func_name, func_type,
+            args=[args[0], value],
+            may_return_none=False,
+            is_temp=node.is_temp,
+            utility_code=utility_code,
+        )
+        if node.result_is_used:
+            new_node = new_node.coerce_to(node.type, self.current_env())
+        return new_node
+
     PyObject_Pop_func_type = PyrexTypes.CFuncType(
         PyrexTypes.py_object_type, [
             PyrexTypes.CFuncTypeArg("list", PyrexTypes.py_object_type, None),

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3334,10 +3334,14 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             return node
 
         value = value.as_none_safe_node("can't extend bytearray with NoneType")
+        ba_obj = args[0].as_none_safe_node(
+            "'NoneType' object has no attribute '%.30s'",
+            error="PyExc_AttributeError",
+            format_args=['extend'])
 
         new_node = ExprNodes.PythonCapiCallNode(
             node.pos, func_name, func_type,
-            args=[args[0], value],
+            args=[ba_obj, value],
             may_return_none=False,
             is_temp=node.is_temp,
             utility_code=utility_code,

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1322,6 +1322,71 @@ static CYTHON_INLINE int __Pyx_PyByteArray_Append(PyObject* bytearray, int value
 }
 
 
+//////////////////// ByteArrayExtend.proto ////////////////////
+
+static int __Pyx_PyByteArray_Extend_fallback(PyObject* bytearray, PyObject* value); /*proto*/
+#if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBuffer(PyObject* bytearray, PyObject *value, const char* bytes, Py_ssize_t length); /*proto*/
+#endif
+
+//////////////////// ByteArrayExtend ////////////////////
+//@requires: ObjectHandling.c::PyObjectCallMethod1
+//@requires: IncludeStringH
+
+static int __Pyx_PyByteArray_Extend_fallback(PyObject* bytearray, PyObject* value) {
+    PyObject *retval = __Pyx_PyObject_CallMethod1(bytearray, PYIDENT("extend"), value);
+    if (unlikely(!retval))
+        return -1;
+    Py_DECREF(retval);
+    return 0;
+}
+
+#if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBuffer(PyObject* bytearray, PyObject *value, const char* bytes, Py_ssize_t length) {
+    int retval = 1;
+    __Pyx_BEGIN_CRITICAL_SECTION(bytearray);
+    Py_ssize_t n = Py_SIZE(bytearray);
+    if (likely(n < PY_SSIZE_T_MAX - length)) {
+        retval = PyByteArray_Resize(bytearray, n + length);
+        if (likely(retval == 0)) {
+            char *buffer = PyByteArray_AS_STRING(bytearray) + n;
+            memcpy(buffer, bytes, (size_t) length);
+        }
+    }
+    __Pyx_END_CRITICAL_SECTION();
+    if (likely(retval != 1)) {
+        return retval;
+    }
+
+    return __Pyx_PyByteArray_Extend_fallback(bytearray, value);
+}
+#endif
+
+
+//////////////////// ByteArrayExtendBytes.proto ////////////////////
+
+static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBytes(PyObject* bytearray, PyObject* value); /*proto*/
+
+//////////////////// ByteArrayExtendBytes.proto ////////////////////
+//@requires: ByteArrayExtend
+
+static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBytes(PyObject* bytearray, PyObject* value) {
+#if CYTHON_COMPILING_IN_CPYTHON
+    char* bytes;
+    Py_ssize_t length;
+    if (unlikely(PyBytes_AsStringAndSize(value, &bytes, &length) == -1)) {
+        return -1;
+    }
+    if (unlikely(length == 0)) {
+        return 0;
+    }
+    return __Pyx_PyByteArray_ExtendBuffer(bytearray, value, bytes, length);
+#else
+    return __Pyx_PyByteArray_Extend_fallback(bytearray, value);
+#endif
+}
+
+
 //////////////////// PyObjectFormat.proto ////////////////////
 
 #if CYTHON_USE_UNICODE_WRITER

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1367,6 +1367,10 @@ static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBuffer(PyObject* bytearray, PyO
 
 static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBytes(PyObject* bytearray, PyObject* value); /*proto*/
 
+#define __Pyx_PyByteArray_ExtendObject(bytearray, value)  (PyBytes_CheckExact(value) ? \
+    __Pyx_PyByteArray_ExtendBytes(bytearray, value) : \
+    __Pyx_PyByteArray_Extend_fallback(bytearray, value))
+
 //////////////////// ByteArrayExtendBytes ////////////////////
 //@requires: ByteArrayExtend
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1367,7 +1367,7 @@ static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBuffer(PyObject* bytearray, PyO
 
 static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBytes(PyObject* bytearray, PyObject* value); /*proto*/
 
-//////////////////// ByteArrayExtendBytes.proto ////////////////////
+//////////////////// ByteArrayExtendBytes ////////////////////
 //@requires: ByteArrayExtend
 
 static CYTHON_INLINE int __Pyx_PyByteArray_ExtendBytes(PyObject* bytearray, PyObject* value) {

--- a/tests/run/bytearraymethods.pyx
+++ b/tests/run/bytearraymethods.pyx
@@ -319,6 +319,10 @@ def bytearray_extend(bytearray b, value):
     b''
     >>> bytearray_extend(bytearray(b'abc'), b'')
     b'abc'
+    >>> bytearray_extend(bytearray(b'abc'), bytearray(b''))
+    b'abc'
+    >>> bytearray_extend(bytearray(b'abc'), bytearray(b'xyz'))
+    b'abcxyz'
 
     >>> b = bytearray(b'')
     >>> bytearray_extend(b, b)
@@ -330,6 +334,9 @@ def bytearray_extend(bytearray b, value):
     >>> bytearray_extend(bytearray(b'abc'), None)
     Traceback (most recent call last):
     TypeError: can't extend bytearray with NoneType
+    >>> bytearray_extend(None, b'abc')
+    Traceback (most recent call last):
+    AttributeError: 'NoneType' object has no attribute 'extend'
    """
     b.extend(value)
     return bytes(b)
@@ -346,6 +353,9 @@ def bytearray_extend_bytes(bytearray b, bytes arg):
     >>> bytearray_extend_bytes(bytearray(b'xx'), None)
     Traceback (most recent call last):
     TypeError: can't extend bytearray with NoneType
+    >>> bytearray_extend_bytes(None, b'abc')
+    Traceback (most recent call last):
+    AttributeError: 'NoneType' object has no attribute 'extend'
     """
     b.extend(b'')
     b.extend(b'a')
@@ -361,6 +371,9 @@ def bytearray_extend_bytearray(bytearray b):
     >>> b = bytearray(b'')
     >>> bytearray_extend_bytearray(b)
     b'aabcdefg'
+    >>> bytearray_extend_bytearray(None)
+    Traceback (most recent call last):
+    AttributeError: 'NoneType' object has no attribute 'extend'
     """
     b.extend(bytearray(b''))
     b.extend(bytearray(b'a'))

--- a/tests/run/bytearraymethods.pyx
+++ b/tests/run/bytearraymethods.pyx
@@ -307,3 +307,64 @@ def fromhex(bytearray b):
     >>> fromhex(bytearray(b""))
     """
     assert b.fromhex('2Ef0 F1f2  ') == b'.\xf0\xf1\xf2'
+
+
+def bytearray_extend(bytearray b, value):
+    """
+    >>> bytearray_extend(bytearray(b''), b'xyz')
+    b'xyz'
+    >>> bytearray_extend(bytearray(b'abc'), b'xyz')
+    b'abcxyz'
+    >>> bytearray_extend(bytearray(b''), b'')
+    b''
+    >>> bytearray_extend(bytearray(b'abc'), b'')
+    b'abc'
+
+    >>> b = bytearray(b'')
+    >>> bytearray_extend(b, b)
+    b''
+    >>> b = bytearray(b'xyz')
+    >>> bytearray_extend(b, b)
+    b'xyzxyz'
+
+    >>> bytearray_extend(bytearray(b'abc'), None)
+    Traceback (most recent call last):
+    TypeError: can't extend bytearray with NoneType
+   """
+    b.extend(value)
+    return bytes(b)
+
+
+@cython.test_fail_if_path_exists('//SimpleCallNode[@function.attribute = "extend"]')
+@cython.test_assert_path_exists('//PythonCapiCallNode')
+def bytearray_extend_bytes(bytearray b, bytes arg):
+    """
+    >>> bytearray_extend_bytes(bytearray(b''), b'')
+    b'aabcdefg'
+    >>> bytearray_extend_bytes(bytearray(b'xx'), b'yy')
+    b'xxaabcdefgyy'
+    >>> bytearray_extend_bytes(bytearray(b'xx'), None)
+    Traceback (most recent call last):
+    TypeError: can't extend bytearray with NoneType
+    """
+    b.extend(b'')
+    b.extend(b'a')
+    b.extend(b'')
+    b.extend(b'abcdefg')
+    b.extend(b'')
+    b.extend(arg)
+    return bytes(b)
+
+
+def bytearray_extend_bytearray(bytearray b):
+    """
+    >>> b = bytearray(b'')
+    >>> bytearray_extend_bytearray(b)
+    b'aabcdefg'
+    """
+    b.extend(bytearray(b''))
+    b.extend(bytearray(b'a'))
+    b.extend(bytearray(b''))
+    b.extend(bytearray(b'abcdefg'))
+    b.extend(bytearray(b''))
+    return bytes(b)


### PR DESCRIPTION
I constrained it to the most common case of `bytes` values for now because mutable objects like `bytearray` and `memoryview` require nested critical section guards, which is not trivial.

This PR includes 3.2.x PR https://github.com/cython/cython/pull/7796 which should be merged first.