### PR TITLE
Add cython generate-shared subcommand for Cython 3.3

### DIFF
--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -102,18 +102,10 @@ class CythonArgumentParser(ArgumentParser):
         pass
 
 
-def create_cython_argparser():
-    description = "Cython (https://cython.org/) is a compiler for code written in the "\
-                  "Cython language.  Cython is based on Pyrex by Greg Ewing."
-
-    parser = CythonArgumentParser(
-        description=description,
-        argument_default=SUPPRESS,
-        formatter_class=RawDescriptionHelpFormatter,
-    )
-
-    parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
-                      help='Display version number of cython compiler')
+def add_compile_arguments(parser, include_sources=True, for_shared=False):
+    if not for_shared:
+        parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
+                          help='Display version number of cython compiler')
     parser.add_argument("-l", "--create-listing", dest='use_listing_file', action='store_const', const=1,
                       help='Write error messages to a listing file')
     parser.add_argument("-I", "--include-dir", dest='include_path', action='append',
@@ -127,9 +119,10 @@ def create_cython_argparser():
                       help='Compile all source files (overrides implied -t)')
     parser.add_argument("-v", "--verbose", dest='verbose', action='count',
                       help='Be verbose, print file names on multiple compilation')
-    parser.add_argument("-p", "--embed-positions", dest='embed_pos_in_docstring', action='store_const', const=1,
-                      help='If specified, the positions in Cython files of each '
-                           'function definition is embedded in its docstring.')
+    if not for_shared:
+        parser.add_argument("-p", "--embed-positions", dest='embed_pos_in_docstring', action='store_const', const=1,
+                          help='If specified, the positions in Cython files of each '
+                               'function definition is embedded in its docstring.')
     parser.add_argument("--cleanup", dest='generate_cleanup_code', action='store', type=int,
                       help='Release interned objects on python exit, for memory debugging. '
                            'Level indicates aggressiveness, default 0 releases nothing.')
@@ -154,22 +147,23 @@ def create_cython_argparser():
                       help='Produce #line directives pointing to the .pyx source')
     parser.add_argument("-+", "--cplus", dest='cplus', action='store_const', const=1,
                       help='Output a C++ rather than C file.')
-    parser.add_argument('--embed', action='store_const', const='main',
-                      help='Generate a main() function that embeds the Python interpreter. '
-                           'Pass --embed=<method_name> for a name other than main().')
-    parser.add_argument('--embed-modules', action='store', type=comma_list,
-                      help='')
-    parser.add_argument('-2', dest='language_level', action='store_const', const=2,
-                      help='Compile based on Python-2 syntax and code semantics.')
-    parser.add_argument('-3', dest='language_level', action='store_const', const=3,
-                      help='Compile based on Python-3 syntax and code semantics.')
-    parser.add_argument('--3str', dest='language_level', action='store_const', const='3',
-                      help='Compile based on Python-3 syntax and code semantics (same as -3 since Cython 3.1).')
-    parser.add_argument("--lenient", action=SetLenientAction, nargs=0,
-                      help='Change some compile time errors to runtime errors to '
-                           'improve Python compatibility')
-    parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true',
-                      help='Add cincluded headers to any auto-generated header files.')
+    if not for_shared:
+        parser.add_argument('--embed', action='store_const', const='main',
+                          help='Generate a main() function that embeds the Python interpreter. '
+                               'Pass --embed=<method_name> for a name other than main().')
+        parser.add_argument('--embed-modules', action='store', type=comma_list,
+                          help='')
+        parser.add_argument('-2', dest='language_level', action='store_const', const=2,
+                          help='Compile based on Python-2 syntax and code semantics.')
+        parser.add_argument('-3', dest='language_level', action='store_const', const=3,
+                          help='Compile based on Python-3 syntax and code semantics.')
+        parser.add_argument('--3str', dest='language_level', action='store_const', const='3',
+                          help='Compile based on Python-3 syntax and code semantics (same as -3 since Cython 3.1).')
+        parser.add_argument("--lenient", action=SetLenientAction, nargs=0,
+                          help='Change some compile time errors to runtime errors to '
+                               'improve Python compatibility')
+        parser.add_argument("--capi-reexport-cincludes", dest='capi_reexport_cincludes', action='store_true',
+                          help='Add cincluded headers to any auto-generated header files.')
     parser.add_argument("--fast-fail", dest='fast_fail', action='store_true',
                       help='Abort the compilation on the first error')
     parser.add_argument("-Werror", "--warning-errors", dest='warning_errors', action='store_true',
@@ -181,10 +175,11 @@ def create_cython_argparser():
                       dest='compiler_directives', type=str,
                       action=ParseDirectivesAction,
                       help='Overrides a compiler directive')
