### PR TITLE
Mark some internal functions as @cfunc.

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -29,7 +29,8 @@ copy_once_if_newer = cached_function(copy_file_to_dir_if_newer)
 safe_makedirs_once = cached_function(safe_makedirs)
 
 
-def _make_relative(file_paths, base=None):
+@cython.cfunc
+def _make_relative(file_paths, base=None) -> list[str]:
     if not base:
         base = os.getcwd()
     if base[-1] != os.path.sep:
@@ -158,6 +159,7 @@ distutils_settings = {
 }
 
 
+@cython.cfunc
 def _legacy_strtobool(val):
     # Used to be "distutils.util.strtobool", adapted for deprecation warnings.
     if val == "True":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -79,7 +79,8 @@ class NotConstant:
 not_a_constant = NotConstant()
 constant_value_not_set = object()
 
-def _type_to_itself(tp):
+@cython.cfunc
+def _type_to_itself(tp) -> tuple:
     return tp, tp
 
 # error messages when coercing from key[0] to key[1]
@@ -1740,6 +1741,7 @@ class FloatNode(ConstNode):
             self.result_code = c_value
 
 
+@cython.cfunc
 def _analyse_name_as_type(name, pos, env):
     ctype = PyrexTypes.parse_basic_type(name)
     if ctype is not None and env.in_c_type_context:

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -4348,7 +4348,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 # cimport/export code for functions and pointers.
 
 @cython.cfunc
-def _deduplicate_inout_signatures(item_tuples) -> tuple[list[str], tuple[str], tuple[str]]:
+def _deduplicate_inout_signatures(item_tuples) -> tuple[list[str], tuple[str, ...], tuple[str, ...]]:
     # We can save runtime space for identical signatures by reusing the same C strings.
     # To deduplicate the signatures, we sort by them and store duplicates as empty C strings.
     signatures, names, items = zip(*sorted(item_tuples))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -4347,7 +4347,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
 # cimport/export code for functions and pointers.
 
-def _deduplicate_inout_signatures(item_tuples):
+@cython.cfunc
+def _deduplicate_inout_signatures(item_tuples) -> tuple[list[str], tuple[str], tuple[str]]:
     # We can save runtime space for identical signatures by reusing the same C strings.
     # To deduplicate the signatures, we sort by them and store duplicates as empty C strings.
     signatures, names, items = zip(*sorted(item_tuples))
@@ -4363,6 +4364,7 @@ def _deduplicate_inout_signatures(item_tuples):
     return signatures, names, items
 
 
+@cython.cfunc
 def _generate_import_export_code(code: Code.CCodeWriter, pos, inout_item_tuples, per_item_func, target, pointer_decl, use_pybytes, is_import):
     signatures, names, inout_items = _deduplicate_inout_signatures(inout_item_tuples)
 
@@ -4405,6 +4407,7 @@ def _generate_import_export_code(code: Code.CCodeWriter, pos, inout_item_tuples,
     code.putln("}")  # while
 
 
+@cython.cfunc
 def _generate_export_code(code: Code.CCodeWriter, pos, exports, export_func, pointer_decl):
     """Generate function/pointer export code.
 
@@ -4429,6 +4432,7 @@ def _generate_export_code(code: Code.CCodeWriter, pos, exports, export_func, poi
     code.putln("}")
 
 
+@cython.cfunc
 def _generate_import_code(code, pos, imports, qualified_module_name, import_func, pointer_decl):
     """Generate function/pointer import code.
 

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -67,6 +67,7 @@ def filter_none_node(node):
     return node
 
 
+@cython.cfunc
 def _unpack_union_type_nodes(union_type_nodes: list):
     # Unpack 'int | float | None' etc.
     BitwiseOrNode = ExprNodes.BitwiseOrNode
@@ -137,14 +138,16 @@ class _YieldNodeCollector(Visitor.TreeVisitor):
         pass
 
 
-def _find_single_yield_expression(node):
+@cython.cfunc
+def _find_single_yield_expression(node) -> tuple:
     yield_statements = _find_yield_statements(node)
     if len(yield_statements) != 1:
         return None, None
     return yield_statements[0]
 
 
-def _find_yield_statements(node):
+@cython.cfunc
+def _find_yield_statements(node) -> list[tuple]:
     collector = _YieldNodeCollector()
     collector.visitchildren(node)
     try:


### PR DESCRIPTION
Reduce code, enable direct calls and optimisations.