### PR TITLE
Fix inplace assignments to C properties.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6446,22 +6446,6 @@ class SimpleCallNode(CallNode):
         node = cls(pos, function=function, args=[obj])
         return node
 
-    @classmethod
-    def for_cproperty_set(cls, pos, obj, entry):
-        # Create a call node for C property access.
-        # This actually returns a utility node that wraps the call node.
-        property_scope = entry.scope
-        setter_entry = property_scope.lookup_here("__set__")
-        if not setter_entry:
-            error(pos, "Assignment to a read-only property")
-            return None
-        from . import UtilNodes
-        function = NameNode(pos, name=entry.name, entry=setter_entry, type=setter_entry.type)
-        arg_type = setter_entry.type.args[1].type
-        arg1 = RawCNameExprNode(pos, type=arg_type)
-        node = cls(pos, function=function, args=[obj, arg1])
-        return UtilNodes.CPropertySetNode(pos, call_node=node, type=arg_type, arg1=arg1)
-
     def analyse_as_type(self, env):
         attr = self.function.as_cython_attribute()
         if attr == 'pointer':
@@ -6739,37 +6723,15 @@ class SimpleCallNode(CallNode):
         self.overflowcheck = env.directives['overflowcheck']
 
     def calculate_result_code(self):
-        return self.c_call_code()
-
-    def c_call_code(self):
         func_type = self.function_type()
         if self.type is PyrexTypes.error_type or not func_type.is_cfunction:
             return "<error>"
-        formal_args = func_type.args
-        arg_list_code = []
-        args = list(zip(formal_args, self.args))
-        max_nargs = len(func_type.args)
-        expected_nargs = max_nargs - func_type.optional_arg_count
-        actual_nargs = len(self.args)
-        for formal_arg, actual_arg in args[:expected_nargs]:
-            arg_code = actual_arg.move_result_rhs_as(formal_arg.type)
-            arg_list_code.append(arg_code)
 
-        if func_type.is_overridable:
-            arg_list_code.append(str(int(self.wrapper_call or self.function.entry.is_unbound_cmethod)))
-
-        if func_type.optional_arg_count:
-            if expected_nargs == actual_nargs:
-                optional_args = 'NULL'
-            else:
-                optional_args = "&%s" % self.opt_arg_struct
-            arg_list_code.append(optional_args)
-
-        for actual_arg in self.args[len(formal_args):]:
-            arg_list_code.append(actual_arg.move_result_rhs())
-
-        result = "%s(%s)" % (self.function.result(), ', '.join(arg_list_code))
-        return result
+        return build_c_call_code(
+            func_type, self.function.result(), self.args,
+            is_wrapper_call=self.wrapper_call or (
+                func_type.is_overridable and self.function.entry.is_unbound_cmethod),
+        )
 
     def is_c_result_required(self):
         func_type = self.function_type()
@@ -6847,73 +6809,129 @@ class SimpleCallNode(CallNode):
                     arg_code,
                     code.error_goto_if_null(self.result(), self.pos)))
             self.generate_gotref(code)
