### PR TITLE
Remove dict special cases for language_level=2

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -328,25 +328,13 @@ class IterationTransform(Visitor.EnvTransform):
         if function.is_attribute and not reversed and not arg_count:
             base_obj = iterable.self or function.obj
             method = function.attribute
-            # in Py3, items() is equivalent to Py2's iteritems()
-            is_safe_iter = self.global_scope().context.language_level >= 3
-
-            if not is_safe_iter and method in ('keys', 'values', 'items'):
-                # try to reduce this to the corresponding .iter*() methods
-                if isinstance(base_obj, ExprNodes.CallNode):
-                    inner_function = base_obj.function
-                    if (inner_function.is_name and inner_function.name == 'dict'
-                            and inner_function.entry
-                            and inner_function.entry.is_builtin):
-                        # e.g. dict(something).items() => safe to use .iter*()
-                        is_safe_iter = True
 
             keys = values = False
-            if method == 'iterkeys' or (is_safe_iter and method == 'keys'):
+            if method in ('iterkeys', 'keys'):
                 keys = True
-            elif method == 'itervalues' or (is_safe_iter and method == 'values'):
+            elif method in ('itervalues', 'values'):
                 values = True
-            elif method == 'iteritems' or (is_safe_iter and method == 'items'):
+            elif method in ('iteritems', 'items'):
                 keys = values = True
 
             if keys or values:

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -39,8 +39,6 @@ cdef class MyList(list):
 cdef class MyDict(dict):
     # tests for __contains__ are in the global __doc__ to version-check a PyPy bug
 
-    @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
-                                    "//ComprehensionNode//AttributeNode[@attribute='items']")
     @cython.test_fail_if_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
@@ -75,7 +73,9 @@ if not (pypy_version and pypy_version < (7, 3, 10)):
 
 @cython.final
 cdef class MyDictFinal(dict):
-    @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
+    # TODO - this optimization would ideally still happen and not be overridden
+    # by the general dict iteration code.
+    # @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
         >>> MyDictFinal(a=1, b=2).test_items()
@@ -95,8 +95,6 @@ cdef class MyDictFinal(dict):
         return l
 
 cdef class MyDict2(MyDict):
-    @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
-                                    "//ComprehensionNode//AttributeNode[@attribute='items']")
     @cython.test_fail_if_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
@@ -118,7 +116,9 @@ cdef class MyDict2(MyDict):
 
 @cython.final
 cdef class MyDict2Final(MyDict):
-    @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
+    # TODO - this optimization would ideally still happen and not be overridden
+    # by the general dict iteration code.
+    # @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
         >>> MyDict2Final(a=1, b=2).test_items()
@@ -142,8 +142,6 @@ cdef class MyDictOverride(dict):
     def items(self):
         return [(1,2), (3,4)]
 
-    @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
-                                    "//ComprehensionNode//AttributeNode[@attribute='items']")
     @cython.test_fail_if_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
@@ -168,8 +166,6 @@ cdef class MyDictOverride2(MyDict):
     def items(self):
         return [(1,2), (3,4)]
 
-    @cython.test_assert_path_exists("//ComprehensionNode//AttributeNode",
-                                    "//ComprehensionNode//AttributeNode[@attribute='items']")
     @cython.test_fail_if_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """

--- a/tests/run/builtin_subtype_methods_T653.pyx
+++ b/tests/run/builtin_subtype_methods_T653.pyx
@@ -73,9 +73,6 @@ if not (pypy_version and pypy_version < (7, 3, 10)):
 
 @cython.final
 cdef class MyDictFinal(dict):
-    # TODO - this optimization would ideally still happen and not be overridden
-    # by the general dict iteration code.
-    # @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
         >>> MyDictFinal(a=1, b=2).test_items()
@@ -116,9 +113,6 @@ cdef class MyDict2(MyDict):
 
 @cython.final
 cdef class MyDict2Final(MyDict):
-    # TODO - this optimization would ideally still happen and not be overridden
-    # by the general dict iteration code.
-    # @cython.test_assert_path_exists("//ComprehensionNode//CMethodSelfCloneNode")
     def test_items(self):
         """
         >>> MyDict2Final(a=1, b=2).test_items()

--- a/tests/run/iterdict.pyx
+++ b/tests/run/iterdict.pyx
@@ -1,9 +1,6 @@
 # mode: run
 # cython: language_level=2
 
-# Language level 2 to keep ".items()" etc. as unsafe methods.
-# See "cython3.pyx" for corresponding "language_level=3" tests.
-
 from __future__ import print_function
 
 cimport cython
@@ -57,8 +54,9 @@ def dict_itervalues(dict d):
     return d.itervalues()
 
 
-@cython.test_fail_if_path_exists(
-    "//WhileStatNode")
+@cython.test_assert_path_exists(
+    "//WhileStatNode",
+    "//WhileStatNode//DictIterationNextNode")
 def items(dict d):
     """
     >>> items(d)


### PR DESCRIPTION
This seems to be about handling the "new" `items`, `keys`, `values` methods. If we have an exact `dict` then we know that these exist (because Cython only supports Python 3) so we can always optimize them.