### PR TITLE
Cygdb: only activate virtual environment if it matches

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -41,9 +41,13 @@ def make_command_file(path_to_debug_info, prefix_code='',
         f.write(prefix_code)
         virtualenv_code = ''
         virtualenv = os.getenv('VIRTUAL_ENV')
+        sys_version_info_code = repr(sys.version_info[:2])
+        has_gil_code = repr(hasattr(sys, "_is_gil_enabled"))
+        platform_machine_code = repr("") 
         if virtualenv:
             import site
             import pathlib
+            import platform
             # Emulating the virtual env we're in will always be imperfect. But:
             # * Work out the site packages from the current interpreter and add those
             #   to the start of the path to let those be found first.
@@ -58,6 +62,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
                 f'import site; {"; ".join(f"site.addsitedir({p!r})" for p in sitepackages)}; '
                 f'print("gdb command file: Activating virtualenv: {virtualenv}")'
             )
+            platform_machine_code = repr(platform.machine())
         f.write(textwrap.dedent(f'''\
             # This is a gdb command file
             # See https://sourceware.org/gdb/onlinedocs/gdb/Command-Files.html
@@ -67,8 +72,16 @@ def make_command_file(path_to_debug_info, prefix_code='',
 
             python
             try:
-                # Activate virtualenv, if we were launched from one
-                {virtualenv_code}
+                import sys
+                import platform
+                if (sys.version_info[:2] == {sys_version_info_code} and
+                        hasattr(sys, "_is_gil_enabled") == {has_gil_code} and
+                        platform.machine() == {platform_machine_code}):
+                    # Activate virtualenv, if we were launched from one
+                    {virtualenv_code}
+                else:
+                    print("Not activating virtual environment for mismatched Python version",
+                        {sys_version_info_code}, {has_gil_code}, {platform_machine_code})
                 from Cython.Debugger import libcython, libpython
             except Exception as ex:
                 from traceback import print_exc

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -39,11 +39,13 @@ def make_command_file(path_to_debug_info, prefix_code='',
     f = os.fdopen(fd, 'w')
     try:
         f.write(prefix_code)
-        virtualenv_code = ''
+
+        activate_virtualenv = report_virtualenv_error = 'pass'
+        check_virtualenv_version = 'False'
         virtualenv = os.getenv('VIRTUAL_ENV')
-        sys_version_info_code = repr(sys.version_info[:2])
-        has_gil_code = repr(hasattr(sys, "_is_gil_enabled"))
-        platform_machine_code = repr("")
+        has_gil = getattr(sys, "_is_gil_enabled", True)
+        platform_machine = ""
+
         if virtualenv:
             import site
             import pathlib
@@ -57,12 +59,22 @@ def make_command_file(path_to_debug_info, prefix_code='',
             # the interpreter linked into GDB.
             sitepackages = site.getsitepackages()
             sitepackages = [ p for p in sitepackages if pathlib.Path(p).is_relative_to(virtualenv) ]
-            virtualenv_code = (
+            activate_virtualenv = (
                 f'import sys; sys.path[:0] = {sitepackages!r}; '
                 f'import site; {"; ".join(f"site.addsitedir({p!r})" for p in sitepackages)}; '
                 f'print("gdb command file: Activating virtualenv: {virtualenv}")'
             )
-            platform_machine_code = repr(platform.machine())
+            platform_machine = platform.machine()
+            check_virtualenv_version = (
+                f'sys.version_info[:2] == {sys.version_info[:2] !r} and '
+                f'getattr(sys, "_is_gil_enabled", True) == {has_gil !r} and '
+                f'platform.machine() == {platform_machine !r}'
+            )
+            report_virtualenv_error = (
+                'print("Not activating virtual environment for mismatched Python version %d.%d%s (%s)" % ('
+                f'{sys.version_info[0]}, {sys.version_info[1]}, {"" if has_gil else "t" !r}, {platform_machine !r}))'
+            )
+
         f.write(textwrap.dedent(f'''\
             # This is a gdb command file
             # See https://sourceware.org/gdb/onlinedocs/gdb/Command-Files.html
@@ -71,17 +83,15 @@ def make_command_file(path_to_debug_info, prefix_code='',
             set print pretty on
 
             python
+            import sys
             try:
-                import sys
-                import platform
-                if (sys.version_info[:2] == {sys_version_info_code} and
-                        hasattr(sys, "_is_gil_enabled") == {has_gil_code} and
-                        platform.machine() == {platform_machine_code}):
-                    # Activate virtualenv, if we were launched from one
-                    {virtualenv_code}
-                else:
-                    print("Not activating virtual environment for mismatched Python version",
-                        {sys_version_info_code}, {has_gil_code}, {platform_machine_code})
+                # Activate virtualenv, if we were launched from one that matches what gdb uses.
+                if {bool(virtualenv) !r}:
+                    import platform
+                    if {check_virtualenv_version}:
+                        {activate_virtualenv}
+                    else:
+                        {report_virtualenv_error}
                 from Cython.Debugger import libcython, libpython
             except Exception as ex:
                 from traceback import print_exc

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -43,7 +43,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
         virtualenv = os.getenv('VIRTUAL_ENV')
         sys_version_info_code = repr(sys.version_info[:2])
         has_gil_code = repr(hasattr(sys, "_is_gil_enabled"))
-        platform_machine_code = repr("") 
+        platform_machine_code = repr("")
         if virtualenv:
             import site
             import pathlib


### PR DESCRIPTION
i.e. don't try to activate virtual environments for different Python versions, such as when gdb has been compiled against a different version of Python.