-        elif func_type.is_cfunction:
-            nogil = not code.funcstate.gil_owned
-            if self.has_optional_args:
-                actual_nargs = len(self.args)
-                expected_nargs = len(func_type.args) - func_type.optional_arg_count
-                self.opt_arg_struct = code.funcstate.allocate_temp(
-                    func_type.op_arg_struct.base_type, manage_ref=True)
-                code.putln("%s.%s = %s;" % (
-                        self.opt_arg_struct,
-                        Naming.pyrex_prefix + "n",
-                        len(self.args) - expected_nargs))
-                args = list(zip(func_type.args, self.args))
-                for formal_arg, actual_arg in args[expected_nargs:actual_nargs]:
-                    code.putln("%s.%s = %s;" % (
-                            self.opt_arg_struct,
-                            func_type.opt_arg_cname(formal_arg.name),
-                            actual_arg.result_as(formal_arg.type)))
-            exc_checks = []
-            if self.type.is_pyobject and self.is_temp:
-                exc_checks.append("!%s" % self.result())
-            elif self.type.is_memoryviewslice:
-                assert self.is_temp
-                exc_checks.append(self.type.error_condition(self.result()))
-            elif func_type.exception_check != '+':
-                exc_val = func_type.exception_value
-                exc_check = func_type.exception_check
-                if exc_val is not None:
-                    exc_checks.append(exc_val.exception_test_code(self.result(), code))
-                if exc_check:
-                    if nogil:
-                        if not exc_checks:
-                            perf_hint_entry = getattr(self.function, "entry", None)
-                            PyrexTypes.write_noexcept_performance_hint(
-                                self.pos, code.funcstate.scope,
-                                function_name=perf_hint_entry.name if perf_hint_entry else None,
-                                void_return=self.type.is_void, is_call=True,
-                                is_from_pxd=(perf_hint_entry and perf_hint_entry.defined_in_pxd))
-                        code.globalstate.use_utility_code(
-                            UtilityCode.load_cached("ErrOccurredWithGIL", "Exceptions.c"))
-                        exc_checks.append("__Pyx_ErrOccurredWithGIL()")
-                    else:
-                        exc_checks.append("PyErr_Occurred()")
-            if self.is_temp or exc_checks:
-                rhs = self.c_call_code()
-                if self.result():
-                    lhs = "%s = " % self.result()
-                    if self.is_temp and self.type.is_pyobject:
-                        #return_type = self.type # func_type.return_type
-                        #print "SimpleCallNode.generate_result_code: casting", rhs, \
-                        #    "from", return_type, "to pyobject" ###
-                        rhs = typecast(py_object_type, self.type, rhs)
-                else:
-                    lhs = ""
-                if func_type.exception_check == '+':
-                    translate_cpp_exception(code, self.pos, '%s%s;' % (lhs, rhs),
-                                            self.result() if self.type.is_pyobject else None,
-                                            func_type.exception_value, nogil)
-                else:
-                    if exc_checks:
-                        goto_error = code.error_goto_if(" && ".join(exc_checks), self.pos)
-                    else:
-                        goto_error = ""
-                    code.putln("%s%s; %s" % (lhs, rhs, goto_error))
-                if self.type.is_pyobject and self.result():
-                    self.generate_gotref(code)
-            if self.has_optional_args:
-                code.funcstate.release_temp(self.opt_arg_struct)
+        elif func_type.is_cfunction and self.is_temp:
+            generate_cfunction_call(
+                self.pos, code, func_type, self.function.result(), self.args,
+                has_optional_args=self.has_optional_args,
+                result_cname=self.result() if self.is_temp else None,
+                func_entry=getattr(self.function, 'entry', None),
+                is_wrapper_call=self.wrapper_call or (
+                    func_type.is_overridable and self.function.entry.is_unbound_cmethod),
+            )
+
+
+def build_c_call_code(func_type, function_cname, args, opt_arg_struct_cname=None, is_wrapper_call=False):
+    formal_args = func_type.args
+    arg_list_code = []
+    mapped_args = list(zip(formal_args, args))
+    max_nargs = len(func_type.args)
+    expected_nargs = max_nargs - func_type.optional_arg_count
+    actual_nargs = len(mapped_args)
+
+    for formal_arg, actual_arg in mapped_args[:expected_nargs]:
+        arg_code = actual_arg.move_result_rhs_as(formal_arg.type)
+        arg_list_code.append(arg_code)
+
+    if func_type.is_overridable:
+        arg_list_code.append("1" if is_wrapper_call else "0")
+
+    if func_type.optional_arg_count:
+        if expected_nargs == actual_nargs:
+            optional_args = 'NULL'
+        else:
+            optional_args = f"&{opt_arg_struct_cname}"
+        arg_list_code.append(optional_args)
+
+    for actual_arg in args[len(formal_args):]:
+        arg_list_code.append(actual_arg.move_result_rhs())
+
+    result = f"{function_cname}({', '.join(arg_list_code)})"
+    return result
+
+
+def generate_cfunction_call(
+        pos, code, func_type, function_cname, args,
+        result_cname=None, func_entry=None, has_optional_args=False, is_wrapper_call=False):
+    nogil = not code.funcstate.gil_owned
+    return_type = func_type.return_type
+    return_temp = None  # Used if we need the result only for error checking.
+    opt_arg_struct = None
+
+    if has_optional_args:
+        actual_nargs = len(args)
+        expected_nargs = len(func_type.args) - func_type.optional_arg_count
+        opt_arg_struct = code.funcstate.allocate_temp(
+            func_type.op_arg_struct.base_type, manage_ref=True)
+        code.putln("%s.%s = %s;" % (
+                opt_arg_struct,
+                Naming.pyrex_prefix + "n",
+                len(args) - expected_nargs))
+        mapped_args = list(zip(func_type.args, args))
+        for formal_arg, actual_arg in mapped_args[expected_nargs:actual_nargs]:
+            code.putln("%s.%s = %s;" % (
+                    opt_arg_struct,
+                    func_type.opt_arg_cname(formal_arg.name),
+                    actual_arg.result_as(formal_arg.type)))
+
+    exc_checks = []
+    if return_type.is_pyobject:
+        if result_cname is None:
+            return_temp = result_cname = code.funcstate.allocate_temp(return_type, manage_ref=True)
+        exc_checks.append(f"!{result_cname}")
+    elif return_type.is_memoryviewslice:
+        assert result_cname
+        exc_checks.append(return_type.error_condition(result_cname))
+    elif func_type.exception_check != '+':
+        exc_val = func_type.exception_value
+        exc_check = func_type.exception_check
+        if exc_val is not None:
+            if result_cname is None:
+                return_temp = result_cname = code.funcstate.allocate_temp(return_type, manage_ref=True)
+            exc_checks.append(exc_val.exception_test_code(result_cname, code))
+        if exc_check:
+            if nogil:
+                if not exc_checks:
+                    PyrexTypes.write_noexcept_performance_hint(
+                        pos, code.funcstate.scope,
+                        function_name=func_entry.name if func_entry else None,
+                        void_return=return_type.is_void, is_call=True,
+                        is_from_pxd=(func_entry and func_entry.defined_in_pxd))
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("ErrOccurredWithGIL", "Exceptions.c"))
+                exc_checks.append("__Pyx_ErrOccurredWithGIL()")
+            else:
+                exc_checks.append("PyErr_Occurred()")
+
+    rhs = build_c_call_code(
+        func_type, function_cname, args,
+        opt_arg_struct_cname=opt_arg_struct,
+        is_wrapper_call=is_wrapper_call,
+    )
+
+    if result_cname:
+        lhs = f"{result_cname} = "
+        if return_type.is_pyobject:
+            #return_type = self.type # func_type.return_type
+            #print "SimpleCallNode.generate_result_code: casting", rhs, \
+            #    "from", return_type, "to pyobject" ###
+            rhs = typecast(py_object_type, return_type, rhs)
+    else:
+        lhs = ""
+    if func_type.exception_check == '+':
+        translate_cpp_exception(code, pos, f'{lhs}{rhs};',
+                                result_cname if return_type.is_pyobject else None,
+                                func_type.exception_value, nogil)
+    else:
+        goto_error = code.error_goto_if(" && ".join(exc_checks), pos) if exc_checks else ""
+        code.putln(f"{lhs}{rhs}; {goto_error}")
+
+    if return_type.is_pyobject and return_temp is None:
+        code.put_gotref(result_cname, py_object_type)
+
+    if return_temp is not None:
+        code.funcstate.release_temp(return_temp)
+    if opt_arg_struct is not None:
+        code.funcstate.release_temp(opt_arg_struct)
 
 
 class NumPyMethodCallNode(ExprNode):
