### PR TITLE
Remove inconsistent C4551 explanatory comments

### DIFF
--- a/Cython/Utility/ExtensionTypes.c
+++ b/Cython/Utility/ExtensionTypes.c
@@ -137,7 +137,6 @@ static int __Pyx_PyType_Ready(PyTypeObject *t) {
 
 #if CYTHON_USE_TYPE_SPECS || !CYTHON_COMPILING_IN_CPYTHON
     // avoid C warning about unused helper function
-    // (take the address so MSVC does not warn C4551 about a missing call)
     (void)&__Pyx_PyObject_CallMethod0;
 #if CYTHON_USE_TYPE_SPECS
     (void)&__Pyx_validate_bases_tuple;

--- a/Cython/Utility/MatchCase.c
+++ b/Cython/Utility/MatchCase.c
@@ -363,7 +363,7 @@ static PyObject *__Pyx_MatchCase_TupleSliceToList(PyObject *x, Py_ssize_t start,
 #else
     PyObject **array;
 
-    (void)&__Pyx_MatchCase_OtherSequenceSliceToList; // clear unused warning (address-of avoids MSVC C4551)
+    (void)&__Pyx_MatchCase_OtherSequenceSliceToList; // clear unused warning
 
     array = &PyTuple_GET_ITEM(x, 0);
     return __Pyx_PyList_FromArray(array+start, end-start);

--- a/Cython/Utility/ObjectHandling.c
+++ b/Cython/Utility/ObjectHandling.c
@@ -214,7 +214,7 @@ static CYTHON_INLINE PyObject *__Pyx_PyIter_Next_Plain(PyObject *iterator) {
     result = PyObject_CallFunctionObjArgs(next, iterator, NULL);
     return result;
 #else
-    (void)&__Pyx_GetBuiltinName; // only for early limited API (address-of avoids MSVC C4551)
+    (void)&__Pyx_GetBuiltinName; // only for early limited API
     iternextfunc iternext = __Pyx_PyObject_GetIterNextFunc(iterator);
     assert(iternext);
     return iternext(iterator);


### PR DESCRIPTION
Follow-up to #7911, actioning @scoder's review comment ([r3838819988](https://github.com/cython/cython/pull/7911#discussion_r3838819988)):

> These comments are in some places but not all, so they serve little purpose but make the `void` lines look more important than they are. Either readers already know the pattern, or they wouldn't even notice the difference, or they wouldn't care, or if they do care and don't know it (which is the only case in which the comment would help), then they'd probably still have to look it up because they are more likely to hit a spot without comment than one with comment. I'll remove them.

Removes the C4551 explanatory comments from the three sites where they were added (`ExtensionTypes.c`, `MatchCase.c`, `ObjectHandling.c`). The `(void)&func;` fix itself is unchanged.
