### PR TITLE
Split exception check utility code from fast type checking.

### DIFF
--- a/Cython/Compiler/Builtin.py
+++ b/Cython/Compiler/Builtin.py
@@ -822,6 +822,8 @@ def init_builtin_exceptions():
     for name in ['UnicodeError', 'UnicodeDecodeError', 'UnicodeEncodeError', 'UnicodeTranslateError']:
         special_properties[name] = unicode_error_properties
 
+    type_check_utility_code = UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c")
+
     for name in PyrexTypes.KNOWN_EXCEPTION_NAMES:
         if name in PyrexTypes.uncachable_builtins:
             # Exclude builtins specific to later Python versions or platforms.
@@ -830,14 +832,20 @@ def init_builtin_exceptions():
         objstruct_cname = None
         if name == 'BaseException':
             objstruct_cname = "PyBaseExceptionObject"
-        elif name == 'Exception':
-            objstruct_cname = "PyBaseExceptionObject"
+            utility_code = UtilityCode(
+                proto="#define __Pyx_PyExc_BaseException_Check(obj)  PyExceptionInstance_Check(obj)",
+                name=f"Py{name}_Check",
+            )
+        else:
+            if name == 'Exception':
+                objstruct_cname = "PyBaseExceptionObject"
+            utility_code = UtilityCode(
+                proto=f"#define __Pyx_PyExc_{name}_Check(obj)  __Pyx_TypeCheck(obj, PyExc_{name})",
+                name=f"Py{name}_Check",
+                requires=[type_check_utility_code],
+            )
 
         assert builtin_scope.lookup_here(name) is None  # should not be declared above
-        utility_code = UtilityCode(
-            proto=f"#define __Pyx_PyExc_{name}_Check(obj)  __Pyx_TypeCheck(obj, PyExc_{name})",
-            name=f"Py{name}_Check",
-        )
         exc_type = builtin_types[name] = builtin_scope.declare_builtin_type(
             name, f"((PyTypeObject*)PyExc_{name})",
             objstruct_cname=objstruct_cname,

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3347,6 +3347,8 @@ class IteratorNode(ScopedExprNode):
             code.putln(code.error_goto_if_null(result_name, self.pos))
             code.put("} else ")
 
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("GivenExceptionMatches", "Exceptions.c"))
         code.putln("{")
         code.putln(f"{result_name} = {self.iter_func_ptr}({self.py_result()});")
         code.putln("if (unlikely(!%s)) {" % result_name)