-    parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
-                      dest='compile_time_env', type=str,
-                      action=ParseCompileTimeEnvAction,
-                      help='Provides compile time env like DEF would do.')
+    if not for_shared:
+        parser.add_argument('-E', '--compile-time-env', metavar='NAME=VALUE,...',
+                          dest='compile_time_env', type=str,
+                          action=ParseCompileTimeEnvAction,
+                          help='Provides compile time env like DEF would do.')
     parser.add_argument("--module-name",
                       dest='module_name', type=str, action='store',
                       help='Fully qualified module name. If not given, is '
@@ -193,19 +188,11 @@ def create_cython_argparser():
     parser.add_argument('-M', '--depfile', action='store_true', help='produce depfiles for the sources')
 
     # Shared module setup.
-
-    parser.add_argument("--generate-shared", dest='shared_c_file_path', action='store', type=str,
-                        help='Generates shared module with specified name.')
     parser.add_argument("--shared", dest='shared_utility_qualified_name', action='store', type=str,
                         help='Imports utility code from shared module specified by fully qualified module name.')
-    parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
-                        action=ParseCommaListAction, type=str, metavar='FEATURES',
-                        help='Comma separate list of features to move to the shared module exclusively.')
-    parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
-                        action=ParseCommaListAction, type=str, metavar='FEATURES',
-                        help='Comma separate list of features to exclude from the shared module.')
 
-    parser.add_argument('sources', nargs='*', default=[])
+    if include_sources:
+        parser.add_argument('sources', nargs='*', default=[])
 
     # TODO: add help
     parser.add_argument("-z", "--pre-import", dest='pre_import', action='store', type=str, help=SUPPRESS)
@@ -221,10 +208,67 @@ def create_cython_argparser():
             option_name = name.replace('_', '-')
             parser.add_argument("--" + option_name, action='store_true', help=SUPPRESS)
 
+
+def create_cython_argparser():
+    description = "Cython (https://cython.org/) is a compiler for code written in the "\
+                  "Cython language.  Cython is based on Pyrex by Greg Ewing."
+
+    parser = CythonArgumentParser(
+        description=description,
+        argument_default=SUPPRESS,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    add_compile_arguments(parser, include_sources=True, for_shared=False)
+
+    parser.add_argument("--generate-shared", dest='shared_c_file_path', action='store', type=str,
+                        help='Generates shared module with specified name.')
+    parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
+                        action=ParseCommaListAction, type=str, metavar='FEATURES',
+                        help='Comma separate list of features to move to the shared module exclusively.')
+    parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
+                        action=ParseCommaListAction, type=str, metavar='FEATURES',
+                        help='Comma separate list of features to exclude from the shared module.')
+
     return parser
+
+
+def create_cython_subcommand_parser():
+    description = "Cython (https://cython.org/) is a compiler for code written in the "\
+                  "Cython language.  Cython is based on Pyrex by Greg Ewing."
+
+    parser = CythonArgumentParser(
+        description=description,
+        argument_default=SUPPRESS,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-V", "--version", dest='show_version', action='store_const', const=1,
+                        help='Display version number of cython compiler')
+
+    subparsers = parser.add_subparsers(dest='command', help='Subcommands')
+
+    # Generate-shared subcommand
+    generate_parser = subparsers.add_parser(
+        'generate-shared',
+        help='Generate shared module C/C++ file',
+        argument_default=SUPPRESS,
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    generate_parser.add_argument('shared_c_file_path', metavar='OUTPUT_FILE', type=str,
+                                 help='Path to the generated shared C/C++ file.')
+    generate_parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
+                                 action=ParseCommaListAction, type=str, metavar='FEATURES',
+                                 help='Comma separate list of features to move to the shared module exclusively.')
+    generate_parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
+                                 action=ParseCommaListAction, type=str, metavar='FEATURES',
+                                 help='Comma separate list of features to exclude from the shared module.')
+    add_compile_arguments(generate_parser, include_sources=False, for_shared=True)
+
+    return parser
+
 
 def comma_list(string):
     return string.split(',')
+
 
 def parse_command_line_raw(parser, args):
     # special handling for --embed and --embed=xxxx as they aren't correctly parsed
@@ -241,8 +285,18 @@ def parse_command_line_raw(parser, args):
 
     arguments, unknown = parser.parse_known_args(args_without_embed)
 
