### PR TITLE
Improve source file encoding detection

### DIFF
--- a/Cython/Tests/TestCythonUtils.py
+++ b/Cython/Tests/TestCythonUtils.py
@@ -1,10 +1,10 @@
 import sys
-from io import StringIO
+from io import StringIO, BytesIO
 
 from Cython.Utils import (
     _CACHE_NAME_PATTERN, _build_cache_name, _find_cache_attributes,
     build_hex_version, cached_method, clear_method_caches, try_finally_contextmanager,
-    print_version, normalise_float_repr,
+    print_version, normalise_float_repr, detect_opened_file_encoding
 )
 from Cython.TestUtils import TimedTest
 
@@ -200,3 +200,36 @@ class TestCythonUtils(TimedTest):
                 result, norm_str,
                 "normalise_float_repr(%r) == %r != %r  (%.330f)" % (float_str, result, norm_str, float(float_str))
             )
+
+    def test_detect_file_encoding(self):
+        def make_fake_file(lines):
+            return BytesIO(b"\n".join(lines))
+        for empty_variation in [
+            [b"", b""],
+            [b""],
+            [b"# innocent comment", b"", b"# coding: ascii"],
+            [b"print('hello')", b""],
+            [b"print('hello')", b"# coding: ascii"],
+            [b"print('coding: ascii')", b""],
+            [b"'''coding: ascii'''"],
+            [b"# cython: c_string_encoding=ascii"],
+        ]:
+            empty = detect_opened_file_encoding(
+                make_fake_file(empty_variation))
+            self.assertEqual(empty, "UTF-8", empty_variation)
+        for ascii_variation in [
+            [b"# coding: ascii", b"print('hello')"],
+            [b"# Comment", b"# coding: ascii"],
+            [b"", b"# coding: ascii"],
+            [b" ", b"# coding: ascii"],
+            [b" #", b"# coding: ascii"],
+            [b"\t", b"# coding: ascii"],
+            [b"# cython: c_string_encoding=latin-1", b"# coding: ascii"],
+            [b"# coding: ascii", b"# coding: latin-1"],
+            [b"# -*- coding: ascii -*-"],
+            [b"  # -*- coding: ascii -*-"],
+        ]:
+            ascii = detect_opened_file_encoding(
+                make_fake_file(ascii_variation))
+            self.assertEqual(ascii, "ascii", ascii_variation)
+        

--- a/Cython/Tests/TestCythonUtils.py
+++ b/Cython/Tests/TestCythonUtils.py
@@ -204,31 +204,34 @@ class TestCythonUtils(TimedTest):
     def test_detect_file_encoding(self):
         def make_fake_file(lines):
             return BytesIO(b"\n".join(lines))
-        for empty_variation in [
-            [b"", b""],
-            [b""],
-            [b"# innocent comment", b"", b"# coding: ascii"],
-            [b"print('hello')", b""],
-            [b"print('hello')", b"# coding: ascii"],
-            [b"print('coding: ascii')", b""],
-            [b"'''coding: ascii'''"],
-            [b"# cython: c_string_encoding=ascii"],
-        ]:
-            empty = detect_opened_file_encoding(
-                make_fake_file(empty_variation))
-            self.assertEqual(empty, "UTF-8", empty_variation)
-        for ascii_variation in [
-            [b"# coding: ascii", b"print('hello')"],
-            [b"# Comment", b"# coding: ascii"],
-            [b"", b"# coding: ascii"],
-            [b" ", b"# coding: ascii"],
-            [b" #", b"# coding: ascii"],
-            [b"\t", b"# coding: ascii"],
-            [b"# cython: c_string_encoding=latin-1", b"# coding: ascii"],
-            [b"# coding: ascii", b"# coding: latin-1"],
-            [b"# -*- coding: ascii -*-"],
-            [b"  # -*- coding: ascii -*-"],
-        ]:
-            ascii = detect_opened_file_encoding(
-                make_fake_file(ascii_variation))
-            self.assertEqual(ascii, "ascii", ascii_variation)
+        for sep in [': ', ':', '= ', '=']:
+            for empty_variation in [
+                ["", ""],
+                [""],
+                ["# innocent comment", "", f"# coding{sep}ascii"],
+                ["print('hello')", ""],
+                ["print('hello')", f"# coding{sep}ascii"],
+                [f"print('coding{sep}ascii')", ""],
+                [f"'''coding{sep}ascii'''"],
+                [f"# cython{sep}c_string_encoding=ascii"],
+            ]:
+                empty_variation = [v.encode("ascii") for v in empty_variation]
+                empty = detect_opened_file_encoding(
+                    make_fake_file(empty_variation))
+                self.assertEqual(empty, "UTF-8", empty_variation)
+            for ascii_variation in [
+                [f"# coding{sep}ascii", "print('hello')"],
+                ["# Comment", f"# coding{sep}ascii"],
+                ["", f"# coding{sep}ascii"],
+                [" ", f"# coding{sep}ascii"],
+                [" #", f"# coding{sep}ascii"],
+                ["\t", f"# coding{sep}ascii"],
+                [f"# cython{sep}c_string_encoding=latin-1", f"# coding{sep}ascii"],
+                [f"# coding{sep}ascii", f"# coding{sep}latin-1"],
+                [f"# -*- coding{sep}ascii -*-"],
+                [f"  # -*- coding{sep}ascii -*-"],
+            ]:
+                ascii_variation = [v.encode("ascii") for v in ascii_variation]
+                ascii = detect_opened_file_encoding(
+                    make_fake_file(ascii_variation))
+                self.assertEqual(ascii, "ascii", ascii_variation)

