### PR TITLE
Use Limited API version in __PYX_ABI_MODULE_NAME

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -1478,12 +1478,33 @@ static int __Pyx_init_tpflags_variables(void) {
     // The limited API makes some significant changes to data structures, so we don't
     // want to share the implementations compiled with and without the limited API.
     #if CYTHON_VECTORCALL
-        #define __PYX_VECTORCALL_ABI_SUFFIX  "_vectorcall"
+        #define __PYX_VECTORCALL_ABI_SUFFIX  "vectorcall"
     #else
         #define __PYX_VECTORCALL_ABI_SUFFIX
     #endif
 
-    #define __PYX_LIMITED_ABI_SUFFIX "limited" __PYX_VECTORCALL_ABI_SUFFIX __PYX_AM_SEND_ABI_SUFFIX
+    #if __PYX_LIMITED_VERSION_HEX >= 0x03100000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "16"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030F0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "15"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030E0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "14"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030d0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "13"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030C0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "12"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030B0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "11"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x030A0000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "10"
+    #elif __PYX_LIMITED_VERSION_HEX >= 0x03090000
+        #define __PYX_LIMITED_ABI_V_SUFFIX "9"
+    #else
+        // 8 and below are unsupported anyway
+        #define __PYX_LIMITED_ABI_V_SUFFIX "8"
+    #endif
+
+    #define __PYX_LIMITED_ABI_SUFFIX "limited" __PYX_LIMITED_ABI_V_SUFFIX "_" __PYX_VECTORCALL_ABI_SUFFIX __PYX_AM_SEND_ABI_SUFFIX
 #else
     #define __PYX_LIMITED_ABI_SUFFIX
 #endif

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -57,7 +57,6 @@ for version in range(9, sys.version_info[1]+1):
 
     all_extensions.extend(
         cythonize(extensions, build_dir=build_dir))
-    all_extensions.extend(extensions)
 
 setup(
     ext_modules = all_extensions,

--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -21,6 +21,7 @@ PYTHON run.py limited_multi_phase
 import pathlib
 import sys
 import sysconfig
+import shutil
 
 from setuptools import setup, Extension
 
@@ -41,20 +42,22 @@ all_extensions = []
 
 for version in range(9, sys.version_info[1]+1):
     version_hex = f"0x03{version:02x}0000"
+    build_dir = cwd / f"py3{version}"
     extensions = []
 
     for module in modules:
+        shutil.copyfile(f"{module}.pyx", f"{module}_{version}.pyx")
         ext = Extension(
             f"{module}_{version}",
-            sources=[f"{module}.pyx"],
+            sources=[f"{module}_{version}.pyx"],
             define_macros=[('Py_LIMITED_API', version_hex)],
             py_limited_api=True,
         )
         extensions.append(ext)
 
-    build_dir = cwd / f"py3{version}"
     all_extensions.extend(
         cythonize(extensions, build_dir=build_dir))
+    all_extensions.extend(extensions)
 
 setup(
     ext_modules = all_extensions,
@@ -73,7 +76,7 @@ if sysconfig.get_config_var("Py_GIL_DISABLED"):
     exit(0)  # At least for 3.13, freethreading and limited API don't mix
 
 
-def run_one(module_name):
+def run_one(module_name, version):
     limited = __import__(module_name)
 
     limited.fib(11)
@@ -130,10 +133,17 @@ def run_one(module_name):
 
     assert limited.get_template_string_result(1, 2) == "x=1 however y=2"
 
+    # Check limited ABI suffix
+    abi_module_name = type(limited.add_one).__module__
+    assert abi_module_name.startswith("_cython")
+    abi_suffix_version = int(abi_module_name.split("limited")[1].split("_")[0])
+    assert abi_suffix_version == version, (abi_module_name, version)
+
+
 module_name = sys.argv[1]
 
 for version in range(9, sys.version_info[1]+1):
-    run_one(f"{module_name}_{version}")
+    run_one(f"{module_name}_{version}", version)
 
 ##################### limited_single_phase.pyx ################
 


### PR DESCRIPTION
since there are subtle differences and it's difficult to keep track of them all and remember to update it when things change.

Fixes #7914. The cost is that Cython won't identiy cyfunctions compiled with a different Limited API versions as cyfunctions. Which mostly means it won't do any cyfunc-specific optimizations.