### PR TITLE
Include subtypes of builtin types in some optimisations.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -3145,6 +3145,7 @@ class IteratorNode(ScopedExprNode):
     type = py_object_type
     iter_func_ptr = None
     counter_cname = None
+    _is_list_iter_flag = None
     reversed = False      # currently only used for list/tuple types (see Optimize.py)
     is_async = False
     has_local_scope = False
@@ -3227,12 +3228,14 @@ class IteratorNode(ScopedExprNode):
         if not is_builtin_sequence:
             # reversed() not currently optimised (see Optimize.py)
             assert not self.reversed, "internal error: reversed() only implemented for list/tuple objects"
+        seq_result = self.sequence.py_result()
         self.may_be_a_sequence = not sequence_type.is_builtin_type
         if self.may_be_a_sequence:
+            self._is_list_iter_flag = code.funcstate.allocate_temp(PyrexTypes.c_bint_type, manage_ref=False)
+            code.putln(f"{self._is_list_iter_flag} = __Pyx_IsListIter({seq_result});")
             code.putln(
-                "if (likely(PyList_CheckExact(%s)) || PyTuple_CheckExact(%s)) {" % (
-                    self.sequence.py_result(),
-                    self.sequence.py_result()))
+                f"if (likely({self._is_list_iter_flag}) || __Pyx_IsTupleIter({seq_result})) {{"
+            )
 
         if is_builtin_sequence or self.may_be_a_sequence:
             code.putln("%s = %s; __Pyx_INCREF(%s);" % (
@@ -3339,7 +3342,7 @@ class IteratorNode(ScopedExprNode):
 
         if self.may_be_a_sequence:
             code.putln("if (likely(!%s)) {" % self.iter_func_ptr)
-            code.putln("if (likely(PyList_CheckExact(%s))) {" % self.py_result())
+            code.putln(f"if (likely({self._is_list_iter_flag})) {{")
             self.generate_next_sequence_item('List', result_name, code)
             code.putln("} else {")
             self.generate_next_sequence_item('Tuple', result_name, code)
@@ -3365,6 +3368,10 @@ class IteratorNode(ScopedExprNode):
     def free_temps(self, code):
         if self.counter_cname:
             code.funcstate.release_temp(self.counter_cname)
+            self.counter_cname = None
+        if self._is_list_iter_flag:
+            code.funcstate.release_temp(self._is_list_iter_flag)
+            self._is_list_iter_flag = None
         if self.iter_func_ptr:
             code.funcstate.release_temp(self.iter_func_ptr)
             self.iter_func_ptr = None
@@ -8937,9 +8944,11 @@ class SequenceNode(ExprNode):
         else:
             sequence_types = ['Tuple', 'List']
             get_size_func = "__Pyx_PySequence_SIZE"
-            tuple_check = 'likely(PyTuple_CheckExact(%s))' % rhs.py_result()
-            list_check  = 'PyList_CheckExact(%s)' % rhs.py_result()
-            sequence_type_test = "(%s) || (%s)" % (tuple_check, list_check)
+            # Unpacking depends on iteration, so it's enough if the sequence uses
+            # the normal list/tuple ".__iter__" slot to bypass it.
+            tuple_check = f'likely(__Pyx_IsTupleIter({rhs.py_result()}))'
+            list_check  = f'__Pyx_IsListIter({rhs.py_result()})'
+            sequence_type_test = f"({tuple_check}) || ({list_check})"
 
         code.putln("if (%s) {" % sequence_type_test)
         code.putln("PyObject* sequence = %s;" % rhs.py_result())
@@ -8961,7 +8970,7 @@ class SequenceNode(ExprNode):
         code.putln("#if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS")
         # unpack items from list/tuple in unrolled loop (can't fail)
         if len(sequence_types) == 2:
-            code.putln("if (likely(Py%s_CheckExact(sequence))) {" % sequence_types[0])
+            code.putln(f"if (likely(__Pyx_IsTupleIter(sequence))) {{")
         sequence_sharing_status = self.may_be_unsafe_shared() if 'List' in sequence_types else 'UNUSED'
         for i, item in enumerate(self.unpacked_items):
             if sequence_types[0] == "List":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8931,6 +8931,7 @@ class SequenceNode(ExprNode):
     def generate_special_parallel_unpacking_code(self, code, rhs, use_loop):
         sequence_type_test = '1'
         none_check = "likely(%s != Py_None)" % rhs.py_result()
+        flag_temp = None
         if rhs.type.is_pylist_type:
             sequence_types = ['List']
             get_size_func = "__Pyx_PyList_GET_SIZE"
@@ -8944,9 +8945,10 @@ class SequenceNode(ExprNode):
         else:
             sequence_types = ['Tuple', 'List']
             get_size_func = "__Pyx_PySequence_SIZE"
+            flag_temp = code.funcstate.allocate_temp(PyrexTypes.c_bint_type, manage_ref=False)
             # Unpacking depends on iteration, so it's enough if the sequence uses
             # the normal list/tuple ".__iter__" slot to bypass it.
-            tuple_check = f'likely(__Pyx_IsTupleIter({rhs.py_result()}))'
+            tuple_check = f'likely({flag_temp} = __Pyx_IsTupleIter({rhs.py_result()}))'
             list_check  = f'__Pyx_IsListIter({rhs.py_result()})'
             sequence_type_test = f"({tuple_check}) || ({list_check})"
 
@@ -8957,20 +8959,16 @@ class SequenceNode(ExprNode):
         code.putln("Py_ssize_t size = %s(sequence);" % get_size_func)
         code.putln("if (unlikely(size != %d)) {" % len(self.args))
         code.globalstate.use_utility_code(
-            UtilityCode.load_cached("RaiseTooManyValuesToUnpack", "ObjectHandling.c"))
-        code.putln("if (size > %d) __Pyx_RaiseTooManyValuesError(%d);" % (
-            len(self.args), len(self.args)))
-        code.globalstate.use_utility_code(
-            UtilityCode.load_cached("RaiseNeedMoreValuesToUnpack", "ObjectHandling.c"))
-        code.putln("else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);")
-        # < 0 => exception
-        code.putln(code.error_goto(self.pos))
+            UtilityCode.load_cached("RaiseUnpackSizeError", "ObjectHandling.c"))
+        code.putln(f"__Pyx_RaiseUnpackSizeError(size, {len(self.args)}); {code.error_goto(self.pos)}")
         code.putln("}")
 
         code.putln("#if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS")
         # unpack items from list/tuple in unrolled loop (can't fail)
         if len(sequence_types) == 2:
-            code.putln(f"if (likely(__Pyx_IsTupleIter(sequence))) {{")
+            code.putln(f"if ({flag_temp}) {{")
+            code.funcstate.release_temp(flag_temp)
+            flag_temp = None
         sequence_sharing_status = self.may_be_unsafe_shared() if 'List' in sequence_types else 'UNUSED'
         for i, item in enumerate(self.unpacked_items):
             if sequence_types[0] == "List":

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -13634,9 +13634,14 @@ class ModNode(DivNode):
         type1, type2 = self.operand1.type, self.operand2.type
         # ("..." % x)  must call "x.__rmod__()" for string subtypes.
         if type1.is_pystr_type:
-            if self.operand1.may_be_none() or (
-                    type2.is_extension_type and type2.subtype_of(type1) or
+            if self.operand1.may_be_none():
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("PyUnicodeFormatSafe", "StringTools.c"))
+                return '__Pyx_PyUnicode_FormatNoneSafe'
+            elif (type2.is_extension_type and type2.subtype_of(type1) or
                     type2 is py_object_type and not isinstance(self.operand2, CoerceToPyTypeNode)):
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("PyUnicodeFormatSafe", "StringTools.c"))
                 return '__Pyx_PyUnicode_FormatSafe'
             else:
                 return 'PyUnicode_Format'

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8928,101 +8928,98 @@ class SequenceNode(ExprNode):
             self.args[i].generate_assignment_code(
                 self.coerced_unpacked_items[i], code)
 
