### PR TITLE
Try to fix errors on windows in shared utility tests

### DIFF
--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -26,17 +26,20 @@ PYTHON -c "import pkg1.pkg11.feature_extensiontypes as ext; assert hasattr(ext.E
 ######## delete_generated_files.py ########
 
 import os
+import shutil
 from pathlib import Path
 
-ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
-for directory, _, files in os.walk(os.getcwd()):
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd", ".obj", ".exp", ".lib"}
+for directory, _, files in os.walk(os.getcwd(), topdown=False):
     path = Path(directory)
     for filename in files:
         file = path / filename
         if file.suffix.lower() in ext_to_delete:
             print(f"Deleting {file}")
             file.unlink()
-
+    if path.name == "build":
+        print(f"Removing directory {directory}")
+        shutil.rmtree(directory, ignore_errors=True)
 
 ######## setup_with_sources.py ########
 


### PR DESCRIPTION
This is an attempt to fix the intermittent

```
LINK : fatal error LNK1158: cannot run 'rc.exe'
```

that sometimes happens on Windows. It isn't well-tested (because I haven't managed to reproduce the issue locally). My theory is that it's to do with files not being cleaned up correctly between the steps. Therefore, I removed some Windows-specific file names, and also the entire build directory.

Not at all sure it's going to work, but I think it's worth a try.