### PR TITLE
Tune LZSS string compression to allow storing slightly longer offsets.

### DIFF
--- a/Cython/LZSS.py
+++ b/Cython/LZSS.py
@@ -39,8 +39,8 @@ def lzss_compress(data: bytes) -> bytes:
         if pos + 3 > input_size:
             return (0, 0)
 
-        # 14-bit offset (max 16KiB lookback)
-        WINDOW_SIZE: cython.long = 1 << 14
+        # 14-bit offset + 128 (~ max 16KiB lookback)
+        WINDOW_SIZE: cython.long = (1 << 14) + 128
         # 8-bit length + 3, allowing up to 258 bytes.
         MAX_MATCH: cython.long = min(255 + 3, input_size - pos)
 
@@ -69,8 +69,9 @@ def lzss_compress(data: bytes) -> bytes:
 
             # Prefer longer matches, break ties by preferring closer offsets.
             if match_len > best_len:
-                best_len = match_len
-                best_offset = pos - prev_pos
+                if pos - prev_pos - match_len < WINDOW_SIZE:  # Can we store the result?
+                    best_len = match_len
+                    best_offset = pos - prev_pos
 
         # Lazy matching: check if next position has a better match.
         next_key = data[pos + 1:pos + 4]
@@ -88,7 +89,8 @@ def lzss_compress(data: bytes) -> bytes:
                     match_len += 1
 
                 if match_len > next_best_len:
-                    next_best_len = match_len
+                    if pos - prev_pos - next_best_len < WINDOW_SIZE:  # Can we store the result?
+                        next_best_len = match_len
 
             # If the next position has a significantly better match, ignore this one.
             if next_best_len > best_len + 1:
@@ -102,7 +104,7 @@ def lzss_compress(data: bytes) -> bytes:
     flags_pos: cython.Py_ssize_t = 0
     flags: cython.int = 0xFF0000
 
-    stats = [0, 0, 0, 0]
+    stats = [0] * 5
 
     while pos < input_size:
         offset, length = find_longest_match(pos)
@@ -120,30 +122,42 @@ def lzss_compress(data: bytes) -> bytes:
 
         # See if the match is worth it and store a single literal byte otherwise.
 
-        if length > 2 and 0 <= offset <= 0x7F:
-            # Store 7 bit offset and length as two bytes.
+        if length < 3 or offset < 0:
+            # Not worth compressing, store single byte.
+            flag = 1
+            stats[0] += 1
+        elif offset <= 0x7F:
+            # Store 7 bit offset and length as one byte each.
             output.append(offset)
             #assert output[-1] & 0x80 == 0
             output.append(length - 3)
             stats[1] += 1
-        elif length > 2 and length - 3 <= 0x1F and 0 <= offset <= 0x1FF:
-            # Store a longer 7+2 bit offset at the cost of a shorter 5 bit length.
-            output.append((offset & 0x7F) | 0x80)
-            output.append(((offset & 0x180) >> 2) | (length - 3))
-            #assert output[-1] & 0x80 == 0
-            stats[2] += 1
-        elif length > 3 and 0 <= offset < (1 << 14):
-            # Store a 7+7 bit offset with a separate 8 bit length.
-            output.append(offset & 0x7F | 0x80)
-            output.append((offset >> 7) & 0x7F | 0x80)
-            output.append(length - 3)
-            stats[3] += 1
         else:
+            # offset 0-0x7F is already handled above.
+            offset -= 0x80
+            length_bits = length - 3
+
+            if length_bits < (1 << 5) and offset < (1 << 9):
+                # Store a longer 7+2 bit offset at the cost of a shorter 5 bit length.
+                output.append((offset & 0x7F) | 0x80)
+                output.append(((offset & 0x180) >> 2) | length_bits)
+                #assert output[-1] & 0x80 == 0
+                stats[2] += 1
+            elif length > 3 and offset < (1 << 14):
+                # Store a 7+7 bit offset with a separate 8 bit length.
+                output.append(offset & 0x7F | 0x80)
+                output.append((offset >> 7) & 0x7F | 0x80)
+                output.append(length_bits)
+                stats[3] += 1
+            else:
+                flag = 1
+                stats[4] += 1
+
+        if flag == 1:
             # Encode 8 bit literal + 1 bit flag.
             flag = 1
             length = 1
             output.append(data[pos])
