### PR TITLE
Simple feature list for shared module based on utility file names

### DIFF
--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -5,6 +5,7 @@ from Cython.Compiler import (
 )
 from Cython.Compiler.StringEncoding import EncodedString
 from Cython.Compiler.Scanning import SharedUtilitySourceDescriptor
+from Cython.Compiler.Errors import warning
 
 
 def list_of_features(included=None, excluded=None, _list_of_features=[]):
@@ -17,12 +18,25 @@ def list_of_features(included=None, excluded=None, _list_of_features=[]):
     return _select_features(feature_names, included, excluded)
 
 
-def _select_features(names, included, excluded):
+def _select_features(all_names, included, excluded):
+    names = all_names
     if included:
         included = set(included)
+        unknown = included.difference(all_names)
+        if unknown:
+            warning(None, f"Unknown shared module features selected: {', '.join(sorted(unknown))}")
+
         names = [name for name in names if name in included]
+
     if excluded:
         excluded = set(excluded)
+        unknown = excluded.difference(all_names)
+        if unknown:
+            warning(None, f"Unknown shared module features excluded: {', '.join(sorted(unknown))}")
+        unused = excluded.difference(names)
+        if unused:
+            warning(None, f"Shared module features excluded that was not included: {', '.join(sorted(unused))}")
+
         names = [name for name in names if name not in excluded]
 
     return names

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -7,7 +7,54 @@ from Cython.Compiler.StringEncoding import EncodedString
 from Cython.Compiler.Scanning import SharedUtilitySourceDescriptor
 
 
-def create_shared_library_pipeline(context, scope, options, result):
+def list_of_features(included=None, excluded=None, _list_of_features=[]):
+    if _list_of_features:
+        feature_names = _list_of_features[:]
+    else:
+        feature_names = sorted({feature_name for feature_name, _, _ in _iter_exports()})
+        _list_of_features[:] = feature_names
+
+    return _select_features(feature_names, included, excluded)
+
+
+def _select_features(names, included, excluded):
+    if included:
+        included = set(included)
+        names = [name for name in names if name in included]
+    if excluded:
+        excluded = set(excluded)
+        names = [name for name in names if name not in excluded]
+
+    return names
+
+
+def _iter_exports(selected_features=None):
+    UtilityCode = Code.UtilityCode
+    match_special = UtilityCode.get_special_comment_matcher('/')
+
+    for c_utility_file in os.listdir(Code.get_utility_dir()):
+        if not c_utility_file.endswith('.c'):
+            continue
+
+        file_base_name = os.path.splitext(os.path.basename(c_utility_file))[0]
+        feature_name = file_base_name.partition('_')[0]
+
+        if selected_features is not None and feature_name not in selected_features:
+            continue
+
+        for line in Code.read_utilities_hook(c_utility_file):
+            if '////' not in line:
+                continue
+            if not ((m := match_special(line)) and (name := m.group('name'))):
+                continue
+            if not (section_title := UtilityCode.match_section_title(name)):
+                continue
+            name, section_type = section_title.groups()
+            if section_type == 'export':
+                yield (feature_name, name, c_utility_file)
+
+
+def create_shared_library_pipeline(context, scope, options, result, selected_features=None):
 
     parse = Pipeline.parse_stage_factory(context)
 
@@ -15,11 +62,13 @@ def create_shared_library_pipeline(context, scope, options, result):
         def generate_tree(compsrc):
             tree = parse(compsrc)
 
-            tree.scope.use_utility_code(
-                MemoryView.get_view_utility_code(options.shared_utility_qualified_name))
+            if selected_features is None or 'MemoryView' in selected_features:
+                tree.scope.use_utility_code(
+                    MemoryView.get_view_utility_code(options.shared_utility_qualified_name))
 
-            tree.scope.use_utility_code(MemoryView._get_memviewslice_declare_code())
-            tree.scope.use_utility_code(MemoryView._get_typeinfo_to_format_code())
+                tree.scope.use_utility_code(MemoryView._get_memviewslice_declare_code())
+                tree.scope.use_utility_code(MemoryView._get_typeinfo_to_format_code())
+
             context.include_directories.append(Code.get_utility_dir())
             return tree
 
@@ -27,18 +76,8 @@ def create_shared_library_pipeline(context, scope, options, result):
 
     def generate_c_utilities(module_node):
         UtilityCode = Code.UtilityCode
