### PR TITLE
[Bug] Fix __Pyx_ArgsSlice_FASTCALL when CYTHON_VECTORCALL is disabled

### DIFF
--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -963,10 +963,10 @@ static CYTHON_INLINE int __Pyx_MergeKeywords(PyObject *kwdict, PyObject *source_
 
 #define __Pyx_ArgsSlice_VARARGS(args, start, stop) PyTuple_GetSlice(args, start, stop)
 
-#if CYTHON_VECTORCALL || (CYTHON_COMPILING_IN_CPYTHON && CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS)
+#if CYTHON_VECTORCALL
 #define __Pyx_ArgsSlice_FASTCALL(args, start, stop) __Pyx_PyTuple_FromArray(args + start, stop - start)
 #else
-#define __Pyx_ArgsSlice_FASTCALL(args, start, stop) PyTuple_GetSlice(args, start, stop)
+#define __Pyx_ArgsSlice_FASTCALL __Pyx_ArgsSlice_VARARGS
 #endif
 
 /////////////// fastcall ///////////////


### PR DESCRIPTION
When CYTHON_VECTORCALL is 0, the _FASTCALL argument macros alias their _VARARGS counterparts and the args parameter is a tuple, not a C array. The old '|| (CYTHON_COMPILING_IN_CPYTHON && CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS)' clause dates from when the macro took the address of __Pyx_Arg_FASTCALL(args, start) (a GET_ITEM lvalue inside the tuple); with the current 'args + start' pointer arithmetic it hands the tuple object itself to __Pyx_PyTuple_FromArray, which no longer compiles (incompatible pointer type) - any def with *args built with -DCYTHON_VECTORCALL=0 fails to build. Alias _FASTCALL to _VARARGS like every other fastcall macro.