### PR TITLE
Ensure isolated limited test used correct Py_LIMITED_API

### DIFF
--- a/tests/run/isolated_limited_api_tests.srctree
+++ b/tests/run/isolated_limited_api_tests.srctree
@@ -20,6 +20,7 @@ from setuptools import setup, Extension
 from Cython.Build import cythonize
 import os
 import sys
+import shutil
 
 if sysconfig.get_config_var("Py_GIL_DISABLED"):
     print("Skipping isolated_limited_api tests on free-threading build")
@@ -35,9 +36,10 @@ for version in range(8, sys.version_info[1]+1):
     all_extensions = []
     for module in modules:
         version_hex = f"0x03{version:02x}0000"
+        shutil.copyfile(f"{module}.pyx", f"{module}_{version}.pyx")
         ext = Extension(
             f"{module}_{version}",
-            sources=[f"{module}.pyx"],
+            sources=[f"{module}_{version}.pyx"],
             define_macros=[('Py_LIMITED_API', version_hex)],
             py_limited_api=True)
         all_extensions.append(ext)
@@ -45,7 +47,7 @@ for version in range(8, sys.version_info[1]+1):
         ext_modules = cythonize(all_extensions),
     )
     for module in modules:
-        os.remove(f"{module}.c")  # make sure it's rebuilt on the next version loop
+        os.remove(f"{module}_{version}.c")  # make sure it's rebuilt on the next version loop
 
 ##################### run.py ##################################
 


### PR DESCRIPTION
Cython was spotting the same file name, and caching the `define_macros` so it wasn't actually compiling with different limited API versions as intended.