### PR TITLE
Allow `cyfunction.__annotate__` to be pickled

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -594,13 +594,26 @@ __Pyx_CyFunction_get_annotate_from_dict_if_exists(PyObject *op_in, PyObject **an
     return __Pyx_PyDict_GetItemRef(dict, PYIDENT("__annotate__"), annotate);
 }
 
+// if value==NULL, removes annotate from dict.
 static int
 __Pyx_CyFunction_set_annotate_in_dict_if_exists(PyObject *op_in, PyObject *value) {
     PyObject *dict;
     int dict_found;
     dict_found = __Pyx_CyFunction_get_dict_if_exists(op_in, &dict);
     if (!dict_found) return 0;
-    return PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
+    if (value) {
+        return PyDict_SetItem(dict, PYIDENT("__annotate__"), value);
+    } else {
+#if !CYTHON_COMPILING_IN_LIMITED_API && PY_VERSION_HEX >= 0x030d0000
+        return PyDict_Pop(dict, PYIDENT("__annotate__"), NULL);
+#else
+        int result = PyDict_Contains(dict, PYIDENT("__annotate__"));
+        if (result == 1) {
+            result = PyDict_DelItem(dict, PYIDENT("__annotate__"));
+        }
+        return result;
+#endif
+    }
 }
 
 static int
@@ -652,8 +665,11 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
 
     PyObject *format = PyLong_FromLong(1L);  // annotationlib.Format.VALUE
     if (likely(format)) {
-        result = __Pyx_PyObject_CallOneArg(annotate, format);
-        Py_DECREF(format);
+        if (!Py_EnterRecursiveCall(" cyfunction __annotations__.__get__")) {
+            result = __Pyx_PyObject_CallOneArg(annotate, format);
+            Py_LeaveRecursiveCall();
+            Py_DECREF(format);
+        }
     }
     Py_DECREF(annotate);
     if (unlikely(!result)) return NULL;
@@ -668,34 +684,27 @@ __Pyx_CyFunction_get_annotations(PyObject *op_in, void *context) {
     return result;
 }
 
-static PyObject *__Pyx_CyFunction_annotate_impl(PyObject *self,
-#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
-    PyObject *args
-#else
-    PyObject* const* args, Py_ssize_t nargs
-#endif
-) {
-    // The signature of this function is 0 or 1 args, where arg should be an int (if passed).
-    // However, for this basic placeholder implementation, we don't care and don't check it.
-    CYTHON_UNUSED_VAR(args);
-#if !CYTHON_COMPILING_IN_LIMITED_API || __PYX_LIMITED_VERSION_HEX >= 0x030A0000
-    CYTHON_UNUSED_VAR(nargs);
-#endif
+static PyObject *__Pyx_CyFunction_annotate_impl(PyObject *self, PyObject *arg) {
+    CYTHON_UNUSED_VAR(arg);
     if (unlikely(!self)) {
         PyErr_SetString(PyExc_SystemError, "cython __annotate__ called without 'self' argument");
+        return NULL;
     }
-    Py_XINCREF(self);
-    return self;
+    // Although we guard against trivial recursive calls from self.__annotate__ = self.__annotate__
+    // we can't guard against all recursive calls.
+    PyObject *result;
+    if (Py_EnterRecursiveCall(" in cyfunction annotate")) {
+        return NULL;
+    }
+    result = __Pyx_CyFunction_get_annotations(self, NULL);
+    Py_LeaveRecursiveCall();
+    return result;
 }
 
-static PyMethodDef __Pyx_CyFunction_annotate_method = {
-    "__annotate__",
-    (PyCFunction)(void (*)(void))__Pyx_CyFunction_annotate_impl,
-#if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030A0000
-    METH_VARARGS,
-#else
-    METH_FASTCALL,
-#endif
+static const PyMethodDef __Pyx_CyFunction_annotate_method = {
+    "__annotate_cython__",
+    __Pyx_CyFunction_annotate_impl,
+    METH_O,
     "Placeholder __annotate__ function to allow 'functools.wraps' to work "
     "on Cython functions."
 };
@@ -709,12 +718,9 @@ __Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
     if (unlikely(__Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in, &annotate) < 0)) return NULL;
     if (annotate) return annotate;
 
-    PyObject *annotations = __Pyx_CyFunction_get_annotations(op_in, NULL);
-    if (unlikely(!annotations)) return NULL;
     PyObject *method = PyCFunction_New(
-        &__Pyx_CyFunction_annotate_method,
-        annotations);
-    Py_DECREF(annotations);
+        (PyMethodDef*)&__Pyx_CyFunction_annotate_method,
+        op_in);
     return method;
 }
 