-            stats[0] += 1
 
         pos += length
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -178,11 +178,11 @@ static CYTHON_SMALL_CODE size_t __pyx_lzss_decompress(const uint8_t* src, uint8_
                     match_length = hi;
                 } else if (!(hi & 0x80)) {
                     // 2+7 bit offset + 5 bit length
-                    end_offset_of_last_occurrence = ((hi << 2) & 0x180) | (lo & 0x7F);
+                    end_offset_of_last_occurrence = 0x80 + (((hi << 2) & 0x180) | (lo & 0x7F));
                     match_length = hi & 0x1F;
                 } else {
                     // 7+7 bit offset + 8 bit length
-                    end_offset_of_last_occurrence = (hi & 0x7F) << 7 | (lo & 0x7F);
+                    end_offset_of_last_occurrence = 0x80 + ((hi & 0x7F) << 7 | (lo & 0x7F));
                     match_length = src[pos++];
                 }
 

--- a/tests/run/lzss_compression.pyx
+++ b/tests/run/lzss_compression.pyx
@@ -64,10 +64,10 @@ def decompress_py(compressed: bytes):
                         p = lo
                         ml = hi
                     elif (hi & 0x80) == 0:
-                        p = ((hi << 2) & 0x180) | (lo & 0x7F)
+                        p = 0x80 + (((hi << 2) & 0x180) | (lo & 0x7F))
                         ml = hi & 0x1F
                     else:
-                        p = (hi & 0x7F) << 7 | (lo & 0x7F)
+                        p = 0x80 + ((hi & 0x7F) << 7 | (lo & 0x7F))
                         ml = next(iter_bytes)
 
                     ml += 3;
@@ -106,6 +106,8 @@ def test(data: bytes) -> None:
     SIZE: 197 -> 19
     >>> test(b'a' * 317)
     SIZE: 317 -> 19
+    >>> test(b'abcdefgabcdefg')  # flags + b'abcdefg' + (offset(0), length(7)-3)
+    SIZE: 14 -> 10
     >>> test(b'avx' * 317)
     SIZE: 951 -> 27
     >>> test(b'\\0')
@@ -121,11 +123,32 @@ def test(data: bytes) -> None:
     >>> test(b'0123456789' * 463)
     SIZE: 4630 -> 74
 
-    # Test cutoff at max offset (7+7 bits):
-    >>> test(b'0123456789' + b'x' * ((1 << 14) - 4) + b'234569')
-    SIZE: 16396 -> 227
-    >>> test(b'0123456789' + b'x' * ((1 << 14) - 3) + b'234569')
-    SIZE: 16397 -> 231
+    # Test cutoff at max length 5 bits:
+    >>> length_cutoff = (1 << 5) - 1 + 3
+    >>> test(b'012' + b'x' * (length_cutoff + 0) + b'3' * 0x80 + b'x' * (length_cutoff + 0))
+    SIZE: 199 -> 34
+    >>> test(b'012' + b'x' * (length_cutoff + 1) + b'3' * 0x80 + b'x' * (length_cutoff + 0))
+    SIZE: 200 -> 34
+    >>> test(b'012' + b'x' * (length_cutoff + 1) + b'3' * 0x80 + b'x' * (length_cutoff + 1))
+    SIZE: 201 -> 35
+    >>> test(b'012' + b'x' * (length_cutoff + 2) + b'3' * 0x80 + b'x' * (length_cutoff + 2))
+    SIZE: 203 -> 35
+
+    # Test cutoff at max offset (7+7 bits + 128):
+    >>> (1 << 14) - 1 + 128 - 3
+    16508
+
+    >>> data = b'0123456789' + b'x' * ((1 << 14) - 1 - len(b'23456789') + len(b'234569') + 127) + b'234569'
+    >>> data.index(b'23456', 1 << 14) - data.index(b'23456') - len(b'23456') - 3
+    16508
+    >>> test(data)
+    SIZE: 16524 -> 230
+
+    >>> data = b'0123456789' + b'x' * ((1 << 14) - 1 - len(b'23456789') + len(b'234569') + 128) + b'234569'
+    >>> data.index(b'23456', 1 << 14) - data.index(b'23456') - len(b'23456') - 3
+    16509
+    >>> test(data)
+    SIZE: 16525 -> 233
 
     >>> len(MAKE_SURE_THERE_IS_SOMETHING_TO_COMPRESS)
     1717


### PR DESCRIPTION
Since the first encoding already covers all 7-bit offsets, we can reduce the stored offset by 0x80 in the other cases, thus saving the third byte here and there.