### PR TITLE
Fix scope tracking transform

### DIFF
--- a/Cython/Compiler/Visitor.pxd
+++ b/Cython/Compiler/Visitor.pxd
@@ -22,9 +22,9 @@ cdef class CythonTransform(VisitorTransform):
     cdef public current_directives
 
 cdef class ScopeTrackingTransform(CythonTransform):
-    cdef public scope_type
+    cdef public str scope_type
     cdef public scope_node
-    cdef visit_scope(self, node, scope_type)
+    cdef _visit_scope(self, node, scope_type: str)
 
 cdef class EnvTransform(CythonTransform):
     cdef public list env_stack

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -368,6 +368,11 @@ class ScopeTrackingTransform(CythonTransform):
     #scope_type: can be either of 'module', 'function', 'cclass', 'pyclass', 'struct'
     #scope_node: the node that owns the current scope
 
+    def __init__(self, context):
+        super().__init__(context)
+        self.scope_type = 'module'
+        self.scope_node = None
+
     def visit_ModuleNode(self, node):
         self.scope_type = 'module'
         self.scope_node = node

--- a/Cython/Compiler/Visitor.py
+++ b/Cython/Compiler/Visitor.py
@@ -373,31 +373,29 @@ class ScopeTrackingTransform(CythonTransform):
         self.scope_type = 'module'
         self.scope_node = None
 
-    def visit_ModuleNode(self, node):
-        self.scope_type = 'module'
-        self.scope_node = node
-        self._process_children(node)
-        return node
-
-    def visit_scope(self, node, scope_type):
-        prev = self.scope_type, self.scope_node
+    @cython.final
+    def _visit_scope(self, node, scope_type):
+        outer_scope_type, outer_scope_node = self.scope_type, self.scope_node
         self.scope_type = scope_type
         self.scope_node = node
         self._process_children(node)
-        self.scope_type, self.scope_node = prev
+        self.scope_type, self.scope_node = outer_scope_type, outer_scope_node
         return node
 
+    def visit_ModuleNode(self, node):
+        return self._visit_scope(node, 'module')
+
     def visit_CClassDefNode(self, node):
-        return self.visit_scope(node, 'cclass')
+        return self._visit_scope(node, 'cclass')
 
     def visit_PyClassDefNode(self, node):
-        return self.visit_scope(node, 'pyclass')
+        return self._visit_scope(node, 'pyclass')
 
     def visit_FuncDefNode(self, node):
-        return self.visit_scope(node, 'function')
+        return self._visit_scope(node, 'function')
 
     def visit_CStructOrUnionDefNode(self, node):
-        return self.visit_scope(node, 'struct')
+        return self._visit_scope(node, 'struct')
 
 
 class EnvTransform(CythonTransform):

--- a/tests/run/test_named_expressions.py
+++ b/tests/run/test_named_expressions.py
@@ -78,11 +78,7 @@ class NamedExpressionInvalidTest(TimedTest):
         def check_syntax(code, gl=None, loc=None):
             assert not gl, gl
             assert not loc, loc
-            if '[' in code:
-                # Comprehensions fail with scope attribute error in PostParse.
-                cls._orig_exec(code, gl, loc)
-            else:
-                py_parse_code(code)
+            py_parse_code(code)
 
         cls._orig_exec = exec
         globals()['exec'] = check_syntax


### PR DESCRIPTION
There were several issues with it.
- It didn't always initialise its attributes, only when starting from a `ModuleNode`.
- Storing away the attributes inefficiently created a new tuple.
- Calls to `.visit_scope()` needlessly went through the vtable.