@@ -8177,10 +8195,17 @@ class AttributeNode(ExprNode):
                 self.result_ctype = py_object_type
         elif self.entry and self.entry.is_cproperty:
             if target:
-                call_node = SimpleCallNode.for_cproperty_set(self.pos, self.obj, self.entry)
+                cmethod_entry = self.entry.scope.lookup_here("__set__")
+                if not cmethod_entry or not cmethod_entry.is_cfunction or len(cmethod_entry.type.args) < 2:
+                    error(self.pos, "Assignment to a read-only property")
+                    return None
+                # Use the type of the setter value argument as attribute type, not the property (getter) type.
+                self.type = cmethod_entry.type.args[1].type
+                self.is_temp = True
             else:
+                # Transform directly into a getter call node.
                 call_node = SimpleCallNode.for_cproperty_get(self.pos, self.obj, self.entry)
-            return call_node.analyse_types(env) if call_node is not None else None
+                return call_node.analyse_types(env)
         elif target and self.obj.type.is_builtin_type:
             error(self.pos, "Assignment to an immutable object field")
         #elif self.type.is_memoryviewslice and not target:
@@ -8465,6 +8490,10 @@ class AttributeNode(ExprNode):
                 rhs.result_as(self.ctype())))
             rhs.generate_disposal_code(code)
             rhs.free_temps(code)
+        elif self.entry.is_cproperty:
+            self.generate_cproperty_assignment(code, rhs)
+            rhs.generate_disposal_code(code)
+            rhs.free_temps(code)
         else:
             select_code = self.result()
             if self.type.is_pyobject and self.use_managed_ref:
@@ -8487,6 +8516,22 @@ class AttributeNode(ExprNode):
             rhs.free_temps(code)
         self.obj.generate_disposal_code(code)
         self.obj.free_temps(code)
+
+    def generate_cproperty_assignment(self, code, rhs):
+        cmethod_entry = self.entry.scope.lookup_here("__set__")
+        assert cmethod_entry is not None  # errors were handled during type analysis
+        cfunc_type = cmethod_entry.type
+        return_type = cfunc_type.return_type
+
+        if cmethod_entry.utility_code is not None:
+            code.globalstate.use_utility_code(cmethod_entry.utility_code)
+
+        generate_cfunction_call(
+            self.pos, code, cfunc_type, cmethod_entry.cname,
+            args=[self.obj, rhs],
+            result_cname=self.result() if self.is_temp else None,
+            func_entry=cmethod_entry,
+        )
 
     def generate_deletion_code(self, code, ignore_nonexisting=False):
         self.obj.generate_evaluation_code(code)

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6861,16 +6861,12 @@ def generate_cfunction_call(
         expected_nargs = len(func_type.args) - func_type.optional_arg_count
         opt_arg_struct = code.funcstate.allocate_temp(
             func_type.op_arg_struct.base_type, manage_ref=True)
-        code.putln("%s.%s = %s;" % (
-                opt_arg_struct,
-                Naming.pyrex_prefix + "n",
-                len(args) - expected_nargs))
+        code.putln(
+            f"{opt_arg_struct}.{Naming.opt_args_count_field} = {len(args) - expected_nargs};")
         mapped_args = list(zip(func_type.args, args))
         for formal_arg, actual_arg in mapped_args[expected_nargs:actual_nargs]:
-            code.putln("%s.%s = %s;" % (
-                    opt_arg_struct,
-                    func_type.opt_arg_cname(formal_arg.name),
-                    actual_arg.result_as(formal_arg.type)))
+            code.putln(
+                f"{opt_arg_struct}.{func_type.opt_arg_cname(formal_arg.name)} = {actual_arg.result_as(formal_arg.type)};")
 
     exc_checks = []
     if return_type.is_pyobject:

--- a/Cython/Compiler/Naming.py
+++ b/Cython/Compiler/Naming.py
@@ -57,6 +57,7 @@ unicode_structmember_prefix = pyrex_prefix + "Umember_"
 # as above -
 # not normally mangled but punycode names cause specific problems
 opt_arg_prefix    = pyrex_prefix + "opt_args_"
+opt_args_count_field    = pyrex_prefix + "n"
 convert_func_prefix = pyrex_prefix + "convert_"
 closure_scope_prefix = pyrex_prefix + "scope_"
 closure_class_prefix = pyrex_prefix + "scope_struct_"

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -3084,6 +3084,8 @@ class FindInvalidUseOfFusedTypes(TreeVisitor):
 
 
 class ExpandInplaceOperators(EnvTransform):
+    """Expand in-place operators into separate read/write operations.
+    """
 
     def visit_InPlaceAssignmentNode(self, node):
         lhs = node.lhs
@@ -3108,26 +3110,30 @@ class ExpandInplaceOperators(EnvTransform):
                 return ExprNodes.IndexNode(node.pos, base=base, index=index), temps + [index]
             elif node.is_attribute:
                 obj, temps = side_effect_free_reference(node.obj, setting=setting)
-                return ExprNodes.AttributeNode(node.pos, obj=obj, attribute=node.attribute), temps
+                return ExprNodes.AttributeNode.from_node(
+                    node, obj=obj, attribute=node.attribute, constant_result=ExprNodes.not_a_constant), temps
             elif isinstance(node, ExprNodes.BufferIndexNode):
                 raise ValueError("Don't allow things like attributes of buffer indexing operations")
             else:
                 node = LetRefNode(node)
                 return node, [node]
+
         try:
             lhs, let_ref_nodes = side_effect_free_reference(lhs, setting=True)
         except ValueError:
             return node
+
         dup = lhs.__class__(**lhs.__dict__)
+        dup = dup.analyse_types(env)  # FIXME: no need to reanalyse the copy, right?
         binop = ExprNodes.binop_node(node.pos,
                                      operator = node.operator,
                                      operand1 = dup,
                                      operand2 = rhs,
                                      inplace=True)
+
         # Manually analyse types for new node.
         lhs.is_target = True
         lhs = lhs.analyse_target_types(env)
-        dup.analyse_types(env)  # FIXME: no need to reanalyse the copy, right?
         binop.analyse_operation(env)
         node = Nodes.SingleAssignmentNode(
             node.pos,

--- a/Cython/Compiler/UtilNodes.py
+++ b/Cython/Compiler/UtilNodes.py
@@ -387,32 +387,3 @@ class HasNoGilNode(AtomicExprNode):
 
     def calculate_result_code(self):
         return str(int(self.in_nogil_context))
-
-
-class CPropertySetNode(ExprNodes.ExprNode):
-    subexprs = ['call_node']
-    arg1 : ExprNodes.RawCNameExprNode
-    call_node : ExprNodes.ExprNode
-
-    def is_lvalue(self):
-        return True
-
-    def analyse_types(self, env):
-        self.call_node = self.call_node.analyse_types(env)
-        return self
-
-    def generate_assignment_code(self, rhs, code, overloaded_assignment=False, exception_check=None, exception_value=None):
-        assert not overloaded_assignment
-        assert exception_check is None, exception_check
-        assert exception_value is None, exception_value
-        self.arg1.set_cname(rhs.result())
-
-        self.call_node.generate_evaluation_code(code)
-        if not self.call_node.is_temp:
-            assert self.call_node.type.is_void, self.call_node.type
-            code.putln(f"{self.call_node.result()};")  # actually call the (void) setter
-        self.call_node.generate_disposal_code(code)
-        self.call_node.free_temps(code)
-
-        rhs.generate_disposal_code(code)
-        rhs.free_temps(code)

--- a/tests/run/ext_attr_setter.pyx
+++ b/tests/run/ext_attr_setter.pyx
@@ -128,8 +128,7 @@ def test_get_obj_temp(*args):
     return Exception(*args).args_obj
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_set_obj(o):
     """
     >>> test_set_obj((1, 2))
@@ -142,8 +141,20 @@ def test_set_obj(o):
     return e
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
+def test_assign_obj_inplace(o):
+    """
+    >>> test_assign_obj_inplace((1, 2))
+    Exception(3, 4, 1, 2)
+    >>> test_assign_obj_inplace(())
+    Exception(3, 4)
+    """
+    e = Exception(3, 4)
+    e.args_obj += o
+    return e
+
+
+@cython.test_assert_path_exists("//AttributeNode")
 def test_set_raising(o):
     """
     >>> test_set_raising((1, 2))
@@ -161,8 +172,7 @@ def test_set_raising(o):
 def forward(o):
     return o
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_set_obj_from_temp(o):
     """
     >>> test_set_obj_from_temp((1, 2))
@@ -175,8 +185,7 @@ def test_set_obj_from_temp(o):
     return e
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_set_obj_temp(*args):
     """
     Setting to a temp isn't hugely useful because we can't check the result
@@ -203,8 +212,7 @@ def test_get_int(Exception e):
     return e.arg0_int
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_set_int(value):
     """
     >>> test_set_int(10)
@@ -218,8 +226,7 @@ def test_set_int(value):
     return e
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_mixed_str(const char* s):
     """
     >>> test_mixed_str(b"Hello")
@@ -230,8 +237,7 @@ def test_mixed_str(const char* s):
     return e.arg0_mixed_str
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_fail_mixed_str(v):
     """
     >>> test_fail_mixed_str([1, 2, 3])  # doctest: +ELLIPSIS
@@ -241,8 +247,10 @@ def test_fail_mixed_str(v):
     Exception().arg0_mixed_str = v
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists(
+    "//SimpleCallNode",
+    "//AttributeNode",
+)
 def test_mixed_double(v):
     """
     >>> test_mixed_double(5.5)
@@ -264,8 +272,7 @@ def test_fail_mixed_double(Exception e):
     return e.arg0_mixed_double
 
 
-@cython.test_assert_path_exists("//SimpleCallNode")
-@cython.test_fail_if_path_exists("//AttributeNode")
+@cython.test_assert_path_exists("//AttributeNode")
 def test_setter_maybe_raising(x):
     """
     >>> test_setter_maybe_raising(0)


### PR DESCRIPTION
Instead of using a separate special node for C property setters, the handling is now folded into AttributeNode, which better integrates with regular attribute usages and processing. It reuses the C function calling code of SimpleCallNode.

Closes https://github.com/cython/cython/issues/7890