### PR TITLE
Do not auto-pickle extension types with memoryview attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Cython Changelog
 Bugs fixed
 ----------
 
+* Auto-pickling an extension type with a typed memoryview attribute no longer
+  generates unusable pickle code.  ``@cython.auto_pickle(True)`` now reports a
+  compile-time error for such classes, matching other unpickleable members.
+  (Github issue :issue:`6767`)
+
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 

--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -2308,18 +2308,24 @@ if VALUE is not None:
 
         non_py = [
             e for e in all_members
-            if not e.type.is_pyobject and (not e.type.can_coerce_to_pyobject(env)
-                                           or not e.type.can_coerce_from_pyobject(env))
+            if not e.type.is_pyobject and not e.type.is_memoryviewslice and (
+                not e.type.can_coerce_to_pyobject(env)
+                or not e.type.can_coerce_from_pyobject(env))
         ]
+        # Memoryviews coerce to a Python memoryview, which is not pickleable.
+        memoryviews = [e for e in all_members if e.type.is_memoryviewslice]
 
         structs = [e for e in all_members if e.type.is_struct_or_union]
 
-        if cinit or non_py or (structs and not auto_pickle_forced):
+        if cinit or non_py or memoryviews or (structs and not auto_pickle_forced):
             if cinit:
                 # TODO(robertwb): We could allow this if __cinit__ has no require arguments.
                 msg = 'no default __reduce__ due to non-trivial __cinit__'
             elif non_py:
                 msg = "%s cannot be converted to a Python object for pickling" % ','.join("self.%s" % e.name for e in non_py)
+            elif memoryviews:
+                msg = ("%s cannot be pickled because typed memoryviews "
+                       "are not pickleable" % ','.join("self.%s" % e.name for e in memoryviews))
             else:
                 # Extern structs may be only partially defined.
                 # TODO(robertwb): Limit the restriction to extern

--- a/docs/src/userguide/extension_types.rst
+++ b/docs/src/userguide/extension_types.rst
@@ -994,6 +994,9 @@ Controlling pickling
 By default, Cython will generate a ``__reduce__()`` method to allow pickling
 an extension type if and only if each of its members are convertible to Python
 and it has no ``__cinit__`` method.
+Typed memoryview attributes are treated as unpickleable even though they can
+be converted to a Python ``memoryview`` object, because that object cannot
+itself be pickled.
 To require this behavior (i.e. throw an error at compile time if a class
 cannot be pickled) decorate the class with ``@cython.auto_pickle(True)``.
 One can also annotate with ``@cython.auto_pickle(False)`` to get the old

--- a/tests/errors/e_auto_pickle_memoryview.pyx
+++ b/tests/errors/e_auto_pickle_memoryview.pyx
@@ -1,0 +1,15 @@
+# mode: error
+# tag: memoryview
+# ticket: 6767
+
+cimport cython
+
+
+@cython.auto_pickle(True)
+cdef class TestClass:
+    cdef double[:, :] x
+
+
+_ERRORS = """
+8:0: self.x cannot be pickled because typed memoryviews are not pickleable
+"""

--- a/tests/run/reduce_pickle_memoryview.pyx
+++ b/tests/run/reduce_pickle_memoryview.pyx
@@ -1,0 +1,23 @@
+# mode: run
+# tag: pickle, memoryview
+# ticket: 6767
+
+cdef class NoReduceDueToMemoryview:
+    """
+    >>> import pickle
+    >>> pickle.dumps(NoReduceDueToMemoryview())
+    Traceback (most recent call last):
+    ...
+    TypeError: self.x cannot be pickled because typed memoryviews are not pickleable
+    """
+    cdef double[:, :] x
+
+
+cdef class NoReduceDueToInheritedMemoryview(NoReduceDueToMemoryview):
+    """
+    >>> import pickle
+    >>> pickle.dumps(NoReduceDueToInheritedMemoryview())
+    Traceback (most recent call last):
+    ...
+    TypeError: self.x cannot be pickled because typed memoryviews are not pickleable
+    """


### PR DESCRIPTION
Closes #6767.

Typed memoryview attributes can be converted to a Python `memoryview` object, so auto-pickle treated them as pickleable and generated `__reduce_cython__`. Pickling then failed at runtime with the memoryview type's own `no default __reduce__ due to non-trivial __cinit__` error, and `@cython.auto_pickle(True)` did not report a compile-time error as documented.

Memoryviews are now classified as unpickleable members. Default auto-pickle injects a TypeError naming the attribute. `@cython.auto_pickle(True)` is a compile-time error, matching other unpickleable members.

Tests:

- `python runtests.py -T 6767 --no-cpp`
- `python runtests.py reduce_pickle --no-cpp`