### PR TITLE
Fix type checks for exception base types.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2596,8 +2596,7 @@ class NameNode(AtomicExprNode):
         entry = self.entry
         if entry is None:
             return  # There was an error earlier
-        if entry.utility_code:
-            code.globalstate.use_utility_code(entry.utility_code)
+        code.globalstate.use_entry_utility_code(entry)
         if entry.is_builtin and entry.is_const:
             return  # Lookup already cached
         elif entry.is_pyclass_attr:
@@ -8528,8 +8527,7 @@ class AttributeNode(ExprNode):
         cfunc_type = cmethod_entry.type
         return_type = cfunc_type.return_type
 
-        if cmethod_entry.utility_code is not None:
-            code.globalstate.use_utility_code(cmethod_entry.utility_code)
+        code.globalstate.use_entry_utility_code(cmethod_entry)
 
         generate_cfunction_call(
             self.pos, code, cfunc_type, cmethod_entry.cname,

--- a/Cython/Compiler/PyrexTypes.py
+++ b/Cython/Compiler/PyrexTypes.py
@@ -1864,6 +1864,7 @@ class BuiltinObjectType(PyObjectType):
     typedef_flag = True
     is_external = True
     decl_type = 'PyObject'
+    type_check_utility_code = None
 
     _builtin_type_flag_mapping = {
         'int': ['is_pyint_type'],
@@ -1890,7 +1891,7 @@ class BuiltinObjectType(PyObjectType):
 
     _get_type_flags_for = _builtin_type_flag_mapping.get
 
-    def __init__(self, name, cname, objstruct_cname=None):
+    def __init__(self, name, cname, objstruct_cname=None, type_check_utility_code=None):
         self.name = name
         self.cname = cname
         self.objstruct_cname = objstruct_cname
@@ -1900,6 +1901,8 @@ class BuiltinObjectType(PyObjectType):
             # Special case the type type, as many C API calls (and other
             # libraries) actually expect a PyTypeObject* for type arguments.
             self.decl_type = objstruct_cname
+        if type_check_utility_code:
+            self.type_check_utility_code = type_check_utility_code
 
         self._init_builtin_type_flags(name)
         if self.is_exception_type:
@@ -1974,13 +1977,14 @@ class BuiltinObjectType(PyObjectType):
     def isinstance_code(self, arg):
         return '%s(%s)' % (self.type_check_function(exact=False), arg)
 
-    def type_test_code(self, scope, arg, allow_none=True, exact=True):
+    def type_test_code(self, scope_or_globalstate, arg, allow_none=True, exact=True):
         type_check = self.type_check_function(exact=exact)
         check = f'likely({type_check}({arg}))'
         if len(self.name) > 42:
             warning(None, f"Name length in 'RaiseUnexpectedTypeError' needs adjustment to at least {len(self.name)}", 1)
-        scope.use_utility_code(UtilityCode.load_cached(
-                    "RaiseUnexpectedTypeError", "ObjectHandling.c"))
+        scope_or_globalstate.use_utility_code(self.type_check_utility_code)
+        scope_or_globalstate.use_utility_code(
+            UtilityCode.load_cached("RaiseUnexpectedTypeError", "ObjectHandling.c"))
         if allow_none:
             check += f'||(({arg}) == Py_None)'
         return check + f' || __Pyx_RaiseUnexpectedTypeError("{self.name}", {arg})'

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1328,7 +1328,7 @@ class BuiltinScope(Scope):
                              objstruct_cname=None, type_class=PyrexTypes.BuiltinObjectType,
                              utility_code=None):
         name = EncodedString(name)
-        type = type_class(name, cname, objstruct_cname)
+        type = type_class(name, cname, objstruct_cname, type_check_utility_code=utility_code)
         scope = CClassScope(name, outer_scope=None, visibility='extern', parent_type=type)
         scope.directives = {}
         type.set_scope(scope)

--- a/tests/run/type_inference.pyx
+++ b/tests/run/type_inference.pyx
@@ -106,6 +106,20 @@ def exception_hierarchy_inference(x):
     print(cython.typeof(arith_exc_cascade))
 
 
+def exception_hierarchy_raise(x):
+    """
+    See https://github.com/cython/cython/issues/7902
+
+    >>> exception_hierarchy_raise(True)
+    Traceback (most recent call last):
+    ConnectionAbortedError
+    >>> exception_hierarchy_raise(False)
+    Traceback (most recent call last):
+    ConnectionRefusedError
+    """
+    raise ConnectionAbortedError() if x else ConnectionRefusedError()
+
+
 def try_except_target(call):
     """
     >>> try_except_target(list)


### PR DESCRIPTION
If they are not used directly in the code, their type check utility code was not necessarily included.

Also cleans up a few places where entry utility code was used but not the method that was made for it.

Closes https://github.com/cython/cython/issues/7902