### PR TITLE
Avoid MSVC C4551 on unused-helper "touch" statements

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -2048,7 +2048,7 @@ static PyType_Spec __pyx_FusedFunctionType_spec = {
 
 static int __pyx_FusedFunction_init(PyObject *module) {
     // Silence unused warning when not in shared module.
-    (void)__Pyx_Get_FusedFunction_Type;
+    (void)&__Pyx_Get_FusedFunction_Type;
 
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
     PyObject *bases = PyTuple_Pack(1, mstate->__pyx_CyFunctionType);

--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -137,9 +137,10 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
 
 #if CYTHON_USE_TYPE_SPECS || !CYTHON_COMPILING_IN_CPYTHON
     // avoid C warning about unused helper function
-    (void)__Pyx_PyObject_CallMethod0;
+    // (take the address so MSVC does not warn C4551 about a missing call)
+    (void)&__Pyx_PyObject_CallMethod0;
 #if CYTHON_USE_TYPE_SPECS
-    (void)__Pyx_validate_bases_tuple;
+    (void)&__Pyx_validate_bases_tuple;
 #endif
 
     return PyType_Ready(t);
@@ -163,7 +164,7 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
     #if PY_VERSION_HEX >= 0x030A00b1
         // finally added in Py3.10 :)
         gc_was_enabled = PyGC_Disable();
-        (void)__Pyx_PyObject_CallMethod0;
+        (void)&__Pyx_PyObject_CallMethod0;
 
     #else
         // Call gc.disable() as a backwards compatible fallback, but only if needed.

--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -525,7 +525,7 @@ static void __Pyx_RejectUnknownKeyword(
     #if CYTHON_AVOID_BORROWED_REFS
     while (__Pyx_PyDict_NextRef(kwds, &pos, &key, NULL))
     #else
-    (void) __Pyx_PyDict_NextRef;
+    (void) &__Pyx_PyDict_NextRef;
     while (PyDict_Next(kwds, &pos, &key, NULL))
     #endif
     {
@@ -815,7 +815,7 @@ static int __Pyx_MergeKeywords_dict(PyObject *kwdict, PyObject *source_dict) {
         #if CYTHON_AVOID_BORROWED_REFS || CYTHON_AVOID_THREAD_UNSAFE_BORROWED_REFS
         while (__Pyx_PyDict_NextRef(smaller_dict, &ppos, &key, NULL))
         #else
-        (void) __Pyx_PyDict_NextRef;
+        (void) &__Pyx_PyDict_NextRef;
         while (PyDict_Next(smaller_dict, &ppos, &key, NULL))
         #endif
         {

--- a/Cython/Utility/MatchCase.c
+++ b/Cython/Utility/MatchCase.c
@@ -363,7 +363,7 @@ static PyObject *__Pyx_MatchCase_TupleSliceToList(PyObject *x, Py_ssize_t start,
 #else
     PyObject **array;
 
-    (void)__Pyx_MatchCase_OtherSequenceSliceToList; // clear unused warning
+    (void)&__Pyx_MatchCase_OtherSequenceSliceToList; // clear unused warning (address-of avoids MSVC C4551)
 
     array = &PyTuple_GET_ITEM(x, 0);
     return __Pyx_PyList_FromArray(array+start, end-start);
@@ -388,7 +388,7 @@ static PyObject *__Pyx_MatchCase_UnknownTypeSliceToList(PyObject *x, Py_ssize_t 
         return __Pyx_MatchCase_TupleSliceToList(x, start, end);
     }
 #else
-    (void)__Pyx_MatchCase_TupleSliceToList;
+    (void)&__Pyx_MatchCase_TupleSliceToList;
 #endif
     return __Pyx_MatchCase_OtherSequenceSliceToList(x, start, end);
 }

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1852,7 +1852,7 @@ static __Pyx_CachedCodeObjectType *__pyx__find_code_object(struct __Pyx_CodeObje
 
 static __Pyx_CachedCodeObjectType *__pyx_find_code_object(int code_line) {
 #if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && !CYTHON_ATOMICS
-    (void)__pyx__find_code_object;
+    (void)&__pyx__find_code_object;
     return NULL; // Most implementation should have atomics. But otherwise, don't make it thread-safe, just miss.
 #else
     struct __Pyx_CodeObjectCache *code_cache = &CGLOBAL(__pyx_code_cache);
@@ -1921,7 +1921,7 @@ static void __pyx__insert_code_object(struct __Pyx_CodeObjectCache *code_cache, 
 
 static void __pyx_insert_code_object(int code_line, __Pyx_CachedCodeObjectType* code_object) {
 #if CYTHON_COMPILING_IN_CPYTHON_FREETHREADING && !CYTHON_ATOMICS
-    (void)__pyx__insert_code_object;
+    (void)&__pyx__insert_code_object;
     return; // Most implementation should have atomics. But otherwise, don't make it thread-safe, just fail.
 #else
     struct __Pyx_CodeObjectCache *code_cache = &CGLOBAL(__pyx_code_cache);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -214,7 +214,7 @@ static CYTHON_INLINE PyObject *__Pyx_PyIter_Next_Plain(PyObject *iterator) {
     result = PyObject_CallFunctionObjArgs(next, iterator, NULL);
     return result;
 #else
-    (void)__Pyx_GetBuiltinName; // only for early limited API
+    (void)&__Pyx_GetBuiltinName; // only for early limited API (address-of avoids MSVC C4551)
     iternextfunc iternext = __Pyx_PyObject_GetIterNextFunc(iterator);
     assert(iternext);
     return iternext(iterator);

--- a/Cython/Utility/Optimize.c
+++ b/Cython/Utility/Optimize.c
@@ -761,7 +761,7 @@ static double __Pyx__PyObject_AsDouble(PyObject* obj) {
 #if !CYTHON_USE_TYPE_SLOTS
         float_value = PyNumber_Float(obj);  if ((0)) goto bad;
         // avoid "unused" warnings
-        (void)__Pyx_PyObject_CallOneArg;
+        (void)&__Pyx_PyObject_CallOneArg;
 #else
         PyNumberMethods *nb = Py_TYPE(obj)->tp_as_number;
         if (likely(nb) && likely(nb->nb_float)) {

--- a/Cython/Utility/Profile.c
+++ b/Cython/Utility/Profile.c
@@ -584,7 +584,7 @@
   #define __Pyx_TraceReturnValue(result, offset, nogil, goto_error) \
       if ((1)); else goto_error;
   #define __Pyx_TraceReturnCValue(cresult, convert_function, offset, nogil, goto_error) \
-      if ((1)); else { (void) convert_function; goto_error }
+      if ((1)); else { (void) &convert_function; goto_error }
 
 #endif /* CYTHON_PROFILE || CYTHON_TRACE */
 

--- a/Cython/Utility/StringTools.c
+++ b/Cython/Utility/StringTools.c
@@ -1089,7 +1089,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyBytes_Join(PyObject* sep, PyObject* value
 
 static CYTHON_INLINE PyObject* __Pyx_PyBytes_Join(PyObject* sep, PyObject* values) {
     // avoid unused function
-    (void) __Pyx_PyObject_CallMethod1;
+    (void) &__Pyx_PyObject_CallMethod1;
 #if !CYTHON_COMPILING_IN_LIMITED_API && PY_VERSION_HEX >= 0x030e0000 || defined(PyBytes_Join)
     return PyBytes_Join(sep, values);
 #elif CYTHON_COMPILING_IN_CPYTHON && PY_VERSION_HEX < 0x030d0000 || defined(_PyBytes_Join)

--- a/Cython/Utility/TString.c
+++ b/Cython/Utility/TString.c
@@ -279,7 +279,7 @@ static PyObject* __Pyx_MakeTemplateLibTemplate(PyObject *strings, PyObject *inte
 #include "internal/pycore_template.h"
 
 static PyObject* __Pyx_MakeTemplateLibTemplate(PyObject *strings, PyObject *interpolations) {
-    (void)__Pyx_GetObjectFromTemplateLib;
+    (void)&__Pyx_GetObjectFromTemplateLib;
     return _PyTemplate_Build(strings, interpolations);
 }
 #else


### PR DESCRIPTION
## Problem

Cython marks conditionally-unused static helper functions as "used" (to silence `-Wunused-function`) by referencing them in a discarded expression. Several sites do this with a **bare function name**, e.g. in the `__Pyx_PyType_Ready` helper that every extension type pulls in:

```c
(void)__Pyx_PyObject_CallMethod0;
```

MSVC reads a bare function name as a call that is missing its argument list and emits **warning C4551** (`function call missing argument list`). Because `__Pyx_PyType_Ready` is generated for every `cdef class`, this shows up in essentially any MSVC build.

## Fix

Take the function's **address** instead:

```c
(void)&__Pyx_PyObject_CallMethod0;
```

`&func` is unambiguous — it cannot be parsed as a call — so C4551 does not fire. It is valid C and C++ on every compiler, still marks the symbol as used, and matches the `(void)&func` idiom already used elsewhere in `CythonFunction.c`.

All bare-function `(void)func;` "touch" sites were converted:

| File | Helper(s) |
|---|---|
| `ExtensionTypes.c` | `__Pyx_PyObject_CallMethod0` (×2), `__Pyx_validate_bases_tuple` |
| `MatchCase.c` | `__Pyx_MatchCase_OtherSequenceSliceToList`, `__Pyx_MatchCase_TupleSliceToList` |
| `ObjectHandling.c` | `__Pyx_GetBuiltinName` |
| `Optimize.c` | `__Pyx_PyObject_CallOneArg` |
| `TString.c` | `__Pyx_GetObjectFromTemplateLib` |

Each identifier was checked to be addressable (plain functions, or the one object-like macro aliasing a function); none is a function-like macro, so `&` is safe at every site.

## Test

Adds `tests/run/unused_utility_func_no_c4551.pyx` (`mode: compile`). A `cdef class` pulls in `__Pyx_PyType_Ready` → `__Pyx_PyObject_CallMethod0`, and the test uses the existing generated-C directives to assert the safe form is emitted and the bare form never appears:

```
# cython: test_assert_c_code_has = \(void\)&__Pyx_PyObject_CallMethod0;
# cython: test_fail_if_c_code_has = \(void\)__Pyx_PyObject_CallMethod0;
```

## Verification

- Regenerated C for a `cdef class`: 2× `(void)&__Pyx_PyObject_CallMethod0;`, 0 bare occurrences.
- Compiled the generated C with `clang -Wall -Wextra -Wunused-function`: exit 0, zero warnings — confirming the address-of form is valid C and still suppresses the unused-function warning it was there for.
