### PR TITLE
Allow temps in the PyInit sub-functions

### DIFF
--- a/Cython/Compiler/Code.pxd
+++ b/Cython/Compiler/Code.pxd
@@ -56,6 +56,7 @@ cdef class FunctionState:
     cdef public bint can_trace
     cdef public bint gil_owned
 
+    cdef CCodeWriter temp_decl_writer
     cdef list[tuple] temps_allocated
     cdef dict[tuple, tuple] temps_free
     cdef dict[object, tuple] temps_used_type

--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -988,6 +988,7 @@ class FunctionState:
         self.can_trace = False
         self.gil_owned = True
 
+        self.temp_decl_writer = None  # if set, insertion point for temp declarations
         self.temps_allocated = []  # of (name, type, manage_ref, static)
         self.temps_free = {}  # (type, manage_ref) -> list of free vars with same type/managed status
         self.temps_used_type = {}  # name -> (type, manage_ref)
@@ -2660,6 +2661,8 @@ class CCodeWriter:
     def exit_cfunc_scope(self):
         if self.funcstate is None:
             return
+        if self.funcstate.temp_decl_writer:
+            self.funcstate.temp_decl_writer.put_temp_declarations(self.funcstate)
         self.funcstate.validate_exit()
         self.funcstate = None
 
@@ -2675,6 +2678,7 @@ class CCodeWriter:
         self.putln(f"static {signature} {{")
         if refnanny:
             self.put_declare_refcount_context()
+        self.funcstate.temp_decl_writer = self.insertion_point()
 
     def start_slotfunc(self, class_scope, return_type, c_slot_name, args_signature,
                        needs_funcstate=True, needs_prototype=False,

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1026,10 +1026,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             code.putln('static PyObject *%s;' % Naming.preimport_cname)
         code.putln('#endif')
 
-        code.putln('static int %s;' % Naming.lineno_cname)
-        code.putln('static int %s = 0;' % Naming.clineno_cname)
         code.putln('static const char * const %s = %s;' % (Naming.cfilenm_cname, Naming.file_c_macro))
-        code.putln('static const char *%s;' % Naming.filename_cname)
 
         env.use_utility_code(UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c"))
         env.use_utility_code(UtilityCode.load("GetRuntimeVersion", "ModuleSetupCode.c"))

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3641,7 +3641,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                 assert re.match("^[a-zA-Z0-9_]+$", cname)
                 self.cfunc_name = "__Pyx_modinit_%s" % cname
                 self.description = code_type
-                self.tempdecl_code = None
                 self.call_code = None
 
             def set_call_code(self, code):

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3658,7 +3658,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                     f"int {self.cfunc_name}({Naming.modulestatetype_cname} *{Naming.modulestatevalue_cname})",
                     scope, refnanny=True)
                 code.putln(f"CYTHON_UNUSED_VAR({Naming.modulestatevalue_cname});")
-                self.tempdecl_code = code.insertion_point()
                 code.put_setup_refcount_context(EncodedString(self.cfunc_name))
                 # Leave a grepable marker that makes it easy to find the generator source.
                 code.putln("/*--- %s ---*/" % self.description)
@@ -3667,15 +3666,12 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             def __exit__(self, exc_type, exc_value, exc_tb):
                 if exc_type is not None:
                     # Don't generate any code or do any validations on errors.
-                    self.tempdecl_code = self.call_code = None
+                    self.call_code = None
                     return
 
                 code = function_code
                 code.put_finish_refcount_context()
                 code.putln("return 0;")
-
-                self.tempdecl_code.put_temp_declarations(code.funcstate)
-                self.tempdecl_code = None
 
                 needs_error_handling = code.label_used(code.error_label)
                 if needs_error_handling:

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -7255,7 +7255,7 @@ class RaiseStatNode(StatNode):
             return
         elif self.builtin_exc_name == 'StopIteration' and not self.exc_type:
             code.putln('%s = 1;' % Naming.error_without_exception_cname)
-            code.putln('%s;' % code.error_goto(None))
+            code.putln(code.error_goto(self.pos))
             code.funcstate.error_without_exception = True
             return
 


### PR DESCRIPTION
Ties a declaration code writer to the `FuncState` that is created for the init sub-functions and uses it to inject the temp variable declarations when ending the function generation.