### PR TITLE
doc: Remove instructions for building gdb with Python 2

### DIFF
--- a/docs/src/userguide/debugging.rst
+++ b/docs/src/userguide/debugging.rst
@@ -8,18 +8,7 @@ Debugging your Cython program
 
 Cython comes with an extension for the GNU Debugger that helps users debug
 Cython code. To use this functionality, you will need to install gdb 7.2 or
-higher, built with Python support (linked to Python 2.6 or higher).
-The debugger supports debuggees with versions 2.6 and higher. For Python 3,
-code should be built with Python 3 and the debugger should be run with
-Python 2 (or at least it should be able to find the Python 2 Cython
-installation). Note that in recent versions of Ubuntu, for instance, ``gdb``
-installed with ``apt-get`` is configured with Python 3. On such systems, the
-proper configuration of ``gdb`` can be obtained by downloading the ``gdb``
-source, and then running::
-
-    ./configure --with-python=python2
-    make
-    sudo make install
+higher, built with Python 3 support.
 
 Installing the Cython debugger can be quite tricky. `This installation script and example code <https://gitlab.com/volkerweissmann/cygdb_installation>`_ might be useful.
 


### PR DESCRIPTION
Cygdb requires Python 3 now. I followed the instructions to build gdb with Python 2, but Cygdb doesn't work with it:
```
/home/sanotehu/.local/share/virtualenv/renovel/lib/python3.12/site-packages/Cython/Debugger/Cygdb.py:143: UserWarning: Using deprecated positional parameter to find build directory. Use "--build-dir module/build" argument instead.
  warnings.warn(f'Using deprecated positional parameter to find build directory. Use "--build-dir {path_to_debug_info}" argument instead.')
Traceback (most recent call last):
  File "/usr/local/share/gdb/python/gdb/__init__.py", line 182, in _auto_load_packages
    __import__(modname)
  File "/usr/local/share/gdb/python/gdb/command/missing_files.py", line 268, in <module>
    register_missing_file_handler_commands()
  File "/usr/local/share/gdb/python/gdb/command/missing_files.py", line 263, in register_missing_file_handler_commands
    InfoMissingFileHandlers(handler_type)
  File "/usr/local/share/gdb/python/gdb/command/missing_files.py", line 95, in __init__
    super().__init__(
TypeError: super() takes at least 1 argument (0 given)

GNU gdb (GDB) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from python...
(No debugging symbols found in python)
gdb command file: Activating virtualenv: /home/sanotehu/.local/share/virtualenv/renovel; path_to_activate_this_py: /home/sanotehu/.local/share/virtualenv/renovel/bin/activate_this.py
There was an error in Python code originating from the file /home/sanotehu/.local/share/virtualenv/renovel/lib/python3.12/site-packages/Cython/Debugger/Cygdb.py
--Type <RET> for more, q to quit, c to continue without paging--
It used the Python interpreter /usr/local/bin/python
Traceback (most recent call last):
  File "<string>", line 12, in <module>
  File "<string>", line 19
    raise AssertionError(msg) from exc
                                 ^
SyntaxError: invalid syntax
```

So this PR removes the instructions to build gdb with Python 2.