### PR TITLE
fix: add `CYTHON_UNUSED` to `__Pyx_pretend_to_initialize`

### DIFF
--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -2478,7 +2478,7 @@ static void __Pyx_FastGilFuncInit(void) {
 #endif
 
 template <typename T>
-static void __Pyx_pretend_to_initialize(T* ptr) {
+CYTHON_UNUSED static void __Pyx_pretend_to_initialize(T* ptr) {
     // In C++11 we have enough introspection to work out which types it's actually
     // necessary to apply this to (non-trivial types will have been initialized by
     // the definition). Below C++11 just initialize everything.


### PR DESCRIPTION
While attempting to build SciPy with clang-23, I observed:

```
scipy/special/_ufuncs_cxx.cpython-312-aarch64-linux-gnu.so.p/_ufuncs_cxx.cpp:1488:13: error: unused function template '__Pyx_pretend_to_initialize' [-Werror,-Wunused-template]
 1488 | static void __Pyx_pretend_to_initialize(T* ptr) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After investigating a little with claude code, this seems like the solution.

Ref. https://github.com/scipy/scipy/pull/26041