### PR TITLE
[3.2.x] Update OS version for 3.2.x docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the versions of the tools
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
 


### PR DESCRIPTION
It looks like the old version is no-longer supported. This matches what the master branch is already set to.