### PR TITLE
Fix bare except clauses in Build/Dependencies.py and Build/Tests/TestInline.py

### DIFF
--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 
 try:
     import pythran
-except:
+except ImportError:
     pythran = None
 
 from .. import Utils
@@ -1189,7 +1189,7 @@ if os.environ.get('XML_RESULTS'):
             try:
                 try:
                     func(*args)
-                except:
+                except Exception:
                     success = False
             finally:
                 t = time.time() - t

--- a/Cython/Build/Tests/TestInline.py
+++ b/Cython/Build/Tests/TestInline.py
@@ -8,7 +8,7 @@ from Cython.TestUtils import CythonTest, TimedTest
 try:
     import numpy
     has_numpy = True
-except:
+except ImportError:
     has_numpy = False
 
 test_kwds = dict(force=True, quiet=True)


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types.

**Changes:**
- `Cython/Build/Dependencies.py`: `except ImportError:` for `import pythran` guard; `except Exception:` for `func(*args)` error tracking
- `Cython/Build/Tests/TestInline.py`: `except ImportError:` for `import numpy` guard

Bare `except:` catches `BaseException` (including `KeyboardInterrupt`, `SystemExit`). Using specific types makes intent explicit and avoids swallowing signals.