### PR TITLE
Add some type declarations to Cython modules for "compile-all".

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -6,7 +6,12 @@
 import cython
 cython.declare(Naming=object, Options=object, PyrexTypes=object, TypeSlots=object,
                error=object, warning=object, py_object_type=object, UtilityCode=object,
-               EncodedString=object, itertools=object, operator=object, re=object)
+               IncludeCode=object, TempitaUtilityCode=object,
+               EncodedString=object, itertools=object, operator=object, re=object,
+               defaultdict=object, json=object, os=object, sys=object,
+               CPtrType=object, Code=object, Nodes=object,
+               bytes_literal=object, has_np_pythran=object,
+)
 
 from collections import defaultdict
 import itertools
@@ -28,19 +33,22 @@ from . import TypeSlots
 from . import PyrexTypes
 from . import Pythran
 
-from .Errors import error, warning, CompileError, format_position
-from .PyrexTypes import py_object_type, get_all_subtypes
+from .Errors import error, warning, CompileError
+from .PyrexTypes import py_object_type
 from ..Utils import open_new_file, replace_suffix, decode_filename, build_hex_version, is_cython_generated_file
 from .Code import UtilityCode, IncludeCode, TempitaUtilityCode
 from .StringEncoding import EncodedString, bytes_literal, encoded_string_or_bytes_literal
 from .Pythran import has_np_pythran
 
 
+@cython.cfunc
 def replace_suffix_encoded(path, newsuf):
     # calls replace suffix and returns a EncodedString or BytesLiteral with the encoding set
     newpath = replace_suffix(path, newsuf)
     return as_encoded_filename(newpath)
 
+
+@cython.cfunc
 def as_encoded_filename(path):
     # wraps the path with either EncodedString or BytesLiteral (depending on its input type)
     # and sets the encoding to the file system encoding
@@ -58,6 +66,7 @@ def check_c_declarations(module_node):
     return module_node
 
 
+@cython.cfunc
 def generate_c_code_config(env, options):
     if Options.annotate or options.annotate:
         emit_linenums = False
@@ -73,12 +82,13 @@ def generate_c_code_config(env, options):
         emit_code_comments=env.directives['emit_code_comments'],
         c_line_in_traceback=options.c_line_in_traceback)
 
+
 # The code required to generate one comparison from another.
 # The keys are (from, to).
 # The comparison operator always goes first, with equality possibly second.
 # The first value specifies if the comparison is inverted. The second is the
 # logic op to use, and the third is if the equality is inverted or not.
