### PR TITLE
Add support of PGO builds

### DIFF
--- a/Cython/Build/Cythonize.py
+++ b/Cython/Build/Cythonize.py
@@ -134,7 +134,7 @@ def _build(ext_modules, parallel):
 
 def run_distutils(args):
     try:
-        from distutils.core import setup
+        from setuptools import setup
     except ImportError:
         try:
             from setuptools import setup

--- a/Cython/Build/Dependencies.py
+++ b/Cython/Build/Dependencies.py
@@ -854,6 +854,7 @@ def create_extension_list(patterns, exclude=None, ctx=None, aliases=None, quiet=
                 m, metadata = create_extension(template, kwds)
                 m.np_pythran = np_pythran or getattr(m, 'np_pythran', False)
                 m.shared_utility_qualified_name = shared_utility_qualified_name
+                m.pgo_dir = ctx.options.pgo_dir
                 if m.np_pythran:
                     update_pythran_extension(m)
                 module_list.append(m)

--- a/Cython/Build/IpythonMagic.py
+++ b/Cython/Build/IpythonMagic.py
@@ -444,16 +444,17 @@ class CythonMagics(Magics):
         compiler_type = build_extension.compiler.compiler_type
         if compiler_type == 'unix':
             compiler_cmd = build_extension.compiler.compiler_so
-            # TODO: we could try to call "[cmd] --version" for better insights
             if not compiler_cmd:
                 pass
             elif 'clang' in compiler_cmd or 'clang' in compiler_cmd[0]:
-                compiler_type = 'clang'
+                compiler_type = 'gcc'
             elif 'icc' in compiler_cmd or 'icc' in compiler_cmd[0]:
                 compiler_type = 'icc'
             elif 'gcc' in compiler_cmd or 'gcc' in compiler_cmd[0]:
                 compiler_type = 'gcc'
             elif 'g++' in compiler_cmd or 'g++' in compiler_cmd[0]:
+                compiler_type = 'gcc'
+            else:
                 compiler_type = 'gcc'
         config = PGO_CONFIG.get(compiler_type)
         orig_flags = []

--- a/Cython/Compiler/Options.py
+++ b/Cython/Compiler/Options.py
@@ -829,6 +829,7 @@ default_options = dict(
     common_utility_include_dir=None,
     output_dir=None,
     build_dir=None,
+    pgo_dir=None,
     cache=None,
     create_extension=None,
     np_pythran=False,

--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -101,7 +101,7 @@ class build_ext(_build_ext):
     def get_extension_attr(self, extension, option_name, default=False):
         return getattr(self, option_name) or getattr(extension, option_name, default)
 
-    def _add_pgo_flags(self, step_name, temp_dir):
+    def _add_pgo_flags(self, ext, step_name, temp_dir):
         compiler_type = self.compiler.compiler_type
         if compiler_type == 'unix':
             compiler_cmd = self.compiler.compiler_so
@@ -121,10 +121,9 @@ class build_ext(_build_ext):
         orig_flags = []
         if config and step_name in config:
             flags = [f.format(TEMPDIR=temp_dir) for f in config[step_name]]
-            for extension in self.extensions:
-                orig_flags.append((extension.extra_compile_args, extension.extra_link_args))
-                extension.extra_compile_args = extension.extra_compile_args + flags
-                extension.extra_link_args = extension.extra_link_args + flags
+            orig_flags.append((ext.extra_compile_args, ext.extra_link_args))
+            ext.extra_compile_args = ext.extra_compile_args + flags
+            ext.extra_link_args = ext.extra_link_args + flags
         else:
             print("No PGO %s configuration known for C compiler type '%s'" % (step_name, compiler_type),
                   file=sys.stderr)
@@ -164,10 +163,10 @@ class build_ext(_build_ext):
         pgo_dir = self.get_extension_attr(ext, 'pgo_dir', default=None)
 
         if self.cython_gen_pgo:
-            self._add_pgo_flags('gen', pgo_dir)
+            self._add_pgo_flags(ext, 'gen', pgo_dir)
         if self.cython_use_pgo:
             self.force = 1
-            self._add_pgo_flags('use', pgo_dir)
+            self._add_pgo_flags(ext, 'use', pgo_dir)
             np_pythran = getattr(ext, 'np_pythran', False)
             c_sources = []
             for source in ext.sources:

--- a/Cython/Distutils/build_ext.py
+++ b/Cython/Distutils/build_ext.py
@@ -25,6 +25,18 @@ if _build_ext is None:
 if _build_ext is None:
     from distutils.command.build_ext import build_ext as _build_ext
 
+PGO_CONFIG = {
+    'gcc': {
+        'gen': ['-fprofile-generate', '-fprofile-dir={TEMPDIR}'],
+        'use': ['-fprofile-use', '-fprofile-correction', '-fprofile-dir={TEMPDIR}'],
+    },
+    # blind copy from 'configure' script in CPython 3.7
+    'icc': {
+        'gen': ['-prof-gen'],
+        'use': ['-prof-use'],
+    }
+}
+PGO_CONFIG['mingw32'] = PGO_CONFIG['gcc']
 
 class build_ext(_build_ext):
 
@@ -41,6 +53,10 @@ class build_ext(_build_ext):
              "put generated C files in temp directory"),
         ('cython-gen-pxi', None,
             "generate .pxi file for public declarations"),
+        ('cython-gen-pgo', None,
+            "generate PGO file"),
+        ('cython-use-pgo', None,
+            "use PGO file"),
         ('cython-directives=', None,
             "compiler directive overrides"),
         ('cython-gdb', None,
@@ -51,7 +67,7 @@ class build_ext(_build_ext):
 
     boolean_options = _build_ext.boolean_options + [
         'cython-cplus', 'cython-create-listing', 'cython-line-directives',
-        'cython-c-in-temp', 'cython-gdb',
+        'cython-c-in-temp', 'cython-gdb', 'cython-use-pgo', 'cython-gen-pgo'
     ]
 
     def initialize_options(self):
@@ -63,6 +79,9 @@ class build_ext(_build_ext):
         self.cython_directives = None
         self.cython_c_in_temp = 0
         self.cython_gen_pxi = 0
+        self.cython_gen_pgo = 0
+        self.cython_use_pgo = 0
+        self.pgo_dir = None
         self.cython_gdb = False
         self.cython_compile_time_env = None
         self.shared_utility_qualified_name = None
@@ -81,6 +100,35 @@ class build_ext(_build_ext):
 
     def get_extension_attr(self, extension, option_name, default=False):
         return getattr(self, option_name) or getattr(extension, option_name, default)
+
+    def _add_pgo_flags(self, step_name, temp_dir):
+        compiler_type = self.compiler.compiler_type
+        if compiler_type == 'unix':
+            compiler_cmd = self.compiler.compiler_so
+            if not compiler_cmd:
+                pass
+            elif 'clang' in compiler_cmd or 'clang' in compiler_cmd[0]:
+                compiler_type = 'gcc'
+            elif 'icc' in compiler_cmd or 'icc' in compiler_cmd[0]:
+                compiler_type = 'icc'
+            elif 'gcc' in compiler_cmd or 'gcc' in compiler_cmd[0]:
+                compiler_type = 'gcc'
+            elif 'g++' in compiler_cmd or 'g++' in compiler_cmd[0]:
+                compiler_type = 'gcc'
+            else:
+                compiler_type = 'gcc'
+        config = PGO_CONFIG.get(compiler_type)
+        orig_flags = []
+        if config and step_name in config:
+            flags = [f.format(TEMPDIR=temp_dir) for f in config[step_name]]
+            for extension in self.extensions:
+                orig_flags.append((extension.extra_compile_args, extension.extra_link_args))
+                extension.extra_compile_args = extension.extra_compile_args + flags
+                extension.extra_link_args = extension.extra_link_args + flags
+        else:
+            print("No PGO %s configuration known for C compiler type '%s'" % (step_name, compiler_type),
+                  file=sys.stderr)
+        return orig_flags
 
     def build_extension(self, ext):
         from Cython.Build.Dependencies import cythonize
@@ -112,6 +160,25 @@ class build_ext(_build_ext):
 
         if self.get_extension_attr(ext, 'cython_cplus'):
             ext.language = 'c++'
+
+        pgo_dir = self.get_extension_attr(ext, 'pgo_dir', default=None)
+
+        if self.cython_gen_pgo:
+            self._add_pgo_flags('gen', pgo_dir)
+        if self.cython_use_pgo:
+            self.force = 1
+            self._add_pgo_flags('use', pgo_dir)
+            np_pythran = getattr(ext, 'np_pythran', False)
+            c_sources = []
+            for source in ext.sources:
+                base, ex = os.path.splitext(source)
+                if ex in ('.pyx', '.py'):
+                   c_file = base + ('.cpp' if ext.language == 'c++' or np_pythran else '.c')
+                   c_sources.append(c_file)
+                else:
+                    c_sources.append(source)
+            ext.sources = c_sources
+            return super().build_extension(ext)
 
         if hasattr(ext, 'no_c_in_traceback'):
             c_line_in_traceback = not ext.no_c_in_traceback


### PR DESCRIPTION
To compile cython with PGO follow next steps:
1. Patch setup.py:
   ```diff
   diff --git a/setup.py b/setup.py
   index dc8c28746..91b625ab6 100755
   --- a/setup.py
   +++ b/setup.py
   @@ -205,6 +205,7 @@ def compile_cython_modules(profile=False, coverage=False, compile_minimal=False,
   
        for ext in extensions:
            ext.cython_directives = cython_directives
   +        ext.pgo_dir = 'pgo'
   
        # Make 'build_ext' use Cython.
        from Cython.Distutils.build_ext import build_ext as cy_build_ext
   ```
2. Build cython with enabled collecting of profile data: `CFLAGS='-g0 -O2' python setup.py build_ext -i --cython-gen-pgo`
3. Run some load to collect profiling data - e.g. test suite can be run: 
   `python runtests.py --cython-only pep memoryview import gil method class fuse func`
   After this step, `pgo` directory should created and filled with pgo profile data
4. Final build of cython using profile data: `CFLAGS='-g0 -O2' python setup.py build_ext --cython-use-pgo`

> [!NOTE]
> `CFLAGS` are used only to ensure optimization and removal of debug symbols, they do not have any effect on PGO and can be avoided.

This PR is a draft for early feedback. PGO for IPythonMagic is broken and does not work (in master too). I am not sure whether it make sense to fix it...