-    def generate_special_parallel_unpacking_code(self, code, rhs, use_loop):
-        sequence_type_test = '1'
-        none_check = "likely(%s != Py_None)" % rhs.py_result()
-        flag_temp = None
-        if rhs.type.is_pylist_type:
-            sequence_types = ['List']
-            get_size_func = "__Pyx_PyList_GET_SIZE"
-            if rhs.may_be_none():
-                sequence_type_test = none_check
-        elif rhs.type.is_pytuple_type:
-            sequence_types = ['Tuple']
-            get_size_func = "__Pyx_PyTuple_GET_SIZE"
-            if rhs.may_be_none():
-                sequence_type_test = none_check
+    def generate_list_parallel_unpacking_code(self, code, sequence, use_loop):
+        code.putln(f"Py_ssize_t size = __Pyx_PyList_GET_SIZE({sequence});")
+        code.putln(f"if (unlikely(size != {len(self.args)})) {{")
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("RaiseUnpackSizeError", "ObjectHandling.c"))
+        code.putln(f"__Pyx_RaiseUnpackSizeError(size, {len(self.args)}); {code.error_goto(self.pos)}")
+        code.putln("}")
+
+        sequence_sharing_status = self.may_be_unsafe_shared()
+        if use_loop:
+            code.putln("Py_ssize_t i;")
+            code.putln("PyObject** temps[%d] = {%s};" % (
+                len(self.unpacked_items),
+                ','.join([f'&{item.result()}' for item in self.unpacked_items])))
+            code.putln(f"for (i=0; i < {len(self.unpacked_items)}; i++) {{")
+            code.putln(
+                f"PyObject* item = __Pyx_PyList_GET_ITEM_REF({sequence}, i, {sequence_sharing_status}); "
+                f"{code.error_goto_if_null('item', self.pos)}"
+            )
+            code.put_gotref('item', py_object_type)
+            code.putln("*(temps[i]) = item;")
+            code.putln("}")
         else:
