### PR TITLE
[3.2.x] [Bug] Fix __Pyx_ArgsSlice_FASTCALL when CYTHON_VECTORCALL is disabled

### DIFF
--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -960,10 +960,10 @@ static CYTHON_INLINE int __Pyx_MergeKeywords(PyObject *kwdict, PyObject *source_
 
 #define __Pyx_ArgsSlice_VARARGS(args, start, stop) PyTuple_GetSlice(args, start, stop)
 
-#if CYTHON_METH_FASTCALL || (CYTHON_COMPILING_IN_CPYTHON && CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS)
+#if CYTHON_METH_FASTCALL
 #define __Pyx_ArgsSlice_FASTCALL(args, start, stop) __Pyx_PyTuple_FromArray(args + start, stop - start)
 #else
-#define __Pyx_ArgsSlice_FASTCALL(args, start, stop) PyTuple_GetSlice(args, start, stop)
+#define __Pyx_ArgsSlice_FASTCALL __Pyx_ArgsSlice_VARARGS
 #endif
 
 /////////////// fastcall ///////////////

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -2211,7 +2211,7 @@ static PyObject* __Pyx_PyObject_FastCall_fallback(PyObject *func, PyObject * con
 static CYTHON_INLINE vectorcallfunc __Pyx_PyVectorcall_Function(PyObject *callable) {
     PyTypeObject *tp = Py_TYPE(callable);
 
-    #if defined(__Pyx_CyFunction_USED)
+    #if defined(__Pyx_CyFunction_USED) && CYTHON_METH_FASTCALL
     if (__Pyx_CyFunction_CheckExact(callable)) {
         return __Pyx_CyFunction_func_vectorcall(callable);
     }


### PR DESCRIPTION
This was incorrectly forcing the vectorcall code on `(CYTHON_COMPILING_IN_CPYTHON && CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS)` when it should just use `CYTHON_VECTORCALL`

An extra change to guard `__Pyx_CyFunction_func_vectorcall` is needed on 3.2.x