--- a/Cython/Tests/TestCythonUtils.py
+++ b/Cython/Tests/TestCythonUtils.py
@@ -232,4 +232,3 @@ class TestCythonUtils(TimedTest):
             ascii = detect_opened_file_encoding(
                 make_fake_file(ascii_variation))
             self.assertEqual(ascii, "ascii", ascii_variation)
-        

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -357,15 +357,16 @@ def detect_opened_file_encoding(f, default='UTF-8'):
         if m:
             return default
         m = _match_file_encoding(line)
-        if m:
-            if m.group(1) != b'c_string_encoding':
-                return m.group(2).decode('iso8859-1')
-            else:
-                from .Compiler.Errors import warning
-                warning(
-                    None,
-                    "c_string_encoding in first two lines of a file is interpreted as a directive "
-                    "in Cython and a source file-encoding in Python", 2)
+        if not m:
+            continue
+        if m.group(1) == b'c_string_encoding':
+            from .Compiler.Errors import warning
+            warning(
+                None,
+                "c_string_encoding in the first two lines of a file is interpreted as a directive "
+                "in Cython and a source file-encoding in Python", 2)
+            continue
+        return m.group(2).decode('iso8859-1')
     return default
 
 

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -12,6 +12,7 @@ cython.declare(
     os=object, sys=object, re=object, io=object, glob=object, shutil=object, tempfile=object,
     update_wrapper=object, partial=object, wraps=object, cython_version=object,
     _cache_function=object, _function_caches=list, _parse_file_version=object, _match_file_encoding=object,
+    _match_non_comment_line=object
 )
 
 import os
@@ -334,6 +335,7 @@ def decode_filename(filename):
 
 # support for source file encoding detection
 
+_match_non_comment_line = re.compile(br"\s*[^\s#]").match
 _match_file_encoding = re.compile(br"(\w*coding)[:=]\s*([-\w.]+)").search
 
 
@@ -350,13 +352,20 @@ def detect_opened_file_encoding(f, default='UTF-8'):
         if not data:
             break
 
-    m = _match_file_encoding(lines[0])
-    if m and m.group(1) != b'c_string_encoding':
-        return m.group(2).decode('iso8859-1')
-    elif len(lines) > 1:
-        m = _match_file_encoding(lines[1])
+    for line in lines[:2]:
+        m = _match_non_comment_line(line)
         if m:
-            return m.group(2).decode('iso8859-1')
+            return default
+        m = _match_file_encoding(line)
+        if m:
+            if m.group(1) != b'c_string_encoding':
+                return m.group(2).decode('iso8859-1')
+            else:
+                from .Compiler.Errors import warning
+                warning(
+                    None,
+                    "c_string_encoding in first two lines of a file is interpreted as a directive "
+                    "in Cython and a source file-encoding in Python", 2)
     return default
 
 


### PR DESCRIPTION
Fixes #7935

A few improvements:
* Non-comment lines are detected, and correctly cause the search to ignore them (and anything after them).
* The c_string_encoding exception-to-the-rule is detected on both the first and the second line instead of just the first.
* The c_string_encoding exception-to-the-rule generates a warning on the basis that it is different from Python.