### PR TITLE
Remove opaque objects define in the 3.15 Limited API

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -162,8 +162,7 @@
   #undef CYTHON_OPAQUE_OBJECTS
   #define CYTHON_OPAQUE_OBJECTS 0
   #elif !defined(CYTHON_OPAQUE_OBJECTS)
-  // From 3.15 it starts being needed for freethreading compatibility
-  #define CYTHON_OPAQUE_OBJECTS (__PYX_LIMITED_VERSION_HEX >= 0x030F0000)
+  #define CYTHON_OPAQUE_OBJECTS 0
   #endif
 
 #elif defined(GRAALVM_PYTHON)


### PR DESCRIPTION
This was written before the freethreading stable ABI was finalized. There's now a different macro that defines that stable ABI so it isn't needed for plain Limited API support.

We'll add the proper switch later when it's actually supported.