@@ -11571,6 +11573,11 @@ class AwaitIterNextExprNode(AwaitExprNode):
     # Breaks out of loop on StopAsyncIteration exception.
 
     def _generate_break(self, code):
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("PyThreadStateGet", "Exceptions.c"))
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("GivenExceptionMatches", "Exceptions.c"))
+
         code.putln("PyObject* exc_type = __Pyx_PyErr_CurrentExceptionType();")
         code.putln("if (unlikely(exc_type && (exc_type == PyExc_StopAsyncIteration || ("
                    " exc_type != PyExc_StopIteration && exc_type != PyExc_GeneratorExit &&"

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -1039,7 +1039,6 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
 
         code.putln('static const char * const %s = %s;' % (Naming.cfilenm_cname, Naming.file_c_macro))
 
-        env.use_utility_code(UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c"))
         env.use_utility_code(UtilityCode.load("GetRuntimeVersion", "ModuleSetupCode.c"))
         env.use_utility_code(UtilityCode.load_cached("AddModuleRef", "ModuleSetupCode.c"))
         if has_np_pythran(env):

--- a/Cython/Compiler/Nodes.py
+++ b/Cython/Compiler/Nodes.py
@@ -8574,7 +8574,7 @@ class ExceptClauseNode(Node):
             exc_tests = []
             if exc_type:
                 code.globalstate.use_utility_code(
-                    UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c"))
+                    UtilityCode.load_cached("GivenExceptionMatches", "Exceptions.c"))
                 if len(patterns) == 2:
                     exc_tests.append("__Pyx_PyErr_GivenExceptionMatches2(%s, %s, %s)" % (
                         exc_type, patterns[0], patterns[1],
@@ -8586,7 +8586,7 @@ class ExceptClauseNode(Node):
                     )
             elif len(patterns) == 2:
                 code.globalstate.use_utility_code(
-                    UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c"))
+                    UtilityCode.load_cached("GivenExceptionMatches", "Exceptions.c"))
                 exc_tests.append("__Pyx_PyErr_ExceptionMatches2(%s, %s)" % (
                     patterns[0], patterns[1],
                 ))

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -3036,7 +3036,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
 
         builtin_tests = set()
         for test_type_node in types:
-            builtin_type = entry = None
+            builtin_type = entry = utility_code = None
             if test_type_node.is_name and test_type_node.entry:
                 entry = env.lookup(test_type_node.entry.name)
                 if entry and entry.type and entry.type.is_builtin_type:
@@ -3052,9 +3052,12 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
                     continue
                 builtin_tests.add(type_check_function)
                 type_check_args = [arg]
+                if entry is not None:
+                    utility_code = entry.utility_code
             elif test_type_node.type is Builtin.type_type:
                 type_check_function = '__Pyx_TypeCheck'
                 type_check_args = [arg, test_type_node]
+                utility_code = UtilityCode.load_cached("FastTypeChecks", "ModuleSetupCode.c")
             else:
                 if not test_type_node.is_literal:
                     test_type_node = UtilNodes.ResultRefNode(test_type_node)
@@ -3065,7 +3068,7 @@ class OptimizeBuiltinCalls(Visitor.NodeRefCleanupMixin,
                 ExprNodes.PythonCapiCallNode(
                     test_type_node.pos, type_check_function, self.Py_type_check_func_type,
                     args=type_check_args,
-                    utility_code=entry.utility_code if entry is not None else None,
+                    utility_code=utility_code,
                     is_temp=True,
                 ))
 

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1497,8 +1497,8 @@ _special_type_check_functions = {
     'frozenset': 'PyFrozenSet_Check',
     'frozendict': '__Pyx_PyFrozenDict_Check',
     'memoryview': 'PyMemoryView_Check',
-    'Exception': '__Pyx_PyException_Check',
-    'BaseException': '__Pyx_PyBaseException_Check',
+    'Exception': '__Pyx_PyExc_Exception_Check',
+    'BaseException': '__Pyx_PyExc_BaseException_Check',
 }
 
 # Builtins as of Python version ...

--- a/Cython/Utility/AsyncGen.c
+++ b/Cython/Utility/AsyncGen.c
@@ -93,6 +93,7 @@ __Pyx_PyAsyncGen_Fini();
 //@requires: Coroutine.c::ReturnWithStopIteration
 //@requires: ObjectHandling.c::PyObjectCall2Args
 //@requires: ExtensionTypes.c::CallTypeTraverse
+//@requires: Exceptions.c::GivenExceptionMatches
 
 PyDoc_STRVAR(__Pyx_async_gen_send_doc,
 "send(arg) -> send 'arg' into generator,\n\

--- a/Cython/Utility/Builtins.c
+++ b/Cython/Utility/Builtins.c
@@ -765,6 +765,7 @@ static CYTHON_INLINE int __Pyx_PySet_Update(PyObject* set, PyObject* it) {
 }
 
 //////////////////// PyRange_Check.proto ////////////////////
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 #if CYTHON_COMPILING_IN_PYPY && !defined(PyRange_Check)
   #define PyRange_Check(obj)  __Pyx_TypeCheck((obj), &PyRange_Type)

--- a/Cython/Utility/Coroutine.c
+++ b/Cython/Utility/Coroutine.c
@@ -383,6 +383,7 @@ static void __Pyx_Generator_Replace_StopIteration(int in_async_gen); /*proto*/
 
 //////////////////// pep479 ////////////////////
 //@requires: Exceptions.c::GetException
+//@requires: Exceptions.c::GivenExceptionMatches
 
 static void __Pyx_Generator_Replace_StopIteration(int in_async_gen) {
     PyObject *exc, *val, *tb, *cur_exc, *new_exc;
@@ -567,6 +568,7 @@ static CYTHON_INLINE PyObject *__Pyx_Generator_GetInlinedResult(PyObject *self);
 //@requires: Exceptions.c::SwapException
 //@requires: Exceptions.c::RaiseException
 //@requires: Exceptions.c::SaveResetException
+//@requires: Exceptions.c::GivenExceptionMatches
 //@requires: ObjectHandling.c::PyObjectCallMethod1
 //@requires: ObjectHandling.c::PyObjectCallNoArg
 //@requires: ObjectHandling.c::PyObjectCallOneArg
@@ -577,6 +579,7 @@ static CYTHON_INLINE PyObject *__Pyx_Generator_GetInlinedResult(PyObject *self);
 //@requires: ObjectHandling.c::IterNextPlain
 //@requires: CommonStructures.c::FetchCommonType
 //@requires: CommonStructures.c::CommonTypesMetaclass
+//@requires: ModuleSetupCode.c::FastTypeChecks
 //@requires: ModuleSetupCode.c::IncludeStructmemberH
 //@requires: ExtensionTypes.c::CallTypeTraverse
 //@requires: Synchronization.c::CriticalSections

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -19,6 +19,7 @@ if (likely(__pyx_CyFunction_init($module_cname) == 0)); else
 //////////////////// CythonFunctionPerModule.proto //////////////////////////
 // This section always gets included whether we're using CythonFunction through
 // shared utility code or not.
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 #define __Pyx_CyFunction_USED
 
@@ -252,6 +253,7 @@ static PyObject * __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS_METHOD(PyObject 
 //@requires: ObjectHandling.c::PyMethodNew
 //@requires: ObjectHandling.c::PyVectorcallFastCallDict
 //@requires: Exceptions.c::IgnoreException
+//@requires: ModuleSetupCode.c::FastTypeChecks
 //@requires: ModuleSetupCode.c::IncludeStructmemberH
 //@requires: ObjectHandling.c::PyObjectGetAttrStr
 //@requires: ObjectHandling.c::PyObjectCallOneArg
@@ -2106,6 +2108,7 @@ CYTHON_UNUSED static PyObject* __Pyx_Method_ClassMethod(PyObject *method); /*pro
 
 //////////////////// ClassMethod ////////////////////
 //@requires: ObjectHandling.c::CachedMethodType
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 static PyObject* __Pyx_Method_ClassMethod(PyObject *method) {
 #if CYTHON_COMPILING_IN_PYPY && PYPY_VERSION_NUM <= 0x05080000

--- a/Cython/Utility/Exceptions.c
+++ b/Cython/Utility/Exceptions.c
@@ -85,6 +85,84 @@ static CYTHON_INLINE int __Pyx_ErrOccurredWithGIL(void) {
 #endif
 
 
+/////////////// GivenExceptionMatches.proto ///////////////
+//@requires: PyThreadStateGet
+
+#if CYTHON_COMPILING_IN_CPYTHON
+static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches(PyObject *err, PyObject *type);/*proto*/
+static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *type1, PyObject *type2);/*proto*/
+#else
+#define __Pyx_PyErr_GivenExceptionMatches(err, type) PyErr_GivenExceptionMatches(err, type)
+static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *type1, PyObject *type2) {
+    return PyErr_GivenExceptionMatches(err, type1) || PyErr_GivenExceptionMatches(err, type2);
+}
+#endif
+#define __Pyx_PyErr_ExceptionMatches2(err1, err2)  __Pyx_PyErr_GivenExceptionMatches2(__Pyx_PyErr_CurrentExceptionType(), err1, err2)
+
+/////////////// GivenExceptionMatches ///////////////
+//@requires: ModuleSetupCode.c::FastTypeChecks
+//@requires: PyErrFetchRestore
+
+#if CYTHON_COMPILING_IN_CPYTHON
+
+static CYTHON_INLINE int __Pyx_inner_PyErr_GivenExceptionMatches2(PyObject *err, PyObject* exc_type1, PyObject *exc_type2) {
+    if (exc_type1) {
+        return __Pyx_IsAnySubtype2((PyTypeObject*)err, (PyTypeObject*)exc_type1, (PyTypeObject*)exc_type2);
+    } else {
+        return __Pyx_IsSubtype((PyTypeObject*)err, (PyTypeObject*)exc_type2);
+    }
+}
+
+// so far, we only call PyErr_GivenExceptionMatches() with an exception type (not instance) as first argument
+// => optimise for that case
+
+static int __Pyx_PyErr_GivenExceptionMatchesTuple(PyObject *exc_type, PyObject *tuple) {
+    Py_ssize_t i, n;
+    assert(PyExceptionClass_Check(exc_type));
+    n = PyTuple_GET_SIZE(tuple);
+    // the tight subtype checking in Py3 allows faster out-of-order comparison
+    for (i=0; i<n; i++) {
+        if (exc_type == PyTuple_GET_ITEM(tuple, i)) return 1;
+    }
+    for (i=0; i<n; i++) {
+        PyObject *t = PyTuple_GET_ITEM(tuple, i);
+        if (likely(PyExceptionClass_Check(t))) {
+            if (__Pyx_inner_PyErr_GivenExceptionMatches2(exc_type, NULL, t)) return 1;
+        } else {
+            // FIXME: Py3: PyErr_SetString(PyExc_TypeError, "catching classes that do not inherit from BaseException is not allowed");
+        }
+    }
+    return 0;
+}
+
+static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches(PyObject *err, PyObject* exc_type) {
+    if (likely(err == exc_type)) return 1;
+    if (likely(PyExceptionClass_Check(err))) {
+        if (likely(PyExceptionClass_Check(exc_type))) {
+            return __Pyx_inner_PyErr_GivenExceptionMatches2(err, NULL, exc_type);
+        } else if (likely(PyTuple_Check(exc_type))) {
+            return __Pyx_PyErr_GivenExceptionMatchesTuple(err, exc_type);
+        } else {
+            // FIXME: Py3: PyErr_SetString(PyExc_TypeError, "catching classes that do not inherit from BaseException is not allowed");
+        }
+    }
+    return PyErr_GivenExceptionMatches(err, exc_type);
+}
+
+static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *exc_type1, PyObject *exc_type2) {
+    // Only used internally with known exception types => pure safety check assertions.
+    assert(PyExceptionClass_Check(exc_type1));
+    assert(PyExceptionClass_Check(exc_type2));
+    if (likely(err == exc_type1 || err == exc_type2)) return 1;
+    if (likely(PyExceptionClass_Check(err))) {
+        return __Pyx_inner_PyErr_GivenExceptionMatches2(err, exc_type1, exc_type2);
+    }
+    return (PyErr_GivenExceptionMatches(err, exc_type1) || PyErr_GivenExceptionMatches(err, exc_type2));
+}
+
+#endif
+
+
 /////////////// PyErrExceptionMatches.proto ///////////////
 //@substitute: naming
 
@@ -96,6 +174,7 @@ static CYTHON_INLINE int __Pyx_PyErr_ExceptionMatchesInState(PyThreadState* tsta
 #endif
 
 /////////////// PyErrExceptionMatches ///////////////
+//@requires: GivenExceptionMatches
 
 #if CYTHON_FAST_THREAD_STATE
 static int __Pyx_PyErr_ExceptionMatchesTuple(PyObject *exc_type, PyObject *tuple) {
@@ -138,6 +217,7 @@ static CYTHON_INLINE int __Pyx_PyErr_ExceptionMatchesInState(PyThreadState* tsta
     return result;
 }
 #endif
+
 
 /////////////// PyErrFetchRestore.proto ///////////////
 //@substitute: naming

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -655,6 +655,7 @@ static int __Pyx_UpdateUnpickledDict(PyObject *obj, PyObject *state, Py_ssize_t 
 
 
 /////////////// BinopSlot ///////////////
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 static CYTHON_INLINE PyObject *{{func_name}}_maybe_call_slot(PyTypeObject* type, PyObject *left, PyObject *right {{extra_arg_decl}}) {
     {{slot_type}} slot;

--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -6,6 +6,7 @@ static CYTHON_INLINE int __Pyx_ArgTypeTest(PyObject *obj, PyTypeObject *type, in
 
 //////////////////// ArgTypeTest ////////////////////
 //@requires: ArgTypeTestError
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 static CYTHON_INLINE int __Pyx_ArgTypeTest(PyObject *obj, PyTypeObject *type, int none_allowed, const char *name, int exact) {
     if (likely(Py_IS_TYPE(obj, type) | (none_allowed && (obj == Py_None))))
@@ -23,6 +24,7 @@ static CYTHON_INLINE int __Pyx_ArgTypeTest(PyObject *obj, PyTypeObject *type, in
 static void __Pyx_ArgTypeError(PyObject *obj, PyTypeObject *type, const char *name, int exact); /*proto*/
 
 //////////////////// ArgTypeTestError ////////////////////
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 static void __Pyx_ArgTypeError(PyObject *obj, PyTypeObject *type, const char *name, int exact)
 {

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1571,30 +1571,13 @@ if (likely(__Pyx_init_co_variables() == 0 && __Pyx_init_tpflags_variables() == 0
 #define __Pyx_TypeCheck2(obj, type1, type2) __Pyx_IsAnySubtype2(Py_TYPE(obj), (PyTypeObject *)type1, (PyTypeObject *)type2)
 static CYTHON_INLINE int __Pyx_IsSubtype(PyTypeObject *a, PyTypeObject *b);/*proto*/
 static CYTHON_INLINE int __Pyx_IsAnySubtype2(PyTypeObject *cls, PyTypeObject *a, PyTypeObject *b);/*proto*/
-static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches(PyObject *err, PyObject *type);/*proto*/
-static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *type1, PyObject *type2);/*proto*/
 #else
 #define __Pyx_TypeCheck(obj, type) PyObject_TypeCheck(obj, (PyTypeObject *)type)
 #define __Pyx_TypeCheck2(obj, type1, type2) (PyObject_TypeCheck(obj, (PyTypeObject *)type1) || PyObject_TypeCheck(obj, (PyTypeObject *)type2))
-#define __Pyx_PyErr_GivenExceptionMatches(err, type) PyErr_GivenExceptionMatches(err, type)
-static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *type1, PyObject *type2) {
-    return PyErr_GivenExceptionMatches(err, type1) || PyErr_GivenExceptionMatches(err, type2);
-}
-#endif
-#define __Pyx_PyErr_ExceptionMatches2(err1, err2)  __Pyx_PyErr_GivenExceptionMatches2(__Pyx_PyErr_CurrentExceptionType(), err1, err2)
-
-#define __Pyx_PyException_Check(obj) __Pyx_TypeCheck(obj, PyExc_Exception)
-#define __Pyx_PyBaseExceptionGroup_Check(obj) __Pyx_TypeCheck(obj, PyExc_BaseExceptionGroup)
-#ifdef PyExceptionInstance_Check
-  #define __Pyx_PyBaseException_Check(obj) PyExceptionInstance_Check(obj)
-#else
-  #define __Pyx_PyBaseException_Check(obj) __Pyx_TypeCheck(obj, PyExc_BaseException)
 #endif
 
 
 /////////////// FastTypeChecks ///////////////
-//@requires: Exceptions.c::PyThreadStateGet
-//@requires: Exceptions.c::PyErrFetchRestore
 
 #if CYTHON_COMPILING_IN_CPYTHON
 static int __Pyx_InBases(PyTypeObject *a, PyTypeObject *b) {
@@ -1640,63 +1623,6 @@ static CYTHON_INLINE int __Pyx_IsAnySubtype2(PyTypeObject *cls, PyTypeObject *a,
     // should only get here for incompletely initialised types, i.e. never under normal usage patterns
     return __Pyx_InBases(cls, a) || __Pyx_InBases(cls, b);
 }
-
-
-static CYTHON_INLINE int __Pyx_inner_PyErr_GivenExceptionMatches2(PyObject *err, PyObject* exc_type1, PyObject *exc_type2) {
-    if (exc_type1) {
-        return __Pyx_IsAnySubtype2((PyTypeObject*)err, (PyTypeObject*)exc_type1, (PyTypeObject*)exc_type2);
-    } else {
-        return __Pyx_IsSubtype((PyTypeObject*)err, (PyTypeObject*)exc_type2);
-    }
-}
-
-// so far, we only call PyErr_GivenExceptionMatches() with an exception type (not instance) as first argument
-// => optimise for that case
-
-static int __Pyx_PyErr_GivenExceptionMatchesTuple(PyObject *exc_type, PyObject *tuple) {
-    Py_ssize_t i, n;
-    assert(PyExceptionClass_Check(exc_type));
-    n = PyTuple_GET_SIZE(tuple);
-    // the tight subtype checking in Py3 allows faster out-of-order comparison
-    for (i=0; i<n; i++) {
-        if (exc_type == PyTuple_GET_ITEM(tuple, i)) return 1;
-    }
-    for (i=0; i<n; i++) {
-        PyObject *t = PyTuple_GET_ITEM(tuple, i);
-        if (likely(PyExceptionClass_Check(t))) {
-            if (__Pyx_inner_PyErr_GivenExceptionMatches2(exc_type, NULL, t)) return 1;
-        } else {
-            // FIXME: Py3: PyErr_SetString(PyExc_TypeError, "catching classes that do not inherit from BaseException is not allowed");
-        }
-    }
-    return 0;
-}
-
-static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches(PyObject *err, PyObject* exc_type) {
-    if (likely(err == exc_type)) return 1;
-    if (likely(PyExceptionClass_Check(err))) {
-        if (likely(PyExceptionClass_Check(exc_type))) {
-            return __Pyx_inner_PyErr_GivenExceptionMatches2(err, NULL, exc_type);
-        } else if (likely(PyTuple_Check(exc_type))) {
-            return __Pyx_PyErr_GivenExceptionMatchesTuple(err, exc_type);
-        } else {
-            // FIXME: Py3: PyErr_SetString(PyExc_TypeError, "catching classes that do not inherit from BaseException is not allowed");
-        }
-    }
-    return PyErr_GivenExceptionMatches(err, exc_type);
-}
-
-static CYTHON_INLINE int __Pyx_PyErr_GivenExceptionMatches2(PyObject *err, PyObject *exc_type1, PyObject *exc_type2) {
-    // Only used internally with known exception types => pure safety check assertions.
-    assert(PyExceptionClass_Check(exc_type1));
-    assert(PyExceptionClass_Check(exc_type2));
-    if (likely(err == exc_type1 || err == exc_type2)) return 1;
-    if (likely(PyExceptionClass_Check(err))) {
-        return __Pyx_inner_PyErr_GivenExceptionMatches2(err, exc_type1, exc_type2);
-    }
-    return (PyErr_GivenExceptionMatches(err, exc_type1) || PyErr_GivenExceptionMatches(err, exc_type2));
-}
-
 #endif
 
 

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -230,6 +230,7 @@ static CYTHON_INLINE PyObject *__Pyx_PyIter_Next2(PyObject *, PyObject *); /*pro
 /////////////// IterNext ///////////////
 //@requires: Exceptions.c::PyThreadStateGet
 //@requires: Exceptions.c::PyErrFetchRestore
+//@requires: Exceptions.c::GivenExceptionMatches
 //@requires: RaiseErrorWithObjectType
 //@requires: GetBuiltinName
 //@requires: IterNextPlain
@@ -301,7 +302,7 @@ static CYTHON_INLINE int __Pyx_IterFinish(void); /*proto*/
 
 /////////////// IterFinish ///////////////
 //@requires: Exceptions.c::PyThreadStateGet
-//@requires: Exceptions.c::PyErrFetchRestore
+//@requires: Exceptions.c::GivenExceptionMatches
 
 // When PyIter_Next(iter) has returned NULL in order to signal termination,
 // this function does the right cleanup and returns 0 on success.  If it
@@ -1413,6 +1414,7 @@ static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type); /*pr
 
 /////////////// ExtTypeTest ///////////////
 //@requires: RaiseErrorWithObjectTypes
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
     if (unlikely(!type)) {
@@ -1899,6 +1901,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target); /*proto
 //@requires: UnpackUnboundCMethod_decl
 //@requires: PyObjectGetAttrStr
 //@requires: Exceptions.c::IgnoreException
+//@requires: ModuleSetupCode.c::FastTypeChecks
 
 #if CYTHON_COMPILING_IN_LIMITED_API && __PYX_LIMITED_VERSION_HEX < 0x030C0000
 static PyObject *__Pyx_SelflessCall(PyObject *method, PyObject *args, PyObject *kwargs) {
@@ -1992,7 +1995,7 @@ static int __Pyx_TryUnpackUnboundCMethod(__Pyx_CachedCFunction* target) {
 #define __Pyx_CallCFunctionFastWithKeywords(cfunc, self, args, nargs, kwnames) \
     ((__Pyx_PyCFunctionFastWithKeywords)(void(*)(void))(PyCFunction)(cfunc)->func)(self, args, nargs, kwnames)
 
-    
+
 /////////////// CallUnboundCMethod0.proto ///////////////
 
 CYTHON_UNUSED


### PR DESCRIPTION
Make both independently optional.
They used to be combined for purely practical reasons that no longer strictly apply.

Also, `PyExceptionInstance_Check()` seems to be available in all supported Python versions now, so we can remove the special case for it.