### PR TITLE
Fix redeclaration error of global annotated variable.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2359,7 +2359,10 @@ class NameNode(AtomicExprNode):
         elif (self.entry and self.entry.is_inherited and
                 self.annotation and env.is_c_dataclass_scope):
             error(self.pos, "Cannot redeclare inherited fields in Cython dataclasses")
-        elif self.entry and self.annotation and env.directives['annotation_typing']:
+        elif self.entry and self.annotation and env.directives['annotation_typing'] and not self.entry.scope.is_module_scope:
+            # Type annotations of global variables (module scope) are ignored by cython.
+            # Hence, we support following declaration:
+            # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
             error(self.pos, f"'{self.name}' redeclared")
         if not self.entry:
             if env.directives['warn.undeclared']:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2363,9 +2363,9 @@ class NameNode(AtomicExprNode):
             if not self.entry.scope.is_module_scope:
                 error(self.pos, f"'{self.name}' redeclared")
             else:
-            # Type annotations of global variables (module scope) are ignored by cython.
-            # Hence, we support somewhat contradictory declarations like:
-            # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
+                # Type annotations of global variables (module scope) are ignored by cython.
+                # Hence, we support somewhat contradictory declarations like:
+                # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
                 annotation_type = self.annotation.analyse_as_type(env)
                 entry_type = self.entry.type
                 if not (annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)):

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2361,7 +2361,7 @@ class NameNode(AtomicExprNode):
             error(self.pos, "Cannot redeclare inherited fields in Cython dataclasses")
         elif self.entry and self.annotation and env.directives['annotation_typing'] and not self.entry.scope.is_module_scope:
             # Type annotations of global variables (module scope) are ignored by cython.
-            # Hence, we support following declaration:
+            # Hence, we support somewhat contradictory declarations like:
             # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
             error(self.pos, f"'{self.name}' redeclared")
         if not self.entry:

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2359,11 +2359,19 @@ class NameNode(AtomicExprNode):
         elif (self.entry and self.entry.is_inherited and
                 self.annotation and env.is_c_dataclass_scope):
             error(self.pos, "Cannot redeclare inherited fields in Cython dataclasses")
-        elif self.entry and self.annotation and env.directives['annotation_typing'] and not self.entry.scope.is_module_scope:
+        elif self.entry and self.annotation and env.directives['annotation_typing']:
+            if not self.entry.scope.is_module_scope:
+                error(self.pos, f"'{self.name}' redeclared")
+            else:
             # Type annotations of global variables (module scope) are ignored by cython.
             # Hence, we support somewhat contradictory declarations like:
             # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
-            error(self.pos, f"'{self.name}' redeclared")
+                annotation_type = self.annotation.analyse_as_type(env)
+                entry_type = self.entry.type
+                if not (annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)):
+                    warning(self.pos,
+                        f"Annotation type '{annotation_type}' is not compatible "
+                        f"with declaration type '{entry_type}'.", 1)
         if not self.entry:
             if env.directives['warn.undeclared']:
                 warning(self.pos, "implicit declaration of '%s'" % self.name, 1)

--- a/tests/errors/pure_warnings.py
+++ b/tests/errors/pure_warnings.py
@@ -42,6 +42,8 @@ def bar3() -> stdint.bar:  # warning
 def bar4(a: cython.foo[:]):  # error
     pass
 
+cvar: list = cython.declare(dict, {}) # warning
+
 _WARNINGS = """
 12:10: Unknown type declaration 'Bar' in annotation, ignoring
 15:16: Unknown type declaration 'stdint.bar' in annotation, ignoring
@@ -51,6 +53,7 @@ _WARNINGS = """
 21:14: Unknown type declaration in annotation, ignoring
 35:14: Unknown type declaration 'Bar' in annotation, ignoring
 39:20: Unknown type declaration 'stdint.bar' in annotation, ignoring
+45:0: Annotation type 'list object' is not compatible with declaration type 'dict object'.
 
 # Spurious warnings from utility code - not part of the core test
 26:10: 'cpdef_method' redeclared

--- a/tests/errors/pure_warnings.py
+++ b/tests/errors/pure_warnings.py
@@ -42,7 +42,7 @@ def bar3() -> stdint.bar:  # warning
 def bar4(a: cython.foo[:]):  # error
     pass
 
-cvar: list = cython.declare(dict, {}) # warning
+cvar: list = cython.declare(dict, {})  # warning
 
 _WARNINGS = """
 12:10: Unknown type declaration 'Bar' in annotation, ignoring

--- a/tests/run/pep526_variable_annotations.py
+++ b/tests/run/pep526_variable_annotations.py
@@ -23,6 +23,7 @@ except ImportError:
 
 pyobj_var = 1  # type: annotation
 var: cython.int = 2
+cvar: cython.int = cython.declare(cython.int, 5)
 fvar: cython.float = 1.2
 some_number: cython.int    # variable without initial value
 some_list: List[cython.int] = []  # variable with initial value
@@ -57,6 +58,16 @@ def f():
     descr_only: "descriptions are allowed but ignored"
 
     return var, fvar, some_list, t
+
+
+def test_global_variables():
+    """
+    >>> test_global_variables()
+    2 Python object
+    5 int
+    """
+    print(var, cython.typeof(var) if cython.compiled else 'Python object')
+    print(cvar, cython.typeof(cvar))
 
 
 class BasicStarship(object):


### PR DESCRIPTION
Currently cython ignores annotations of global variables. Hence, when
global variable is declared `cython.declare` we should not fail with
redeclared error. This PR allows following code snippet:

```python
var: tuple[typing.Any] = cython.declare(tuple, ())
```

Fixes #7874