-            sequence_types = ['Tuple', 'List']
-            get_size_func = "__Pyx_PySequence_SIZE"
-            flag_temp = code.funcstate.allocate_temp(PyrexTypes.c_bint_type, manage_ref=False)
-            # Unpacking depends on iteration, so it's enough if the sequence uses
-            # the normal list/tuple ".__iter__" slot to bypass it.
-            tuple_check = f'likely({flag_temp} = __Pyx_IsTupleIter({rhs.py_result()}))'
-            list_check  = f'__Pyx_IsListIter({rhs.py_result()})'
-            sequence_type_test = f"({tuple_check}) || ({list_check})"
+            for i, item in enumerate(self.unpacked_items):
+                code.putln(f"{item.result()} = __Pyx_PyList_GET_ITEM_REF({sequence}, {i}, {sequence_sharing_status});")
+                code.putln(code.error_goto_if_null(item.result(), self.pos))
+                code.put_gotref(item.result(), item.ctype())
 
-        code.putln("if (%s) {" % sequence_type_test)
-        code.putln("PyObject* sequence = %s;" % rhs.py_result())
-
-        # list/tuple => check size
-        code.putln("Py_ssize_t size = %s(sequence);" % get_size_func)
-        code.putln("if (unlikely(size != %d)) {" % len(self.args))
+    def generate_tuple_parallel_unpacking_code(self, code, sequence, use_loop):
+        code.putln(f"Py_ssize_t size = __Pyx_PyTuple_GET_SIZE({sequence});")
+        code.putln(f"if (unlikely(size != {len(self.args)})) {{")
         code.globalstate.use_utility_code(
             UtilityCode.load_cached("RaiseUnpackSizeError", "ObjectHandling.c"))
         code.putln(f"__Pyx_RaiseUnpackSizeError(size, {len(self.args)}); {code.error_goto(self.pos)}")
         code.putln("}")
 
         code.putln("#if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS")
-        # unpack items from list/tuple in unrolled loop (can't fail)
-        if len(sequence_types) == 2:
-            code.putln(f"if ({flag_temp}) {{")
-            code.funcstate.release_temp(flag_temp)
-            flag_temp = None
-        sequence_sharing_status = self.may_be_unsafe_shared() if 'List' in sequence_types else 'UNUSED'
+        # unpack items from tuple in unrolled loop (can't fail)
         for i, item in enumerate(self.unpacked_items):
-            if sequence_types[0] == "List":
-                code.putln(f"{item.result()} = __Pyx_PyList_GET_ITEM_REF(sequence, {i}, {sequence_sharing_status});")
-                code.putln(code.error_goto_if_null(item.result(), self.pos))
-                code.put_xgotref(item.result(), item.ctype())
-            else:  # Tuple
-                code.putln(f"{item.result()} = PyTuple_GET_ITEM(sequence, {i});")
-                code.put_incref(item.result(), item.ctype())
-        if len(sequence_types) == 2:
-            code.putln("} else {")
-            assert sequence_types[1] == 'List', sequence_types
-            for i, item in enumerate(self.unpacked_items):
-                code.putln(f"{item.result()} = __Pyx_PyList_GET_ITEM_REF(sequence, {i}, {sequence_sharing_status});")
-                code.putln(code.error_goto_if_null(item.result(), self.pos))
-                code.put_xgotref(item.result(), item.ctype())
-            code.putln("}")
+            code.putln(f"{item.result()} = PyTuple_GET_ITEM({sequence}, {i});")
+            code.put_incref(item.result(), item.ctype())
 
         code.putln("#else")
         # in non-CPython, use the PySequence protocol (which can fail)
-        if not use_loop:
-            for i, item in enumerate(self.unpacked_items):
-                code.putln("%s = __Pyx_PySequence_ITEM(sequence, %d); %s" % (
-                    item.result(), i,
-                    code.error_goto_if_null(item.result(), self.pos)))
-                code.put_gotref(item.result(), item.type)
-        else:
-            code.putln("{")
+        if use_loop:
             code.putln("Py_ssize_t i;")
