### PR TITLE
Fix some syntax errors in cygdb script

### DIFF
--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -61,8 +61,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
             sitepackages = [ p for p in sitepackages if pathlib.Path(p).is_relative_to(virtualenv) ]
             activate_virtualenv = (
                 f'import sys; sys.path[:0] = {sitepackages!r}; '
-                f'import site; {"; ".join(f"site.addsitedir({p!r})" for p in sitepackages)}'
-                f'{";" if sitepackages else ""}'
+                f'import site; {"".join(f"site.addsitedir({p!r}); " for p in sitepackages)}'
                 f'print("gdb command file: Activating virtualenv: {virtualenv}")'
             )
             platform_machine = platform.machine()

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -43,7 +43,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
         activate_virtualenv = report_virtualenv_error = 'pass'
         check_virtualenv_version = 'False'
         virtualenv = os.getenv('VIRTUAL_ENV')
-        has_gil = getattr(sys, "_is_gil_enabled", True)
+        has_gil = hasattr(sys, "_is_gil_enabled")
         platform_machine = ""
 
         if virtualenv:
@@ -61,13 +61,14 @@ def make_command_file(path_to_debug_info, prefix_code='',
             sitepackages = [ p for p in sitepackages if pathlib.Path(p).is_relative_to(virtualenv) ]
             activate_virtualenv = (
                 f'import sys; sys.path[:0] = {sitepackages!r}; '
-                f'import site; {"; ".join(f"site.addsitedir({p!r})" for p in sitepackages)}; '
+                f'import site; {"; ".join(f"site.addsitedir({p!r})" for p in sitepackages)}'
+                f'{";" if sitepackages else ""}'
                 f'print("gdb command file: Activating virtualenv: {virtualenv}")'
             )
             platform_machine = platform.machine()
             check_virtualenv_version = (
                 f'sys.version_info[:2] == {sys.version_info[:2] !r} and '
-                f'getattr(sys, "_is_gil_enabled", True) == {has_gil !r} and '
+                f'hasattr(sys, "_is_gil_enabled") == {has_gil !r} and '
                 f'platform.machine() == {platform_machine !r}'
             )
             report_virtualenv_error = (

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -40,11 +40,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
     try:
         f.write(prefix_code)
 
-        activate_virtualenv = report_virtualenv_error = 'pass'
-        check_virtualenv_version = 'False'
         virtualenv = os.getenv('VIRTUAL_ENV')
-        platform_machine = ""
-
         if virtualenv:
             import site
             import pathlib
@@ -57,7 +53,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
             #   be imported for example.
             # This will work best if the virtual environment is the same Python version as
             # the interpreter linked into GDB.
-            is_freethreaded_build = sysconfig.get_config_var("Py_GIL_DISABLED")
+            is_freethreaded_build = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
             sitepackages = site.getsitepackages()
             sitepackages = [ p for p in sitepackages if pathlib.Path(p).is_relative_to(virtualenv) ]
             activate_virtualenv = (
@@ -65,17 +61,10 @@ def make_command_file(path_to_debug_info, prefix_code='',
                 f'import site; {"".join(f"site.addsitedir({p!r}); " for p in sitepackages)}'
                 f'print("gdb command file: Activating virtualenv: {virtualenv}")'
             )
-            platform_machine = platform.machine()
-            check_virtualenv_version = (
-                f'sys.version_info[:2] == {sys.version_info[:2] !r} and '
-                f'sysconfig.get_config_var("Py_GIL_DISABLED") == {is_freethreaded_build !r} and '
-                f'platform.machine() == {platform_machine !r}'
-            )
-            report_virtualenv_error = (
-                'print("Not activating virtual environment for mismatched Python version '
-                f'{sys.version_info[0]}, {sys.version_info[1]}, '
-                f'{"t" if is_freethreaded_build else "" !r}, {platform_machine !r}")'
-            )
+            call_args = f'{sys.version_info[:2] !r}, {is_freethreaded_build !r}, {platform.machine() !r}'
+        else:
+            activate_virtualenv = 'pass'
+            call_args = '0, 0, False, ""'
 
         f.write(textwrap.dedent(f'''\
             # This is a gdb command file
@@ -85,16 +74,27 @@ def make_command_file(path_to_debug_info, prefix_code='',
             set print pretty on
 
             python
+            def _cygdb_check_virtualenv_match(venv_pyversion, venv_is_freethreading, venv_machine):
+                import sys
+                if sys.version_info[:2] == venv_pyversion:
+                    import sysconfig
+                    if bool(sysconfig.get_config_var("Py_GIL_DISABLED")) == venv_is_freethreading:
+                        import platform
+                        if platform.machine() == venv_machine:
+                            return True
+
+                print("Not activating virtual environment for mismatched Python version %d.%d%s (%s)" % (
+                    venv_pyversion[0], venv_pyversion[1],
+                    "t" if is_freethreaded_build else "",
+                    platform_machine,
+                )
+                return False
+
             import sys
             try:
                 # Activate virtualenv, if we were launched from one that matches what gdb uses.
-                if {bool(virtualenv) !r}:
-                    import platform
-                    import sysconfig
-                    if {check_virtualenv_version}:
-                        {activate_virtualenv}
-                    else:
-                        {report_virtualenv_error}
+                if {bool(virtualenv) !r} and _cygdb_check_virtualenv_match({call_args}):
+                    {activate_virtualenv}
                 from Cython.Debugger import libcython, libpython
             except Exception as ex:
                 from traceback import print_exc

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -43,13 +43,13 @@ def make_command_file(path_to_debug_info, prefix_code='',
         activate_virtualenv = report_virtualenv_error = 'pass'
         check_virtualenv_version = 'False'
         virtualenv = os.getenv('VIRTUAL_ENV')
-        is_freethreaded_build = hasattr(sys, "_is_gil_enabled")
         platform_machine = ""
 
         if virtualenv:
             import site
             import pathlib
             import platform
+            import sysconfig
             # Emulating the virtual env we're in will always be imperfect. But:
             # * Work out the site packages from the current interpreter and add those
             #   to the start of the path to let those be found first.
@@ -57,6 +57,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
             #   be imported for example.
             # This will work best if the virtual environment is the same Python version as
             # the interpreter linked into GDB.
+            is_freethreaded_build = sysconfig.get_config_var("Py_GIL_DISABLED")
             sitepackages = site.getsitepackages()
             sitepackages = [ p for p in sitepackages if pathlib.Path(p).is_relative_to(virtualenv) ]
             activate_virtualenv = (
@@ -67,12 +68,13 @@ def make_command_file(path_to_debug_info, prefix_code='',
             platform_machine = platform.machine()
             check_virtualenv_version = (
                 f'sys.version_info[:2] == {sys.version_info[:2] !r} and '
-                f'hasattr(sys, "_is_gil_enabled") == {is_freethreaded_build !r} and '
+                f'sysconfig.get_config_var("Py_GIL_DISABLED") == {is_freethreaded_build !r} and '
                 f'platform.machine() == {platform_machine !r}'
             )
             report_virtualenv_error = (
-                'print("Not activating virtual environment for mismatched Python version %d.%d%s (%s)" % ('
-                f'{sys.version_info[0]}, {sys.version_info[1]}, {"t" if is_freethreaded_build else "" !r}, {platform_machine !r}))'
+                'print("Not activating virtual environment for mismatched Python version '
+                f'{sys.version_info[0]}, {sys.version_info[1]}, '
+                f'{"t" if is_freethreaded_build else "" !r}, {platform_machine !r}")'
             )
 
         f.write(textwrap.dedent(f'''\
@@ -88,6 +90,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
                 # Activate virtualenv, if we were launched from one that matches what gdb uses.
                 if {bool(virtualenv) !r}:
                     import platform
+                    import sysconfig
                     if {check_virtualenv_version}:
                         {activate_virtualenv}
                     else:

--- a/Cython/Debugger/Cygdb.py
+++ b/Cython/Debugger/Cygdb.py
@@ -43,7 +43,7 @@ def make_command_file(path_to_debug_info, prefix_code='',
         activate_virtualenv = report_virtualenv_error = 'pass'
         check_virtualenv_version = 'False'
         virtualenv = os.getenv('VIRTUAL_ENV')
-        has_gil = hasattr(sys, "_is_gil_enabled")
+        is_freethreaded_build = hasattr(sys, "_is_gil_enabled")
         platform_machine = ""
 
         if virtualenv:
@@ -67,12 +67,12 @@ def make_command_file(path_to_debug_info, prefix_code='',
             platform_machine = platform.machine()
             check_virtualenv_version = (
                 f'sys.version_info[:2] == {sys.version_info[:2] !r} and '
-                f'hasattr(sys, "_is_gil_enabled") == {has_gil !r} and '
+                f'hasattr(sys, "_is_gil_enabled") == {is_freethreaded_build !r} and '
                 f'platform.machine() == {platform_machine !r}'
             )
             report_virtualenv_error = (
                 'print("Not activating virtual environment for mismatched Python version %d.%d%s (%s)" % ('
-                f'{sys.version_info[0]}, {sys.version_info[1]}, {"" if has_gil else "t" !r}, {platform_machine !r}))'
+                f'{sys.version_info[0]}, {sys.version_info[1]}, {"t" if is_freethreaded_build else "" !r}, {platform_machine !r}))'
             )
 
         f.write(textwrap.dedent(f'''\


### PR DESCRIPTION
Fixup to 6dcfa5a66885076994718eb40afd91acc4f57d72. I don't think it solves the Python 3.16 sanitizer tests problem but it definitely solves some invalid syntax.