### PR TITLE
Fix use of PyState_RemoveModule on module init failure path

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3613,7 +3613,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("if (pystate_addmodule_run) {")
         code.putln("PyObject *tp, *value, *tb;")
         code.putln("__Pyx_PyErr_FetchException(&tp, &value, &tb);")
-        code.putln("PyState_RemoveModule(&%s);" % Naming.pymoduledef_cname)
+        code.putln("__Pyx_State_RemoveModule(&%s);" % Naming.pymoduledef_cname)
         code.putln("__Pyx_PyErr_RestoreException(tp, value, tb);")
         code.putln("}")
         code.putln("#endif")

--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -3613,7 +3613,7 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         code.putln("if (pystate_addmodule_run) {")
         code.putln("PyObject *tp, *value, *tb;")
         code.putln("__Pyx_PyErr_FetchException(&tp, &value, &tb);")
-        code.putln("__Pyx_State_RemoveModule(&%s);" % Naming.pymoduledef_cname)
+        code.putln(f"__Pyx_State_RemoveModule(&{Naming.pymoduledef_cname});")
         code.putln("__Pyx_PyErr_RestoreException(tp, value, tb);")
         code.putln("}")
         code.putln("#endif")

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2721,6 +2721,8 @@ done:
 ////////////////////////// MultiPhaseInitModuleState.proto /////////////
 
 #if CYTHON_PEP489_MULTI_PHASE_INIT && CYTHON_USE_MODULE_STATE
+#include <stdlib.h>
+
 // This defines an ad-hoc, single module version of PyState_FindModule that
 // works for multi-phase init modules. It's intended to be the last option
 // when all the other official ways of getting the module are unavailable.


### PR DESCRIPTION
Hopefully fixes https://github.com/cython/cython/issues/7905 (or at least will do when merged into the relevant branch)

We should always use our wrapping of it (which may be expanded to nothing or our own implementation if using multi-phase init). On the abi3t implementation this ends up being a compile time issue because we don't have a ModuleDef, but it's a still wrong in regular builds.