-            code.putln("PyObject** temps[%s] = {%s};" % (
+            code.putln("PyObject** temps[%d] = {%s};" % (
                 len(self.unpacked_items),
                 ','.join(['&%s' % item.result() for item in self.unpacked_items])))
-            code.putln("for (i=0; i < %s; i++) {" % len(self.unpacked_items))
-            code.putln("PyObject* item = __Pyx_PySequence_ITEM(sequence, i); %s" % (
-                code.error_goto_if_null('item', self.pos)))
+            code.putln(f"for (i=0; i < {len(self.unpacked_items)}; i++) {{")
+            code.putln(f"PyObject* item = __Pyx_PySequence_ITEM({sequence}, i); {code.error_goto_if_null('item', self.pos)}")
             code.put_gotref('item', py_object_type)
             code.putln("*(temps[i]) = item;")
             code.putln("}")
-            code.putln("}")
-
+        else:
+            for i, item in enumerate(self.unpacked_items):
+                code.putln(
+                    f"{item.result()} = __Pyx_PySequence_ITEM({sequence}, {i}); "
+                    f"{code.error_goto_if_null(item.result(), self.pos)}"
+                )
+                code.put_gotref(item.result(), item.type)
         code.putln("#endif")
-        rhs.generate_disposal_code(code)
 
-        if sequence_type_test == '1':
-            code.putln("}")  # all done
-        elif sequence_type_test == none_check:
-            # either tuple/list or None => save some code by generating the error directly
-            code.putln("} else {")
+    def generate_special_parallel_unpacking_code(self, code, rhs, use_loop):
+        sequence = rhs.py_result()
+
+        if (rhs.type.is_pylist_type or rhs.type.is_pytuple_type) and rhs.may_be_none():
             code.globalstate.use_utility_code(
                 UtilityCode.load_cached("RaiseNoneIterError", "ObjectHandling.c"))
-            code.putln("__Pyx_RaiseNoneNotIterableError(); %s" % code.error_goto(self.pos))
-            code.putln("}")  # all done
+            code.putln(
+                f"if (unlikely({sequence} == Py_None)) "
+                f"{{ __Pyx_RaiseNoneNotIterableError(); {code.error_goto(self.pos)} }}"
+            )
+
+        if rhs.type.is_pylist_type:
+            code.putln("{")
+            self.generate_list_parallel_unpacking_code(code, sequence, use_loop)
+            rhs.generate_disposal_code(code)
+            code.putln("}")
+        elif rhs.type.is_pytuple_type:
+            code.putln("{")
+            self.generate_tuple_parallel_unpacking_code(code, sequence, use_loop)
+            rhs.generate_disposal_code(code)
+            code.putln("}")
         else:
-            code.putln("} else {")  # needs iteration fallback code
+            code.putln(f"if (__Pyx_IsTupleIter({sequence})) {{")
+            self.generate_tuple_parallel_unpacking_code(code, sequence, use_loop)
+            rhs.generate_disposal_code(code)
+            code.putln(f"}} else if (__Pyx_IsListIter({sequence})) {{")
+            self.generate_list_parallel_unpacking_code(code, sequence, use_loop)
+            rhs.generate_disposal_code(code)
+            code.putln("} else {")
             self.generate_generic_parallel_unpacking_code(
                 code, rhs, self.unpacked_items, use_loop=use_loop)
             code.putln("}")

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -8911,7 +8911,7 @@ class SequenceNode(ExprNode):
             item.allocate(code)
         special_unpack = (rhs.type.may_be_pytuple_type or rhs.type.may_be_pylist_type
                           or not rhs.type.is_builtin_type)
-        long_enough_for_a_loop = len(self.unpacked_items) > 3
+        long_enough_for_a_loop = len(self.unpacked_items) > (3 if self.slow else 12)
 
         if special_unpack:
             self.generate_special_parallel_unpacking_code(

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -984,6 +984,24 @@ static CYTHON_INLINE void *__Pyx__PyModule_GetState(PyObject *op)
   #define __Pyx_PyType_TryGetSubSlot(obj, sub, name, func_ctype) __Pyx_PyType_TryGetSlot(obj, name, func_ctype)
 #endif
 
+#if CYTHON_USE_TYPE_SLOTS
+  #define __Pyx_SlotIsInherited(obj, base_type, slot_name)  \
+    (__Pyx_PyObject_GetSlot(obj, slot_name, void*) == __Pyx_PyType_GetSlot(base_type, slot_name, void*))
+  #define __Pyx_SubSlotIsInherited(obj, base_type, sub, slot_name)  \
+    (__Pyx_PyObject_GetSubSlot(obj, sub, slot_name, void*) == __Pyx_PyType_GetSubSlot(base_type, sub, slot_name, void*))
+#else
+  #define __Pyx_SlotIsInherited(obj, base_type, slot_name)  (0)
+  #define __Pyx_SubSlotIsInherited(obj, base_type, sub, slot_name)  (0)
+#endif
+
+// In many cases where we specialise list/tuple, it's enough to know that "tp_iter" has not been overwritten
+// by a subtype to decide that we can safely assume standard iteration/unpacking/etc. behaviour.
+#define __Pyx_IsListIter(obj) \
+  (PyList_CheckExact(obj) || __Pyx_SlotIsInherited(obj, &PyList_Type, tp_iter))
+
+#define __Pyx_IsTupleIter(obj) \
+  (PyTuple_CheckExact(obj) || __Pyx_SlotIsInherited(obj, &PyTuple_Type, tp_iter))
+
 #if CYTHON_COMPILING_IN_CPYTHON || defined(_PyDict_NewPresized)
 #define __Pyx_PyDict_NewPresized(n)  ((n <= 8) ? PyDict_New() : _PyDict_NewPresized(n))
 #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1155,9 +1155,6 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict,
   #endif
 #endif
 
-// ("..." % x)  must call PyNumber_Remainder() if x is a string subclass that implements "__rmod__()".
-#define __Pyx_PyUnicode_FormatSafe(a, b)  ((unlikely((a) == Py_None || (PyUnicode_Check(b) && !PyUnicode_CheckExact(b)))) ? PyNumber_Remainder(a, b) : PyUnicode_Format(a, b))
-
 #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX >= 0x030E0000
   #define __Pyx_PySequence_ListKeepNew(obj) \
     (likely(PyList_CheckExact(obj) && PyUnstable_Object_IsUniquelyReferenced(obj)) ? __Pyx_NewRef(obj) : PySequence_List(obj))

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -984,7 +984,12 @@ static CYTHON_INLINE void *__Pyx__PyModule_GetState(PyObject *op)
   #define __Pyx_PyType_TryGetSubSlot(obj, sub, name, func_ctype) __Pyx_PyType_TryGetSlot(obj, name, func_ctype)
 #endif
 
-#if CYTHON_USE_TYPE_SLOTS
+#if CYTHON_COMPILING_IN_CPYTHON && CYTHON_USE_TYPE_SLOTS
+  // In CPython, if a type specific slot of a builtin type appears in an unknown type,
+  // we can assume identical behaviour.  That is not necessarily the case in PyPy (and others?),
+  // which may use more generic slot implementations.
+  // Also, this assumption does not hold for ambiguous slot functions like
+  // "PyType_GenericAlloc", "PyType_GenericGetAttr" or "PyObject_SelfIter".
   #define __Pyx_SlotIsInherited(obj, base_type, slot_name)  \
     (__Pyx_PyObject_GetSlot(obj, slot_name, void*) == __Pyx_PyType_GetSlot(base_type, slot_name, void*))
   #define __Pyx_SubSlotIsInherited(obj, base_type, sub, slot_name)  \

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -40,6 +40,22 @@ static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
                  index, (index == 1) ? "" : "s");
 }
 
+
+/////////////// RaiseUnpackSizeError.proto ///////////////
+//@requires: RaiseTooManyValuesToUnpack
+//@requires: RaiseNeedMoreValuesToUnpack
+
+static void __Pyx_RaiseUnpackSizeError(Py_ssize_t size, Py_ssize_t expected);
+
+/////////////// RaiseUnpackSizeError ///////////////
+
+static void __Pyx_RaiseUnpackSizeError(Py_ssize_t size, Py_ssize_t expected) {
+    if (size > expected) __Pyx_RaiseTooManyValuesError(expected);
+    else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
+    else { /* size < 0  => exception reading the size. */ }
+}
+
+
 /////////////// UnpackTupleError.proto ///////////////
 
 static void __Pyx_UnpackTupleError(PyObject *, Py_ssize_t index); /*proto*/

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -548,7 +548,7 @@ static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* dict, int is_dict, 
 
 static CYTHON_INLINE PyObject* __Pyx_dict_iterator(PyObject* iterable, int is_dict, PyObject* method_name,
                                                    Py_ssize_t* p_orig_length, int* p_source_is_dict) {
-    is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable));
+    is_dict = is_dict || likely(__Pyx_PyAnyDict_CheckExact(iterable)) || __Pyx_SlotIsInherited(iterable, &PyDict_Type, tp_iter);
     *p_source_is_dict = is_dict;
 #if !CYTHON_AVOID_BORROWED_REFS
     if (is_dict) {

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1505,24 +1505,24 @@ static CYTHON_INLINE {{c_ret_type}} __Pyx_PyObject_Compare{{'' if return_obj els
 {{py: return_error = "return NULL" if return_obj else "return -1"}}
 {{py: c_op_reversed = {'==': '==', '!=': '!=', '<': '>=', '<=': '>', '>=': '<', '>': '<='}[c_op] }}
 {{py:
-check_functions = {
-    'float': "PyFloat_CheckExact",
-    'int': 'PyLong_CheckExact',
-    'str': 'PyUnicode_CheckExact',
-    'bytes': 'PyBytes_CheckExact',
-    'bytearray': 'PyByteArray_CheckExact',
+ctype_names = {
+    'float': "PyFloat",
+    'int': 'PyLong',
+    'str': 'PyUnicode',
+    'bytes': 'PyBytes',
+    'bytearray': 'PyByteArray',
 }
 }}
 {{py:
-def is_type(operand, expected, type1=type1, type2=type2, check_functions=check_functions):
+def is_type(operand, expected, type1=type1, type2=type2, ctype_names=ctype_names):
     assert operand in ('op1', 'op2'), operand
-    assert expected in check_functions, expected
+    assert expected in ctype_names, expected
     type = type1 if operand == 'op1' else type2
     if type == expected:
         check = f"likely({operand} != Py_None)"
     else:
-        function = check_functions[expected]
-        check = f"{function}({operand})"
+        c_type_name = ctype_names[expected]
+        check = f"{c_type_name}_CheckExact({operand}) || __Pyx_SlotIsInherited({operand}, &{c_type_name}_Type, tp_richcompare)"
         other_type = type2 if operand == 'op1' else type1
         if other_type == expected:
             check = f"likely({check})"
@@ -2055,7 +2055,7 @@ static CYTHON_INLINE {{c_ret_type}} __Pyx_PyLong_{{'' if ret_type.is_pyobject el
     }
 
     #if CYTHON_USE_PYLONG_INTERNALS
-    if (likely(PyLong_CheckExact({{pyval}}))) {
+    if (likely(PyLong_CheckExact({{pyval}})) || __Pyx_SlotIsInherited({{pyval}}, &PyLong_Type, tp_richcompare)) {
         int unequal;
         unsigned long uintval;
         Py_ssize_t size = __Pyx_PyLong_DigitCount({{pyval}});
@@ -2090,7 +2090,7 @@ static CYTHON_INLINE {{c_ret_type}} __Pyx_PyLong_{{'' if ret_type.is_pyobject el
     }
     #endif
 
-    if (PyFloat_CheckExact({{pyval}})) {
+    if (PyFloat_CheckExact({{pyval}}) || __Pyx_SlotIsInherited({{pyval}}, &PyFloat_Type, tp_richcompare)) {
         const long {{'a' if order == 'CObj' else 'b'}} = intval;
         double {{ival}} = __Pyx_PyFloat_AS_DOUBLE({{pyval}});
         {{return_compare('(double)a', '(double)b', c_op)}}

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -1125,7 +1125,7 @@ static PyObject* __Pyx__PyNumber_PowerOf2(PyObject *two, PyObject *exp, PyObject
 // see https://bugs.python.org/issue21420
 #if !CYTHON_COMPILING_IN_PYPY
     Py_ssize_t shiftby;
-    if (likely(PyLong_CheckExact(exp))) {
+    if (likely(PyLong_CheckExact(exp)) || __Pyx_SubSlotIsInherited(exp, &PyLong_Type, tp_as_number, nb_power)) {
         #if CYTHON_USE_PYLONG_INTERNALS
         if (__Pyx_PyLong_IsZero(exp)) {
             return PyLong_FromLong(1L);

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -581,7 +581,8 @@ static CYTHON_INLINE int __Pyx_set_iter_next(
 static CYTHON_INLINE PyObject* __Pyx_set_iterator(PyObject* iterable, int is_set,
                                                   Py_ssize_t* p_orig_length, int* p_source_is_set) {
 #if CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX < 0x030d0000
-    is_set = is_set || likely(PySet_CheckExact(iterable) || PyFrozenSet_CheckExact(iterable));
+    is_set = is_set || likely(PySet_CheckExact(iterable) || PyFrozenSet_CheckExact(iterable)) || (
+        __Pyx_SlotIsInherited(iterable, &PySet_Type, tp_iter) || __Pyx_SlotIsInherited(iterable, &PyFrozenSet_Type, tp_iter));
     *p_source_is_set = is_set;
     if (likely(is_set)) {
         *p_orig_length = PySet_Size(iterable);

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1515,6 +1515,31 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_FormatAndDecref(PyObject* s, PyObj
 }
 
 
+//////////////////// PyUnicodeFormatSafe.proto ////////////////////
+
+#define __Pyx_PyUnicode_FormatNoneSafe(a, b) \
+    (unlikely((a) == Py_None) ? PyNumber_Remainder(a, b) : __Pyx_PyUnicode_FormatSafe(a, b))
+
+static CYTHON_INLINE PyObject* __Pyx_PyUnicode_FormatSafe(PyObject *a, PyObject *b); /*proto*/
+
+//////////////////// PyUnicodeFormatSafe ////////////////////
+
+// ("..." % x)  must call PyNumber_Remainder() if x is a string subclass that implements "__rmod__()".
+static CYTHON_INLINE PyObject* __Pyx_PyUnicode_FormatSafe(PyObject *a, PyObject *b) {
+    if (unlikely(PyUnicode_Check(b) && !PyUnicode_CheckExact(b))) {
+        #if CYTHON_COMPILING_IN_CPYTHON && CYTHON_USE_TYPE_SLOTS
+        PyNumberMethods *b_as_number = Py_TYPE(b)->tp_as_number;
+        if (likely(b_as_number) && unlikely((b_as_number->nb_remainder != NULL) & (b_as_number->nb_remainder != PyUnicode_Type.tp_as_number->nb_remainder))) {
+            return b_as_number->nb_remainder(a, b);
+        }
+        #else
+        return PyNumber_Remainder(a, b);
+        #endif
+    }
+    return PyUnicode_Format(a, b);
+}
+
+
 //////////////////// PyUnicode_Unicode.proto ////////////////////
 
 static CYTHON_INLINE PyObject* __Pyx_PyUnicode_Unicode(PyObject *obj);/*proto*/

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -337,7 +337,7 @@ static CYTHON_INLINE int __Pyx_PyUnicode_ContainsTF(PyObject* substring, PyObjec
 #define __Pyx_PyObject_Equals_uchar(s1, s2, ch2, equals, s1_is_str) (\
     ((s1) == (s2)) ? ((equals) == Py_EQ) : \
     ((s1) == Py_None) ? ((equals) == Py_NE) : \
-    (likely((s1_is_str) || PyUnicode_CheckExact(s1)) ? \
+    (likely((s1_is_str) || PyUnicode_CheckExact(s1) || __Pyx_SlotIsInherited(s1, &PyUnicode_Type, tp_richcompare)) ? \
         __Pyx__PyUnicode_EqualsUCS4(s1, ch2, equals) : \
         __Pyx_PyObject_RichCompareBool(s1, s2, equals) \
     ))

--- a/Demos/benchmarks/bm_microbinop.pyx
+++ b/Demos/benchmarks/bm_microbinop.pyx
@@ -33,6 +33,13 @@ class Wrapped:
         return self._value > other
 
 
+class SubInt(int):
+    pass
+
+class SubFloat(int):
+    pass
+
+
 @cython.cfunc
 def _bubblesort_steps(items: list, _type1: item_types1, _type2: item_types2):
     """A few iterations of bubblesort that scale linearly with the number of elements.
@@ -128,6 +135,8 @@ def _comparisons(type_selection: cython.int, item_type, scale: cython.Py_ssize_t
 # Number benchmarks
 bm_cmp_obj_obj_mix = partial(_comparisons, 1, lambda v: v if v&1 else float(v))
 bm_cmp_obj_obj_numext = partial(_comparisons, 1, lambda v: Wrapped(v) if v % 3 == 0 else float(v) if v % 3 == 1 else v)
+bm_cmp_obj_obj_intsub = partial(_comparisons, 1, lambda v: SubInt(v) if v % 2 == 1 else v)
+bm_cmp_obj_obj_floatsub = partial(_comparisons, 1, lambda v: SubFloat(v) if v % 2 == 1 else float(v))
 bm_cmp_obj_obj_int = partial(_comparisons, 1, int)
 bm_cmp_obj_obj_float = partial(_comparisons, 1, float)
 bm_cmp_obj_int = partial(_comparisons, 2, int)

--- a/Demos/benchmarks/bm_unpack_sequence.py
+++ b/Demos/benchmarks/bm_unpack_sequence.py
@@ -11,17 +11,15 @@ import cython
 
 DEFAULT_TIMER = time.perf_counter
 
+seq_type = cython.fused_type(tuple, list, object)
 
-def _single_run(to_unpack, iterations: cython.long):
-    x: cython.long
-    y: cython.long
-
+def _single_run(to_unpack: seq_type, iterations: list):
     # Unpack to C integers
     c: cython.int
     f: cython.long
     h: cython.size_t
 
-    for y in range(iterations):
+    for y in iterations:
         a, b, c, d, e, f, g, h, i, j = to_unpack
         a, b, c, d, e, f, g, h, i, j = to_unpack
         a, b, c, d, e, f, g, h, i, j = to_unpack
@@ -82,11 +80,14 @@ def _single_run(to_unpack, iterations: cython.long):
         a, b, c, d, e, f, g, h, i, j = to_unpack
         a, b, c, d, e, f, g, h, i, j = to_unpack
 
+
+bench_func = _single_run[object] if cython.compiled else _single_run
 
 @cython.cfunc
-def do_unpacking(iterations: cython.long, to_unpack, timer=DEFAULT_TIMER):
+def do_unpacking(iterations: cython.long, to_unpack, timer=DEFAULT_TIMER, bench_func=bench_func):
+    loop = [None] * iterations
     t0 = timer()
-    _single_run(to_unpack, iterations)
+    bench_func(to_unpack, loop)
     t = timer() - t0
     return t
 
@@ -96,8 +97,32 @@ def bm_tuple_unpacking(iterations: cython.int, timer=DEFAULT_TIMER):
     return do_unpacking(iterations, x, timer)
 
 
+def bm_tuple_unpacking_typed(iterations: cython.int, timer=DEFAULT_TIMER):
+    x = tuple(range(10))
+    bench_func = _single_run[tuple] if cython.compiled else _single_run
+    return do_unpacking(iterations, x, timer, bench_func)
+
+
+def bm_pytuple_unpacking(iterations: cython.int, timer=DEFAULT_TIMER):
+    class PyTuple(tuple): pass
+    x = PyTuple(range(10))
+    return do_unpacking(iterations, x, timer)
+
+
 def bm_list_unpacking(iterations: cython.int, timer=DEFAULT_TIMER):
     x = list(range(10))
+    return do_unpacking(iterations, x, timer)
+
+
+def bm_list_unpacking_typed(iterations: cython.int, timer=DEFAULT_TIMER):
+    x = list(range(10))
+    bench_func = _single_run[list] if cython.compiled else _single_run
+    return do_unpacking(iterations, x, timer, bench_func)
+
+
+def bm_pylist_unpacking(iterations: cython.int, timer=DEFAULT_TIMER):
+    class PyList(list): pass
+    x = PyList(range(10))
     return do_unpacking(iterations, x, timer)
 
 

--- a/tests/run/for_in_iter.py
+++ b/tests/run/for_in_iter.py
@@ -34,6 +34,20 @@ def for_in_list():
     """
 
 
+def for_in_seq_subtype():
+    """
+    >>> class PyListSubclass(list): pass
+
+    >>> for_in_pyiter(PyListSubclass([1,2,3,4,5]))
+    [1, 2, 3, 4, 5]
+
+    >>> class PyTupleSubclass(tuple): pass
+
+    >>> for_in_pyiter(PyTupleSubclass([1,2,3,4,5]))
+    [1, 2, 3, 4, 5]
+    """
+
+
 @cython.test_assert_path_exists('//TupleNode//IntNode')
 @cython.test_fail_if_path_exists('//ListNode//IntNode')
 def for_in_literal_list():

--- a/tests/run/unpack.pyx
+++ b/tests/run/unpack.pyx
@@ -21,6 +21,7 @@ cdef class ItCount(object):
         self.count += 1
         return next(self.values)
 
+
 def kunterbunt(obj1, obj2, obj3, obj4, obj5):
     """
     >>> kunterbunt(1, (2,), (3,4,5), (6,(7,(8,9))), 0)
@@ -32,6 +33,7 @@ def kunterbunt(obj1, obj2, obj3, obj4, obj5):
     obj1, (obj2, obj3) = obj4
     [obj1, obj2] = obj3
     return obj1, obj2, obj3, obj4, obj5
+
 
 def unpack_tuple(tuple it):
     """
@@ -48,6 +50,7 @@ def unpack_tuple(tuple it):
     a,b,c = it
     return a,b,c
 
+
 def unpack_list(list it):
     """
     >>> unpack_list([1,2,3])
@@ -62,6 +65,37 @@ def unpack_list(list it):
     """
     a,b,c = it
     return a,b,c
+
+
+def unpack_builtin_subtype(object it):
+    """
+    >>> class List(list): pass
+    >>> unpack_builtin_subtype(List([1,2,3]))
+    (1, 2, 3)
+
+    >>> class Tuple(tuple): pass
+    >>> unpack_builtin_subtype(Tuple([1,2,3]))
+    (1, 2, 3)
+
+    >>> class List(list):
+    ...     def __iter__(self): return iter([4,5,6])
+    >>> unpack_builtin_subtype(List([1,2,3]))
+    (4, 5, 6)
+    >>> a, b, c = List([1,2,3])
+    >>> a, b, c
+    (4, 5, 6)
+
+    >>> class Tuple(tuple):
+    ...     def __iter__(self): return iter([4,5,6])
+    >>> unpack_builtin_subtype(Tuple([1,2,3]))
+    (4, 5, 6)
+    >>> a, b, c = Tuple([1,2,3])
+    >>> a, b, c
+    (4, 5, 6)
+    """
+    a,b,c = it
+    return a,b,c
+
 
 def unpack_to_itself(it):
     """


### PR DESCRIPTION
In some cases, we generate inlined special casing code that matches a type slot and target it at certain known types, e.g. list/tuple iteration. We currently exclude subtypes because they can overwrite the base type's behaviour in arbitrary ways.

But it's easy and quick (in CPython) to compare the slot function pointer to that of the base type. If it has not been overwritten by the subclass, we can apply the same optimisation because we know that the behaviour has not changed.

It's not entirely clear that this is worth it and in which cases. Subtypes are rare, and having more guard conditions in place can slow down the really important (plain type) cases.

It should be worth doing when the initial overhead is small compared to the operation, e.g. when deciding whether to optimise a for-loop. For very short-running operations, it's probably less helpful.