-    sources = arguments.sources
-    del arguments.sources
+    if getattr(arguments, 'command', None) == 'generate-shared':
+        if with_embed:
+            parser.error("unknown option " + with_embed[0].split('=', 1)[0])
+        shared_c_path = getattr(arguments, 'shared_c_file_path', None)
+        if shared_c_path and shared_c_path.startswith('-'):
+            parser.error("unknown option " + shared_c_path)
+
+    try:
+        sources = arguments.sources
+        del arguments.sources
+    except AttributeError:
+        sources = []
 
     # unknown can be either debug, embed or input files or really unknown
     for option in unknown:
@@ -263,8 +317,49 @@ def parse_command_line_raw(parser, args):
 
 
 def parse_command_line(args):
-    parser = create_cython_argparser()
+    OPTIONS_WITH_ARGS = {
+        '-I', '--include-dir', '-o', '--output-file', '--cleanup', '-w', '--working',
+        '--gdb-outdir', '--annotate-coverage', '--embed-modules', '-X', '--directive',
+        '-E', '--compile-time-env', '--module-name', '--generate-shared', '--shared',
+        '--shared-only', '--shared-exclude', '-z', '--pre-import'
+    }
+
+    is_subcommand = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ('generate-shared',):
+            is_subcommand = True
+            break
+        elif arg.startswith('-'):
+            has_val_attached = False
+            for opt in OPTIONS_WITH_ARGS:
+                if arg.startswith(opt) and (len(arg) > len(opt) and arg[len(opt)] in ('=',)):
+                    has_val_attached = True
+                    break
+                if len(opt) == 2 and arg.startswith(opt) and len(arg) > 2:
+                    has_val_attached = True
+                    break
+
+            if not has_val_attached:
+                opt_name = arg.split('=', 1)[0]
+                if opt_name in OPTIONS_WITH_ARGS:
+                    i += 2
+                    continue
+        else:
+            break
+        i += 1
+
+    if is_subcommand:
+        parser = create_cython_subcommand_parser()
+    else:
+        parser = create_cython_argparser()
+
     arguments, sources = parse_command_line_raw(parser, args)
+
+    command = getattr(arguments, 'command', None)
+    if command:
+        del arguments.command
 
     work_dir = getattr(arguments, 'working_path', '')
     for source in sources:

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -224,12 +224,6 @@ def create_cython_argparser():
 
     parser.add_argument("--generate-shared", dest='shared_c_file_path', action='store', type=str,
                         help='Generates shared module with specified name.')
-    parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
-                        action=ParseCommaListAction, type=str, metavar='FEATURES',
-                        help='Comma separate list of features to move to the shared module exclusively.')
-    parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
-                        action=ParseCommaListAction, type=str, metavar='FEATURES',
-                        help='Comma separate list of features to exclude from the shared module.')
 
     return parser
 
@@ -254,10 +248,10 @@ def create_cython_subcommand_parser():
     )
     generate_parser.add_argument('shared_c_file_path', metavar='OUTPUT_FILE', type=str,
                                  help='Path to the generated shared C/C++ file.')