-        match_special = UtilityCode.get_special_comment_matcher('/')
-        for c_utility_file in os.listdir(Code.get_utility_dir()):
-            if not c_utility_file.endswith('.c'):
-                continue
-            for line in Code.read_utilities_hook(c_utility_file):
-                if not ((m := match_special(line)) and (name := m.group('name'))):
-                    continue
-                if not (section_title := UtilityCode.match_section_title(name)):
-                    continue
-                name, section_type = section_title.groups()
-                if section_type == 'export':
-                    module_node.scope.use_utility_code(UtilityCode.load_cached(name, c_utility_file))
+        for _, name, c_utility_file in _iter_exports(selected_features):
+            module_node.scope.use_utility_code(UtilityCode.load_cached(name, c_utility_file))
         return module_node
 
     orig_cimport_from_pyx = Options.cimport_from_pyx
@@ -71,6 +110,13 @@ def generate_shared_module(options):
     pyx_file = os.path.splitext(dest_c_file)[0] + '.pyx'
     module_name = os.path.splitext(os.path.basename(dest_c_file))[0]
 
+    selected_features = None
+    if options.shared_utility_features_enabled or options.shared_utility_features_disabled:
+        selected_features = list_of_features(
+            options.shared_utility_features_enabled,
+            options.shared_utility_features_disabled,
+        )
+
     context = Main.Context.from_options(options)
     scope = Symtab.ModuleScope('MemoryView', parent_module = None, context = context, is_package=False)
 
@@ -78,7 +124,10 @@ def generate_shared_module(options):
     comp_src = Main.CompilationSource(source_desc, EncodedString(module_name), os.getcwd())
     result = Main.create_default_resultobj(comp_src, options)
 
-    pipeline = create_shared_library_pipeline(context, scope, options, result)
+    pipeline = create_shared_library_pipeline(
+        context, scope, options, result,
+        selected_features=selected_features,
+    )
     err, enddata = Pipeline.run_pipeline(pipeline, comp_src)
 
     return err, enddata

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -53,10 +53,6 @@ def _iter_exports(selected_features=None):
         file_base_name = os.path.splitext(os.path.basename(c_utility_file))[0]
         current_feature_name = file_base_name.partition('_')[0]
 
-        if selected_features is not None and current_feature_name not in selected_features:
-            # Disable whole file feature, including any @features declared therein.
-            continue
-
         current_section = None
         for line in Code.read_utilities_hook(c_utility_file):
             if '//' not in line or not line.startswith('//'):
@@ -80,7 +76,8 @@ def _iter_exports(selected_features=None):
 
             elif (tag := match.group('tag')) and tag.startswith('feature') and current_section:
                 if current_section[0] != current_feature_name:
-                    # Ignore file feature name if at least one tag was declared.
+                    # Allow multiple feature name tags for a section, but ignore the main file
+                    # feature name if at least one feature name was explicitly declared.
                     if selected_features is None or current_section[0] in selected_features:
                         yield current_section
 

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -51,21 +51,39 @@ def _iter_exports(selected_features=None):
             continue
 
         file_base_name = os.path.splitext(os.path.basename(c_utility_file))[0]
-        feature_name = file_base_name.partition('_')[0]
+        current_feature_name = file_base_name.partition('_')[0]
 
-        if selected_features is not None and feature_name not in selected_features:
+        if selected_features is not None and current_feature_name not in selected_features:
             continue
 
+        next_match = []  # Look-ahead to allow parsing "//@tags".
         for line in Code.read_utilities_hook(c_utility_file):
-            if '////' not in line:
+            if '//' not in line or not line.startswith('//'):
                 continue
-            if not ((m := match_special(line)) and (name := m.group('name'))):
+            match = match_special(line)
+            if match is None:
                 continue
-            if not (section_title := UtilityCode.match_section_title(name)):
-                continue
-            name, section_type = section_title.groups()
-            if section_type == 'export':
-                yield (feature_name, name, c_utility_file)
+
+            name = match.group('name')
+            if name:
+                if '.export' not in name:
+                    continue
+                section_title = UtilityCode.match_section_title(name)
+                if not section_title:
+                    continue
+                name, section_type = section_title.groups()
+                if section_type == 'export':
+                    if next_match:
+                        yield next_match
+                    next_match = [current_feature_name, name, c_utility_file]
+
+            elif (tag := match.group('tag')) and tag.startswith('feature') and next_match:
+                # Overwrite the file based feature name with the explicit @feature name.
+                explicit_feature_name = tag.split(':', 1)[-1].strip()
+                next_match[0] = explicit_feature_name
+
+        if next_match:
+            yield next_match
 
 
 def create_shared_library_pipeline(context, scope, options, result, selected_features=None):

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -75,13 +75,10 @@ def _iter_exports(selected_features=None):
                         current_section = [current_feature_name, name, c_utility_file]
 
             elif (tag := match.group('tag')) and tag.startswith('feature') and current_section:
-                if current_section[0] != current_feature_name:
-                    # Allow multiple feature name tags for a section, but ignore the main file
-                    # feature name if at least one feature name was explicitly declared.
-                    if selected_features is None or current_section[0] in selected_features:
-                        yield current_section
-
                 explicit_feature_name = tag.split(':', 1)[-1].strip()
+                assert current_section[0] == current_feature_name, (
+                    "Conflicting feature names given to the same utility code section: "
+                    f"{current_section[0]!r} and {explicit_feature_name!r}")
                 current_section[0] = explicit_feature_name
 
         if current_section:

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -54,9 +54,10 @@ def _iter_exports(selected_features=None):
         current_feature_name = file_base_name.partition('_')[0]
 
         if selected_features is not None and current_feature_name not in selected_features:
+            # Disable whole file feature, including any @features declared therein.
             continue
 
-        next_match = []  # Look-ahead to allow parsing "//@tags".
+        current_section = None
         for line in Code.read_utilities_hook(c_utility_file):
             if '//' not in line or not line.startswith('//'):
                 continue
@@ -66,24 +67,29 @@ def _iter_exports(selected_features=None):
 
             name = match.group('name')
             if name:
-                if '.export' not in name:
-                    continue
-                section_title = UtilityCode.match_section_title(name)
-                if not section_title:
-                    continue
-                name, section_type = section_title.groups()
-                if section_type == 'export':
-                    if next_match:
-                        yield next_match
-                    next_match = [current_feature_name, name, c_utility_file]
+                if current_section:
+                    if selected_features is None or current_section[0] in selected_features:
+                        yield current_section
+                current_section = None
 
-            elif (tag := match.group('tag')) and tag.startswith('feature') and next_match:
-                # Overwrite the file based feature name with the explicit @feature name.
+                section_title = UtilityCode.match_section_title(name) if '.export' in name else None
+                if section_title:
+                    name, section_type = section_title.groups()
+                    if section_type == 'export':
+                        current_section = [current_feature_name, name, c_utility_file]
+
+            elif (tag := match.group('tag')) and tag.startswith('feature') and current_section:
+                if current_section[0] != current_feature_name:
+                    # Ignore file feature name if at least one tag was declared.
+                    if selected_features is None or current_section[0] in selected_features:
+                        yield current_section
+
                 explicit_feature_name = tag.split(':', 1)[-1].strip()
-                next_match[0] = explicit_feature_name
+                current_section[0] = explicit_feature_name
 
-        if next_match:
-            yield next_match
+        if current_section:
+            if selected_features is None or current_section[0] in selected_features:
+                yield current_section
 
 
 def create_shared_library_pipeline(context, scope, options, result, selected_features=None):

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -30,6 +30,19 @@ class ParseOptionsAction(Action):
         setattr(namespace, self.dest, options)
 
 
+class ParseCommaListAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        options = list(getattr(namespace, self.dest, []))
+
+        seen = set(options)
+        for opt in values.split(','):
+            if opt not in seen:
+                seen.add(opt)
+                options.append(opt)
+
+        setattr(namespace, self.dest, options)
+
+
 class ParseCompileTimeEnvAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         old_env = dict(getattr(namespace, self.dest, {}))
@@ -185,10 +198,11 @@ def create_cython_argparser():
                         help='Generates shared module with specified name.')
     parser.add_argument("--shared", dest='shared_utility_qualified_name', action='store', type=str,
                         help='Imports utility code from shared module specified by fully qualified module name.')
-    parser.add_argument("--shared-only", dest='shared_utility_features_enabled', action='store', type=str, metavar='FEATURES',
+    parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
+                        action=ParseCommaListAction, type=str, metavar='FEATURES',
                         help='Comma separate list of features to move to the shared module exclusively.')
     parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
-                        action='store', type=str, metavar='FEATURES',
+                        action=ParseCommaListAction, type=str, metavar='FEATURES',
                         help='Comma separate list of features to exclude from the shared module.')
 
     parser.add_argument('sources', nargs='*', default=[])

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -67,17 +67,36 @@ class SetAnnotateCoverageAction(Action):
         namespace.annotate = True
         namespace.annotate_coverage_xml = values
 
