### PR TITLE
Disable cygdb_venv test

### DIFF
--- a/tests/bugs.txt
+++ b/tests/bugs.txt
@@ -57,3 +57,7 @@ inlined_generator_expressions
 # crash in C++ on i686 (possibly others?)
 # See https://github.com/cython/cython/issues/5768
 gil_in_var_initialization_tests
+
+# Test doesn't actually activate the virtual env and
+# PYTHONPATH from outer environment interferes.
+cygdb_venv


### PR DESCRIPTION
The issues with the test are
1. The test doesn't actually activate the virtual environment (it just uses the interpreter directly). Which means it isn't really testing the right thing.
2. PYTHONPATH from any outer virtual environment interfers with the interpreter in gdb (assuming that they're different Python versions).
3. Cython would need to be installed and accessible to the interpreter in gdb too in order to work correctly (if you clear PYTHONPATH then it fails to find Cython).