### PR TITLE
BUG(dev): fix a bug where builds would incorrectly fail when Py_LIMITED_API is set down to a release level

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -894,7 +894,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
                    "please install development version of Python.")
         code.putln("#elif PY_VERSION_HEX < 0x03090000")
         code.putln("    #error Cython requires Python 3.9+.")
-        code.putln("#elif defined(Py_LIMITED_API) && Py_LIMITED_API > (PY_VERSION_HEX & 0xFFFF0000)")
+        code.putln("#elif defined(Py_LIMITED_API) && (Py_LIMITED_API & 0xFFFF0000) > (PY_VERSION_HEX & 0xFFFF0000)")
         code.putln("    #error 'Py_LIMITED_API' can only select past Python X.Y versions, not future ones.")
         code.putln("#else")
         code.globalstate["end"].putln("#endif /* Py_PYTHON_H */")


### PR DESCRIPTION
Follow up to https://github.com/cython/cython/commit/3c2bc9c6bb37f1dfd305256fab2977246f41ee61
I maintain a couple projects where we set `Py_LIMITED_API` with almost-full accuracy (performed with `sys.hexversion & 0xFFFF00F0`), and that commit broke builds because the release level is masked, but I don't see a good reason why it should be.

for context, here are some [example logs](https://github.com/h5py/h5py/actions/runs/29717968557) where a build fails for Python 3.14.6, which is definitely not in the future.