### PR TITLE
Support PEP 798 unpacking in comprehensions

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9702,6 +9702,40 @@ class ComprehensionAppendNode(Node):
     def annotate(self, code):
         self.expr.annotate(code)
 
+
+class ComprehensionUpdateNode(ComprehensionAppendNode):
+    """Extend or update a comprehension result with each expression value."""
+
+    def generate_execution_code(self, code):
+        self.expr.generate_evaluation_code(code)
+
+        if self.target.type.is_pylist_type:
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached("ListExtend", "Optimize.c"))
+            code.put_error_if_neg(self.pos, "__Pyx_PyList_Extend(%s, %s)" % (
+                self.target.result(), self.expr.py_result()))
+        elif self.target.type.is_pyset_type:
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached("PySet_Update", "Builtins.c"))
+            code.put_error_if_neg(self.pos, "__Pyx_PySet_Update(%s, %s)" % (
+                self.target.result(), self.expr.py_result()))
+        elif self.target.type.is_pydict_type:
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached("RaiseMappingExpected", "FunctionArguments.c"))
+            code.putln("if (unlikely(PyDict_Update(%s, %s) < 0)) {" % (
+                self.target.result(), self.expr.py_result()))
+            code.putln("if (PyErr_ExceptionMatches(PyExc_AttributeError)) "
+                       "__Pyx_RaiseMappingExpectedError(%s);" % self.expr.py_result())
+            code.putln(code.error_goto(self.pos))
+            code.putln("}")
+        else:
+            raise InternalError(
+                "Invalid type for comprehension node: %s" % self.target.type)
+
+        self.expr.generate_disposal_code(code)
+        self.expr.free_temps(code)
+
+
 class DictComprehensionAppendNode(ComprehensionAppendNode):
     child_attrs = ['key_expr', 'value_expr']
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9678,14 +9678,18 @@ class ComprehensionAppendNode(Node):
         steal_temp = False
         if self.target.type.is_pylist_type:
             if self.is_starred:
-                code.globalstate.use_utility_code(
-                    UtilityCode.load_cached("ListExtend", "Optimize.c"))
+                utility_code_name = "ListExtend"
                 function = "__Pyx_PyList_Extend"
+            elif self.expr.is_temp:
+                steal_temp = True
+                utility_code_name = "ListCompAppendAndDecref"
+                function = "__Pyx_ListComp_AppendAndDecref"
             else:
