### PR TITLE
Fix some issues with UnicodeConcatInPlace

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12966,7 +12966,7 @@ class AddNode(NumBinopNode):
                 if self.inplace or self.operand1.result_in_temp():
                     code.globalstate.use_utility_code(
                         UtilityCode.load_cached("UnicodeConcatInPlace", "ObjectHandling.c"))
-                    func += self.may_be_unsafe_shared()
+                    func += self.operand1.may_be_unsafe_shared()
 
         if func:
             # any necessary utility code will be got by "NumberAdd" in generate_evaluation_code

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2934,8 +2934,8 @@ static CYTHON_INLINE PyObject *__Pyx_PyUnicode_ConcatInPlaceImpl(PyObject **p_le
     }
     new_len = left_len + right_len;
 
-    if (left != right &&
-            __Pyx_unicode_modifiable(left, unsafe_shared)
+    if (left != right
+            && __Pyx_unicode_modifiable(left, unsafe_shared)
             && PyUnicode_CheckExact(right)
             && PyUnicode_KIND(right) <= PyUnicode_KIND(left)
             // Don't resize for ascii += latin1. Convert ascii to latin1 requires

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2850,7 +2850,7 @@ static PyObject *__Pyx_PyMethod_New2Arg(PyObject *func, PyObject *self) {
     #endif
     #define __Pyx_PyUnicode_Concat__Pyx_ReferenceSharing_DefinitelyUniqueInPlace(left, right) __Pyx_PyUnicode_ConcatInPlace(left, right, __Pyx_ReferenceSharing_DefinitelyUnique)
     #define __Pyx_PyUnicode_Concat__Pyx_ReferenceSharing_OwnStrongReferenceInPlace(left, right) __Pyx_PyUnicode_ConcatInPlace(left, right, __Pyx_ReferenceSharing_OwnStrongReference)
-    #define __Pyx_PyUnicode_Concat__Pyx_ReferenceSharing_FunctionArgumentInPlace(left, right) __Pyx_PyUnicode_ConcatInPlace(left, right, __Pyx_ReferenceSharing_DefinitelyUnique)
+    #define __Pyx_PyUnicode_Concat__Pyx_ReferenceSharing_FunctionArgumentInPlace(left, right) __Pyx_PyUnicode_ConcatInPlace(left, right, __Pyx_ReferenceSharing_FunctionArgument)
     #define __Pyx_PyUnicode_Concat__Pyx_ReferenceSharing_SharedReferenceInPlace(left, right) __Pyx_PyUnicode_ConcatInPlace(left, right, __Pyx_ReferenceSharing_SharedReference)
     // __Pyx_PyUnicode_ConcatInPlace is slightly odd because it has the potential to modify the input
     // argument (but only in cases where no user should notice). Therefore, it needs to keep Cython's
@@ -2934,7 +2934,8 @@ static CYTHON_INLINE PyObject *__Pyx_PyUnicode_ConcatInPlaceImpl(PyObject **p_le
     }
     new_len = left_len + right_len;
 
-    if (__Pyx_unicode_modifiable(left, unsafe_shared)
+    if (left != right &&
+            __Pyx_unicode_modifiable(left, unsafe_shared)
             && PyUnicode_CheckExact(right)
             && PyUnicode_KIND(right) <= PyUnicode_KIND(left)
             // Don't resize for ascii += latin1. Convert ascii to latin1 requires

--- a/tests/run/inplace.pyx
+++ b/tests/run/inplace.pyx
@@ -254,3 +254,143 @@ def conditional_inplace(value, a, condition, b):
     """
     value += a if condition else b
     return value
+
+
+# Unicode inplace concatenation is special because it attempts to do a
+# resize for uniquely referenced objects
+
+def unicode_concat_local(a: unicode):
+    """
+    >>> s = "123"
+    >>> unicode_concat_local(s)
+    '123abc'
+    >>> s
+    '123'
+    >>> unicode_concat_local("123456")
+    '123456abc'
+    """
+    local = a
+    local += 'abc'
+    return local
+
+def unicode_concat_unique_local(deuniquify):
+    """
+    >>> unicode_concat_unique_local(True)
+    'some string?'
+    >>> unicode_concat_unique_local(False)
+    'some string?'
+    """
+    a = "some string"
+    if deuniquify:
+        b = a
+    a += "?"
+    return a
+
+
+def unicode_concat_arg(a: unicode):
+    """
+    >>> s = "an argument"
+    >>> unicode_concat_arg(s)
+    'an argument with some extra stuff'
+    >>> s
+    'an argument'
+    >>> unicode_concat_arg('another argument')
+    'another argument with some extra stuff'
+    """
+    a += ' with some extra stuff'
+    return a
+
+def unicode_concat_arg_self(a: unicode):
+    """
+    >>> unicode_concat_arg_self('babababababa')
+    'babababababababababababa'
+    >>> s = '0987654321'
+    >>> unicode_concat_arg_self(s)
+    '09876543210987654321'
+    >>> s
+    '0987654321'
+    """
+    a += a
+    return a
+
+cdef unicode global_unicode = "glglgl"
+
+def get_global_unicode():
+    return global_unicode
+
+def reset_global_unicode():
+    global global_unicode
+    global_unicode = "glglgl"
+
+def unicode_concat_global():
+    """
+    >>> unicode_concat_global()
+    'glglgl xxxx'
+    >>> get_global_unicode()
+    'glglgl xxxx'
+    """
+    global global_unicode
+    global_unicode += ' xxxx'
+    return global_unicode
+
+cdef class UnicodeAttr:
+    cdef public unicode u
+    def do_concat(self):
+        """
+        >>> inst = UnicodeAttr()
+        >>> inst.u = 'attr_string'
+        >>> inst.do_concat()
+        >>> inst.u
+        'attr_string!'
+        >>> old = inst.u
+        >>> inst.do_concat()
+        >>> inst.u
+        'attr_string!!'
+        >>> old
+        'attr_string!'
+        """
+        self.u += "!"
+
+    def do_concat_self(self):
+        """
+        >>> inst = UnicodeAttr()
+        >>> inst.u = 'attr_string'
+        >>> inst.do_concat_self()
+        >>> inst.u
+        'attr_stringattr_string'
+        >>> old = inst.u
+        >>> inst.do_concat_self()
+        >>> inst.u
+        'attr_stringattr_stringattr_stringattr_string'
+        >>> old
+        'attr_stringattr_string'
+        """
+        self.u += self.u
+
+def unicode_concat_closure():
+    """
+    >>> reset_global_unicode()
+    >>> f = unicode_concat_closure()
+    >>> f('get')
+    'hmmmmm'
+    >>> f('concat')
+    'hmmmmm?'
+    >>> f('concat')
+    'hmmmmm??'
+    >>> f('get')
+    'hmmmmm??'
+    >>> f = unicode_concat_closure()
+    >>> (old := f('get'))
+    'hmmmmm'
+    >>> f('concat')
+    'hmmmmm?'
+    >>> old
+    'hmmmmm'
+    """
+    s = "hmmmmm"
+    def cl(op):
+        nonlocal s
+        if op == 'concat':
+            s += '?'
+        return s
+    return cl


### PR DESCRIPTION
There's a few issues which I think are mostly theoretical but are worth cleaning up:

* The "function arg" version was wrong. In practice this didn't matter because of point 2.
* The sharing was based on the type of the result rather than the type of the operand (and therefore was always treated as a temp).
* self += self could go wrong if it was reallocated (because we don't always hold a separate reference for the rhs). This is a real issue I think, but hard to reproduce reliably.

It's hard to check the threading logic particular reliably because we don't make the read-write access to globals/non-locals intrinsically thread safe. But that's a design choice elsewhere and not something intrinsic to unicode.