### PR TITLE
Allow "cython.py_int" etc. for Python builtins 

### DIFF
--- a/Cython/Compiler/CythonScope.py
+++ b/Cython/Compiler/CythonScope.py
@@ -4,9 +4,20 @@ from .UtilityCode import CythonUtilityCode
 from .Errors import error
 from .Scanning import StringSourceDescriptor
 from . import MemoryView
+from . import Builtin
 from .StringEncoding import EncodedString
 
 NON_TYPE_NAMES = {'pointer', 'const', 'volatile', 'restrict', 'struct', 'union', 'enum'}
+
+PYTHON_TYPE_ALIASES = {
+    # There isn't really a good way to get at Python's C-shadowed int/float/etc. types
+    # in a C context, so we provide 'cython.py_int' for the cases when you have to.
+    'py_int': Builtin.int_type,
+    'py_float': Builtin.float_type,
+    'py_bool': Builtin.bool_type,
+    'py_complex': Builtin.complex_type,
+}
+
 
 class CythonScope(ModuleScope):
     is_cython_builtin = 1
@@ -45,6 +56,9 @@ class CythonScope(ModuleScope):
         # This function should go away when types are all first-level objects.
         if name in NON_TYPE_NAMES:
             return None
+        type = PYTHON_TYPE_ALIASES.get(name)
+        if type:
+            return type
         type = parse_basic_type(name)
         if type:
             return type

--- a/Cython/Compiler/FlowControl.pxd
+++ b/Cython/Compiler/FlowControl.pxd
@@ -11,11 +11,11 @@ cdef class ControlBlock:
     cdef readonly set bounded
 
     # Big integer bitsets
-    cdef object i_input
-    cdef object i_output
-    cdef object i_gen
-    cdef object i_kill
-    cdef object i_state
+    cdef cython.py_int i_input
+    cdef cython.py_int i_output
+    cdef cython.py_int i_gen
+    cdef cython.py_int i_kill
+    cdef cython.py_int i_state
 
     cpdef bint empty(self)
     cpdef detach(self)
@@ -27,7 +27,7 @@ cdef class ExitBlock(ControlBlock):
 cdef class NameAssignment:
     cdef public bint is_arg
     cdef public bint is_deletion
-    cdef public object bit
+    cdef public cython.py_int bit
     cdef public object inferred_type
     cdef readonly object lhs
     cdef readonly object rhs
@@ -39,8 +39,8 @@ cdef class NameAssignment:
 
 @cython.final
 cdef class AssignmentList:
-    cdef object bit
-    cdef object mask
+    cdef cython.py_int bit
+    cdef cython.py_int mask
     cdef list[NameAssignment] stats
 
 cdef class AssignmentCollector(TreeVisitor):

--- a/Cython/Shadow.py
+++ b/Cython/Shadow.py
@@ -657,6 +657,7 @@ def fused_type(*args: Any) -> Type[Any]:
 
 py_int = typedef(int, "int")
 py_long = typedef(int, "long")  # for legacy Py2 code only
+py_bool = typedef(bool, "bool")
 py_float = typedef(float, "float")
 py_complex = typedef(complex, "double complex")
 

--- a/Cython/Tests/TestShadow.py
+++ b/Cython/Tests/TestShadow.py
@@ -91,20 +91,35 @@ class TestShadow(TimedTest):
             future_directives = []
         cython_scope._context = Context
 
+        type_names = {
+            name for (_, _, name), _ in PyrexTypes.modifiers_and_name_to_type.items()
+        } | {
+            'py_bool',
+            'py_float',
+            'py_int',
+            'py_complex',
+        }
+
         missing_types = []
         missing_lookups = []
-        for (signed, longness, name), type_ in PyrexTypes.modifiers_and_name_to_type.items():
+
+        for name in type_names:
             if name == 'object':
                 continue  # This probably shouldn't be in Shadow
             if not hasattr(Shadow, name):
                 missing_types.append(name)
             if not cython_scope.lookup_type(name):
                 missing_lookups.append(name)
+
+            if name.startswith('py_'):
+                return
+
             for ptr in range(1, 4):
                 ptr_name = 'p' * ptr + '_' + name
                 if not hasattr(Shadow, ptr_name):
                     missing_types.append(ptr_name)
                 if not cython_scope.lookup_type(ptr_name):
                     missing_lookups.append(ptr_name)
+
         self.assertEqual(missing_types, [])
         self.assertEqual(missing_lookups, [])


### PR DESCRIPTION
These were already available in Shadow.py but not in the compiled `cython` namespace.
There isn't really a good way otherwise to use them in a C type context because they are shadowed by C `int`, `float`, etc.

With the recent optimisations for the Python `int` and `float` data types, there is increased interest in using them, although probably mostly in situation where users control the type (and not as input argument).