### PR TITLE
Implement boolean coercion for the C return type.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -15304,6 +15304,8 @@ class CoerceToPyTypeNode(CoercionNode):
             elif arg.type.equivalent_type is not None and arg.type.equivalent_type.is_pyobject:
                 # Includes bint.
                 self.type = arg.type.equivalent_type
+            elif arg.type.is_returncode:
+                self.type = py_object_type  # constant None
             elif arg.type.is_int:
                 self.type = Builtin.int_type
             elif arg.type.is_float:
@@ -15323,6 +15325,9 @@ class CoerceToPyTypeNode(CoercionNode):
     gil_message = "Converting to Python object"
 
     def may_be_none(self):
+        if self.arg.type.is_returncode:
+            # We do not set '.constant_result = None' to prevent accidental node elimination.
+            return True
         # FIXME: is this always safe?
         return False
 
@@ -15330,6 +15335,9 @@ class CoerceToPyTypeNode(CoercionNode):
         arg_type = self.arg.type
         if arg_type is PyrexTypes.c_bint_type or arg_type.is_pybool_type:
             return self.arg.coerce_to_temp(env)
+        elif arg_type.is_returncode:
+            # Result is constant false, but we must execute the side-effects.
+            return self.arg.coerce_to_temp(env).coerce_to_boolean(env)
         elif arg_type.is_string:
             # Test for 0-length string with "ptr[0] != '\0'" instead of just "ptr != 0".
             # This is safe because we know that we're otherwise coercing to Python 'bytes' / 'str',
@@ -15505,6 +15513,9 @@ class CoerceToBooleanNode(CoercionNode):
         return self.arg.check_const()
 
     def calculate_result_code(self):
+        if self.arg.type.is_returncode:
+            # bool(None) == False
+            return "(0)"
         return "(%s != 0)" % self.arg.result()
 
     def generate_result_code(self, code):

--- a/tests/run/set.pyx
+++ b/tests/run/set.pyx
@@ -69,6 +69,63 @@ def test_set_add():
     return s1
 
 
+def test_set_add_returns_None():
+    """
+    >>> type(test_set_add_returns_None()) is set
+    True
+    >>> sorted(test_set_add_returns_None())
+    [1, 2, 3]
+    """
+    cdef set s1
+    s1 = {1, 2}
+    s1.add(1)
+
+    # Tests for the expected 'None' return value.
+    none1 = s1.add(1)
+    assert none1 is None, none1
+    try:
+        x = none1  # new inferred variable
+        ignored = x + 1
+    except TypeError:
+        pass
+    else:
+        assert False, f"None + 1 == {ignored}"
+
+    none3 = s1.add(3)
+    assert none3 is None, none3
+
+    return s1
+
+
+def test_set_add_in_condition(seq):
+    """
+    >>> test_set_add_in_condition([1,2,3,4])
+    [1, 2, 3, 4]
+    >>> test_set_add_in_condition([1,2,3,2,4,3,3,4])
+    [1, 2, 3, 4]
+    """
+    # Found in https://github.com/cython/cython/issues/7946
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
+
+
+def test_set_add_in_fstring(s: set):
+    """
+    >>> s = {1}
+    >>> test_set_add_in_fstring(s)
+    'None'
+    >>> s
+    {1}
+    >>> s = {2}
+    >>> test_set_add_in_fstring(s)
+    'None'
+    >>> s
+    {1, 2}
+    """
+    return f"{s.add(1)}"  # returns a constant 'None'
+
+
 def test_set_contains(v):
     """
     >>> test_set_contains(1)

--- a/tests/run/set.pyx
+++ b/tests/run/set.pyx
@@ -120,8 +120,8 @@ def test_set_add_in_fstring(s: set):
     >>> s = {2}
     >>> test_set_add_in_fstring(s)
     'None'
-    >>> s
-    {1, 2}
+    >>> sorted(s)
+    [1, 2]
     """
     return f"{s.add(1)}"  # returns a constant 'None'
 


### PR DESCRIPTION
We represent the result as 'None' in Python objects, so a coercion to boolean must return constant false but still evaluate the expression.

Closes https://github.com/cython/cython/issues/7946