### PR TITLE
Report an error instead of crashing on cast to an unresolved typeof() type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,10 @@ Bugs fixed
   It now uses a dedicated enum implementation class to allow this.
   (Github issue :issue:`7185`)
 
+* Casting to an unresolved ``typeof()`` type (e.g. ``cython.cast(cython.typeof(x), ...)``
+  where the type could not be inferred) crashed the compiler instead of reporting an error.
+  (Github issue :issue:`7683`)
+
 * ``cpdef fused`` functions generated redundant code.
   (Github issue :issue:`7778`)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -12044,6 +12044,12 @@ class TypecastNode(ExprNode):
             error(self.pos,
                 "Cannot cast to a function type")
             self.type = PyrexTypes.error_type
+        elif self.type.is_unspecified:
+            # e.g. cython.cast(cython.typeof(x), ...) where typeof() could not
+            # be resolved to a concrete type; report an error instead of crashing.
+            error(self.pos,
+                "Unable to determine the type to cast to")
+            self.type = PyrexTypes.error_type
         self.operand = self.operand.analyse_types(env)
         if self.type is PyrexTypes.c_bint_type:
             # short circuit this to a coercion

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1152,6 +1152,8 @@ class ExprNode(Node):
         return src
 
     def fail_assignment(self, dst_type):
+        if self.type.is_error or dst_type.is_error:
+            return  # Reported elsewhere.
         src_name = self.entry.name if hasattr(self, "entry") else None
         src_resolved = f" (alias of '{self.type.resolve()}')" if self.type.is_typedef else ""
         dst_resolved = f" (alias of '{dst_type.resolve()}')" if dst_type.is_typedef else ""

--- a/tests/errors/cast_unspecified_type.pyx
+++ b/tests/errors/cast_unspecified_type.pyx
@@ -1,0 +1,15 @@
+# mode: error
+# ticket: 7683
+
+import cython
+
+def f():
+    s = ""
+    y: cython.typeof(s)
+    b = cython.cast(cython.typeof(y), s)
+
+
+_ERRORS = u"""
+9:14: Unable to determine the type to cast to
+9:14: Cannot assign type '<error>' to '<unspecified>'
+"""

--- a/tests/errors/cast_unspecified_type.pyx
+++ b/tests/errors/cast_unspecified_type.pyx
@@ -11,5 +11,4 @@ def f():
 
 _ERRORS = u"""
 9:14: Unable to determine the type to cast to
-9:14: Cannot assign type '<error>' to '<unspecified>'
 """


### PR DESCRIPTION
Closes #7683.

`cython.cast(cython.typeof(x), ...)` crashes the compiler when `typeof()` can't be resolved to a concrete type:

```python
import cython

def f():
    s = ""
    y: cython.typeof(s)
    b = cython.cast(cython.typeof(y), s)
```

```
AttributeError: 'UnspecifiedType' object has no attribute 'create_from_py_utility_code'
```

`TypecastNode.analyse_types()` rejects a few invalid cast targets (function types and so on) but not an unspecified one, so it falls through to the Python conversion path and calls `create_from_py_utility_code()` on `UnspecifiedType`, which doesn't have it.

The fix rejects an unspecified cast target with a normal compile error, recovering via `error_type` like the neighbouring checks do. That follows da-woods' point on the issue that `cast` is an explicit request and should fail rather than be silently ignored, while annotations stay tolerant of types Cython doesn't understand.

Added `tests/errors/cast_unspecified_type.pyx` plus a CHANGES entry. The input crashes on master and gives the error with this change.
