### PR TITLE
Fix `except` clause with fused-type return value 

### DIFF
--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -832,6 +832,19 @@ class CFuncDeclaratorNode(CDeclaratorNode):
                         error(self.exception_value.pos,
                               "Exception value must be a Python exception, or C++ function with no arguments, or *.")
                     exc_val = self.exception_value
+                elif return_type.is_fused:
+                    # Return type is not specialized yet. Since there is no exact return type, the enclosing function
+                    # is copied per fused-type permutation in FusedNode.py(), so it can't convert the exception value
+                    # to a specific C type here. Check the exception as-is against all potential types.
+                    # Also, CFuncType.specialize() re-targets the resulting ExceptionValue
+                    # at the concrete return type of each specialization.
+                    self.exception_value = self.exception_value.analyse_types(env).analyse_const_expression(env)
+                    exc_val = self.exception_value.as_exception_value(env)
+                    permutations = PyrexTypes.get_all_specialized_permutations(return_type.get_fused_types())
+                    if not all(return_type.specialize(mapping).assignable_from(self.exception_value.type)
+                                    for _, mapping in permutations):
+                        error(self.exception_value.pos,"Exception value incompatible with function return type")
+
                 else:
                     self.exception_value = self.exception_value.analyse_types(env).coerce_to(
                         return_type, env).analyse_const_expression(env)

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -3918,10 +3918,18 @@ class CFuncType(CType):
         return '(%s)' % s
 
     def specialize(self, values):
-        result = CFuncType(self.return_type.specialize(values),
+        return_type = self.return_type.specialize(values)
+        exception_value = self.exception_value
+        if self.return_type.is_fused and isinstance(exception_value, CFuncType.ExceptionValue):
+            exception_value = CFuncType.ExceptionValue(
+                exception_value.python_value, exception_value.c_repr, return_type
+            )
+        # After cheching the error against all possible types, now it's being retargetted at
+        # this specialization's concrete return type. So C code generation doesn't break.
+        result = CFuncType(return_type,
                            [arg.specialize(values) for arg in self.args],
                            has_varargs = self.has_varargs,
-                           exception_value = self.exception_value,
+                           exception_value = exception_value,
                            exception_check = self.exception_check,
                            calling_convention = self.calling_convention,
                            nogil = self.nogil,
@@ -3931,7 +3939,6 @@ class CFuncType(CType):
                            is_const_method = self.is_const_method,
                            is_static_method = self.is_static_method,
                            templates = self.templates)
-
         result.from_fused = self.is_fused
         return result
 

--- a/tests/run/fused_except_value_GH7819.pyx
+++ b/tests/run/fused_except_value_GH7819.pyx
@@ -1,0 +1,33 @@
+# mode: run
+
+cdef fused IntOrFloat:
+    int 
+    double
+
+cdef IntOrFloat c_maybe_raise(IntOrFloat x) except? -1:
+    if x < -1:
+        raise ValueError("Can not be less than -1. Too negative")
+    return x
+
+def maybe_raise_int(int x):
+    """
+    >>> maybe_raise_int(5)
+    5
+    >>> maybe_raise_int(-1)
+    -1
+    >>> maybe_raise_int(-5)
+    ValueError: Can not be less than -1. Too negative
+    """
+    return c_maybe_raise(x)
+
+def maybe_raise_float(double x):
+    """
+    >>> maybe_raise_float(5.5)
+    5.5
+    >>> maybe_raise_float(-1.0)
+    -1.0
+    >>> maybe_raise_float(-5.5)
+    Traceback (most recent callback):
+    ValueError: Can not be less than -1. Too negative
+    """
+    return c_maybe_raise(x)


### PR DESCRIPTION
Fixes #7819

## Summary
Using an exception check like `except -1` (or `except? -1`) on a function with a fused type failed to compile. 
Cython gave the error: *"Cannot coerce to a type that is not specialized"*.

This happened because Cython tried to convert the exception value (like `-1`) to a specific type before it actually knew which specific type (like `int` or `double`) the fused function was going to use. Fused-type specialization happens later in `FusedNode.py`.

## Files Changed:
- **`Nodes.py`**: If the return type is fused, stop trying to force a type conversion early. Instead, just check that the exception value works for every possible type the fused type could become.
- **`PyrexTypes.py` (`CFuncType.specialize`)**: When Cython generates the real C code for each specific type, update the exception value to use that specific return type. Without this, the code compiled, but generated wrong C checks (like improper type casts or broken `NaN` comparisons for floats).

## Tests:
- Added `tests/run/fused_except_value_GH7819.pyx` to test both `int` and `double` functions. It covers normal return values, the `except?` case where `-1` is a valid return value, and actual error handling.