### PR TITLE
Escape depfile targets and remaining make-special characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Cython Changelog
 Bugs fixed
 ----------
 
+* Depfiles now escape the target path, as well as ``#`` and ``$`` in paths,
+  matching GNU make / gcc ``-M``.  Spaces in dependency paths were already
+  escaped (GH-7423).
+
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 

--- a/Cython/Tests/TestCythonUtils.py
+++ b/Cython/Tests/TestCythonUtils.py
@@ -1,10 +1,12 @@
+import os
 import sys
+import tempfile
 from io import StringIO
 
 from Cython.Utils import (
     _CACHE_NAME_PATTERN, _build_cache_name, _find_cache_attributes,
     build_hex_version, cached_method, clear_method_caches, try_finally_contextmanager,
-    print_version, normalise_float_repr,
+    print_version, normalise_float_repr, escape_depfile_path, write_depfile,
 )
 from Cython.TestUtils import TimedTest
 
@@ -165,6 +167,40 @@ class TestCythonUtils(TimedTest):
         from .. import __version__ as version
         self.assertIn(version, stdout)
         self.assertEqual(stdout.count(version), 1)
+
+    def test_escape_depfile_path(self):
+        self.assertEqual(escape_depfile_path('foo.pyx'), 'foo.pyx')
+        self.assertEqual(
+            escape_depfile_path('folder with spaces/foo.pyx'),
+            'folder\\ with\\ spaces/foo.pyx')
+        self.assertEqual(escape_depfile_path('hash#file.pxd'), 'hash\\#file.pxd')
+        self.assertEqual(escape_depfile_path('dol$dir.pxi'), 'dol$$dir.pxi')
+        self.assertEqual(
+            escape_depfile_path('a $b #c d'),
+            'a\\ $$b\\ \\#c\\ d')
+
+    def test_write_depfile_escapes_target_and_deps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                os.makedirs(os.path.join('out dir'))
+                target = os.path.join('out dir', 'mod.c')
+                deps = [
+                    os.path.join('src dir', 'mod.pyx'),
+                    os.path.join('hash#dir', 'a.pxd'),
+                    os.path.join('dol$dir', 'b.pxi'),
+                ]
+                write_depfile(target, deps[0], deps)
+                with open(target + '.dep', encoding='utf-8') as f:
+                    content = f.read()
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertTrue(content.startswith(
+            escape_depfile_path(os.path.join('out dir', 'mod.c')) + ':'))
+        for dep in deps:
+            self.assertIn(escape_depfile_path(dep), content)
 
     def test_normalise_float_repr(self):
         examples = [

--- a/Cython/Utils.py
+++ b/Cython/Utils.py
@@ -612,6 +612,15 @@ def build_hex_version(version_string):
     return '0x%08X' % hexversion
 
 
+def escape_depfile_path(path):
+    """Escape a path for gcc -M / GNU make depfile format.
+
+    ``$`` is doubled; space and ``#`` are backslash-escaped.
+    Backslashes are left unchanged to match gcc -M (GH-7423).
+    """
+    return path.replace('$', '$$').replace('#', '\\#').replace(' ', '\\ ')
+
+
 def write_depfile(target, source, dependencies):
     src_base_dir = os.path.dirname(source)
     cwd = os.getcwd()
@@ -626,11 +635,9 @@ def write_depfile(target, source, dependencies):
             # if they are on different Windows drives, absolute is fine
             newpath = os.path.abspath(fname)
 
-        # Escape spaces
-        newpath = newpath.replace(" ", "\\ ")
-        paths.append(newpath)
+        paths.append(escape_depfile_path(newpath))
 
-    depline = os.path.relpath(target, cwd) + ": \\\n  "
+    depline = escape_depfile_path(os.path.relpath(target, cwd)) + ": \\\n  "
     depline += " \\\n  ".join(paths) + "\n"
 
     with open(target+'.dep', 'w') as outfile:

--- a/tests/build/depfile.srctree
+++ b/tests/build/depfile.srctree
@@ -71,10 +71,11 @@ with open("folder with spaces/foo.c.dep", "r") as f:
     contents_with_spaces = f.readlines()
     contents_with_spaces = [c.replace(f'..{os.sep}', '').lstrip().rstrip(" \\\n") for c in contents_with_spaces]
 
-assert sorted(contents_with_spaces) == [
+expected_with_spaces = [
     os.path.join("Cython", "Includes", "libc", "math.pxd"),
-    os.path.join("folder with spaces", "foo.c:"),
+    os.path.join("folder\\ with\\ spaces", "foo.c:"),
     os.path.join("folder\\ with\\ spaces", "bar.pxd"),
     os.path.join("folder\\ with\\ spaces", "baz\\ with\\ spaces.pxi"),
     os.path.join("folder\\ with\\ spaces", "foo.pyx"),
-], sorted(contents_with_spaces)
+]
+assert sorted(contents_with_spaces) == sorted(expected_with_spaces), sorted(contents_with_spaces)


### PR DESCRIPTION
Follow-up to #7423.

`write_depfile()` escaped spaces in dependency paths but not in the target path, so a `.c` file under a directory with spaces still produced a depfile GNU make / ninja cannot parse. `#` (make comments) and `$` (make variables) in paths were also left unescaped.

Paths in both the target and the dependency list now use gcc `-M` escaping: space and `#` get a backslash, `$` is doubled. Backslashes are still left unchanged, as in #7423.

Tests:

- `python runtests.py Cython.Tests.TestCythonUtils --no-file`
- `python runtests.py depfile -x numpy -x package --no-cpp`