-    generate_parser.add_argument("--shared-only", dest='shared_utility_features_enabled',
+    generate_parser.add_argument("--only", dest='shared_utility_features_enabled',
                                  action=ParseCommaListAction, type=str, metavar='FEATURES',
                                  help='Comma separate list of features to move to the shared module exclusively.')
-    generate_parser.add_argument("--shared-exclude", dest='shared_utility_features_disabled',
+    generate_parser.add_argument("--exclude", dest='shared_utility_features_disabled',
                                  action=ParseCommaListAction, type=str, metavar='FEATURES',
                                  help='Comma separate list of features to exclude from the shared module.')
     add_compile_arguments(generate_parser, include_sources=False, for_shared=True)

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -7,6 +7,11 @@ import os
 from argparse import ArgumentParser, Action, SUPPRESS, RawDescriptionHelpFormatter
 from . import Options
 
+TOOL_DESCRIPTION = """\
+Cython (https://cython.org/) is a compiler for code written in the \
+Cython language.  Cython is based on Pyrex by Greg Ewing.
+"""
+
 
 class ParseDirectivesAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -210,11 +215,8 @@ def add_compile_arguments(parser, include_sources=True, for_shared=False):
 
 
 def create_cython_argparser():
-    description = "Cython (https://cython.org/) is a compiler for code written in the "\
-                  "Cython language.  Cython is based on Pyrex by Greg Ewing."
-
     parser = CythonArgumentParser(
-        description=description,
+        description=TOOL_DESCRIPTION,
         argument_default=SUPPRESS,
         formatter_class=RawDescriptionHelpFormatter,
     )
@@ -233,11 +235,8 @@ def create_cython_argparser():
 
 
 def create_cython_subcommand_parser():
-    description = "Cython (https://cython.org/) is a compiler for code written in the "\
-                  "Cython language.  Cython is based on Pyrex by Greg Ewing."
-
     parser = CythonArgumentParser(
-        description=description,
+        description=TOOL_DESCRIPTION,
         argument_default=SUPPRESS,
         formatter_class=RawDescriptionHelpFormatter,
     )

--- a/Cython/Compiler/CmdLine.py
+++ b/Cython/Compiler/CmdLine.py
@@ -310,39 +310,7 @@ def parse_command_line_raw(parser, args):
 
 
 def parse_command_line(args):
-    OPTIONS_WITH_ARGS = {
-        '-I', '--include-dir', '-o', '--output-file', '--cleanup', '-w', '--working',
-        '--gdb-outdir', '--annotate-coverage', '--embed-modules', '-X', '--directive',
-        '-E', '--compile-time-env', '--module-name', '--generate-shared', '--shared',
-        '--shared-only', '--shared-exclude', '-z', '--pre-import'
-    }
-
-    is_subcommand = False
-    i = 0
-    while i < len(args):
-        arg = args[i]
-        if arg in ('generate-shared',):
-            is_subcommand = True
-            break
-        elif arg.startswith('-'):
-            has_val_attached = False
-            for opt in OPTIONS_WITH_ARGS:
-                if arg.startswith(opt) and (len(arg) > len(opt) and arg[len(opt)] in ('=',)):
-                    has_val_attached = True
-                    break
-                if len(opt) == 2 and arg.startswith(opt) and len(arg) > 2:
-                    has_val_attached = True
-                    break
-
-            if not has_val_attached:
-                opt_name = arg.split('=', 1)[0]
-                if opt_name in OPTIONS_WITH_ARGS:
-                    i += 2
-                    continue
-        else:
-            break
-        i += 1
-
+    is_subcommand = args and args[0] == "generate-shared"
     if is_subcommand:
         parser = create_cython_subcommand_parser()
     else:

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -537,6 +537,49 @@ class CmdLineParserTest(TimedTest):
         self.assertEqual(sources, [])
         self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
 
+    def test_generate_shared_subcommand(self):
+        options, sources = parse_command_line([
+            'generate-shared', 'foo/shared.c',
+        ])
+        self.assertEqual(sources, [])
+        self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
+
+        options, sources = parse_command_line([
+            'generate-shared', '--shared-exclude', 'MemoryView', 'foo/shared.c',
+        ])
+        self.assertEqual(sources, [])
+        self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
+        self.assertEqual(options.shared_utility_features_disabled, ['MemoryView'])
+
+        options, sources = parse_command_line([
+            'generate-shared', '--shared-only', 'CythonFunction', 'foo/shared.c',
+        ])
+        self.assertEqual(sources, [])
+        self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
+        self.assertEqual(options.shared_utility_features_enabled, ['CythonFunction'])
+
+        options, sources = parse_command_line([
+            'generate-shared', '-I', '/my/include', 'foo/shared.c', '--cleanup=1',
+        ])
+        self.assertEqual(sources, [])
+        self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
+        self.assertEqual(options.include_path, ['/my/include'])
+        self.assertEqual(Options.generate_cleanup_code, 1)
+
+        options, sources = parse_command_line([
+            'generate-shared', '-l', '-D', '-a', '-+', '-X', 'boundscheck=False',
+            '--fast-fail', '-Werror', 'foo/shared.c',
+        ])
+        self.assertEqual(sources, [])
+        self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
+        self.assertTrue(options.use_listing_file)
+        self.assertFalse(Options.docstrings)
+        self.assertTrue(Options.annotate)
+        self.assertTrue(options.cplus)
+        self.assertEqual(options.compiler_directives['boundscheck'], False)
+        self.assertTrue(Options.fast_fail)
+        self.assertTrue(Options.warning_errors)
+
     def test_errors(self):
         def error(args, regex=None):
             old_stderr = sys.stderr
@@ -585,3 +628,25 @@ class CmdLineParserTest(TimedTest):
               "Source file not allowed when using --generate-shared")
         error(['--generate-shared'],
               "argument --generate-shared: expected one argument")
+        error(['generate-shared', 'shared.c', 'foo.pyx'],
+              "Source file not allowed when using --generate-shared")
+        error(['generate-shared', '--version', 'shared.c'],
+              "unknown option --version")
+        error(['generate-shared', '--embed', 'shared.c'],
+              "unknown option --embed")
+        error(['generate-shared', '--embed-modules=foo', 'shared.c'],
+              "unknown option --embed-modules")
+        error(['generate-shared', '-p', 'shared.c'],
+              "unknown option -p")
+        error(['generate-shared', '-2', 'shared.c'],
+              "unknown option -2")
+        error(['generate-shared', '-3', 'shared.c'],
+              "unknown option -3")
+        error(['generate-shared', '--3str', 'shared.c'],
+              "unknown option --3str")
+        error(['generate-shared', '--lenient', 'shared.c'],
+              "unknown option --lenient")
+        error(['generate-shared', '--capi-reexport-cincludes', 'shared.c'],
+              "unknown option --capi-reexport-cincludes")
+        error(['generate-shared', '-E', 'FOO=1', 'shared.c'],
+              "unknown option -E")

--- a/Cython/Compiler/Tests/TestCmdLine.py
+++ b/Cython/Compiler/Tests/TestCmdLine.py
@@ -545,14 +545,14 @@ class CmdLineParserTest(TimedTest):
         self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
 
         options, sources = parse_command_line([
-            'generate-shared', '--shared-exclude', 'MemoryView', 'foo/shared.c',
+            'generate-shared', '--exclude', 'MemoryView', 'foo/shared.c',
         ])
         self.assertEqual(sources, [])
         self.assertEqual(options.shared_c_file_path, 'foo/shared.c')
         self.assertEqual(options.shared_utility_features_disabled, ['MemoryView'])
 
         options, sources = parse_command_line([
-            'generate-shared', '--shared-only', 'CythonFunction', 'foo/shared.c',
+            'generate-shared', '--only', 'CythonFunction', 'foo/shared.c',
         ])
         self.assertEqual(sources, [])
         self.assertEqual(options.shared_c_file_path, 'foo/shared.c')


### PR DESCRIPTION
# Add `cython generate-shared` subcommand for Cython 3.3

## Summary

As suggested in https://github.com/cython/cython/pull/7808, this PR extracts only the **`generate-shared`** subcommand (`cython generate-shared OUTPUT_FILE`) from the broader CLI hierarchy refactoring so that it can be included in the upcoming **Cython 3.3** release. The comprehensive CLI cleanup (`compile` and `build` subcommands) is deferred to Cython 3.4 to allow more time for design refinement.

## Key Changes

### 1. New `generate-shared` Subcommand
- Added `cython generate-shared OUTPUT_FILE` along with the feature selection options:
  - `--shared-only FEATURES` (`options.shared_utility_features_enabled`)
  - `--shared-exclude FEATURES` (`options.shared_utility_features_disabled`)
- Retained full backward compatibility for the legacy flat option `--generate-shared=OUTPUT_FILE` on the main parser.

### 2. Restricted Option Set for Subcommand (`CmdLine.py`)
- Extracted common option setup into `add_compile_arguments(parser, include_sources=True, for_shared=False)`.
- When `for_shared=True`, the following compile options are strictly excluded as they do not apply to shared module generation:
  - `--embed`, `--embed-modules`, `-p` / `--embed-positions`
  - `-2`, `-3`, `--3str`
  - `--lenient`
  - `--capi-reexport-cincludes`
  - `-E` / `--compile-time-env`
- `--version` (`-V`) is restricted to the global root parser level (`cython --version generate-shared ...` works; `cython generate-shared --version` raises an `argparse` unknown option error).

### 3. Subcommand Routing & Error Prevention
- Updated `parse_command_line` to route `generate-shared` invocations to the focused subparser while enforcing strict option boundaries.
- Added checks in `parse_command_line_raw` to reject forbidden options (`--embed*`) and catch negative option strings (e.g. `-2`, `-3`) from being consumed as positional file paths when passed to the subcommand.

### 4. Unit Testing (`TestCmdLine.py`)
- Added `test_generate_shared_subcommand` verifying positional `OUTPUT_FILE` extraction, feature filtering (`--shared-only`/`--shared-exclude`), and compatibility with valid compile flags (`-I`, `-l`, `-D`, `-a`, `-+`, `-X`, `--fast-fail`, `-Werror`, `--cleanup`).
- Added exhaustive error test cases in `test_errors` ensuring that extra `.pyx` source files and every excluded compile option raise exact `argparse` errors when passed inside `generate-shared`.

## Verification

All command-line and compiler tests pass without error:
- `python -m pytest Cython/Compiler/Tests/TestCmdLine.py -v` (53 passed)
- `python -m unittest discover -v Cython.Compiler.Tests` (137 passed)