+
+class CythonArgumentParser(ArgumentParser):
+    # Build the epilog lazily at request as it may take time to produce.
+    @property
+    def epilog(self):
+        import textwrap
+        from ..Build import SharedModule
+        return (
+            '\nValid feature names for the shared module:\n  FEATURES: ' +
+            '\n'.join(textwrap.wrap(
+                ' , '.join(SharedModule.list_of_features()),
+                subsequent_indent=" "*12,
+            )) + '\n' +
+            "\nEnvironment variables:\n"
+            "  CYTHON_CACHE_DIR: the base directory containing Cython's caches.\n"
+        )
+
+    @epilog.setter
+    def epilog(self, value):
+        pass
+
+
 def create_cython_argparser():
     description = "Cython (https://cython.org/) is a compiler for code written in the "\
                   "Cython language.  Cython is based on Pyrex by Greg Ewing."
 
-    parser = ArgumentParser(
+    parser = CythonArgumentParser(
         description=description,
         argument_default=SUPPRESS,
         formatter_class=RawDescriptionHelpFormatter,
-        epilog="""\
-Environment variables:
-  CYTHON_CACHE_DIR: the base directory containing Cython's caches."""
     )
 
     parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
@@ -159,10 +178,18 @@ Environment variables:
                            'deduced from the import path if source file is in '
                            'a package, or equals the filename otherwise.')
     parser.add_argument('-M', '--depfile', action='store_true', help='produce depfiles for the sources')
+
+    # Shared module setup.
+
     parser.add_argument("--generate-shared", dest='shared_c_file_path', action='store', type=str,
                         help='Generates shared module with specified name.')
     parser.add_argument("--shared", dest='shared_utility_qualified_name', action='store', type=str,
                         help='Imports utility code from shared module specified by fully qualified module name.')
+    parser.add_argument("--shared-only", dest='shared_utility_features_enabled', action='store', type=str, metavar='FEATURES',
+                        help='Comma separate list of features to move to the shared module exclusively.')
+    parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
+                        action='store', type=str, metavar='FEATURES',
+                        help='Comma separate list of features to exclude from the shared module.')
 
     parser.add_argument('sources', nargs='*', default=[])
 

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -289,16 +289,24 @@ def parse_command_line(args):
 
     if options.use_listing_file and len(sources) > 1:
         parser.error("cython: Only one source file allowed when using -o\n")
+
     if options.shared_c_file_path:
         if len(sources) > 0:
             parser.error("cython: Source file not allowed when using --generate-shared\n")
     elif len(sources) == 0 and not options.show_version:
         parser.error("cython: Need at least one source file\n")
+
+    if options.shared_utility_features_disabled or options.shared_utility_features_enabled:
+        if not options.shared_c_file_path:
+            parser.error("cython: --shared-only and --shared-exclude require --generate-shared")
+
     if Options.embed and len(sources) > 1:
         parser.error("cython: Only one source file allowed when using --embed\n")
+
     if options.module_name:
         if options.timestamps:
             parser.error("cython: Cannot use --module-name with --timestamps\n")
         if len(sources) > 1:
             parser.error("cython: Only one source file allowed when using --module-name\n")
+
     return options, sources

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -377,10 +377,14 @@ class UtilityCodeBase(AbstractUtilityCode):
 
                 tag_name, _, tag_value = tag_value.partition(':')
                 tag_name = tag_name.rstrip()
-                tag_value = tag_value.strip()
 
+                if tag_name == 'feature':
+                    # Only used for shared module code selection.
+                    continue
                 if tag_name not in ('requires', 'substitute', 'proto_block', 'init_block'):
                     raise RuntimeError(f"Found unknown tag name '{tag_name}' in utility section {name}.{type}")
+
+                tag_value = tag_value.strip()
                 if not re.match(r'\S+(\{[^\}]*\})?$', tag_value):
                     raise RuntimeError(f"Found invalid tag value '{tag_value}' in utility section {name}.{type}")
 

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -835,4 +835,6 @@ default_options = dict(
     legacy_implicit_noexcept=None,
     shared_c_file_path=None,
     shared_utility_qualified_name = None,
+    shared_utility_features_enabled = None,
+    shared_utility_features_disabled = None,
 )

--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -66,6 +66,8 @@ class build_ext(_build_ext):
         self.cython_gdb = False
         self.cython_compile_time_env = None
         self.shared_utility_qualified_name = None
+        self.shared_utility_features_enabled = None
+        self.shared_utility_features_disabled = None
 
     def finalize_options(self):
         super().finalize_options()
@@ -126,6 +128,8 @@ class build_ext(_build_ext):
             'c_line_in_traceback': c_line_in_traceback,
             'compile_time_env': self.get_extension_attr(ext, 'cython_compile_time_env', default=None),
             'shared_utility_qualified_name': self.get_extension_attr(ext, 'shared_utility_qualified_name', default=None),