-TOTAL_ORDERING = {
+TOTAL_ORDERING = cython.declare(dict, {
     # a > b from (not a < b) and (a != b)
     ('__lt__', '__gt__'): (True, '&&', True),
     # a <= b from (a < b) or (a == b)
@@ -106,7 +116,7 @@ TOTAL_ORDERING = {
     ('__ge__', '__gt__'): (False, '&&', True),
     # a < b from (not a >= b)
     ('__ge__', '__lt__'): (True, '', None),
-}
+})
 
 class SharedUtilityExporter:
     """

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -88,7 +88,8 @@ def generate_c_code_config(env, options):
 # The comparison operator always goes first, with equality possibly second.
 # The first value specifies if the comparison is inverted. The second is the
 # logic op to use, and the third is if the equality is inverted or not.
-TOTAL_ORDERING = cython.declare(dict[tuple[str, str], tuple[cython.bint, str, Optional[bool]]], {
+# Type is "dict[tuple[str, str], tuple[cython.bint, str, Optional[bool]]]", but Shadow.py doesn't allow it.
+TOTAL_ORDERING = cython.declare(dict, {
     # a > b from (not a < b) and (a != b)
     ('__lt__', '__gt__'): (True, '&&', True),
     # a <= b from (a < b) or (a == b)
@@ -2563,7 +2564,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         if total_ordering:
             # Check this is valid - we must have at least 1 operation defined.
-            comp_names = [from_name for from_name, to_name in TOTAL_ORDERING if from_name in comp_entry]
+            comp_names: list[str] = [from_name for from_name, to_name in TOTAL_ORDERING if from_name in comp_entry]
             if not comp_names:
                 if '__eq__' not in comp_entry and '__ne__'  not in comp_entry:
                     warning(scope.parent_type.pos,
@@ -2593,6 +2594,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             if entry is None:
                 assert total_ordering
                 # We need to generate this from the other methods.
+                invert_comp: bool
+                comp_op: str
                 invert_comp, comp_op, invert_equals = TOTAL_ORDERING[ordering_source, cmp_method]
 
                 # First we always do the comparison.

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -20,7 +20,7 @@ import operator
 import os
 import re
 import sys
-from typing import Sequence
+from typing import Sequence, Optional
 
 from .PyrexTypes import CPtrType
 from . import Future
@@ -88,7 +88,7 @@ def generate_c_code_config(env, options):
 # The comparison operator always goes first, with equality possibly second.
 # The first value specifies if the comparison is inverted. The second is the
 # logic op to use, and the third is if the equality is inverted or not.
-TOTAL_ORDERING = cython.declare(dict, {
+TOTAL_ORDERING = cython.declare(dict[tuple[str, str], tuple[cython.bint, str, Optional[bool]]], {
     # a > b from (not a < b) and (a != b)
     ('__lt__', '__gt__'): (True, '&&', True),
     # a <= b from (a < b) or (a == b)

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1,3 +1,5 @@
+# cython: binding=False
+
 import cython
 cython.declare(UtilityCode=object, EncodedString=object, bytes_literal=object, encoded_string=object,
                Nodes=object, ExprNodes=object, PyrexTypes=object, Builtin=object,
@@ -35,32 +37,37 @@ from .ParseTreeTransforms import SkipDeclarations
 from .. import Utils
 
 
+@cython.cfunc
 def load_c_utility(name):
     return UtilityCode.load_cached(name, "Optimize.c")
 
 
+@cython.cfunc
 def unwrap_coerced_node(node, coercion_nodes=(ExprNodes.CoerceToPyTypeNode, ExprNodes.CoerceFromPyTypeNode)):
     if isinstance(node, coercion_nodes):
         return node.arg
     return node
 
 
+@cython.cfunc
 def unwrap_node(node):
     while isinstance(node, UtilNodes.ResultRefNode):
         node = node.expression
     return node
 
 
-def is_common_value(a, b):
+@cython.cfunc
+def is_common_value(a, b) -> bool:
     a = unwrap_node(a)
     b = unwrap_node(b)
-    if isinstance(a, ExprNodes.NameNode) and isinstance(b, ExprNodes.NameNode):
+    if a.is_name and b.is_name:
         return a.name == b.name
-    if isinstance(a, ExprNodes.AttributeNode) and isinstance(b, ExprNodes.AttributeNode):
+    if a.is_attribute and b.is_attribute:
         return not a.is_py_attr and is_common_value(a.obj, b.obj) and a.attribute == b.attribute
     return False
 
 
+@cython.cfunc
 def filter_none_node(node):
     if node is not None and node.constant_result is None:
         return None

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -13,7 +13,7 @@ import copy
 import codecs
 import itertools
 from functools import partial, reduce
-from typing import Optional
+from typing import Optional, Any
 from operator import attrgetter
 
 from . import TypeSlots
@@ -75,7 +75,7 @@ def filter_none_node(node):
 
 
 @cython.cfunc
-def _unpack_union_type_nodes(union_type_nodes: list):
+def _unpack_union_type_nodes(union_type_nodes: list) -> tuple[list, Any]:
     # Unpack 'int | float | None' etc.
     BitwiseOrNode = ExprNodes.BitwiseOrNode
 
@@ -3641,7 +3641,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
     _handle_simple_method_int___floordiv__ = _handle_simple_method_object___floordiv__
     _handle_simple_method_int___truediv__ = _handle_simple_method_object___truediv__
 
-    def _optimise_num_div(self, operator, node, function, args, is_unbound_method):
+    def _optimise_num_div(self, operator: str, node, function, args: list, is_unbound_method):
         if len(args) != 2 or not args[1].has_constant_result() or args[1].constant_result == 0:
             return node
         if isinstance(args[1], ExprNodes.IntNode):
@@ -3675,7 +3675,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
     def _handle_simple_method_float___ne__(self, node, function, args, is_unbound_method):
         return self._optimise_num_binop('Ne', node, function, args, is_unbound_method)
 
-    def _optimise_num_binop(self, operator, node, function, args, is_unbound_method):
+    def _optimise_num_binop(self, operator: str, node, function, args: list, is_unbound_method):
         """
         Optimise math operators for (likely) float or small integer operations.
         """
@@ -3722,7 +3722,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             ],
             exception_value=-1)
 
-    def _inject_unicode_predicate(self, node, function, args, is_unbound_method):
+    def _inject_unicode_predicate(self, node, function, args: list, is_unbound_method):
         if is_unbound_method or len(args) != 1:
             return node
         ustring = args[0]
@@ -3892,8 +3892,8 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             node, function, args, is_unbound_method, 'str', 'startswith',
             unicode_tailmatch_utility_code, -1)
 
-    def _inject_tailmatch(self, node, function, args, is_unbound_method, type_name,
-                          method_name, utility_code, direction):
+    def _inject_tailmatch(self, node, function, args: list, is_unbound_method, type_name: str,
+                          method_name: str, utility_code, direction):
         """Replace unicode.startswith(...) and unicode.endswith(...)
         by a direct call to the corresponding C-API function.
         """
@@ -4390,7 +4390,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
             args[arg_index] = args[arg_index].coerce_to_boolean(self.current_env())
 
 
-def optimise_numeric_binop(operator, node, ret_type, arg0, arg1):
+def optimise_numeric_binop(operator: str, node, ret_type, arg0, arg1):
     """
     Optimise math operators for (likely) float or small integer operations.
     """
@@ -5037,7 +5037,7 @@ class ConstantFolding(Visitor.VisitorTransform, SkipDeclarations):
             return node
 
         # collect partial cascades: [[value, CmpNode...], [value, CmpNode, ...], ...]
-        cascades = [[node.operand1]]
+        cascades: list[list] = [[node.operand1]]
         final_false_result = []
 
         cmp_node = node


### PR DESCRIPTION
Compiling all Cython modules seems to more common than expected, so we should try to reduce its overhead.