### PR TITLE
Report an error instead of crashing on a C++ constructor call with keyword arguments

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -6355,7 +6355,13 @@ class CallNode(ExprNode):
             node = node.analyse_types(env).coerce_to(type, env)
             return node
         elif type and type.is_cpp_class:
-            self.args = [ arg.analyse_types(env) for arg in self.args ]
+            args, kwds = self.explicit_args_kwds()
+            if kwds:
+                # Only SimpleCallNode has '.args'. Leave a call with keyword
+                # arguments to the normal call analysis, which rejects it, rather
+                # than crashing on the missing attribute below.
+                return None
+            self.args = [ arg.analyse_types(env) for arg in args ]
             constructor = type.scope.lookup("<init>")
             if not constructor:
                 error(self.function.pos, "no constructor found for C++  type '%s'" % self.function.name)
@@ -7516,6 +7522,8 @@ class GeneralCallNode(CallNode):
                     error(self.pos,
                           "Non-trivial keyword arguments and starred "
                           "arguments not allowed in cdef functions.")
+                    self.type = error_type
+                    return self
                 else:
                     # error was already reported
                     pass

--- a/tests/errors/cpp_class_kwargs.pyx
+++ b/tests/errors/cpp_class_kwargs.pyx
@@ -1,0 +1,27 @@
+# mode: error
+# tag: cpp
+# ticket: 7206
+
+cdef extern from *:
+    """
+    class C {
+        public:
+            int i;
+            C() : i(0) {}
+            C(int j) : i(j) {}
+    };
+    """
+
+    cdef cppclass C:
+        int i
+        C()
+        C(int j)
+
+
+def f():
+    cdef C c = C(i=0)
+
+
+_ERRORS = u"""
+22:16: Non-trivial keyword arguments and starred arguments not allowed in cdef functions.
+"""

--- a/tests/errors/cpp_class_kwargs.pyx
+++ b/tests/errors/cpp_class_kwargs.pyx
@@ -19,9 +19,11 @@ cdef extern from *:
 
 
 def f():
-    cdef C c = C(i=0)
+    cdef C wrong_keyword_name = C(i=0)
+    cdef C ok = C(j=0)
 
 
 _ERRORS = u"""
-22:16: Non-trivial keyword arguments and starred arguments not allowed in cdef functions.
+22:33: Non-trivial keyword arguments and starred arguments not allowed in cdef functions.
+23:17: Non-trivial keyword arguments and starred arguments not allowed in cdef functions.
 """


### PR DESCRIPTION
Closes #7206

`C(i=0)` on a C++ class crashes the compiler:

```
AttributeError: 'GeneralCallNode' object has no attribute 'args'
```

`analyse_as_type_constructor` sits on `CallNode`, so both call node types reach it. The struct branch reads its arguments through `explicit_args_kwds()`. The C++ branch reads `self.args` and only `SimpleCallNode` has that. Keyword arguments make the node a `GeneralCallNode`.

So the C++ branch now steps aside when there are keyword arguments. Normal call analysis already rejects them with "Non-trivial keyword arguments and starred arguments not allowed in cdef functions."

The second hunk stops that error cascading. It reported and fell through, so the node ended up typed as a Python object and two more messages followed. `C(1, 2, 3)` gets one message, so this should too. Same `error_type` guard as in #7861.

```
C(i=0) // one error, was a crash
C(*a) // one error, was a crash
C(0) // ok
C() // ok
```

Three cpp_stl_algo tests fail here, but they fail on master too. Recent libc++ wants a comparator reference where the generated code passes a function pointer. It also warns that the platform is no longer supported
