### PR TITLE
Fold "CmpNode.is_c_string_contains()" into "find_special_bool_compare_function()".

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14387,11 +14387,20 @@ class CmpNode:
             or (self.cascade and self.cascade.is_python_result()))
 
     def is_c_string_contains(self):
-        return self.operator in ('in', 'not_in') and \
-               ((self.operand1.type.is_int
-                 and (self.operand2.type.is_string or self.operand2.type.is_pybytes_type)) or
-                (self.operand1.type.is_unicode_char
-                 and self.operand2.type.is_pystr_type))
+        if self.operator not in ('in', 'not_in'):
+            return False
+        op1_type = self.operand1.type
+        op2_type = self.operand2.type
+        if op1_type.is_unicode_char:
+            return op2_type.is_pystr_type
+        if self.operand1.is_string_literal and self.operand1.can_coerce_to_char_literal():
+            if op1_type.is_pystr_type:
+                return op2_type.is_pystr_type
+            if op1_type.is_pybytes_type:
+                return op2_type.is_pybytes_type or op2_type.is_pybytearray_type
+        if op1_type.is_int:
+            return op2_type.is_string or op2_type.is_pybytes_type or op2_type.is_pybytearray_type
+        return False
 
     def is_ptr_contains(self):
         if self.operator in ('in', 'not_in'):
@@ -14660,15 +14669,20 @@ class PrimaryCmpNode(ExprNode, CmpNode):
                 common_type = None
                 if self.cascade:
                     error(self.pos, "Cascading comparison not yet supported for 'int_val in string'.")
+                    self.type = error_type
                     return self
-                if self.operand2.type.is_pystr_type:
+                if type2.is_pystr_type:
+                    self.operand1 = self.operand1.coerce_to(PyrexTypes.c_py_ucs4_type, env)
                     env.use_utility_code(UtilityCode.load_cached("PyUCS4InUnicode", "StringTools.c"))
                 else:
-                    if self.operand1.type is PyrexTypes.c_uchar_type:
+                    if type1 is PyrexTypes.c_uchar_type or type1.is_pybytes_type:
                         self.operand1 = self.operand1.coerce_to(PyrexTypes.c_char_type, env)
-                    if not self.operand2.type.is_pybytes_type:
-                        self.operand2 = self.operand2.coerce_to(bytes_type, env)
-                    env.use_utility_code(UtilityCode.load_cached("BytesContains", "StringTools.c"))
+                    if type2.is_pybytearray_type:
+                        env.use_utility_code(UtilityCode.load_cached("ByteArrayContains", "StringTools.c"))
+                    else:
+                        if not type2.is_pybytes_type:
+                            self.operand2 = self.operand2.coerce_to(bytes_type, env)
+                        env.use_utility_code(UtilityCode.load_cached("BytesContains", "StringTools.c"))
                 self.operand2 = self.operand2.as_none_safe_node(
                     "argument of type 'NoneType' is not iterable")
             elif self.is_ptr_contains():
@@ -14801,6 +14815,8 @@ class PrimaryCmpNode(ExprNode, CmpNode):
         elif self.is_c_string_contains():
             if operand2.type.is_pystr_type:
                 method = "__Pyx_UnicodeContainsUCS4"
+            elif operand2.type.is_pybytearray_type:
+                method = "__Pyx_ByteArrayContains"
             else:
                 method = "__Pyx_BytesContains"
             if self.operator == "not_in":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14365,8 +14365,8 @@ class CmpNode:
               (op, operand1.type, operand2.type))
 
     def is_python_comparison(self):
