### PR TITLE
Fix dangling __Pyx_FakeReference for conditional expr assigned into C++ container element (GH-7927)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Bugs fixed
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 
+* In C++ mode, assigning a conditional expression directly into a container
+  element (e.g. ``d[k] = a if cond else b``) generated a dangling
+  ``__Pyx_FakeReference`` temporary and could store garbage.
+  (Github issue :issue:`7927`)
+
 * A crash was resolved when mixing Cython modules compiled with different Limited API versions.
   (Github issue :issue:`7914`)
 

--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -1602,6 +1602,9 @@ class IntNode(ConstNode):
         return suitable_type
 
     def coerce_to(self, dst_type, env):
+        if dst_type.is_reference:
+            # A literal is a prvalue, so drop the reference (GH-7927).
+            dst_type = dst_type.ref_base_type
         if self.type is dst_type:
             return self
         elif dst_type.is_float or dst_type.is_pyfloat_type:
@@ -1714,6 +1717,9 @@ class FloatNode(ConstNode):
         return float_value
 
     def coerce_to(self, dst_type, env):
+        if dst_type.is_reference:
+            # A literal is a prvalue, so drop the reference (GH-7927).
+            dst_type = dst_type.ref_base_type
         if dst_type.is_pyobject and self.type.is_float:
             return FloatNode(
                 self.pos, value=self.value,

--- a/tests/run/cpp_conditional_container_assignment.pyx
+++ b/tests/run/cpp_conditional_container_assignment.pyx
@@ -1,0 +1,68 @@
+# mode: run
+# tag: cpp, werror, no-cpp-locals
+# cython: test_fail_if_c_code_has = __Pyx_FakeReference<int>
+# cython: test_fail_if_c_code_has = __Pyx_FakeReference<double>
+
+# Assigning a prvalue conditional expression directly into a C++ container
+# element used to make the ternary temp a dangling __Pyx_FakeReference<T>
+# instead of a plain T (GH-7927).
+
+from libcpp.unordered_map cimport unordered_map
+from libcpp.vector cimport vector
+
+
+cdef class Holder:
+    cdef unordered_map[int, vector[int]] logs
+
+    def __init__(self, int n):
+        cdef vector[int] blanks
+        blanks.resize(n, 0)
+        self.logs[0] = blanks
+
+    def store(self, int i, bint cond):
+        self.logs[0][i] = 1 if cond else 2
+
+    def load(self, int i):
+        cdef int result = self.logs[0][i]
+        return result
+
+
+def test_conditional_into_container_element():
+    """
+    >>> test_conditional_into_container_element()
+    """
+    cdef Holder h = Holder(4)
+    h.store(0, True)
+    h.store(1, False)
+    h.store(2, True)
+    h.store(3, False)
+    assert h.load(0) == 1, h.load(0)
+    assert h.load(1) == 2, h.load(1)
+    assert h.load(2) == 1, h.load(2)
+    assert h.load(3) == 2, h.load(3)
+
+
+def test_conditional_into_vector_element(bint cond):
+    """
+    >>> test_conditional_into_vector_element(True)
+    111
+    >>> test_conditional_into_vector_element(False)
+    222
+    """
+    cdef vector[int] v
+    v.resize(1, 0)
+    v[0] = 111 if cond else 222
+    return v[0]
+
+
+def test_float_conditional_into_vector_element(bint cond):
+    """
+    >>> test_float_conditional_into_vector_element(True)
+    1.5
+    >>> test_float_conditional_into_vector_element(False)
+    2.5
+    """
+    cdef vector[double] v
+    v.resize(1, 0)
+    v[0] = 1.5 if cond else 2.5
+    return v[0]


### PR DESCRIPTION
Fixes https://github.com/cython/cython/issues/7927

## Root cause

For `container[i] = a if cond else b` in C++ mode, the assignment target
(`operator[]` returning `T&`) makes `SingleAssignmentNode` call
`rhs.coerce_to(T&)` on the `CondExprNode`. `CondExprNode.coerce_to` overrides
the base `ExprNode.coerce_to` to push the target type onto each branch, but
did not strip the reference first the way the base method does. Each prvalue
branch was stamped with type `T&`, the spanning type became `T&`, and
`analyse_result_type` converted it to `__Pyx_FakeReference<T>`. Since
`__Pyx_FakeReference` has no `operator=`, `__pyx_t = a;` binds its internal
pointer to a temporary that dies at the end of the full-expression; the
following store reads the dangling pointer.

## Fix

In `CondExprNode.coerce_to`, when the target is a reference but the
conditional's own type is not (branches are prvalues), coerce to the
referenced base type instead — mirroring `ExprNode.coerce_to`. The
both-branches-are-lvalue-references case is unchanged.

## Test

`tests/run/cpp_conditional_container_assignment.pyx` uses
`test_fail_if_c_code_has = __Pyx_FakeReference<int>` (deterministic: 3
occurrences before the fix, 0 after) plus runtime value checks.