-                steal_temp = self.expr.is_temp
-                code.globalstate.use_utility_code(
-                    UtilityCode.load_cached("ListCompAppendAndDecref" if steal_temp else "ListCompAppend", "Optimize.c"))
-                function = "__Pyx_ListComp_AppendAndDecref" if steal_temp else "__Pyx_ListComp_Append"
+                utility_code_name = "ListCompAppend"
+                function = "__Pyx_ListComp_Append"
+
+            code.globalstate.use_utility_code(
+                UtilityCode.load_cached(utility_code_name, "Optimize.c"))
         elif self.target.type.is_pyset_type:
             if self.is_starred:
                 code.globalstate.use_utility_code(
@@ -9723,12 +9727,10 @@ class DictComprehensionUpdateNode(ComprehensionAppendNode):
     def generate_execution_code(self, code):
         self.expr.generate_evaluation_code(code)
 
-        if not self.target.type.is_pydict_type:
-            raise InternalError(
-                "Invalid type for dict comprehension node: %s" % self.target.type)
+        assert self.target.type.is_pydict_type, self.target.type
 
-        # PyDict_Update raises AttributeError for non-mappings, whereas **
-        # unpacking raises TypeError. Match Python's unpacking error here.
+        # PyDict_Update raises AttributeError for non-mappings, whereas "**dict" unpacking
+        # raises TypeError. Match Python's unpacking error here.
         code.globalstate.use_utility_code(
             UtilityCode.load_cached("RaiseMappingExpected", "FunctionArguments.c"))
         code.putln("if (unlikely(PyDict_Update(%s, %s) < 0)) {" % (

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9675,35 +9675,24 @@ class ComprehensionAppendNode(Node):
         return self
 
     def generate_execution_code(self, code):
-        if self.is_starred:
-            self.expr.generate_evaluation_code(code)
-
-            if self.target.type.is_pylist_type:
+        steal_temp = False
+        if self.target.type.is_pylist_type:
+            if self.is_starred:
                 code.globalstate.use_utility_code(
                     UtilityCode.load_cached("ListExtend", "Optimize.c"))
                 function = "__Pyx_PyList_Extend"
-            elif self.target.type.is_pyset_type:
+            else:
+                steal_temp = self.expr.is_temp
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("ListCompAppendAndDecref" if steal_temp else "ListCompAppend", "Optimize.c"))
+                function = "__Pyx_ListComp_AppendAndDecref" if steal_temp else "__Pyx_ListComp_Append"
+        elif self.target.type.is_pyset_type:
+            if self.is_starred:
                 code.globalstate.use_utility_code(
                     UtilityCode.load_cached("PySet_Update", "Builtins.c"))
                 function = "__Pyx_PySet_Update"
             else:
-                raise InternalError(
-                    "Invalid type for starred comprehension node: %s" % self.target.type)
-
-            code.put_error_if_neg(self.pos, "%s(%s, %s)" % (
-                function, self.target.result(), self.expr.py_result()))
-            self.expr.generate_disposal_code(code)
-            self.expr.free_temps(code)
-            return
-
-        steal_temp = False
-        if self.target.type.is_pylist_type:
-            steal_temp = self.expr.is_temp
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("ListCompAppendAndDecref" if steal_temp else "ListCompAppend", "Optimize.c"))
-            function = "__Pyx_ListComp_AppendAndDecref" if steal_temp else "__Pyx_ListComp_Append"
-        elif self.target.type.is_pyset_type:
-            function = "PySet_Add"
+                function = "PySet_Add"
         else:
             raise InternalError(
                 "Invalid type for comprehension node: %s" % self.target.type)
@@ -9738,6 +9727,8 @@ class DictComprehensionUpdateNode(ComprehensionAppendNode):
             raise InternalError(
                 "Invalid type for dict comprehension node: %s" % self.target.type)
 
+        # PyDict_Update raises AttributeError for non-mappings, whereas **
+        # unpacking raises TypeError. Match Python's unpacking error here.
         code.globalstate.use_utility_code(
             UtilityCode.load_cached("RaiseMappingExpected", "FunctionArguments.c"))
         code.putln("if (unlikely(PyDict_Update(%s, %s) < 0)) {" % (

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -9661,16 +9661,41 @@ class ComprehensionAppendNode(Node):
 
     child_attrs = ['expr']
     target = None
+    is_starred = False
 
     type = PyrexTypes.c_int_type
 
     def analyse_expressions(self, env):
+        if self.expr.is_starred:
+            self.is_starred = True
+            self.expr = self.expr.target
         self.expr = self.expr.analyse_expressions(env)
         if not self.expr.type.is_pyobject:
             self.expr = self.expr.coerce_to_pyobject(env)
         return self
 
     def generate_execution_code(self, code):
+        if self.is_starred:
+            self.expr.generate_evaluation_code(code)
+
+            if self.target.type.is_pylist_type:
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("ListExtend", "Optimize.c"))
+                function = "__Pyx_PyList_Extend"
+            elif self.target.type.is_pyset_type:
+                code.globalstate.use_utility_code(
+                    UtilityCode.load_cached("PySet_Update", "Builtins.c"))
+                function = "__Pyx_PySet_Update"
+            else:
+                raise InternalError(
+                    "Invalid type for starred comprehension node: %s" % self.target.type)
+
+            code.put_error_if_neg(self.pos, "%s(%s, %s)" % (
+                function, self.target.result(), self.expr.py_result()))
+            self.expr.generate_disposal_code(code)
+            self.expr.free_temps(code)
+            return
+
         steal_temp = False
         if self.target.type.is_pylist_type:
             steal_temp = self.expr.is_temp
@@ -9703,34 +9728,24 @@ class ComprehensionAppendNode(Node):
         self.expr.annotate(code)
 
 
-class ComprehensionUpdateNode(ComprehensionAppendNode):
-    """Extend or update a comprehension result with each expression value."""
+class DictComprehensionUpdateNode(ComprehensionAppendNode):
+    """Update a dict comprehension result with each expression value."""
 
     def generate_execution_code(self, code):
         self.expr.generate_evaluation_code(code)
 
-        if self.target.type.is_pylist_type:
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("ListExtend", "Optimize.c"))
-            code.put_error_if_neg(self.pos, "__Pyx_PyList_Extend(%s, %s)" % (
-                self.target.result(), self.expr.py_result()))
-        elif self.target.type.is_pyset_type:
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("PySet_Update", "Builtins.c"))
-            code.put_error_if_neg(self.pos, "__Pyx_PySet_Update(%s, %s)" % (
-                self.target.result(), self.expr.py_result()))
-        elif self.target.type.is_pydict_type:
-            code.globalstate.use_utility_code(
-                UtilityCode.load_cached("RaiseMappingExpected", "FunctionArguments.c"))
-            code.putln("if (unlikely(PyDict_Update(%s, %s) < 0)) {" % (
-                self.target.result(), self.expr.py_result()))
-            code.putln("if (PyErr_ExceptionMatches(PyExc_AttributeError)) "
-                       "__Pyx_RaiseMappingExpectedError(%s);" % self.expr.py_result())
-            code.putln(code.error_goto(self.pos))
-            code.putln("}")
-        else:
+        if not self.target.type.is_pydict_type:
             raise InternalError(
-                "Invalid type for comprehension node: %s" % self.target.type)
+                "Invalid type for dict comprehension node: %s" % self.target.type)
+
+        code.globalstate.use_utility_code(
+            UtilityCode.load_cached("RaiseMappingExpected", "FunctionArguments.c"))
+        code.putln("if (unlikely(PyDict_Update(%s, %s) < 0)) {" % (
+            self.target.result(), self.expr.py_result()))
+        code.putln("if (PyErr_ExceptionMatches(PyExc_AttributeError)) "
+                   "__Pyx_RaiseMappingExpectedError(%s);" % self.expr.py_result())
+        code.putln(code.error_goto(self.pos))
+        code.putln("}")
 
         self.expr.generate_disposal_code(code)
         self.expr.free_temps(code)

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1376,10 +1376,7 @@ def p_list_maker(s: PyrexScanner):
 
     expr = p_namedexpr_test_or_starred_expr(s)
     if s.sy in ('for', 'async'):
