### PR TITLE
Fix inherited tp_vectorcall and `__init__`

### DIFF
--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -547,7 +547,10 @@ class TpVectorcallSlot(ConstructorSlot):
                 return "0"  # Can't reason about __init__
             # If we don't have the second overloaded alternative for __cinit__ or __init__
             # this means the signature was wrong and so we haven't generated code for the
-            # vectorcall wrappers in DefNode.analyse_declarations
+            # vectorcall wrappers in DefNode.analyse_declarations.
+            # This applies to all base classes (since we need to be able to call their
+            # vectorcall-signature __cinit__, and we won't have generated that function
+            # unless the base class met all the conditions itself).
             cinit_entry = tp.scope.lookup_here("__cinit__")
             if cinit_entry and not (cinit_entry.is_special and cinit_entry.tp_new_can_be_vectorcall):
                 return "0"

--- a/Cython/Compiler/TypeSlots.py
+++ b/Cython/Compiler/TypeSlots.py
@@ -535,7 +535,6 @@ class TpVectorcallSlot(ConstructorSlot):
 
     def slot_code(self, scope):
         tp = scope.parent_type
-        seen_init = False
         while tp:
             if not tp.is_extension_type:
                 return "0"
@@ -552,10 +551,9 @@ class TpVectorcallSlot(ConstructorSlot):
             cinit_entry = tp.scope.lookup_here("__cinit__")
             if cinit_entry and not (cinit_entry.is_special and cinit_entry.tp_new_can_be_vectorcall):
                 return "0"
-            if not seen_init and (init_entry := tp.scope.lookup_here("__init__")):
-                if not (init_entry.is_special and init_entry.tp_new_can_be_vectorcall):
-                    return "0"
-                seen_init = True
+            init_entry = tp.scope.lookup_here("__init__")
+            if init_entry and not (init_entry.is_special and init_entry.tp_new_can_be_vectorcall):
+                return "0"
             tp = tp.base_type
         return super().slot_code(scope)
 

--- a/tests/run/special_methods_T561.pyx
+++ b/tests/run/special_methods_T561.pyx
@@ -1111,4 +1111,33 @@ cdef class TwoOrThreeArgRPow:
     def __rpow__(self, other, base=None):
         return f"{self.name}**{other}[{base}]"
 
+cdef class NonVectorcallInit:
+    """
+    >>> _ = NonVectorcallInit()
+    NonVectorcallInit.__init__ () {}
+    >>> _ = NonVectorcallInit(1, 2)
+    NonVectorcallInit.__init__ (1, 2) {}
+    >>> _ = NonVectorcallInit(a=1, b=2)
+    NonVectorcallInit.__init__ () {'a': 1, 'b': 2}
+    """
+    def __init__(self, *args, **kwds):
+        print(f"NonVectorcallInit.__init__ {args} {kwds}")
+
+cdef class VectorcallableInit(NonVectorcallInit):
+    """
+    Note that tp_vectorcall likely does not get used because the base
+    class prevents it. This is mostly a compile test and we aren't
+    trying to tell which implementation is used.
+
+    >>> _ = VectorcallableInit(0)
+    VectorcallableInit.__init__ 0
+    >>> _ = VectorcallableInit(True)
+    VectorcallableInit.__init__ True
+    NonVectorcallInit.__init__ (True,) {}
+    """
+    def __init__(self, arg):
+        print(f"VectorcallableInit.__init__ {arg}")
+        if arg:
+            super().__init__(arg)
+
 # See special_methods_T561_py38 for some extra tests for ipow


### PR DESCRIPTION
Fixes #7936

My original reasoning was to only look for the first `__init__` in the type hierarchy in that this will be the one that we're actually calling. However that fails because we won't have generated a vectorcall method for the base type if any of the previous `__init__` functions aren't suitable for `tp_vectorcall`.