### PR TITLE
Fix sorted() optimiser crash on typeless argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Cython Changelog
 Bugs fixed
 ----------
 
+* A compiler crash in ``EarlyReplaceBuiltinCalls`` on ``sorted(x.attr or [])``
+  and similar patterns was fixed.
+  (Github issue :issue:`7957`)
+
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 

--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -2033,11 +2033,15 @@ class EarlyReplaceBuiltinCalls(Visitor.EnvTransform):
         else:
             # Interestingly, PySequence_List works on a lot of non-sequence
             # things as well.
+            arg_type = arg.type
+            keep_new = (
+                arg.result_in_temp()
+                and arg_type is not None
+                and (arg_type is PyrexTypes.py_object_type or arg_type.is_pylist_type)
+            )
             list_node = ExprNodes.PythonCapiCallNode(
                 node.pos,
-                "__Pyx_PySequence_ListKeepNew"
-                    if arg.result_in_temp() and (arg.type is PyrexTypes.py_object_type or arg.type.is_pylist_type)
-                    else "PySequence_List",
+                "__Pyx_PySequence_ListKeepNew" if keep_new else "PySequence_List",
                 self.PySequence_List_func_type,
                 args=pos_args, is_temp=True)
 

--- a/tests/run/builtin_sorted.pyx
+++ b/tests/run/builtin_sorted.pyx
@@ -111,6 +111,38 @@ def sorted_tuple_literal():
     return sorted((1, 3, 2) * 2)
 
 
+class _AttrHolder:
+    methods = None
+
+
+def sorted_or_empty_list(x):
+    # See https://github.com/cython/cython/issues/7957
+    # `arg.type` on the ``or`` expression is not resolved when
+    # ``_handle_simple_function_sorted`` runs, so the optimiser must not
+    # dereference it unconditionally.
+    """
+    >>> holder = _AttrHolder()
+    >>> sorted_or_empty_list(holder)
+    []
+    >>> holder.methods = [3, 1, 2]
+    >>> sorted_or_empty_list(holder)
+    [1, 2, 3]
+    """
+    return sorted(x.methods or [])
+
+
+async def sorted_or_empty_list_from_dict_get(mapping):
+    # Same regression as sorted_or_empty_list, in an ``async def`` body.
+    """
+    >>> import asyncio
+    >>> asyncio.run(sorted_or_empty_list_from_dict_get({}))
+    []
+    >>> asyncio.run(sorted_or_empty_list_from_dict_get({"perm_roles": ["b", "a", "c"]}))
+    ['a', 'b', 'c']
+    """
+    return sorted(mapping.get("perm_roles") or [])
+
+
 @cython.test_fail_if_path_exists("//SimpleCallNode")
 def sorted_in_loop(L: list, repeat: cython.int, raise_at: cython.int = -1):
     # See https://github.com/cython/cython/issues/6496


### PR DESCRIPTION
`_handle_simple_function_sorted()` dereferences `arg.type` when
choosing between `__Pyx_PySequence_ListKeepNew` and `PySequence_List`
for a `sorted()` call. `arg.type` can validly be `None` for nodes such
as a top-level `or` expression at `EarlyReplaceBuiltinCalls` time, and
cythonizing e.g. `sorted(route.methods or [])` currently aborts with

```
File "Cython/Compiler/Optimize.py", line 2039, in _handle_simple_function_sorted
    if arg.result_in_temp() and (arg.type is PyrexTypes.py_object_type or arg.type.is_pylist_type)
AttributeError: 'NoneType' object has no attribute 'is_pylist_type'
```

This regressed in the builtin-type refactor from #7543, which replaced
the earlier `arg.type in (PyrexTypes.py_object_type, Builtin.list_type)`
membership check (silently `None`-safe) with
`arg.type.is_pylist_type` on the same branch. Cython 3.2.9 and 3.1.4
compile the reported code fine.

The fix extracts the check into a `keep_new` local and guards it with
`arg_type is not None`, so a typeless argument falls through to the
existing `PySequence_List` path — the same conservative choice the old
code made.

A regression test was added to `tests/run/builtin_sorted.pyx` covering
both shapes from the issue (attribute access, and `dict.get()` inside
an `async def`).

Closes #7957

## Testing

- `python runtests.py builtin_sorted` — 22 tests pass. Confirmed the
  new cases in the file fail on `main` (`AttributeError: 'NoneType'
  object has no attribute 'is_pylist_type'`) and pass with the fix.
- `python runtests.py -j4 Optimize builtin_sorted builtin` — 372 tests
  pass with no regressions.