-        if expr.is_starred:
-            append = ExprNodes.ComprehensionUpdateNode(expr.pos, expr=expr.target)
-        else:
-            append = ExprNodes.ComprehensionAppendNode(pos, expr=expr)
+        append = ExprNodes.ComprehensionAppendNode(pos, expr=expr)
         loop = p_comp_for(s, append)
         s.expect(']')
         return ExprNodes.ComprehensionNode(
@@ -1510,8 +1507,13 @@ def p_dict_or_set_maker(s: PyrexScanner):
                 append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
         elif len(parts) == 1 and not isinstance(parts[0], list):
             item = parts[0]
-            comprehension_type = Builtin.set_type if target_type == 1 else Builtin.dict_type
-            append = ExprNodes.ComprehensionUpdateNode(item.pos, expr=item)
+            if target_type == 1:
+                comprehension_type = Builtin.set_type
+                item = ExprNodes.StarredUnpackingNode(item.pos, target=item)
+                append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
+            else:
+                comprehension_type = Builtin.dict_type
+                append = ExprNodes.DictComprehensionUpdateNode(item.pos, expr=item)
         else:
             # syntax error, e.g. "{1, 2, 3 for ...}"
             s.expect('}')

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1464,9 +1464,10 @@ def p_dict_or_set_maker(s: PyrexScanner):
             elif target_type != len(s.sy):
                 s.error("unexpected %sitem found in %s literal" % (
                     s.sy, 'set' if target_type == 1 else 'dict'))
-            s.next()
-            if s.sy == '*':
-                s.error("expected expression, found '*'")
+            if s.sy == '**':
+                s.next()
+                if s.sy == '*':
+                    s.error("expected expression, found '*'")
             item = p_starred_expr(s)
             parts.append(item)
             last_was_simple_item = False
@@ -1493,35 +1494,32 @@ def p_dict_or_set_maker(s: PyrexScanner):
         else:
             break
 
-    if s.sy in ('for', 'async'):
+    if s.sy in ('for', 'async') and len(parts) == 1:
         # dict/set comprehension
-        if len(parts) == 1 and isinstance(parts[0], list) and len(parts[0]) == 1:
-            item = parts[0][0]
-            if target_type == 2:
-                assert isinstance(item, ExprNodes.DictItemNode), type(item)
-                comprehension_type = Builtin.dict_type
-                append = ExprNodes.DictComprehensionAppendNode(
-                    item.pos, key_expr=item.key, value_expr=item.value)
-            else:
-                comprehension_type = Builtin.set_type
-                append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
-        elif len(parts) == 1 and not isinstance(parts[0], list):
-            item = parts[0]
-            if target_type == 1:
-                comprehension_type = Builtin.set_type
-                item = ExprNodes.StarredUnpackingNode(item.pos, target=item)
-                append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
-            else:
-                comprehension_type = Builtin.dict_type
-                append = ExprNodes.DictComprehensionUpdateNode(item.pos, expr=item)
-        else:
-            # syntax error, e.g. "{1, 2, 3 for ...}"
-            s.expect('}')
-            return ExprNodes.DictNode(pos, key_value_pairs=[])
+        item = parts[0]
+        if isinstance(item, list) and len(item) == 1:
+            item = item[0]
 
-        loop = p_comp_for(s, append)
+        if not isinstance(item, list):
+            if target_type == 2:
+                comprehension_type = Builtin.dict_type
+                if isinstance(item, ExprNodes.DictItemNode):
+                    append = ExprNodes.DictComprehensionAppendNode(
+                        item.pos, key_expr=item.key, value_expr=item.value)
+                else:
+                    append = ExprNodes.DictComprehensionUpdateNode(item.pos, expr=item)
+            else:
+                comprehension_type = Builtin.set_type
+                append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
+
+            loop = p_comp_for(s, append)
+            s.expect('}')
+            return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
+
+    if s.sy in ('for', 'async'):
+        # syntax error, e.g. "{1, 2, 3 for ...}"
         s.expect('}')
-        return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
+        return ExprNodes.DictNode(pos, key_value_pairs=[])
 
     s.expect('}')
     if target_type == 1:
@@ -1535,7 +1533,7 @@ def p_dict_or_set_maker(s: PyrexScanner):
                 if set_items:
                     items.append(ExprNodes.SetNode(set_items[0].pos, args=set_items))
                     set_items = []
-                items.append(part)
+                items.append(part.target if part.is_starred else part)
         if set_items:
             items.append(ExprNodes.SetNode(set_items[0].pos, args=set_items))
         if len(items) == 1 and items[0].is_set_literal:

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1445,81 +1445,76 @@ def p_comp_if(s: PyrexScanner, body):
 #                   (comp_for | (',' (test | star_expr))* [','])) )
 
 @cython.cfunc
-def p_dict_or_set_maker(s: PyrexScanner):
-    # s.sy == '{'
-    pos = s.position()
-    s.next()
-    if s.sy == '}':
-        s.next()
-        return ExprNodes.DictNode(pos, key_value_pairs=[])
+def p_dict_or_set_item(s: PyrexScanner, target_type: cython.int):
+    is_unpacking = s.sy in ('*', '**')
+    if is_unpacking:
+        unpacking_type: cython.int = len(s.sy)
+        if target_type == 0:
+            target_type = unpacking_type
+        elif target_type != unpacking_type:
+            s.error("unexpected %sitem found in %s literal" % (
+                s.sy, 'set' if target_type == 1 else 'dict'))
 
-    parts = []
-    target_type: cython.int = 0
-    last_was_simple_item = False
-    while True:
-        if s.sy in ('*', '**'):
-            # merged set/dict literal
-            if target_type == 0:
-                target_type = 1 if s.sy == '*' else 2  # 'stars'
-            elif target_type != len(s.sy):
-                s.error("unexpected %sitem found in %s literal" % (
-                    s.sy, 'set' if target_type == 1 else 'dict'))
-            if s.sy == '**':
-                s.next()
-                if s.sy == '*':
-                    s.error("expected expression, found '*'")
-            item = p_starred_expr(s)
-            parts.append(item)
-            last_was_simple_item = False
-        else:
-            item = p_test(s)
-            if target_type == 0:
-                target_type = 2 if s.sy == ':' else 1  # dict vs. set
-            if target_type == 2:
-                # dict literal
-                s.expect(':')
-                key = item
-                value = p_test(s)
-                item = ExprNodes.DictItemNode(key.pos, key=key, value=value)
-            if last_was_simple_item:
-                parts[-1].append(item)
-            else:
-                parts.append([item])
-                last_was_simple_item = True
-
-        if s.sy == ',':
+        if unpacking_type == 2:
             s.next()
-            if s.sy == '}':
-                break
+            if s.sy == '*':
+                s.error("expected expression, found '*'")
+        item = p_starred_expr(s)
+    else:
+        item = p_test(s)
+        if target_type == 0:
+            target_type = 2 if s.sy == ':' else 1  # dict vs. set
+        if target_type == 2:
+            s.expect(':')
+            key = item
+            value = p_test(s)
+            item = ExprNodes.DictItemNode(key.pos, key=key, value=value)
+
+    return target_type, item, is_unpacking
+
+
+@cython.cfunc
+def p_dict_or_set_comprehension(s: PyrexScanner, pos, target_type: cython.int, item):
+    if target_type == 2:
+        comprehension_type = Builtin.dict_type
+        if isinstance(item, ExprNodes.DictItemNode):
+            append = ExprNodes.DictComprehensionAppendNode(
+                item.pos, key_expr=item.key, value_expr=item.value)
         else:
+            append = ExprNodes.DictComprehensionUpdateNode(item.pos, expr=item)
+    else:
+        comprehension_type = Builtin.set_type
+        append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
+
+    loop = p_comp_for(s, append)
+    s.expect('}')
+    return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
+
+
+@cython.cfunc
+def p_dict_or_set_literal(
+        s: PyrexScanner, pos, target_type: cython.int, item, is_unpacking: cython.bint):
+    if is_unpacking:
+        # MergedSequenceNode and MergedDictNode take the iterable/mapping itself.
+        parts = [item.target if target_type == 1 else item]
+    else:
+        parts = [[item]]
+    last_was_simple_item = not is_unpacking
+
+    while s.sy == ',':
+        s.next()
+        if s.sy == '}':
             break
 
-    if s.sy in ('for', 'async') and len(parts) == 1:
-        # dict/set comprehension
-        item = parts[0]
-        if isinstance(item, list) and len(item) == 1:
-            item = item[0]
-
-        if not isinstance(item, list):
-            if target_type == 2:
-                comprehension_type = Builtin.dict_type
-                if isinstance(item, ExprNodes.DictItemNode):
-                    append = ExprNodes.DictComprehensionAppendNode(
-                        item.pos, key_expr=item.key, value_expr=item.value)
-                else:
-                    append = ExprNodes.DictComprehensionUpdateNode(item.pos, expr=item)
-            else:
-                comprehension_type = Builtin.set_type
-                append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
-
-            loop = p_comp_for(s, append)
-            s.expect('}')
-            return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
-
-    if s.sy in ('for', 'async'):
-        # syntax error, e.g. "{1, 2, 3 for ...}"
-        s.expect('}')
-        return ExprNodes.DictNode(pos, key_value_pairs=[])
+        target_type, item, is_unpacking = p_dict_or_set_item(s, target_type)
+        if is_unpacking:
+            parts.append(item.target if target_type == 1 else item)
+            last_was_simple_item = False
+        elif last_was_simple_item:
+            parts[-1].append(item)
+        else:
+            parts.append([item])
+            last_was_simple_item = True
 
     s.expect('}')
     if target_type == 1:
@@ -1556,6 +1551,21 @@ def p_dict_or_set_maker(s: PyrexScanner):
         if len(items) == 1 and items[0].is_dict_literal:
             return items[0]
         return ExprNodes.MergedDictNode(pos, keyword_args=items, reject_duplicates=False)
+
+
+@cython.cfunc
+def p_dict_or_set_maker(s: PyrexScanner):
+    # s.sy == '{'
+    pos = s.position()
+    s.next()
+    if s.sy == '}':
+        s.next()
+        return ExprNodes.DictNode(pos, key_value_pairs=[])
+
+    target_type, item, is_unpacking = p_dict_or_set_item(s, 0)
+    if s.sy in ('for', 'async'):
+        return p_dict_or_set_comprehension(s, pos, target_type, item)
+    return p_dict_or_set_literal(s, pos, target_type, item, is_unpacking)
 
 
 # NOTE: no longer in Py3 :)

--- a/Cython/Compiler/Parsing.py
+++ b/Cython/Compiler/Parsing.py
@@ -1377,8 +1377,9 @@ def p_list_maker(s: PyrexScanner):
     expr = p_namedexpr_test_or_starred_expr(s)
     if s.sy in ('for', 'async'):
         if expr.is_starred:
-            s.error("iterable unpacking cannot be used in comprehension")
-        append = ExprNodes.ComprehensionAppendNode(pos, expr=expr)
+            append = ExprNodes.ComprehensionUpdateNode(expr.pos, expr=expr.target)
+        else:
+            append = ExprNodes.ComprehensionAppendNode(pos, expr=expr)
         loop = p_comp_for(s, append)
         s.expect(']')
         return ExprNodes.ComprehensionNode(
@@ -1507,17 +1508,18 @@ def p_dict_or_set_maker(s: PyrexScanner):
             else:
                 comprehension_type = Builtin.set_type
                 append = ExprNodes.ComprehensionAppendNode(item.pos, expr=item)
-            loop = p_comp_for(s, append)
-            s.expect('}')
-            return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
+        elif len(parts) == 1 and not isinstance(parts[0], list):
+            item = parts[0]
+            comprehension_type = Builtin.set_type if target_type == 1 else Builtin.dict_type
+            append = ExprNodes.ComprehensionUpdateNode(item.pos, expr=item)
         else:
-            # syntax error, try to find a good error message
-            if len(parts) == 1 and not isinstance(parts[0], list):
-                s.error("iterable unpacking cannot be used in comprehension")
-            else:
-                # e.g. "{1,2,3 for ..."
-                s.expect('}')
+            # syntax error, e.g. "{1, 2, 3 for ...}"
+            s.expect('}')
             return ExprNodes.DictNode(pos, key_value_pairs=[])
+
+        loop = p_comp_for(s, append)
+        s.expect('}')
+        return ExprNodes.ComprehensionNode(pos, loop=loop, append=append, type=comprehension_type)
 
     s.expect('}')
     if target_type == 1:

--- a/tests/run/comprehension_unpacking_T7898.pyx
+++ b/tests/run/comprehension_unpacking_T7898.pyx
@@ -1,5 +1,5 @@
 # mode: run
-# tag: comprehension
+# tag: comprehension, pure3.15
 # cython: language_level=3
 
 # cython: test_assert_c_code_has = __Pyx_PyList_Extend\(

--- a/tests/run/comprehension_unpacking_T7898.pyx
+++ b/tests/run/comprehension_unpacking_T7898.pyx
@@ -9,7 +9,7 @@
 cimport cython
 
 
-@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+@cython.test_assert_path_exists("//ComprehensionAppendNode")
 def list_unpacking():
     """
     >>> list_unpacking()
@@ -52,7 +52,7 @@ def list_unpacking_assignment_expression_scope():
     return result, square
 
 
-@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+@cython.test_assert_path_exists("//ComprehensionAppendNode")
 def set_unpacking():
     """
     >>> set_unpacking()
@@ -61,7 +61,7 @@ def set_unpacking():
     return sorted({*value for value in ([1, 2], (2, 3), range(3, 5))})
 
 
-@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+@cython.test_assert_path_exists("//DictComprehensionUpdateNode")
 def dict_unpacking():
     """
     >>> dict_unpacking()

--- a/tests/run/comprehension_unpacking_T7898.pyx
+++ b/tests/run/comprehension_unpacking_T7898.pyx
@@ -43,6 +43,15 @@ def list_expression_evaluated_once():
     return result, events
 
 
+def list_unpacking_assignment_expression_scope():
+    """
+    >>> list_unpacking_assignment_expression_scope()
+    ([0, 0, 1, 2, 4, 8, 9, 18], 9)
+    """
+    result = [*((square := value ** 2), 2 * square) for value in range(4)]
+    return result, square
+
+
 @cython.test_assert_path_exists("//ComprehensionUpdateNode")
 def set_unpacking():
     """

--- a/tests/run/comprehension_unpacking_T7898.pyx
+++ b/tests/run/comprehension_unpacking_T7898.pyx
@@ -1,0 +1,132 @@
+# mode: run
+# tag: comprehension
+# cython: language_level=3
+
+# cython: test_assert_c_code_has = __Pyx_PyList_Extend\(
+# cython: test_assert_c_code_has = __Pyx_PySet_Update\(
+# cython: test_assert_c_code_has = PyDict_Update\(
+
+cimport cython
+
+
+@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+def list_unpacking():
+    """
+    >>> list_unpacking()
+    [1, 2, 3, 4, 5]
+    """
+    values = ([1, 2], (), (value for value in [3, 4]), [5])
+    return [*value for value in values]
+
+
+def filtered_nested_list_unpacking():
+    """
+    >>> filtered_nested_list_unpacking()
+    [0, 1, 2, 3]
+    """
+    groups = (([0], [1, 2]), ([3], []))
+    return [*chunk for group in groups for chunk in group if chunk]
+
+
+def list_expression_evaluated_once():
+    """
+    >>> list_expression_evaluated_once()
+    ([1, -1, 2, -2, 3, -3], [1, 2, 3])
+    """
+    events = []
+
+    def produce(value):
+        events.append(value)
+        return value, -value
+
+    result = [*produce(value) for value in range(1, 4)]
+    return result, events
+
+
+@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+def set_unpacking():
+    """
+    >>> set_unpacking()
+    [1, 2, 3, 4]
+    """
+    return sorted({*value for value in ([1, 2], (2, 3), range(3, 5))})
+
+
+@cython.test_assert_path_exists("//ComprehensionUpdateNode")
+def dict_unpacking():
+    """
+    >>> dict_unpacking()
+    [('a', 1), ('b', 20), ('c', 3)]
+    """
+    mappings = ({'a': 1, 'b': 2}, {'b': 20}, {'c': 3})
+    return list({**mapping for mapping in mappings}.items())
+
+
+class Mapping:
+    def __init__(self, values):
+        self.values = values
+
+    def keys(self):
+        return self.values.keys()
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+
+def dict_unpacking_mapping_protocol():
+    """
+    >>> dict_unpacking_mapping_protocol()
+    {'answer': 42}
+    """
+    return {**mapping for mapping in [Mapping({'answer': 42})]}
+
+
+def invalid_list_unpacking():
+    """
+    >>> invalid_list_unpacking()
+    ('TypeError', True)
+    """
+    try:
+        return [*value for value in [None]]
+    except TypeError as exc:
+        return type(exc).__name__, 'iterable' in str(exc)
+
+
+def invalid_set_unpacking():
+    """
+    >>> invalid_set_unpacking()
+    ('TypeError', True)
+    """
+    try:
+        return {*value for value in [None]}
+    except TypeError as exc:
+        return type(exc).__name__, 'iterable' in str(exc)
+
+
+def invalid_dict_unpacking():
+    """
+    >>> invalid_dict_unpacking()
+    ('TypeError', True)
+    """
+    try:
+        return {**mapping for mapping in [[('answer', 42)]]}
+    except TypeError as exc:
+        return type(exc).__name__, 'mapping' in str(exc)
+
+
+async def async_values():
+    yield [1, 2]
+    yield [3]
+
+
+async def async_list_unpacking():
+    return [*value async for value in async_values()]
+
+
+def run_async_list_unpacking():
+    """
+    >>> run_async_list_unpacking()
+    [1, 2, 3]
+    """
+    import asyncio
+    return asyncio.run(async_list_unpacking())


### PR DESCRIPTION
This implements the list, set, and dictionary comprehension portion of PEP 798 from #7898.

List and set comprehensions keep using `ComprehensionAppendNode`. During analysis it records whether the expression is starred, and code generation then extends the result list or updates the result set instead of appending one value. Dictionary unpacking uses a dedicated `DictComprehensionUpdateNode` to update from each produced mapping, preserving later-key-wins behavior and the mapping-specific `TypeError`.

The parser accepts top-level `*` and `**` in the corresponding comprehensions, including async comprehensions. Generator expressions are intentionally left for a separate follow-up because their lowering is different.

The new run test covers filtering and nested loops, evaluation order, assignment-expression scope, all three collection types, duplicate dictionary keys, the mapping protocol, invalid inputs, async comprehensions, C and C++ backends, and the Limited API.

Validation:

- `python runtests.py -v --backends=c,cpp listcomp setcomp dictcomp comprehension_unpacking_T7898` (94 passed)
- `python runtests.py -v --no-cpp --limited-api=3.11 comprehension_unpacking_T7898` (12 passed)
- related compiler unit tests (18 passed)
- code-style check
