### PR TITLE
Constant-fold assert conditions

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7365,15 +7365,21 @@ class AssertStatNode(StatNode):
             UtilityCode.load_cached("AssertionsEnabled", "Exceptions.c"))
         code.putln("#ifndef CYTHON_WITHOUT_ASSERTIONS")
         code.putln("if (unlikely(__pyx_assertions_enabled())) {")
-        code.mark_pos(self.pos)
-        self.condition.generate_evaluation_code(code)
-        code.putln(
-            "if (unlikely(!%s)) {" % self.condition.result())
+
+        if self.condition.constant_result is not False:
+            code.mark_pos(self.pos)
+            self.condition.generate_evaluation_code(code)
+            code.putln(
+                "if (unlikely(!%s)) {" % self.condition.result())
+
         self.exception.generate_execution_code(code)
-        code.putln(
-            "}")
-        self.condition.generate_disposal_code(code)
-        self.condition.free_temps(code)
+
+        if self.condition.constant_result is not False:
+            code.putln(
+                "}")
+            self.condition.generate_disposal_code(code)
+            self.condition.free_temps(code)
+
         code.putln(
             "}")
         code.putln("#else")

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -5100,6 +5100,18 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
         else:
             return Nodes.StatListNode(node.pos, stats=[])
 
+    def visit_AssertStatNode(self, node):
+        self.visitchildren(node)
+        condition = node.condition
+        if condition.has_constant_result():
+            if condition.constant_result:
+                # "assert True" => nothing to do.
+                return None
+            else:
+                # Normalise "assert falsy_value" to "assert False".
+                node.condition = self._bool_node(condition, False)
+        return node
+
     def visit_SliceIndexNode(self, node):
         self._calculate_const(node)
         # normalise start/stop values
@@ -5359,40 +5371,48 @@ class FinalOptimizePhase(Visitor.EnvTransform, Visitor.NodeRefCleanupMixin):
         self.visitchildren(node)
         last_non_unlikely_clause = None
         for i, if_clause in enumerate(node.if_clauses):
-            self._set_ifclause_branch_hint(if_clause, if_clause.body)
+            self._set_ifclause_branch_hint(if_clause, if_clause.body, 'unlikely')
             if not if_clause.branch_hint:
                 last_non_unlikely_clause = if_clause
         if node.else_clause and last_non_unlikely_clause:
             # If the 'else' clause is 'unlikely', then set the preceding 'if' clause to 'likely' to reflect that.
-            self._set_ifclause_branch_hint(last_non_unlikely_clause, node.else_clause, inverse=True)
+            self._set_ifclause_branch_hint(last_non_unlikely_clause, node.else_clause, 'likely')
         return node
 
-    def _set_ifclause_branch_hint(self, clause, statements_node, inverse=False):
+    def _set_ifclause_branch_hint(self, clause, statements_node, branch_hint: str):
         """Inject a branch hint if the if-clause unconditionally leads to a 'raise' statement.
         """
-        if not statements_node.is_terminator:
-            return
+        assert branch_hint in ('likely', 'unlikely'), branch_hint
         # Allow simple statements, but no conditions, loops, etc.
         non_branch_nodes = (
             Nodes.ExprStatNode,
             Nodes.AssignmentNode,
-            Nodes.AssertStatNode,
             Nodes.DelStatNode,
+            Nodes.PrintStatNode,
             Nodes.GlobalNode,
             Nodes.NonlocalNode,
         )
+
+        AssertStatNode: type = Nodes.AssertStatNode
+        GILStatNode: type = Nodes.GILStatNode
+        StatListNode: type = Nodes.StatListNode
+
         statements = [statements_node]
         for next_node_pos, node in enumerate(statements, 1):
-            if isinstance(node, Nodes.GILStatNode):
+            if isinstance(node, GILStatNode):
                 statements.insert(next_node_pos, node.body)
-                continue
-            if isinstance(node, Nodes.StatListNode):
+            elif isinstance(node, StatListNode):
                 statements[next_node_pos:next_node_pos] = node.stats
-                continue
-            if not isinstance(node, non_branch_nodes):
+            elif isinstance(node, AssertStatNode):
+                if node.condition.constant_result is False:
+                    # "assert False" is like unconditional "raise"
+                    clause.branch_hint = branch_hint
+                    break
+                # Assertions can succeed or be disabled, so continue here.
+            elif not isinstance(node, non_branch_nodes):
                 if next_node_pos == len(statements) and isinstance(node, (Nodes.RaiseStatNode, Nodes.ReraiseStatNode)):
                     # Anything that unconditionally raises exceptions at the end should be considered unlikely.
-                    clause.branch_hint = 'likely' if inverse else 'unlikely'
+                    clause.branch_hint = branch_hint
                 break
 
     def visit_JoinedStrNode(self, node: ExprNodes.JoinedStrNode):

--- a/tests/run/assert.pyx
+++ b/tests/run/assert.pyx
@@ -90,3 +90,55 @@ def assert_with_str_arg(a):
     AssertionError: abc
     """
     assert a, 'abc'
+
+
+@cython.test_assert_path_exists(
+    '//AssertStatNode',
+    '//IfClauseNode//AssertStatNode',
+    '//AssertStatNode//RaiseStatNode',
+    '//AssertStatNode[@condition.constant_result = False]',
+)
+@cython.test_fail_if_path_exists(
+    '//AssertStatNode[@condition.constant_result = True]',  # eliminated
+    '//AssertStatNode[@condition.constant_result = 1]',  # eliminated
+    '//AssertStatNode[@condition.constant_result = ""]',  # normalised
+)
+def assert_const(case: str):
+    """
+    >>> assert_const("False")
+    Traceback (most recent call last):
+    AssertionError: hi
+    >>> assert_const("0")
+    Traceback (most recent call last):
+    AssertionError: hi
+    >>> assert_const("")
+    Traceback (most recent call last):
+    AssertionError: hi
+    >>> assert_const("[]")
+    Traceback (most recent call last):
+    AssertionError: hi
+
+    >>> assert_const("True")
+    >>> assert_const("1")
+    >>> assert_const("str")
+    >>> assert_const("[1]")
+    """
+    if case == "False":
+        assert False, "hi"
+    elif case == "0":
+        assert 0, "hi"
+    elif case == "":
+        assert "", "hi"
+    elif case == "[]":
+        assert [], "hi"
+
+    elif case == "True":
+        assert True, "ho"
+    elif case == "1":
+        assert 1, "ho"
+    elif case == "str":
+        assert "str", "ho"
+    elif case == "[1]":
+        assert [1], "ho"
+    else:
+        print("WRONG TEST")


### PR DESCRIPTION
- Discard "assert True".
- Avoid generating the useless C condition for "assert False".
- Mark if-clauses that lead to "assert False" as "unlikely".