+            'shared_utility_features_enabled': self.get_extension_attr(ext, 'shared_utility_features_enabled', default=None),
+            'shared_utility_features_disabled': self.get_extension_attr(ext, 'shared_utility_features_disabled', default=None),
         }
 
         new_ext = cythonize(

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -381,6 +381,7 @@ static void __Pyx_call_next_tp_clear(PyObject* obj, inquiry current_tp_clear) {
 
 
 /////////////// SetupReduce.export ///////////////
+//@feature: AutoPickle
 
 static int __Pyx_setup_reduce(PyObject* type_obj);
 
@@ -576,6 +577,7 @@ static int __Pyx_CheckUnpickleChecksum(long checksum, long checksum1, long check
 
 
 /////////////// UpdateUnpickledDict.export ///////////////
+//@feature: AutoPickle
 
 static int __Pyx_UpdateUnpickledDict(PyObject *obj, PyObject *state, Py_ssize_t index); /*proto*/
 

--- a/docs/src/userguide/source_files_and_compilation.rst
+++ b/docs/src/userguide/source_files_and_compilation.rst
@@ -151,12 +151,12 @@ module which is automatically cimported and used by the user-written extension m
 
 There are a few things to bear in mind when deciding whether to use the shared utility module:
 
-* The bulk of the shared utility module is the memoryview utility code, with some
-  additional frequently-needed code as bonus.  Using the shared utility module is only
+* A large part of the shared utility module is the memoryview utility code, with some
+  additional frequently-needed code as bonus.  Using the shared utility module is most
   likely to be worthwhile if you use :ref:`typed memoryviews<memoryviews>`.
 * The contents and interfaces of the shared utility module are not designed to be
   stable across Python versions.  That means that you must build the shared utility
-  module with the same version of Cython as you build you extension modules.
+  module with the same version of Cython as you build your extension modules.
   In practice that means that each package will ship its own shared utility
   module rather than using a global system module.
 * The shared utility module should be compiled with the same
@@ -233,6 +233,35 @@ The :file:`setup.py` file would be:
     setup(
       ext_modules = cythonize(extensions, shared_utility_qualified_name = 'mypkg.shared._cyutility')
     )
+
+Selecting features to be shared
+-------------------------------
+
+Since Cython 3.3, the content of the shared utility can be controlled via feature selection.
+The list of named features can be found in the output of ``cython --help``, which includes
+names like ``MemoryView`` or ``AutoPickle``.  Cython accepts a positive list and a negative
+list as follows.  If both options are provided, excludes override the positive list.
+
+* via the ``cython`` command:
+
+   .. code-block:: console
+
+       $ cython --generate-shared=shared.c \
+                --shared-only MemoryView,AutoPickle  # positive list
+
+       $ cython --generate-shared=shared.c \
+                --shared-exclude MemoryView  # negative list
+
+via ``cythonize()`` in ``setup.py``:
+
+   .. code-block:: python
+
+       cythonize(
+           extensions,
+           shared_utility_qualified_name='mypkg.shared._cyutility',
+           shared_utility_features_enabled=['MemoryView'],  # positive list
+           shared_utility_features_disabled=['AutoPickle'],  # negative list
+       )
 
 
 .. _integrating_multiple_modules:
@@ -1123,7 +1152,7 @@ most important to least important:
     at compile-time.  Otherwise ``assert`` statements behave like in Python and
     depend on if the interpreter is in debug mode.
     Unlike most other macros here, the behaviour of ``CYTHON_WITHOUT_ASSERTIONS``
-    depends only on whether it is defined and not what it is defined to.  
+    depends only on whether it is defined and not what it is defined to.
 
 There is a further list of macros which turn off various optimizations or language
 features.  Under normal circumstances Cython enables these automatically based on the

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -63,7 +63,6 @@ assert pathlib.Path("pkg2/CythonShared.c").exists()
 
 from Cython.Build import cythonize
 from setuptools import setup, Extension
-import numpy
 
 extensions = [
     Extension("*", ["**/*.pyx"]),
@@ -88,7 +87,6 @@ assert not pathlib.Path("pkg2/CythonShared.c").exists()
 
 from Cython.Build import cythonize
 from setuptools import setup, Extension
-import numpy
 
 extensions = [
     Extension("*", ["**/*.pyx"]),

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -16,6 +16,10 @@ PYTHON -c "import test_shared_utility"
 PYTHON delete_generated_files.py
 PYTHON setup_memoryview_without_extensions.py build_ext --inplace --force -j3
 PYTHON -c "import pkg1.pkg11.feature_memoryview as mv; x = mv.test([1,2,3]); assert x == 6, x"
+
+PYTHON delete_generated_files.py
+PYTHON setup_extensions_without_autopickle.py build_ext --inplace --force -j3
+PYTHON -c "import pkg1.pkg11.feature_extensiontypes as ext; assert hasattr(ext.ExtensionType(), 'x')"
 """
 
 
@@ -61,6 +65,8 @@ setup(
 
 import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
+with open("pkg2/CythonShared.c") as f:
+    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
 
 
 ######## setup_with_builddir.py ########
@@ -86,6 +92,9 @@ import pathlib
 assert pathlib.Path("build/pkg2/CythonShared.c").exists()
 assert not pathlib.Path("pkg2/CythonShared.c").exists()
 
+with open("build/pkg2/CythonShared.c") as f:
+    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
+
 
 ######## setup_without_sources.py ########
 
@@ -109,6 +118,9 @@ import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
 
+with open("pkg2/CythonShared.c") as f:
+    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
+
 
 ######## setup_memoryview_without_extensions.py ########
 # Memoryviews depend on (some) extension type support themselves.
@@ -128,6 +140,38 @@ setup(
         shared_utility_features_disabled = ['ExtensionTypes'],
     )
 )
+
+import pathlib
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+
+with open("pkg2/CythonShared.c") as f:
+    assert '__Pyx_setup_reduce' in f.read()  # MemoryViews use AutoPickle
+
+
+######## setup_extensions_without_autopickle.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+
+extensions = [
+    Extension("*", ["pkg1/pkg11/feature*.pyx"]),
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        shared_utility_features_disabled = ['AutoPickle', 'MemoryView'],
+        compiler_directives={'auto_pickle': False},
+    )
+)
+
+import pathlib
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+
+with open("pkg2/CythonShared.c") as f:
+    assert '__Pyx_setup_reduce' not in f.read()
 
 
 ######## test_shared_utility.py ########
@@ -201,7 +245,7 @@ def imported_func():
 # Using feature "ExtensionTypes".
 
 cdef class ExtensionType:
-    cdef int x
+    cdef public int x
 
 
 ######## pkg1/pkg11/feature_memoryview.pyx ########

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -1,0 +1,192 @@
+# mode: run
+# tag: shared_utility
+
+"""
+PYTHON setup_with_sources.py build_ext --inplace --force -j3
+PYTHON -c "import test_shared_utility"
+
+PYTHON delete_generated_files.py
+PYTHON setup_with_builddir.py build_ext --inplace --force -j3
+PYTHON -c "import test_shared_utility"
+
+PYTHON delete_generated_files.py
+PYTHON setup_without_sources.py build_ext --inplace --force -j3
+PYTHON -c "import test_shared_utility"
+"""
+
+
+######## delete_generated_files.py ########
+
+import os
+from pathlib import Path
+
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
+for directory, _, files in os.walk(os.getcwd()):
+    path = Path(directory)
+    for filename in files:
+        file = path / filename
+        if file.suffix.lower() in ext_to_delete:
+            print(f"Deleting {file}")
+            file.unlink()
+
+
+######## setup_with_sources.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+import sys
+
+extra_cflags = []
+if sys.platform == 'linux':
+    extra_cflags.append('-Wimplicit-function-declaration')
+
+extensions = [
+    Extension("*", ["**/*.pyx"],
+              extra_compile_args=extra_cflags),
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"],
+              extra_compile_args=extra_cflags),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+    )
+)
+
+import pathlib
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+
+
+######## setup_with_builddir.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+import numpy
+
+extensions = [
+    Extension("*", ["**/*.pyx"]),
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+        build_dir = "build",
+    )
+)
+
+import pathlib
+assert pathlib.Path("build/pkg2/CythonShared.c").exists()
+assert not pathlib.Path("pkg2/CythonShared.c").exists()
+
+
+######## setup_without_sources.py ########
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+import numpy
+
+extensions = [
+    Extension("*", ["**/*.pyx"]),
+    Extension("pkg2.CythonShared", sources=[]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+    )
+)
+
+import pathlib
+assert pathlib.Path("pkg2/CythonShared.c").exists()
+assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
+
+
+######## test_shared_utility.py ########
+
+from pkg1.pkg11.add_one import add_one, imported_func
+from pkg1.pkg11.cython_features import fstring
+
+assert add_one(2) == 3
+assert imported_func() == 1
+
+assert 'cython' in type(add_one).__name__, type(add_one).__name__
+assert 'cython' in type(imported_func).__name__, type(imported_func).__name__
+
+from pkg2 import CythonShared
+assert hasattr(CythonShared, '__pyx_capi__'), dir(CythonShared)
+
+s = fstring()
+assert s == ' 5 != 10 ', s
+
+try:
+    from pkg1.pkg11.missing_feature_ExtensionTypes import ExtensionType
+except ImportError:
+    pass
+else:
+    assert False, "Import with missing feature 'ExtensionTypes' succeeded !"
+
+try:
+    from pkg1.pkg11.missing_feature_MemoryView import memview_func
+except ImportError:
+    pass
+else:
+    assert False, "Import with missing feature 'MemoryView' succeeded !"
+
+
+######## pkg1/__init__.py ########
+
+
+######## pkg1/pkg11/__init__.py ########
+
+
+######## pkg1/pkg11/add_one.pyx ########
+
+import sys
+from pkg2 import CythonShared
+# relative import bug https://github.com/cython/cython/issues/7290
+from .import_from_me import imported_func
+
+assert CythonShared in sys.modules.values(), list(sys.modules)
+assert sys.modules['pkg2.CythonShared'] is CythonShared, list(sys.modules)
+
+def add_one(value):
+    return value + 1
+
+
+######## pkg1/pkg11/cython_features.pyx ########
+
+v = 5
+cdef int iv = 10
+
+def fstring():
+    return f" {v} != {iv} "
+
+
+######## pkg1/pkg11/import_from_me.pyx ########
+
+def imported_func():
+    return 1
+
+
+######## pkg1/pkg11/missing_feature_ExtensionTypes.pyx ########
+# Using a disabled feature.
+
+cdef class ExtensionType:
+    cdef int x
+
+
+######## pkg1/pkg11/missing_feature_MemoryViews.pyx ########
+# Using a disabled feature.
+
+def memview_func(int[:] ints):
+    return sum(i for i in range(len(ints)))
+
+
+######## pkg2/__init__.py ########

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -59,14 +59,17 @@ setup(
     ext_modules = cythonize(
         extensions,
         shared_utility_qualified_name = 'pkg2.CythonShared',
-        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes', 'AutoPickle'],
     )
 )
 
 import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 with open("pkg2/CythonShared.c") as f:
-    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
+    shared_c_code = f.read()
+assert '__Pyx_setup_reduce' not in shared_c_code
+assert '__Pyx_memviewslice' not in shared_c_code
+assert '__pyx_memoryview_obj' not in shared_c_code
 
 
 ######## setup_with_builddir.py ########
@@ -83,7 +86,7 @@ setup(
     ext_modules = cythonize(
         extensions,
         shared_utility_qualified_name = 'pkg2.CythonShared',
-        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes', 'AutoPickle'],
         build_dir = "build",
     )
 )
@@ -93,7 +96,10 @@ assert pathlib.Path("build/pkg2/CythonShared.c").exists()
 assert not pathlib.Path("pkg2/CythonShared.c").exists()
 
 with open("build/pkg2/CythonShared.c") as f:
-    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
+    shared_c_code = f.read()
+assert '__Pyx_setup_reduce' not in shared_c_code
+assert '__Pyx_memviewslice' not in shared_c_code
+assert '__pyx_memoryview_obj' not in shared_c_code
 
 
 ######## setup_without_sources.py ########
@@ -110,7 +116,7 @@ setup(
     ext_modules = cythonize(
         extensions,
         shared_utility_qualified_name = 'pkg2.CythonShared',
-        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes'],
+        shared_utility_features_disabled = ['MemoryView', 'ExtensionTypes', 'AutoPickle'],
     )
 )
 
@@ -119,7 +125,10 @@ assert pathlib.Path("pkg2/CythonShared.c").exists()
 assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
 
 with open("pkg2/CythonShared.c") as f:
-    assert '__Pyx_setup_reduce' not in f.read()  # AutoPickle indirectly disabled
+    shared_c_code = f.read()
+assert '__Pyx_setup_reduce' not in shared_c_code
+assert '__Pyx_memviewslice' not in shared_c_code
+assert '__pyx_memoryview_obj' not in shared_c_code
 
 
 ######## setup_memoryview_without_extensions.py ########
@@ -137,7 +146,7 @@ setup(
     ext_modules = cythonize(
         extensions,
         shared_utility_qualified_name = 'pkg2.CythonShared',
-        shared_utility_features_disabled = ['ExtensionTypes'],
+        shared_utility_features_disabled = ['ExtensionTypes', 'AutoPickle'],
     )
 )
 
@@ -145,7 +154,10 @@ import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 
 with open("pkg2/CythonShared.c") as f:
-    assert '__Pyx_setup_reduce' in f.read()  # MemoryViews use AutoPickle
+    shared_c_code = f.read()
+assert '__Pyx_setup_reduce' in shared_c_code  # MemoryViews use AutoPickle
+assert '__Pyx_memviewslice' in shared_c_code
+assert '__pyx_memoryview_obj' in shared_c_code
 
 
 ######## setup_extensions_without_autopickle.py ########
@@ -171,7 +183,10 @@ import pathlib
 assert pathlib.Path("pkg2/CythonShared.c").exists()
 
 with open("pkg2/CythonShared.c") as f:
-    assert '__Pyx_setup_reduce' not in f.read()
+    shared_c_code = f.read()
+assert '__Pyx_setup_reduce' not in shared_c_code
+assert '__Pyx_memviewslice' not in shared_c_code
+assert '__pyx_memoryview_obj' not in shared_c_code
 
 
 ######## test_shared_utility.py ########

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -12,6 +12,10 @@ PYTHON -c "import test_shared_utility"
 PYTHON delete_generated_files.py
 PYTHON setup_without_sources.py build_ext --inplace --force -j3
 PYTHON -c "import test_shared_utility"
+
+PYTHON delete_generated_files.py
+PYTHON setup_memoryview_without_extensions.py build_ext --inplace --force -j3
+PYTHON -c "import pkg1.pkg11.feature_memoryview as mv; x = mv.test([1,2,3]); assert x == 6, x"
 """
 
 
@@ -106,6 +110,26 @@ assert pathlib.Path("pkg2/CythonShared.c").exists()
 assert not pathlib.Path("build/pkg2/CythonShared.c").exists()
 
 
+######## setup_memoryview_without_extensions.py ########
+# Memoryviews depend on (some) extension type support themselves.
+
+from Cython.Build import cythonize
+from setuptools import setup, Extension
+
+extensions = [
+    Extension("*", ["pkg1/pkg11/feature*.pyx"]),
+    Extension("pkg2.CythonShared", sources=["pkg2/CythonShared.c"]),
+]
+
+setup(
+    ext_modules = cythonize(
+        extensions,
+        shared_utility_qualified_name = 'pkg2.CythonShared',
+        shared_utility_features_disabled = ['ExtensionTypes'],
+    )
+)
+
+
 ######## test_shared_utility.py ########
 
 from pkg1.pkg11.add_one import add_one, imported_func
@@ -124,14 +148,14 @@ s = fstring()
 assert s == ' 5 != 10 ', s
 
 try:
-    from pkg1.pkg11.missing_feature_ExtensionTypes import ExtensionType
+    from pkg1.pkg11.feature_extensiontypes import ExtensionType
 except ImportError:
     pass
 else:
     assert False, "Import with missing feature 'ExtensionTypes' succeeded !"
 
 try:
-    from pkg1.pkg11.missing_feature_MemoryView import memview_func
+    from pkg1.pkg11.feature_memoryview import memview_func
 except ImportError:
     pass
 else:
@@ -173,18 +197,23 @@ def imported_func():
     return 1
 
 
-######## pkg1/pkg11/missing_feature_ExtensionTypes.pyx ########
-# Using a disabled feature.
+######## pkg1/pkg11/feature_extensiontypes.pyx ########
+# Using feature "ExtensionTypes".
 
 cdef class ExtensionType:
     cdef int x
 
 
-######## pkg1/pkg11/missing_feature_MemoryViews.pyx ########
-# Using a disabled feature.
+######## pkg1/pkg11/feature_memoryview.pyx ########
+# Using feature "MemoryViews".
+
+def test(ints):
+    from array import array
+    a = array('i', ints)
+    return memview_func(a)
 
 def memview_func(int[:] ints):
-    return sum(i for i in range(len(ints)))
+    return sum(ints[i] for i in range(len(ints)))
 
 
 ######## pkg2/__init__.py ########


### PR DESCRIPTION
This PR allows users to select the features in the shared utility module.

I had first envisioned a semantic list of feature names, but while putting it together, it seemed to correspond broadly with the utility file names that we use. Thus, the list of features to chose from is automatically gathered by finding the names of C files in `Cython/Utility/` that export code, as for the utility code collection before. I added a utility code tag `//@feature: NAME` that allows setting a different (more specific) name for a code section. I do that for the `AutoPickle` feature.

Commenting and trying it out is welcome.