### PR TITLE
Fix dict infer indexed type

### DIFF
--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -5476,11 +5476,11 @@ class BuiltinTypeConstructorObjectType(BuiltinObjectType, PythonTypeConstructorM
     def infer_indexed_type(self, at_index=None):
         container_type = self.get_container_type()
         if container_type.is_pytuple_type:
-            if at_index is None:
-                return self.get_common_item_type()
             if self.has_uniform_element_type:
                 # tuple[TYP, ...]
                 return self.get_subscripted_type(0)
+            if at_index is None:
+                return self.get_common_item_type()
             if isinstance(at_index, int):
                 return self.get_subscripted_type(at_index)
         if container_type.is_pyanydict_type:

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -5475,13 +5475,14 @@ class BuiltinTypeConstructorObjectType(BuiltinObjectType, PythonTypeConstructorM
 
     def infer_indexed_type(self, at_index=None):
         container_type = self.get_container_type()
-        if at_index is None:
-            return self.get_common_item_type()
-        if container_type.is_pytuple_type and self.has_uniform_element_type:
-            # tuple[TYP, ...]
-            return self.get_subscripted_type(0)
-        if container_type.is_pytuple_type and isinstance(at_index, int):
-            return self.get_subscripted_type(at_index)
+        if container_type.is_pytuple_type:
+            if at_index is None:
+                return self.get_common_item_type()
+            if self.has_uniform_element_type:
+                # tuple[TYP, ...]
+                return self.get_subscripted_type(0)
+            if isinstance(at_index, int):
+                return self.get_subscripted_type(at_index)
         if container_type.is_pyanydict_type:
             return self.get_subscripted_type(1)
         if container_type.is_pylist_type or container_type.is_pyanyset_type:

--- a/tests/run/type_inference_generics.py
+++ b/tests/run/type_inference_generics.py
@@ -44,10 +44,21 @@ def test_assign_builtin_method():
     print(cython.typeof(i))
 
 
-def test_builtin_method_expression():
+def test_builtin_methods():
     """
-    >>> test_builtin_method_expression()
-    int
+    >>> test_builtin_methods()
+    int 1
+    int object 2
+    str object a
     """
     l: list[list[cython.int]] = [[1]]
-    print(cython.typeof(l.pop().pop()))
+    lp = l.pop().pop()
+    print(cython.typeof(lp), lp)
+
+    d: dict[str, int] = {'a': 2}
+    dg = d.get('a')
+    print(cython.typeof(dg) + (' object' if not cython.compiled else ''), dg)
+
+    s: set[str] = {'a'}
+    sg = s.pop()
+    print(cython.typeof(sg) + (' object' if not cython.compiled else ''), sg)


### PR DESCRIPTION
The PR fixes issue with type inference of dict `get()` method.