@@ -728,6 +734,23 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
     if (unlikely(value != Py_None && !PyCallable_Check(value))) {
         PyErr_SetString(PyExc_TypeError, "__annotate__ must be callable or None");
         return -1;
+    }
+
+    if (unlikely(__Pyx_TypeCheck(value, &PyCFunction_Type))) {
+#if CYTHON_ASSUME_SAFE_MACROS
+        PyCFunction cfunction = PyCFunction_GetFunction(value);
+        if (unlikely(!cfunction)) return -1;
+        PyObject *value_self = PyCFunction_GetSelf(value);
+        if (unlikely(!value_self && PyErr_Occurred())) return -1;
+#else
+        PyCFunction cfunction = PyCFunction_GET_FUNCTION(value);
+        PyObject *value_self = PyCFunction_GET_SELF(value);
+#endif
+        if (cfunction == __Pyx_CyFunction_annotate_impl && value_self == op_in) {
+            // We're doing self.__annotate__ == self.__annotate__ somehow.
+            // This will result in an infinite recursive call.
+            return __Pyx_CyFunction_set_annotate_in_dict_if_exists(op_in, NULL);
+        }
     }
     if (value != Py_None) {
         __pyx_CyFunctionObject *op = __Pyx_as_CyFunctionObject(op_in);
@@ -958,6 +981,7 @@ __Pyx_CyFunction_reduce(PyObject *m_in, PyObject *args)
 
 static PyMethodDef __pyx_CyFunction_methods[] = {
     {"__reduce__", (PyCFunction)__Pyx_CyFunction_reduce, METH_NOARGS, 0},
+    __Pyx_CyFunction_annotate_method,  // having __annotate_cython__ as an attribute makes it pickleable
     {0, 0, 0, 0}
 };
 

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -748,7 +748,7 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
 #endif
         if (cfunction == __Pyx_CyFunction_annotate_impl && value_self == op_in) {
             // We're doing self.__annotate__ == self.__annotate__ somehow.
-            // This will result in an infinite recursive call.
+            // Just clear it from the dictionary to avoid an infinite recursive call.
             return __Pyx_CyFunction_set_annotate_in_dict_if_exists(op_in, NULL);
         }
     }

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -737,7 +737,7 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
     }
 
     if (unlikely(__Pyx_TypeCheck(value, &PyCFunction_Type))) {
-#if CYTHON_ASSUME_SAFE_MACROS
+#if !CYTHON_ASSUME_SAFE_MACROS
         PyCFunction cfunction = PyCFunction_GetFunction(value);
         if (unlikely(!cfunction)) return -1;
         PyObject *value_self = PyCFunction_GetSelf(value);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -719,7 +719,7 @@ __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
     }
 
     if (unlikely(__Pyx_TypeCheck(value, &PyCFunction_Type))) {
-#if !CYTHON_ASSUME_SAFE_MACROS
+#if !CYTHON_ASSUME_SAFE_MACROS && !CYTHON_COMPILING_IN_PYPY
         PyCFunction cfunction = PyCFunction_GetFunction(value);
         if (unlikely(!cfunction)) return -1;
         PyObject *value_self = PyCFunction_GetSelf(value);

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -701,28 +701,10 @@ static PyObject *__Pyx_CyFunction_annotate_impl(PyObject *self, PyObject *arg) {
     return result;
 }
 
-static const PyMethodDef __Pyx_CyFunction_annotate_method = {
-    "__annotate_cython__",
-    __Pyx_CyFunction_annotate_impl,
-    METH_O,
-    "Placeholder __annotate__ function to allow 'functools.wraps' to work "
-    "on Cython functions."
-};
-
 // We don't yet support PEP649 properly, so __annotate__ is
 // implemented in a minimal way, just so that functools.wraps works.
 static PyObject *
-__Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
-    PyObject *annotate = NULL;
-    CYTHON_UNUSED_VAR(context);
-    if (unlikely(__Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in, &annotate) < 0)) return NULL;
-    if (annotate) return annotate;
-
-    PyObject *method = PyCFunction_New(
-        (PyMethodDef*)&__Pyx_CyFunction_annotate_method,
-        op_in);
-    return method;
-}
+__Pyx_CyFunction_get_annotate(PyObject *op_in, void *context);
 
 static int
 __Pyx_CyFunction_set_annotate(PyObject *op_in, PyObject* value, void *context) {
@@ -980,10 +962,30 @@ __Pyx_CyFunction_reduce(PyObject *m_in, PyObject *args)
 }
 
 static PyMethodDef __pyx_CyFunction_methods[] = {
+    // Having __annotate_cython__ as an attribute makes it pickleable.
+    // Keep it as the first element to make access easier.
+    {"__annotate_cython__", __Pyx_CyFunction_annotate_impl, METH_O,
+        "Placeholder __annotate__ function to allow 'functools.wraps' to work "
+        "on Cython functions."},
     {"__reduce__", (PyCFunction)__Pyx_CyFunction_reduce, METH_NOARGS, 0},
-    __Pyx_CyFunction_annotate_method,  // having __annotate_cython__ as an attribute makes it pickleable
     {0, 0, 0, 0}
 };
