### PR TITLE
Coerce type of builtin functions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6311,10 +6311,15 @@ class CallNode(ExprNode):
             method_obj_type = function.obj.type
             result_type = Builtin.find_return_type_of_builtin_method(self.pos, env, method_obj_type, function.attribute)
             self.may_return_none = result_type is py_object_type
+            ret_type = py_object_type
             if result_type.is_pyobject:
-                self.type = result_type
+                ret_type = result_type
             elif result_type.equivalent_type:
-                self.type = result_type.equivalent_type
+                ret_type = result_type.equivalent_type
+            else:
+                ret_type = result_type
+            return self.coerce_to(ret_type, env)
+        return self
 
     def analyse_as_type_constructor(self, env):
         """
@@ -6472,6 +6477,7 @@ class SimpleCallNode(CallNode):
         if function.is_attribute and function.entry and function.entry.is_cmethod:
             # Take ownership of the object from which the attribute
             # was obtained, because we need to pass it as 'self'.
+
             self.self = function.obj
             function.obj = CloneNode(self.self)
 
@@ -6497,8 +6503,8 @@ class SimpleCallNode(CallNode):
             self.arg_tuple = TupleNode(self.pos, args = self.args)
             self.arg_tuple = self.arg_tuple.analyse_types(env).coerce_to_pyobject(env)
             self.args = None
-            self.set_py_result_type(env, function, func_type)
             self.is_temp = 1
+            return self.set_py_result_type(env, function, func_type)
         else:
             self.args = [ arg.analyse_types(env) for arg in self.args ]
             self.analyse_c_function_call(env)
@@ -7490,9 +7496,8 @@ class GeneralCallNode(CallNode):
         self.positional_args = self.positional_args.analyse_types(env)
         self.positional_args = \
             self.positional_args.coerce_to_pyobject(env)
-        self.set_py_result_type(env, self.function)
         self.is_temp = 1
-        return self
+        return self.set_py_result_type(env, self.function)
 
     def map_to_simple_call_node(self):
         """

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6311,7 +6311,6 @@ class CallNode(ExprNode):
             method_obj_type = function.obj.type
             result_type = Builtin.find_return_type_of_builtin_method(self.pos, env, method_obj_type, function.attribute)
             self.may_return_none = result_type is py_object_type
-            ret_type = py_object_type
             if result_type.equivalent_type:
                 return self.coerce_to(result_type.equivalent_type, env)
             else:
@@ -6474,7 +6473,6 @@ class SimpleCallNode(CallNode):
         if function.is_attribute and function.entry and function.entry.is_cmethod:
             # Take ownership of the object from which the attribute
             # was obtained, because we need to pass it as 'self'.
-
             self.self = function.obj
             function.obj = CloneNode(self.self)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6312,13 +6312,10 @@ class CallNode(ExprNode):
             result_type = Builtin.find_return_type_of_builtin_method(self.pos, env, method_obj_type, function.attribute)
             self.may_return_none = result_type is py_object_type
             ret_type = py_object_type
-            if result_type.is_pyobject:
-                ret_type = result_type
-            elif result_type.equivalent_type:
-                ret_type = result_type.equivalent_type
+            if result_type.equivalent_type:
+                return self.coerce_to(result_type.equivalent_type, env)
             else:
-                ret_type = result_type
-            return self.coerce_to(ret_type, env)
+                return self.coerce_to(result_type, env)
         return self
 
     def analyse_as_type_constructor(self, env):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6311,9 +6311,9 @@ class CallNode(ExprNode):
             method_obj_type = function.obj.type
             result_type = Builtin.find_return_type_of_builtin_method(self.pos, env, method_obj_type, function.attribute)
             self.may_return_none = result_type is py_object_type
-            if result_type.equivalent_type:
-                return self.coerce_to(result_type.equivalent_type, env)
-            else:
+            if result_type != self.type:
+                if not result_type.is_pyobject and result_type.equivalent_type:
+                    result_type = result_type.equivalent_type
                 return self.coerce_to(result_type, env)
         return self
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6283,7 +6283,7 @@ class CallNode(ExprNode):
                 return False
         return ExprNode.may_be_none(self)
 
