### PR TITLE
Fix setitem on declared "list[cy.int]"

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -4557,11 +4557,10 @@ class IndexNode(_IndexingBaseNode):
 
         self.wrap_in_nonecheck_node(env, getting)
 
-        if base_type.supports_container_type and (sub_type := base_type.infer_indexed_type(self.index.constant_result)):
-            if getting and not is_slice:
+        if getting and not is_slice and base_type.supports_container_type:
+            sub_type = base_type.infer_indexed_type(self.index.constant_result)
+            if sub_type:
                 return self.coerce_to(sub_type, env)
-            elif setting:
-                self.type = sub_type
 
         return self
 

--- a/tests/errors/e_typing_errors.pyx
+++ b/tests/errors/e_typing_errors.pyx
@@ -65,7 +65,7 @@ def subscripted_types_assignments_to_variable():
     tb: tuple[str, cython.int] = ('bar', 1)
     z: cython.int = ta[1]
     zz: cython.float = 1.0
-    tb[1] = zz
+    tb[1] = zz  # currently not an error
     h: cython.int
     for h in ta:
         pass
@@ -74,7 +74,7 @@ def subscripted_types_assignments_to_variable():
     lb: list[cython.int] = [1]
     a: cython.int = la[0]
     aa: cython.float = 1.0
-    lb[0] = aa
+    lb[0] = aa  # currently not an error
     i: cython.int
     for i in la:
         pass
@@ -83,7 +83,7 @@ def subscripted_types_assignments_to_variable():
     db: dict[str, cython.int] = {"a": 1.0}
     b: cython.int = da[1]
     bb: cython.float = 1.0
-    db[0] = bb
+    db[0] = bb  # currently not an error
     j: cython.int
     for j in da:
         pass
@@ -333,12 +333,9 @@ _ERRORS = """
 59:9: Cannot assign type 'frozenset[float] object' to 'dict[float,float] object'
 60:9: Cannot assign type 'list[float] object' to 'dict[float,float] object'
 66:22: Cannot assign type 'float' to 'int'
-68:12: Cannot assign type 'float' to 'int'
 75:22: Cannot assign type 'float' to 'int'
-77:12: Cannot assign type 'float' to 'int'
 79:13: Cannot assign type 'float' to 'int'
 84:22: Cannot assign type 'float' to 'int'
-86:12: Cannot assign type 'float' to 'int'
 88:13: Cannot assign type 'float' to 'int'
 93:8: Cannot convert Python object to 'int *'
 93:13: Cannot assign type 'int' to 'int *'

--- a/tests/run/cdef_setitem_T284.pyx
+++ b/tests/run/cdef_setitem_T284.pyx
@@ -1,5 +1,7 @@
 # ticket: t284
 
+import cython
+
 def no_cdef():
     """
     >>> no_cdef()
@@ -10,6 +12,7 @@ def no_cdef():
     cdef object dd = {}
     dd[ob] = -10
 
+
 def with_cdef():
     """
     >>> with_cdef()
@@ -19,6 +22,7 @@ def with_cdef():
     lst[ob] = -10
     cdef dict dd = {}
     dd[ob] = -10
+
 
 def with_external_list(list L):
     """
@@ -32,6 +36,7 @@ def with_external_list(list L):
     L[ob] = -10
     return L
 
+
 def test_list(list L, object i, object a):
     """
     >>> test_list(list(range(11)), -2, None)
@@ -41,4 +46,14 @@ def test_list(list L, object i, object a):
     TypeError: list ... must be ...integer...
     """
     L[i] = a
+    return L
+
+
+def with_ctype_items(L: list[cython.int], i, int j, int value):
+    """
+    >>> with_ctype_items([1,2,3], 1, 2, 4)
+    [1, 5, 4]
+    """
+    L[i] = 5
+    L[j] = value
     return L


### PR DESCRIPTION
If the item type of a container is declared as a C type, we must still coerce a value of the expected C type to a Python object on index assignments. The type of the item in the container is always a plain Python object, regardless of the declared item type.

Fixes https://github.com/cython/cython/pull/7689