-        return (not self.is_ptr_contains()
-            and not self.is_c_string_contains()
+        return (self.special_bool_cmp_function is None
+            and not self.is_ptr_contains()
             and (self.has_python_operands()
                  or (self.cascade and self.cascade.is_python_comparison())
                  or self.operator in ('in', 'not_in')))
@@ -14379,28 +14379,11 @@ class CmpNode:
             self.cascade.coerce_operands_to(dst_type, env)
 
     def is_python_result(self):
-        return ((self.has_python_operands() and
-                 self.special_bool_cmp_function is None and
-                 self.operator not in ('is', 'is_not', 'in', 'not_in') and
-                 not self.is_c_string_contains() and
-                 not self.is_ptr_contains())
+        return ((self.special_bool_cmp_function is None
+                and self.has_python_operands()
+                and self.operator not in ('is', 'is_not', 'in', 'not_in')
+                and not self.is_ptr_contains())
             or (self.cascade and self.cascade.is_python_result()))
-
-    def is_c_string_contains(self):
-        if self.operator not in ('in', 'not_in'):
-            return False
-        op1_type = self.operand1.type
-        op2_type = self.operand2.type
-        if op1_type.is_unicode_char:
-            return op2_type.is_pystr_type
-        if self.operand1.is_string_literal and self.operand1.can_coerce_to_char_literal():
-            if op1_type.is_pystr_type:
-                return op2_type.is_pystr_type
-            if op1_type.is_pybytes_type:
-                return op2_type.is_pybytes_type or op2_type.is_pybytearray_type
-        if op1_type.is_int:
-            return op2_type.is_string or op2_type.is_pybytes_type or op2_type.is_pybytearray_type
-        return False
 
     def is_ptr_contains(self):
         if self.operator in ('in', 'not_in'):
@@ -14409,7 +14392,11 @@ class CmpNode:
                 and not container_type.is_string
 
     def find_special_bool_compare_function(self, env, operand1, result_is_bool=False):
-        # note: currently operand1 must get coerced to a Python object if we succeed here!
+        """Try to find an optimised comparison function.
+
+        Coerces self.operand2 appropriately.
+        Returns a tuple: (success flag, coerced operand1)
+        """
         if self.operator in ('==', '!='):
             type1, type2 = operand1.type, self.operand2.type
             if result_is_bool or (type1.is_builtin_type and type2.is_builtin_type):
@@ -14421,7 +14408,7 @@ class CmpNode:
                         self.special_bool_cmp_utility_code = TempitaUtilityCode.load_cached(
                             "UnicodeEquals_uchar", "StringTools.c", context={'CHAR': character, 'IS_STR': is_str, 'REVERSE': True})
                         self.special_bool_cmp_function = f"__Pyx_PyObject_Equals_ch{character}_{'str' if is_str else 'obj'}"
-                        return True
+                        return True, operand1.coerce_to_pyobject(env)
                     elif self.operand2.is_string_literal and self.operand2.can_coerce_to_char_literal():
                         # We need to keep the signature (obj1, obj2, eq), so we generate one macro function per character.
                         character = ord(self.operand2.value[0])
@@ -14429,7 +14416,7 @@ class CmpNode:
                         self.special_bool_cmp_utility_code = TempitaUtilityCode.load_cached(
                             "UnicodeEquals_uchar", "StringTools.c", context={'CHAR': character, 'IS_STR': is_str, 'REVERSE': False})
                         self.special_bool_cmp_function = f"__Pyx_PyObject_Equals_{'str' if is_str else 'obj'}_ch{character}"
-                        return True
+                        return True, operand1.coerce_to_pyobject(env)
                 elif result_is_bool:
                     from .Optimize import optimise_numeric_binop
                     result = optimise_numeric_binop(
@@ -14444,30 +14431,51 @@ class CmpNode:
                          self.special_bool_cmp_utility_code,
                          self.special_bool_extra_args,
                          _) = result
-                        return True
+                        return True, operand1
         elif self.operator in ('in', 'not_in'):
-            if self.operand2.type.is_pyanydict_type:
+            type1, type2 = operand1.type, self.operand2.type
+            if type2.is_pyanydict_type:
                 self.operand2 = self.operand2.as_none_safe_node("'NoneType' object is not iterable")
                 self.special_bool_cmp_utility_code = UtilityCode.load_cached("PyDictContains", "ObjectHandling.c")
                 self.special_bool_cmp_function = "__Pyx_PyDict_ContainsTF"
-                return True
-            elif self.operand2.type.is_pyset_type:
+                return True, operand1.coerce_to_pyobject(env)
+            elif type2.is_pyset_type:
                 self.operand2 = self.operand2.as_none_safe_node("'NoneType' object is not iterable")
                 self.special_bool_cmp_utility_code = UtilityCode.load_cached("PySetContains", "ObjectHandling.c")
                 self.special_bool_cmp_function = "__Pyx_PySet_ContainsTF"
-                return True
-            elif self.operand2.type.is_pystr_type:
-                self.operand2 = self.operand2.as_none_safe_node("'NoneType' object is not iterable")
-                self.special_bool_cmp_utility_code = UtilityCode.load_cached("PyUnicodeContains", "StringTools.c")
-                self.special_bool_cmp_function = "__Pyx_PyUnicode_ContainsTF"
-                return True
-            else:
-                if not self.operand2.type.is_pyobject:
-                    self.operand2 = self.operand2.coerce_to_pyobject(env)
-                self.special_bool_cmp_utility_code = UtilityCode.load_cached("PySequenceContains", "ObjectHandling.c")
-                self.special_bool_cmp_function = "__Pyx_PySequence_ContainsTF"
-                return True
-        return False
+                return True, operand1.coerce_to_pyobject(env)
+            elif type2.is_pystr_type:
+                self.operand2 = self.operand2.as_none_safe_node("argument of type 'NoneType' is not iterable")
+                if (type1.is_unicode_char or
+                        type1 in (PyrexTypes.c_char_type, PyrexTypes.c_uchar_type) or
+                        operand1.is_string_literal and operand1.can_coerce_to_char_literal()
+                        ):
+                    operand1 = operand1.coerce_to(PyrexTypes.c_py_ucs4_type, env)
+                    self.special_bool_cmp_utility_code = UtilityCode.load_cached("PyUCS4InUnicode", "StringTools.c")
+                    self.special_bool_cmp_function = "__Pyx_UnicodeContainsUCS4"
+                else:
+                    operand1 = operand1.coerce_to_pyobject(env)
+                    self.special_bool_cmp_utility_code = UtilityCode.load_cached("PyUnicodeContains", "StringTools.c")
+                    self.special_bool_cmp_function = "__Pyx_PyUnicode_ContainsTF"
+                return True, operand1
+            elif type2.is_string or type2.is_pybytes_type or type2.is_pybytearray_type:
+                if type1.is_int or (operand1.is_string_literal and operand1.can_coerce_to_char_literal()):
+                    if type2.is_string:
+                        self.operand2 = self.operand2.coerce_to(bytes_type, env)
+                    else:
+                        self.operand2 = self.operand2.as_none_safe_node("argument of type 'NoneType' is not iterable")
+                    operand1 = operand1.coerce_to(PyrexTypes.c_char_type, env)
+                    self.special_bool_cmp_utility_code = UtilityCode.load_cached(
+                        "ByteArrayContains" if type2.is_pybytearray_type else "BytesContains", "StringTools.c")
+                    self.special_bool_cmp_function = "__Pyx_ByteArrayContains" if type2.is_pybytearray_type else "__Pyx_BytesContains"
+                    return True, operand1
+
+            if not type2.is_pyobject:
+                self.operand2 = self.operand2.coerce_to_pyobject(env)
+            self.special_bool_cmp_utility_code = UtilityCode.load_cached("PySequenceContains", "ObjectHandling.c")
+            self.special_bool_cmp_function = "__Pyx_PySequence_ContainsTF"
+            return True, operand1.coerce_to_pyobject(env)
+        return False, operand1
 
     _optimised_compare_types = {
         py_object_type,
@@ -14664,46 +14672,20 @@ class PrimaryCmpNode(ExprNode, CmpNode):
         if self.cascade:
             self.cascade = self.cascade.analyse_types(env)
 
-        if self.operator in ('in', 'not_in'):
-            if self.is_c_string_contains():
-                common_type = None
-                if self.cascade:
-                    error(self.pos, "Cascading comparison not yet supported for 'int_val in string'.")
-                    self.type = error_type
-                    return self
-                if type2.is_pystr_type:
-                    self.operand1 = self.operand1.coerce_to(PyrexTypes.c_py_ucs4_type, env)
-                    env.use_utility_code(UtilityCode.load_cached("PyUCS4InUnicode", "StringTools.c"))
-                else:
-                    if type1 is PyrexTypes.c_uchar_type or type1.is_pybytes_type:
-                        self.operand1 = self.operand1.coerce_to(PyrexTypes.c_char_type, env)
-                    if type2.is_pybytearray_type:
-                        env.use_utility_code(UtilityCode.load_cached("ByteArrayContains", "StringTools.c"))
-                    else:
-                        if not type2.is_pybytes_type:
-                            self.operand2 = self.operand2.coerce_to(bytes_type, env)
-                        env.use_utility_code(UtilityCode.load_cached("BytesContains", "StringTools.c"))
-                self.operand2 = self.operand2.as_none_safe_node(
-                    "argument of type 'NoneType' is not iterable")
-            elif self.is_ptr_contains():
-                if self.cascade:
-                    error(self.pos, "Cascading comparison not supported for 'val in sliced pointer'.")
-                self.type = PyrexTypes.c_bint_type
-                # Will be transformed by IterationTransform
-                return self
-            elif self.find_special_bool_compare_function(env, self.operand1):
-                if not self.operand1.type.is_pyobject:
-                    self.operand1 = self.operand1.coerce_to_pyobject(env)
-                common_type = None  # if coercion needed, the method call above has already done it
-                self.is_temp = True  # error return
-            else:
-                common_type = py_object_type
-                self.is_temp = True  # owned reference
-        elif self.find_special_bool_compare_function(env, self.operand1):
-            if not self.operand1.type.is_pyobject:
-                self.operand1 = self.operand1.coerce_to_pyobject(env)
-            common_type = None  # if coercion needed, the method call above has already done it
+        if self.is_ptr_contains():
+            if self.cascade:
+                error(self.pos, "Cascading comparison not supported for 'val in sliced pointer'.")
+            self.type = PyrexTypes.c_bint_type
+            # Will be transformed by IterationTransform
+            return self
+        found, operand1 = self.find_special_bool_compare_function(env, self.operand1)
+        if found:
+            common_type = None
+            self.operand1 = operand1  # coerced appropriately
             self.is_temp = True  # error return
+        elif self.operator in ('in', 'not_in'):
+            common_type = py_object_type
+            self.is_temp = True  # owned reference
         else:
             common_type = self.find_common_type(env, self.operator, self.operand1)
             if common_type.is_pyobject:
@@ -14774,7 +14756,9 @@ class PrimaryCmpNode(ExprNode, CmpNode):
             return self
 
         # coercing to bool => may allow for more efficient comparison code
-        self.find_special_bool_compare_function(env, self.operand1, result_is_bool=True)
+        found, operand1 = self.find_special_bool_compare_function(env, self.operand1, result_is_bool=True)
+        if found:
+            self.operand1 = operand1
 
         if self.cascade:
             operand2 = self.cascade.optimise_comparison(
@@ -14812,22 +14796,6 @@ class PrimaryCmpNode(ExprNode, CmpNode):
                 operand1.type.binary_op('=='),
                 operand1.result(),
                 operand2.result())
-        elif self.is_c_string_contains():
-            if operand2.type.is_pystr_type:
-                method = "__Pyx_UnicodeContainsUCS4"
-            elif operand2.type.is_pybytearray_type:
-                method = "__Pyx_ByteArrayContains"
-            else:
-                method = "__Pyx_BytesContains"
-            if self.operator == "not_in":
-                negation = "!"
-            else:
-                negation = ""
-            return "(%s%s(%s, %s))" % (
-                negation,
-                method,
-                operand2.result(),
-                operand1.result())
         else:
             if is_pythran_expr(self.type):
                 result1, result2 = operand1.pythran_result(), operand2.pythran_result()
@@ -14923,10 +14891,9 @@ class CascadedCmpNode(Node, CmpNode):
         return False
 
     def optimise_comparison(self, operand1, env, result_is_bool=False):
-        if self.find_special_bool_compare_function(env, operand1, result_is_bool):
+        found, operand1 = self.find_special_bool_compare_function(env, operand1, result_is_bool)
+        if found:
             self.type = PyrexTypes.c_bint_type
-            if not operand1.type.is_pyobject:
-                operand1 = operand1.coerce_to_pyobject(env)
         if self.cascade:
             operand2 = self.cascade.optimise_comparison(self.operand2, env, result_is_bool)
             if operand2 is not self.operand2:

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1310,8 +1310,7 @@ class SwitchTransform(Visitor.EnvTransform):
         if isinstance(cond, ExprNodes.PrimaryCmpNode):
             if cond.cascade is not None:
                 return self.NO_MATCH
-            elif cond.is_c_string_contains() and \
-                   isinstance(cond.operand2, (ExprNodes.UnicodeNode, ExprNodes.BytesNode)):
+            elif cond.operator in ('in', 'not_in') and cond.operand1.type.is_int and cond.operand2.is_string_literal:
                 not_in = cond.operator == 'not_in'
                 if not_in and not allow_not_in:
                     return self.NO_MATCH

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -313,12 +313,13 @@ static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObjec
 
         Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
         Py_ssize_t len_substring = PyUnicode_GET_LENGTH(substring);
-        if (len_substring == 0) return (eq == Py_EQ);
-        if (len_substring > len_text) return (eq == Py_NE);
-
         int kind_substring = PyUnicode_KIND(substring);
         int kind_text = PyUnicode_KIND(text);
+
+        if (len_substring == 0) return (eq == Py_EQ);
+        if (len_substring > len_text) return (eq == Py_NE);
         if (kind_substring > kind_text) return (eq == Py_NE);
+
         if (len_substring == 1) {
             Py_UCS4 character = PyUnicode_READ(kind_substring, PyUnicode_DATA(substring), 0);
             if (kind_text == PyUnicode_1BYTE_KIND) {
@@ -327,6 +328,10 @@ static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObjec
             Py_ssize_t idx = PyUnicode_FindChar(text, character, 0, len_text, 1);
             if (unlikely(idx == -2)) return -1;
             return (idx >= 0) == (eq == Py_EQ);
+        }
+        if (len_substring == len_text) {
+            if (kind_substring != kind_text) return (eq == Py_NE);
+            return (memcmp(PyUnicode_DATA(text), PyUnicode_DATA(substring), kind_text * len_text) == 0) == (eq == Py_EQ);
         }
     }
 #endif

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -284,8 +284,8 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 
 static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq) {
 #if CYTHON_USE_UNICODE_INTERNALS
-    int kind_text = PyUnicode_KIND(text);
-    if (kind_text == 1) {
+    // Not calling __Pyx_PyUnicode_READY(text) here since any non-1 kind value is ignore anyway.
+    if (PyUnicode_KIND(text) == 1) {
         if (character > 0xFF) return (eq == Py_NE);
         Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
         return (memchr(PyUnicode_1BYTE_DATA(text), (unsigned char) character, (size_t) len_text) != NULL) == (eq == Py_EQ);
@@ -308,6 +308,9 @@ static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObjec
 #if CYTHON_USE_UNICODE_INTERNALS
     // We know that 'text' is a str because we got here.
     if (likely(PyUnicode_Check(substring))) {
+        if (unlikely(__Pyx_PyUnicode_READY(text) < 0)) return -1;
+        if (unlikely(__Pyx_PyUnicode_READY(substring) < 0)) return -1;
+
         Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
         Py_ssize_t len_substring = PyUnicode_GET_LENGTH(substring);
         if (len_substring == 0) return (eq == Py_EQ);

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -251,6 +251,26 @@ static CYTHON_INLINE int __Pyx_BytesContains(PyObject* bytes, char character) {
 }
 
 
+//////////////////// ByteArrayContains.proto ////////////////////
+
+static CYTHON_INLINE int __Pyx_ByteArrayContains(PyObject* bytearray, char character); /*proto*/
+
+//////////////////// ByteArrayContains ////////////////////
+//@requires: IncludeStringH
+
+static CYTHON_INLINE int __Pyx_ByteArrayContains(PyObject* bytearray, char character) {
+    const Py_ssize_t length = __Pyx_PyByteArray_GET_SIZE(bytearray);
+#if !CYTHON_ASSUME_SAFE_SIZE
+    if (unlikely(length == -1)) return -1;
+#endif
+    const char* char_start = __Pyx_PyByteArray_AsString(bytearray);
+#if !CYTHON_ASSUME_SAFE_MACROS
+    if (unlikely(!char_start)) return -1;
+#endif
+    return memchr(char_start, (unsigned char)character, (size_t)length) != NULL;
+}
+
+
 //////////////////// PyUCS4InUnicode.proto ////////////////////
 
 static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(PyObject* unicode, Py_UCS4 character); /*proto*/

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -233,12 +233,12 @@ bad:
 
 //////////////////// BytesContains.proto ////////////////////
 
-static CYTHON_INLINE int __Pyx_BytesContains(PyObject* bytes, char character); /*proto*/
+static CYTHON_INLINE int __Pyx_BytesContains(char character, PyObject* bytes, int eq); /*proto*/
 
 //////////////////// BytesContains ////////////////////
 //@requires: IncludeStringH
 
-static CYTHON_INLINE int __Pyx_BytesContains(PyObject* bytes, char character) {
+static CYTHON_INLINE int __Pyx_BytesContains(char character, PyObject* bytes, int eq) {
     const Py_ssize_t length = __Pyx_PyBytes_GET_SIZE(bytes);
 #if !CYTHON_ASSUME_SAFE_SIZE
     if (unlikely(length == -1)) return -1;
@@ -247,18 +247,20 @@ static CYTHON_INLINE int __Pyx_BytesContains(PyObject* bytes, char character) {
 #if !CYTHON_ASSUME_SAFE_MACROS
     if (unlikely(!char_start)) return -1;
 #endif
-    return memchr(char_start, (unsigned char)character, (size_t)length) != NULL;
+
+    int result = memchr(char_start, (unsigned char)character, (size_t)length) != NULL;
+    return (result == (eq == Py_EQ));
 }
 
 
 //////////////////// ByteArrayContains.proto ////////////////////
 
-static CYTHON_INLINE int __Pyx_ByteArrayContains(PyObject* bytearray, char character); /*proto*/
+static CYTHON_INLINE int __Pyx_ByteArrayContains(char character, PyObject* bytearray, int eq); /*proto*/
 
 //////////////////// ByteArrayContains ////////////////////
 //@requires: IncludeStringH
 
-static CYTHON_INLINE int __Pyx_ByteArrayContains(PyObject* bytearray, char character) {
+static CYTHON_INLINE int __Pyx_ByteArrayContains(char character, PyObject* bytearray, int eq) {
     const Py_ssize_t length = __Pyx_PyByteArray_GET_SIZE(bytearray);
 #if !CYTHON_ASSUME_SAFE_SIZE
     if (unlikely(length == -1)) return -1;
@@ -267,23 +269,27 @@ static CYTHON_INLINE int __Pyx_ByteArrayContains(PyObject* bytearray, char chara
 #if !CYTHON_ASSUME_SAFE_MACROS
     if (unlikely(!char_start)) return -1;
 #endif
-    return memchr(char_start, (unsigned char)character, (size_t)length) != NULL;
+
+    int result = memchr(char_start, (unsigned char)character, (size_t)length) != NULL;
+    return (result == (eq == Py_EQ));
 }
 
 
 //////////////////// PyUCS4InUnicode.proto ////////////////////
 
-static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(PyObject* unicode, Py_UCS4 character); /*proto*/
+static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* unicode, int eq); /*proto*/
 
 //////////////////// PyUCS4InUnicode ////////////////////
 
-static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(PyObject* unicode, Py_UCS4 character) {
+static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* unicode, int eq) {
     // Note that from Python 3.7, the indices of FindChar are adjusted to match the bounds
     // so need to check the length
     Py_ssize_t idx = PyUnicode_FindChar(unicode, character, 0, PY_SSIZE_T_MAX, 1);
     if (unlikely(idx == -2)) return -1;
+
     // >= 0: found the index, == -1: not found
-    return idx >= 0;
+    int result = idx >= 0;
+    return (result == (eq == Py_EQ));
 }
 
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -305,39 +305,8 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 
 static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObject* text, int eq) {
     if (substring == text) return (eq == Py_EQ);
-#if CYTHON_USE_UNICODE_INTERNALS
-    // We know that 'text' is a str because we got here.
-    if (likely(PyUnicode_Check(substring))) {
-        if (unlikely(__Pyx_PyUnicode_READY(text) < 0)) return -1;
-        if (unlikely(__Pyx_PyUnicode_READY(substring) < 0)) return -1;
-
-        Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
-        Py_ssize_t len_substring = PyUnicode_GET_LENGTH(substring);
-        int kind_substring = PyUnicode_KIND(substring);
-        int kind_text = PyUnicode_KIND(text);
-
-        if (len_substring == 0) return (eq == Py_EQ);
-        if (len_substring > len_text) return (eq == Py_NE);
-        if (kind_substring > kind_text) return (eq == Py_NE);
-
-        if (len_substring == 1) {
-            Py_UCS4 character = PyUnicode_READ(kind_substring, PyUnicode_DATA(substring), 0);
-            if (kind_text == PyUnicode_1BYTE_KIND) {
-                return (memchr(PyUnicode_1BYTE_DATA(text), (unsigned char) character, (size_t) len_text) != NULL) == (eq == Py_EQ);
-            }
-            Py_ssize_t idx = PyUnicode_FindChar(text, character, 0, len_text, 1);
-            if (unlikely(idx == -2)) return -1;
-            return (idx >= 0) == (eq == Py_EQ);
-        }
-        if (len_substring == len_text) {
-            if (kind_substring != kind_text) return (eq == Py_NE);
-            return (memcmp(PyUnicode_DATA(text), PyUnicode_DATA(substring), kind_text * len_text) == 0) == (eq == Py_EQ);
-        }
-    }
-#endif
-
     int result = PyUnicode_Contains(text, substring);
-    return unlikely(result < 0) ? result : (result == (eq == Py_EQ));
+    return unlikely(result < 0) ? -1 : (result == (eq == Py_EQ));
 }
 
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -284,12 +284,16 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 
 static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq) {
 #if CYTHON_USE_UNICODE_INTERNALS
-    // Not calling __Pyx_PyUnicode_READY(text) here since any non-1 kind value is ignored anyway.
-    if (PyUnicode_KIND(text) == 1) {
-        if (character > 0xFF) return (eq == Py_NE);
+    // Not calling __Pyx_PyUnicode_READY(text) here since other kind values are ignored.
+    int str_kind = PyUnicode_KIND(text);
+    // A large part of real-world strings will be ASCII or Latin-1,
+    // especially when looking for 1-byte characters (which we often know at compile time).
+    if (character <= 0xFF && str_kind == 1) {
         Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
         return (memchr(PyUnicode_1BYTE_DATA(text), (unsigned char) character, (size_t) len_text) != NULL) == (eq == Py_EQ);
     }
+    if (character > 0xFF && str_kind == 1) return (eq == Py_NE);
+    if (character > 0xFFFF && str_kind == 2) return (eq == Py_NE);
 #endif
     Py_ssize_t idx = PyUnicode_FindChar(text, character, 0, PY_SSIZE_T_MAX, 1);
     if (unlikely(idx == -2)) return -1;

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -284,7 +284,7 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 
 static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq) {
 #if CYTHON_USE_UNICODE_INTERNALS
-    // Not calling __Pyx_PyUnicode_READY(text) here since any non-1 kind value is ignore anyway.
+    // Not calling __Pyx_PyUnicode_READY(text) here since any non-1 kind value is ignored anyway.
     if (PyUnicode_KIND(text) == 1) {
         if (character > 0xFF) return (eq == Py_NE);
         Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -283,8 +283,8 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 //@requires: IncludeStringH
 
 static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq) {
-#if CYTHON_USE_UNICODE_INTERNALS
-    // Not calling __Pyx_PyUnicode_READY(text) here since other kind values are ignored.
+#if !(CYTHON_COMPILING_IN_PYPY || CYTHON_COMPILING_IN_LIMITED_API || CYTHON_COMPILING_IN_GRAAL)
+    // Not calling __Pyx_PyUnicode_READY(text) here since the "w_char" kind is simply ignored.
     int str_kind = PyUnicode_KIND(text);
     // A large part of real-world strings will be ASCII or Latin-1,
     // especially when looking for 1-byte characters (which we often know at compile time).

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -277,14 +277,21 @@ static CYTHON_INLINE int __Pyx_ByteArrayContains(char character, PyObject* bytea
 
 //////////////////// PyUCS4InUnicode.proto ////////////////////
 
-static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* unicode, int eq); /*proto*/
+static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq); /*proto*/
 
 //////////////////// PyUCS4InUnicode ////////////////////
+//@requires: IncludeStringH
 
-static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* unicode, int eq) {
-    // Note that from Python 3.7, the indices of FindChar are adjusted to match the bounds
-    // so need to check the length
-    Py_ssize_t idx = PyUnicode_FindChar(unicode, character, 0, PY_SSIZE_T_MAX, 1);
+static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* text, int eq) {
+#if CYTHON_USE_UNICODE_INTERNALS
+    int kind_text = PyUnicode_KIND(text);
+    if (kind_text == 1) {
+        if (character > 0xFF) return (eq == Py_NE);
+        Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
+        return (memchr(PyUnicode_1BYTE_DATA(text), (unsigned char) character, (size_t) len_text) != NULL) == (eq == Py_EQ);
+    }
+#endif
+    Py_ssize_t idx = PyUnicode_FindChar(text, character, 0, PY_SSIZE_T_MAX, 1);
     if (unlikely(idx == -2)) return -1;
 
     // >= 0: found the index, == -1: not found
@@ -294,8 +301,33 @@ static CYTHON_INLINE int __Pyx_UnicodeContainsUCS4(Py_UCS4 character, PyObject* 
 
 
 //////////////////// PyUnicodeContains.proto ////////////////////
+//@requires: IncludeStringH
 
 static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObject* text, int eq) {
+    if (substring == text) return (eq == Py_EQ);
+#if CYTHON_USE_UNICODE_INTERNALS
+    // We know that 'text' is a str because we got here.
+    if (likely(PyUnicode_Check(substring))) {
+        Py_ssize_t len_text = PyUnicode_GET_LENGTH(text);
+        Py_ssize_t len_substring = PyUnicode_GET_LENGTH(substring);
+        if (len_substring == 0) return (eq == Py_EQ);
+        if (len_substring > len_text) return (eq == Py_NE);
+
+        int kind_substring = PyUnicode_KIND(substring);
+        int kind_text = PyUnicode_KIND(text);
+        if (kind_substring > kind_text) return (eq == Py_NE);
+        if (len_substring == 1) {
+            Py_UCS4 character = PyUnicode_READ(kind_substring, PyUnicode_DATA(substring), 0);
+            if (kind_text == PyUnicode_1BYTE_KIND) {
+                return (memchr(PyUnicode_1BYTE_DATA(text), (unsigned char) character, (size_t) len_text) != NULL) == (eq == Py_EQ);
+            }
+            Py_ssize_t idx = PyUnicode_FindChar(text, character, 0, len_text, 1);
+            if (unlikely(idx == -2)) return -1;
+            return (idx >= 0) == (eq == Py_EQ);
+        }
+    }
+#endif
+
     int result = PyUnicode_Contains(text, substring);
     return unlikely(result < 0) ? result : (result == (eq == Py_EQ));
 }

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -323,9 +323,9 @@ def m_str_in_str(str a, str unicode_string):
     >>> m_str_in_str('f', None)
     Traceback (most recent call last):
     TypeError: argument of type 'NoneType' is not iterable
-    >>> m_str_in_str(None, 'f')
+    >>> m_str_in_str(None, 'f')    # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: argument of type 'NoneType' is not iterable
+    TypeError: ...NoneType...
     >>> m_str_in_str(None, None)
     Traceback (most recent call last):
     TypeError: argument of type 'NoneType' is not iterable

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -318,8 +318,10 @@ def m_unicode_literal(Py_UNICODE a):
     cdef int result = a in u'abc\0defg\u1234\uF8D2'
     return result
 
+
 cdef unicode wide_unicode_character = u'\U0010FEDC'
 py_wide_unicode_character = wide_unicode_character
+
 
 @cython.test_assert_path_exists("//SwitchStatNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//PrimaryCmpNode")
@@ -334,6 +336,41 @@ def m_wide_unicode_literal(Py_UCS4 a):
     """
     cdef int result = a in u'abc\0defg\u1234\uF8D2\U0010FEDC'
     return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_wide_unicode_literal_cascade_in(Py_UCS4 a, str cascade):
+    """
+    >>> m_wide_unicode_literal_cascade_in(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_wide_unicode_literal_cascade_in(ord('f'), '  abc\\0defg\\u1234\\uF8D2\\U0010FEDC  ')
+    1
+    >>> m_wide_unicode_literal_cascade_in(ord('f'), 'abc\\0defg\\u1234 XXX \\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_in(ord('X'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_in(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    """
+    cdef int result = a in u'abc\0defg\u1234\uF8D2\U0010FEDC' in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_wide_unicode_literal_cascade_eq(Py_UCS4 a, str cascade):
+    """
+    >>> m_wide_unicode_literal_cascade_eq(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_wide_unicode_literal_cascade_eq(ord('X'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_eq(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    """
+    cdef int result = a in u'abc\0defg\u1234\uF8D2\U0010FEDC' == cascade
+    return result
+
 
 @cython.test_assert_path_exists("//SwitchStatNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//PrimaryCmpNode")

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -152,6 +152,64 @@ def m_bytes_unsigned(unsigned char a, bytes bytes_string):
     cdef int result = a in bytes_string
     return result
 
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_bytearray(char a, bytearray bytearray_string):
+    """
+    >>> m_bytearray(ord('f'), bytearray(py_bytes_string))
+    1
+    >>> m_bytearray(ord('X'), bytearray(py_bytes_string))
+    0
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_bytearray(ord('f'), None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = a in bytearray_string
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_bytes(bytes bytes_string):
+    """
+    >>> m_literal_in_bytes(py_bytes_string)
+    1
+    >>> m_literal_in_bytes(py_bytes_string.replace(b'f', b'F'))
+    0
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_bytes(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = b'f' in bytes_string
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_bytearray(bytearray bytearray_string):
+    """
+    >>> m_literal_in_bytearray(bytearray(py_bytes_string))
+    1
+    >>> m_literal_in_bytearray(bytearray(py_bytes_string.replace(b'f', b'F')))
+    0
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_bytearray(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = b'f' in bytearray_string
+    return result
+
+
 @cython.test_assert_path_exists("//SwitchStatNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//PrimaryCmpNode")
 def m_bytes_literal(char a):
@@ -199,6 +257,49 @@ def m_unicode(Py_UNICODE a, unicode unicode_string):
     """
     cdef int result = a in unicode_string
     return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_unicode(unicode unicode_string):
+    """
+    >>> m_literal_in_unicode(py_unicode_string)
+    1
+    >>> m_literal_in_unicode(py_unicode_string.replace('f', 'F'))
+    0
+
+    >>> 'f' in None   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_unicode(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = 'f' in unicode_string
+    return result
+
+
+'''
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_unicode_cascade(unicode unicode_string):
+    """
+    >>> m_literal_in_unicode_cascade(py_unicode_string)
+    1
+    >>> m_literal_in_unicode_cascade(py_unicode_string.replace('f', 'F'))
+    0
+
+    >>> 'f' in None   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_unicode_cascade(None)   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    """
+    cdef int result = 'f' in unicode_string in unicode_string
+    return result
+'''
+
 
 cdef unicode klingon_character = u'\uF8D2'
 py_klingon_character = klingon_character

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -340,6 +340,46 @@ def m_wide_unicode_literal(Py_UCS4 a):
 
 @cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_unicode_char_cascade_in_char(Py_UCS4 a, str cascade):
+    """
+    >>> m_unicode_char_cascade_in_char(ord('f'), 'f')
+    1
+    >>> m_unicode_char_cascade_in_char(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_unicode_char_cascade_in_char(ord('f'), 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_in_char(ord('X'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_in_char(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    """
+    cdef int result = a in 'f' in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_unicode_char_cascade_in(str a, str cascade):
+    """
+    >>> m_unicode_char_cascade_in('f', 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_unicode_char_cascade_in('f', '  abc\\0defg\\u1234\\uF8D2\\U0010FEDC  ')
+    1
+    >>> m_unicode_char_cascade_in('f', 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_in('X', 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_in('fX', 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_in(py_wide_unicode_character, 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    """
+    cdef int result = a in 'f' in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
 def m_wide_unicode_literal_cascade_in(Py_UCS4 a, str cascade):
     """
     >>> m_wide_unicode_literal_cascade_in(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')

--- a/tests/run/inop.pyx
+++ b/tests/run/inop.pyx
@@ -234,12 +234,14 @@ def m_bytes_literal_unsigned(unsigned char a):
     cdef int result = a in b'ab\0cde\0f\0g'
     return result
 
+
 cdef unicode unicode_string = u'abc\0defg\u1234\uF8D2'
 py_unicode_string = unicode_string
 
+
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
-def m_unicode(Py_UNICODE a, unicode unicode_string):
+def m_unicode(Py_UCS4 a, unicode unicode_string):
     """
     >>> m_unicode(ord('f'), py_unicode_string)
     1
@@ -279,7 +281,6 @@ def m_literal_in_unicode(unicode unicode_string):
     return result
 
 
-'''
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
 def m_literal_in_unicode_cascade(unicode unicode_string):
@@ -298,7 +299,39 @@ def m_literal_in_unicode_cascade(unicode unicode_string):
     """
     cdef int result = 'f' in unicode_string in unicode_string
     return result
-'''
+
+
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode", "//BoolBinopNode")
+def m_str_in_str(str a, str unicode_string):
+    """
+    >>> m_str_in_str('f', py_unicode_string)
+    1
+    >>> m_str_in_str('ef', py_unicode_string)
+    1
+    >>> m_str_in_str('ff', py_unicode_string)
+    0
+    >>> m_str_in_str('X', py_unicode_string)
+    0
+    >>> m_str_in_str('XX', py_unicode_string)
+    0
+    >>> m_str_in_str(py_klingon_character, py_unicode_string)
+    1
+
+    >>> 'f' in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_str_in_str('f', None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    >>> m_str_in_str(None, 'f')
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    >>> m_str_in_str(None, None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = a in unicode_string
+    return result
 
 
 cdef unicode klingon_character = u'\uF8D2'

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -267,6 +267,48 @@ def m_unicode_literal(Py_UNICODE a):
 
 @cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_unicode_char_cascade_notin_char(Py_UCS4 a, str cascade):
+    """
+    >>> m_unicode_char_cascade_notin_char(ord('f'), 'f')
+    0
+    >>> m_unicode_char_cascade_notin_char(ord('X'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin_char(ord('f'), 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin_char(ord('X'), 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_unicode_char_cascade_notin_char(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin_char(ord(py_wide_unicode_character), 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    1
+    """
+    cdef int result = a not in 'f' not in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_unicode_char_cascade_notin(str a, str cascade):
+    """
+    >>> m_unicode_char_cascade_notin('f', 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin('f', 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin('X', 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin('fX', 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_unicode_char_cascade_notin(py_wide_unicode_character, 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_unicode_char_cascade_notin(py_wide_unicode_character, 'abc\\0de XXX g\\u1234\\uF8D2\\U0010FEDC')
+    1
+    """
+    cdef int result = a not in 'f' not in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
 def m_wide_unicode_literal_cascade_notin(Py_UCS4 a, str cascade):
     """
     >>> m_wide_unicode_literal_cascade_notin(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -106,7 +106,7 @@ def m_bytes(char a):
     >>> m_bytes(ord('X'))
     1
     """
-    cdef int result = a not in py_bytes_string
+    cdef int result = a not in bytes_string
     return result
 
 @cython.test_assert_path_exists("//SwitchStatNode")

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -191,7 +191,7 @@ py_wide_unicode_character = wide_unicode_character
 
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode", "//BoolBinopNode")
-def m_unicode(Py_UNICODE a, unicode unicode_string):
+def m_unicode(Py_UCS4 a, unicode unicode_string):
     """
     >>> m_unicode(ord('f'), py_unicode_string)
     0
@@ -199,6 +199,7 @@ def m_unicode(Py_UNICODE a, unicode unicode_string):
     1
     >>> m_unicode(ord(py_klingon_character), py_unicode_string)
     0
+
     >>> 'f' in None    # doctest: +ELLIPSIS
     Traceback (most recent call last):
     TypeError: ...iterable...
@@ -250,9 +251,42 @@ def m_literal_in_unicode_cascade(unicode unicode_string):
     return result
 
 
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode", "//BoolBinopNode")
+def m_str_notin_str(str a, str unicode_string):
+    """
+    >>> m_str_notin_str('f', py_unicode_string)
+    0
+    >>> m_str_notin_str('ef', py_unicode_string)
+    0
+    >>> m_str_notin_str('ff', py_unicode_string)
+    1
+    >>> m_str_notin_str('X', py_unicode_string)
+    1
+    >>> m_str_notin_str('XX', py_unicode_string)
+    1
+    >>> m_str_notin_str(py_klingon_character, py_unicode_string)
+    0
+
+    >>> 'f' in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_str_notin_str('f', None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    >>> m_str_notin_str(None, 'f')
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    >>> m_str_notin_str(None, None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = a not in unicode_string
+    return result
+
+
 @cython.test_assert_path_exists("//SwitchStatNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//BoolBinopNode", "//PrimaryCmpNode")
-def m_unicode_literal(Py_UNICODE a):
+def m_unicode_literal(Py_UCS4 a):
     """
     >>> m_unicode_literal(ord('f'))
     0

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -273,9 +273,9 @@ def m_str_notin_str(str a, str unicode_string):
     >>> m_str_notin_str('f', None)
     Traceback (most recent call last):
     TypeError: argument of type 'NoneType' is not iterable
-    >>> m_str_notin_str(None, 'f')
+    >>> m_str_notin_str(None, 'f')    # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    TypeError: argument of type 'NoneType' is not iterable
+    TypeError: ...NoneType...
     >>> m_str_notin_str(None, None)
     Traceback (most recent call last):
     TypeError: argument of type 'NoneType' is not iterable

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -95,6 +95,7 @@ def m_set(int a):
     return result
 
 cdef bytes bytes_string = b'abcdefg'
+py_bytes_string = bytes_string
 
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode", "//BoolBinopNode")
@@ -105,7 +106,7 @@ def m_bytes(char a):
     >>> m_bytes(ord('X'))
     1
     """
-    cdef int result = a not in bytes_string
+    cdef int result = a not in py_bytes_string
     return result
 
 @cython.test_assert_path_exists("//SwitchStatNode")
@@ -119,6 +120,64 @@ def m_bytes_literal(char a):
     """
     cdef int result = a not in b'abcdefg'
     return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_bytearray(char a, bytearray bytearray_string):
+    """
+    >>> m_bytearray(ord('f'), bytearray(py_bytes_string))
+    0
+    >>> m_bytearray(ord('X'), bytearray(py_bytes_string))
+    1
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_bytearray(ord('f'), None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = a not in bytearray_string
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_bytes(bytes bytes_string):
+    """
+    >>> m_literal_in_bytes(py_bytes_string)
+    0
+    >>> m_literal_in_bytes(py_bytes_string.replace(b'f', b'F'))
+    1
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_bytes(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = b'f' not in bytes_string
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_bytearray(bytearray bytearray_string):
+    """
+    >>> m_literal_in_bytearray(bytearray(py_bytes_string))
+    0
+    >>> m_literal_in_bytearray(bytearray(py_bytes_string.replace(b'f', b'F')))
+    1
+    >>> 'f'.encode('ASCII') in None    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_bytearray(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = b'f' not in bytearray_string
+    return result
+
 
 cdef unicode unicode_string = u'abcdefg\u1234\uF8D2'
 py_unicode_string = unicode_string
@@ -145,6 +204,49 @@ def m_unicode(Py_UNICODE a, unicode unicode_string):
     """
     cdef int result = a not in unicode_string
     return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_unicode(unicode unicode_string):
+    """
+    >>> m_literal_in_unicode(py_unicode_string)
+    0
+    >>> m_literal_in_unicode(py_unicode_string.replace('f', 'F'))
+    1
+
+    >>> 'f' in None   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_unicode(None)
+    Traceback (most recent call last):
+    TypeError: argument of type 'NoneType' is not iterable
+    """
+    cdef int result = 'f' not in unicode_string
+    return result
+
+
+'''
+@cython.test_assert_path_exists("//PrimaryCmpNode")
+@cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
+def m_literal_in_unicode_cascade(unicode unicode_string):
+    """
+    >>> m_literal_in_unicode_cascade(py_unicode_string)
+    0
+    >>> m_literal_in_unicode_cascade(py_unicode_string.replace('f', 'F'))
+    1
+
+    >>> 'f' in None   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    >>> m_literal_in_unicode_cascade(None)   # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    TypeError: ...iterable...
+    """
+    cdef int result = 'f' not in unicode_string in unicode_string
+    return result
+'''
+
 
 @cython.test_assert_path_exists("//SwitchStatNode")
 @cython.test_fail_if_path_exists("//BoolBinopNode", "//BoolBinopNode", "//PrimaryCmpNode")

--- a/tests/run/notinop.pyx
+++ b/tests/run/notinop.pyx
@@ -185,6 +185,10 @@ py_unicode_string = unicode_string
 cdef unicode klingon_character = u'\uF8D2'
 py_klingon_character = klingon_character
 
+cdef unicode wide_unicode_character = u'\U0010FEDC'
+py_wide_unicode_character = wide_unicode_character
+
+
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode", "//BoolBinopNode")
 def m_unicode(Py_UNICODE a, unicode unicode_string):
@@ -226,7 +230,6 @@ def m_literal_in_unicode(unicode unicode_string):
     return result
 
 
-'''
 @cython.test_assert_path_exists("//PrimaryCmpNode")
 @cython.test_fail_if_path_exists("//SwitchStatNode", "//BoolBinopNode")
 def m_literal_in_unicode_cascade(unicode unicode_string):
@@ -245,7 +248,6 @@ def m_literal_in_unicode_cascade(unicode unicode_string):
     """
     cdef int result = 'f' not in unicode_string in unicode_string
     return result
-'''
 
 
 @cython.test_assert_path_exists("//SwitchStatNode")
@@ -261,6 +263,41 @@ def m_unicode_literal(Py_UNICODE a):
     """
     cdef int result = a not in u'abcdefg\u1234\uF8D2'
     return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_wide_unicode_literal_cascade_notin(Py_UCS4 a, str cascade):
+    """
+    >>> m_wide_unicode_literal_cascade_notin(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_notin(ord('X'), '  abc\\0defg\\u1234\\uF8D2\\U0010FEDC  ')
+    0
+    >>> m_wide_unicode_literal_cascade_notin(ord('X'), 'abc\\0defg\\u1234 XXX \\uF8D2\\U0010FEDC')
+    1
+    >>> m_wide_unicode_literal_cascade_notin(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    """
+    cdef int result = a not in u'abc\0defg\u1234\uF8D2\U0010FEDC' not in cascade
+    return result
+
+
+@cython.test_assert_path_exists("//PrimaryCmpNode", "//CascadedCmpNode")
+@cython.test_fail_if_path_exists("//BoolBinopNode", "//SwitchStatNode")
+def m_wide_unicode_literal_cascade_eq(Py_UCS4 a, str cascade):
+    """
+    >>> m_wide_unicode_literal_cascade_eq(ord('f'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    >>> m_wide_unicode_literal_cascade_eq(ord('f'), 'abc\\0defg\\u1234 XXX \\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_eq(ord('X'), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    0
+    >>> m_wide_unicode_literal_cascade_eq(ord(py_wide_unicode_character), 'abc\\0defg\\u1234\\uF8D2\\U0010FEDC')
+    1
+    """
+    cdef int result = a in u'abc\0defg\u1234\uF8D2\U0010FEDC' == cascade
+    return result
+
 
 @cython.test_assert_path_exists("//SwitchStatNode", "//BoolBinopNode")
 @cython.test_fail_if_path_exists("//PrimaryCmpNode")

--- a/tests/run/unicodemethods.pyx
+++ b/tests/run/unicodemethods.pyx
@@ -460,10 +460,22 @@ def endswith_start_end(unicode s, sub, start, end):
     "//CoerceToPyTypeNode", "//PrimaryCmpNode")
 def in_test(unicode s, substring):
     """
+    >>> in_test(text, 's')
+    True
+    >>> in_test(text, 'a')
+    True
     >>> in_test(text, 'sa')
     True
     >>> in_test(text, 'XYZ')
     False
+    >>> in_test(text, '\\N{SNOWMAN}')
+    False
+    >>> in_test(text, '\\N{SEWING NEEDLE}')
+    False
+    >>> in_test('\\N{SNOWMAN}' + text, '\\N{SNOWMAN}')
+    True
+    >>> in_test(text + '\\N{SEWING NEEDLE}', '\\N{SEWING NEEDLE}')
+    True
     >>> in_test(None, 'sa')
     Traceback (most recent call last):
     TypeError: argument of type 'NoneType' is not iterable

--- a/tests/run/unicodemethods.pyx
+++ b/tests/run/unicodemethods.pyx
@@ -466,7 +466,7 @@ def in_test(unicode s, substring):
     False
     >>> in_test(None, 'sa')
     Traceback (most recent call last):
-    TypeError: 'NoneType' object is not iterable
+    TypeError: argument of type 'NoneType' is not iterable
     """
     return substring in s
 


### PR DESCRIPTION
Along the way, optimises `'c' in str`, `b'c' in bytes`, `char in bytearray`.

Closes https://github.com/cython/cython/issues/3888