-    def set_py_result_type(self, env, function, func_type=None):
+    def coerce_to_result_type(self, env, function, func_type=None):
         # Default to 'object' and then try to find a better type.
         self.type = py_object_type
         if func_type is None:
@@ -6499,7 +6499,7 @@ class SimpleCallNode(CallNode):
             self.arg_tuple = self.arg_tuple.analyse_types(env).coerce_to_pyobject(env)
             self.args = None
             self.is_temp = 1
-            return self.set_py_result_type(env, function, func_type)
+            return self.coerce_to_result_type(env, function, func_type)
         else:
             self.args = [ arg.analyse_types(env) for arg in self.args ]
             self.analyse_c_function_call(env)
@@ -7492,7 +7492,7 @@ class GeneralCallNode(CallNode):
         self.positional_args = \
             self.positional_args.coerce_to_pyobject(env)
         self.is_temp = 1
-        return self.set_py_result_type(env, self.function)
+        return self.coerce_to_result_type(env, self.function)
 
     def map_to_simple_call_node(self):
         """

--- a/tests/run/type_inference_generics.py
+++ b/tests/run/type_inference_generics.py
@@ -5,6 +5,7 @@
 # for the benefit of the pure tests, don't require annotations
 # to be evaluated
 from __future__ import annotations
+import cython
 
 class A:
     pass
@@ -31,3 +32,22 @@ def test_iterator_next_node_coercion(N: list[int]):
         if n < 0:
             return True
     return False
+
+
+def test_assign_builtin_method():
+    """
+    >>> test_assign_builtin_method()
+    int
+    """
+    l: list[list[cython.int]] = [[0]]
+    i = l.pop().pop()
+    print(cython.typeof(i))
+
+
+def test_builtin_method_expression():
+    """
+    >>> test_builtin_method_expression()
+    int
+    """
+    l: list[list[cython.int]] = [[1]]
+    print(cython.typeof(l.pop().pop()))


### PR DESCRIPTION
Fixes #7664

As a bonus it optimizes also current code e.g. following line: https://github.com/cython/cython/blob/6d669bf6e19bc497508f092fd3129d17a1573f07/Cython/Compiler/StringEncoding.py#L311

master branch:
```c
__pyx_t_3 = PyLong_FromSsize_t(__pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_3);
__pyx_t_5 = __Pyx_PyUnicode_Substring(__pyx_v_s, (__pyx_v_end - 4), __pyx_v_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_5);
__pyx_t_1 = PyUnicode_Find(((PyObject*)__pyx_t_5), __pyx_mstate_global->__pyx_kp_u__6, 0, PY_SSIZE_T_MAX, 1); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-2))) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
__pyx_t_5 = PyLong_FromSsize_t(__pyx_t_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_5);

__pyx_t_6 = __Pyx_PyLong_SubtractCObj(__pyx_mstate_global->__pyx_int_4, __pyx_t_5, 4, 0, 0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_6);
__Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
__pyx_t_5 = __Pyx_PyNumber_InPlaceSubtract_int_object(__pyx_t_3, __pyx_t_6); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_5);
__Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
__Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
__pyx_t_1 = __Pyx_PyIndex_AsSsize_t(__pyx_t_5); if (unlikely((__pyx_t_1 == (Py_ssize_t)-1) && PyErr_Occurred())) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
__pyx_v_end = __pyx_t_1;
```

PR:
```c
__pyx_t_3 = __Pyx_PyUnicode_Substring(__pyx_v_s, (__pyx_v_end - 4), __pyx_v_end); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_GOTREF(__pyx_t_3);
__pyx_t_1 = PyUnicode_Find(((PyObject*)__pyx_t_3), __pyx_mstate_global->__pyx_kp_u__6, 0, PY_SSIZE_T_MAX, 1); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-2))) __PYX_ERR(0, 311, __pyx_L1_error)
__Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
__pyx_v_end = (__pyx_v_end - (4 - __pyx_t_1));
```

~~Marked as Draft due missing tests.~~