+
+// We don't yet support PEP649 properly, so __annotate__ is
+// implemented in a minimal way, just so that functools.wraps works.
+static PyObject *
+__Pyx_CyFunction_get_annotate(PyObject *op_in, void *context) {
+    PyObject *annotate = NULL;
+    CYTHON_UNUSED_VAR(context);
+    if (unlikely(__Pyx_CyFunction_get_annotate_from_dict_if_exists(op_in, &annotate) < 0)) return NULL;
+    if (annotate) return annotate;
+
+    PyObject *method = PyCFunction_New(
+        &__pyx_CyFunction_methods[0],
+        op_in);
+    return method;
+}
+
 
 
 #if CYTHON_COMPILING_IN_LIMITED_API

--- a/tests/run/cyfunction.pyx
+++ b/tests/run/cyfunction.pyx
@@ -5,7 +5,7 @@
 import platform
 cimport cython
 
-from functools import wraps
+from functools import wraps, update_wrapper
 
 def inspect_isroutine():
     """
@@ -495,8 +495,6 @@ def test_annotate():
     future.
 
     >>> f = test_annotate()
-    >>> list(f.__annotate__().keys())
-    ['a', 'b']
     >>> list(f.__annotate__(1).keys())
     ['a', 'b']
 
@@ -556,6 +554,14 @@ def test_annotate():
     >>> f.__annotations__
     {'a': 'int', 'b': 'str'}
 
+    Setting __annotate__ to itself should not cause a recursion disaster.
+    >>> f = test_annotate()
+    >>> f.__annotate__ = f.__annotate__
+    >>> list(f.__annotate__(1).keys())
+    ['a', 'b']
+    >>> f.__annotations__
+    {'a': 'int', 'b': 'str'}
+
     Setting __annotations__ should clear any assigned lazy annotation function.
     >>> f = test_annotate()
     >>> f.__annotate__ = lambda arg=0: {'different_argument': 5}
@@ -574,6 +580,31 @@ def test_annotate():
     def inner(a: int, b: str):
         pass
     return inner
+
+
+class FuncWrapper:
+    def __init__(self, function):
+        self.function = function
+        update_wrapper(self, self.function)
+
+    def __call__(self, *args, **kwds):
+        return self.function(*args, **kwds)
+
+
+def test_pickle_unpickle() -> int:
+    """
+    >>> import pickle
+    >>> unpickled = pickle.loads(pickle.dumps(test_pickle_unpickle))
+    >>> unpickled()
+    1
+
+    >>> wrapped = FuncWrapper(test_pickle_unpickle)
+    >>> unpickled = pickle.loads(pickle.dumps(wrapped))
+    >>> unpickled()
+    1
+    """
+    return 1
+
 
 
 __doc__ = """


### PR DESCRIPTION
Essentially to allow things that wrap cyfunctions to be pickled, since they will have a copy of `cyfunction.__annotate__`.

For a C method, the pickling mechanism looks up the method name on the type of the `self` argument.
This doesn't work when we use a dict as the `self` argument.

Instead I've used a `cyfunction` as the `self` argument, and created a function called `__annotate_cython__` that can be looked up.

The main notable consequence of this change is that it delays the evaluation of the annotations to when `__annotate__` is called rather than when the attribute is looked up. I think this is fine (especially since it's a cut-down implementation to make some basic functionality work). But it is a small change. It also makes it possible to set up some infinite
recursion, so I've added a little protection to that.

The alternative way of doing it would be to add an extra type for `cyfunction.__annotate__` some some custom pickling.

Fixes #7846