### PR TITLE
Allow pipes in srctree tests

### DIFF
--- a/Cython/TestUtils.py
+++ b/Cython/TestUtils.py
@@ -357,16 +357,20 @@ def unpack_source_tree(tree_file, workdir, cython_root):
                     cur_file = open(path, 'wb')
                 elif cur_file is not None:
                     cur_file.write(line)
-                elif line.strip() and not line.lstrip().startswith(b'#'):
-                    if line.strip() not in (b'"""', b"'''"):
-                        command = shlex.split(line.decode('utf8'))
-                        if not command: continue
-                        # In Python 3: prog, *args = command
-                        prog, args = command[0], command[1:]
-                        try:
-                            header.append(programs[prog]+args)
-                        except KeyError:
-                            header.append(command)
+                elif line.strip() in (b'', b'"""', b"'''") or line.lstrip().startswith(b'#'):
+                    pass
+                else:
+                    command = shlex.split(line.decode('utf8'))
+                    if not command: continue
+                    args = []
+                    next_is_command = True
+                    for arg in command:
+                        if next_is_command and arg in programs:
+                            args.extend(programs[arg])
+                        else:
+                            args.append(arg)
+                            next_is_command = arg == '|'
+                    header.append(args)
         finally:
             if cur_file is not None:
                 cur_file.close()

--- a/runtests.py
+++ b/runtests.py
@@ -2262,11 +2262,14 @@ def _run_pipe(command, workdir, env, capture=True):
             next_stdout = p.stdin
         next_stdout.close()
 
+        # Wait for the final command to finish and collect its output.
+        _out, _ = processes[0].communicate(timeout=8*60)
+
+        # Make sure all commands have terminated and report the first failure code (left to right).
         res = 0
-        _out = None
         for p in reversed(processes):
-            _out, _ = p.communicate()  # last '_out' wins
-            res = res or p.returncode  # first failure wins
+            p.wait()
+            res = res or p.returncode
 
         _err = stderr.read() if stderr is not None else b''
 

--- a/runtests.py
+++ b/runtests.py
@@ -24,7 +24,7 @@ import zlib
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, TemporaryFile
 
 try:
     IS_PYPY = platform.python_implementation() == 'PyPy'
@@ -2207,15 +2207,18 @@ class EndToEndTest(TimedTest):
                 continue
             time_category = 'etoe-build' if (
                 'setup.py' in command or 'cythonize.py' in command or 'cython.py' in command) else 'etoe-run'
+
             with self.stats.time('%s(%d)' % (self.name, command_no), 'c', time_category):
-                if self.capture:
+                if '|' in command:
+                    res, _out, _err = _run_pipe(command, workdir, env, capture=self.capture)
+                elif self.capture:
                     p = subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env, cwd=workdir)
                     _out, _err = p.communicate()
                     res = p.returncode
                 else:
-                    p = subprocess.call(command, env=env, cwd=workdir)
+                    res = subprocess.call(command, env=env, cwd=workdir)
                     _out, _err = b'', b''
-                    res = p
+
             cmd.append(command)
             out.append(_out.decode('utf-8'))
             err.append(_err.decode('utf-8'))
@@ -2235,6 +2238,48 @@ class EndToEndTest(TimedTest):
 
         self.stats.update_module_sizes(workdir)
         self.success = True
+
+
+def _run_pipe(command, workdir, env, capture=True):
+    subcommands = []
+    last_start = 0
+    for i, arg in enumerate(command):
+        if arg == '|':
+            subcommands.append(command[last_start:i])
+            last_start = i + 1
+    subcommands.append(command[last_start:])
+
+    with TemporaryFile() as stderr:
+        next_stdout = subprocess.PIPE
+        if not capture:
+            next_stdout = stderr = None
+
+        # Chain sub-commands right to left, creating last stdin as next stdout.
+        processes = []
+        for subcommand in reversed(subcommands):
+            p = subprocess.Popen(subcommand, stdin=subprocess.PIPE, stderr=stderr, stdout=next_stdout, env=env, cwd=workdir)
+            processes.append(p)
+            next_stdout = p.stdin
+        next_stdout.close()
+
+        res = 0
+        _out = None
+        for p in reversed(processes):
+            _out, _ = p.communicate()  # last '_out' wins
+            res = res or p.returncode  # first failure wins
+
+        _err = stderr.read() if stderr is not None else b''
+
+    if not capture:
+        if _out:
+            sys.stdout.flush()
+            sys.stdout.buffer.write(_out)
+        if _err:
+            sys.stderr.flush()
+            sys.stderr.buffer.write(_err)
+        _out = _err = b''
+
+    return res, _out, _err
 
 
 # TODO: Support cython_freeze needed here as well.

--- a/tests/run/shared_utility_module.srctree
+++ b/tests/run/shared_utility_module.srctree
@@ -2,6 +2,13 @@
 # tag: shared_utility
 
 """
+CYTHON generate-shared --help  |  PYTHON -c "import sys; help=sys.stdin.read(); assert 'MemoryView' in help and 'AutoPickle' in help and '--only' in help and '--exclude' in help, help"
+
+CYTHON generate-shared --only 'ExtensionTypes,AutoPickle,MemoryView' --exclude 'MemoryView' shared_module.c
+PYTHON -c "assert '__Pyx_setup_reduce' in open('shared_module.c').read()"
+PYTHON -c "assert '__Pyx_memviewslice' not in open('shared_module.c').read()"
+
+PYTHON delete_generated_files.py
 PYTHON setup_with_sources.py build_ext --inplace --force
 PYTHON -c "import test_shared_utility"
 


### PR DESCRIPTION
I've had the need a couple of times to do more than one thing in srctree tests, where a pipe would have been a short and obvious way to do it. Pipes aren't easily available on Windows and would only be available via unsafe shell text commands, so here is a pipe implementation for our test runner that starts the piped commands as separate subprocesses.

Note that this does not take care of pipe sizes (only Linux supports them in `Popen()`), so deadlocks can occur when an intermediate pipe runs full. However, unexpected large output would rather occur in stderr and not stdout, and stderr gets gathered in a temporary file. So this is only an issue if an intermediate stdin runs full, which shouldn't normally happen.