### PR TITLE
Fix "plain" return from prange loop

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -10125,6 +10125,7 @@ class ParallelStatNode(StatNode, ParallelNode):
 
         self.any_label_used = False
         self.breaking_label_used = False
+        self.return_label_used = False
         self.error_label_used = False
 
         self.parallel_private_temps = []
@@ -10136,6 +10137,8 @@ class ParallelStatNode(StatNode, ParallelNode):
             if code.label_used(label):
                 self.breaking_label_used = (self.breaking_label_used or
                                             label != code.continue_label)
+                self.return_label_used = (self.return_label_used or
+                                            label == code.return_label)
                 self.any_label_used = True
 
         if self.any_label_used:
@@ -10675,7 +10678,10 @@ class ParallelRangeNode(ParallelStatNode):
             code.end_block()  # end else block
 
         # ------ cleanup ------
-        self.end_parallel_control_flow_block(code)  # end parallel control flow block
+        self.end_parallel_control_flow_block(
+            code,
+            return_=self.return_label_used
+        )  # end parallel control flow block
 
         # And finally, release our privates and write back any closure
         # variables

--- a/tests/run/sequential_parallel.pyx
+++ b/tests/run/sequential_parallel.pyx
@@ -477,6 +477,20 @@ def test_return():
     """
     print parallel_return()
 
+cdef int plain_parallel_return() noexcept nogil:
+    cdef int i
+
+    for i in prange(10):
+        if i == 8:
+            return i
+
+def test_plain_return():
+    """
+    >>> test_plain_return()
+    8
+    """
+    return plain_parallel_return()
+
 def test_parallel_exceptions():
     """
     >>> test_parallel_exceptions()


### PR DESCRIPTION
The `else` case (which is what we tested) worked because we checked the loop exit mode to see if we should enter the "else" block. However, without the `else` we didn't check for early exits from the loop, and so didn't follow a "proper" return value and thus overwrote the return value with a default return value.

Fixes #7587