### PR TITLE
Try to fix memoryview_shared_utility intermittent failures

### DIFF
--- a/tests/memoryview/memoryview_shared_utility.srctree
+++ b/tests/memoryview/memoryview_shared_utility.srctree
@@ -18,16 +18,20 @@ PYTHON -c "import test_shared_utility"
 ######## delete_generated_files.py ########
 
 import os
+import shutil
 from pathlib import Path
 
-ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd"}
-for directory, _, files in os.walk(os.getcwd()):
+ext_to_delete = {".c", ".cpp", ".o", ".so", ".pyd", ".obj", ".exp", ".lib"}
+for directory, _, files in os.walk(os.getcwd(), topdown=False):
     path = Path(directory)
     for filename in files:
         file = path / filename
         if file.suffix.lower() in ext_to_delete:
             print(f"Deleting {file}")
             file.unlink()
+    if path.name == "build":
+        print(f"Removing directory {directory}")
+        shutil.rmtree(directory, ignore_errors=True)
 
 
 ######## setup_with_sources.py ########


### PR DESCRIPTION
These changes were already applied to the `shared_utility_module.srctre` tests, so just apply the same changes to the memoryview tests.

A more thorough cleanup of the build directory and intermediate files.

I'm not completely convinced whether this fixes the problem but it at least seems worth bringing the two files in line with each other.