### PR TITLE
Use type inference for type dependent optimisations before type analysis

### DIFF
--- a/Cython/Compiler/Optimize.py
+++ b/Cython/Compiler/Optimize.py
@@ -1886,8 +1886,8 @@ class EarlyReplaceBuiltinCalls(Visitor.EnvTransform):
             return ExprNodes.FloatNode(node.pos, value='0.0')
         if len(pos_args) > 1:
             self._error_wrong_arg_count('float', node, pos_args, 1)
-        arg_type = getattr(pos_args[0], 'type', None)
-        if arg_type and (arg_type is PyrexTypes.c_double_type or arg_type.is_pyfloat_type):
+        arg_type = pos_args[0].infer_type(self.current_env())
+        if arg_type is PyrexTypes.c_double_type or arg_type.is_pyfloat_type:
             return pos_args[0]
         return node
 
@@ -2031,13 +2031,15 @@ class EarlyReplaceBuiltinCalls(Visitor.EnvTransform):
             list_node = arg.as_list()
 
         else:
-            # Interestingly, PySequence_List works on a lot of non-sequence
-            # things as well.
+            # Interestingly, PySequence_List works on a lot of non-sequence things as well.
+            may_be_new_list = False
+            if arg.result_in_temp():
+                arg_type = arg.infer_type(self.current_env())
+                may_be_new_list = arg_type is PyrexTypes.py_object_type or arg_type.is_pylist_type
+
             list_node = ExprNodes.PythonCapiCallNode(
                 node.pos,
-                "__Pyx_PySequence_ListKeepNew"
-                    if arg.result_in_temp() and (arg.type is PyrexTypes.py_object_type or arg.type.is_pylist_type)
-                    else "PySequence_List",
+                "__Pyx_PySequence_ListKeepNew" if may_be_new_list else "PySequence_List",
                 self.PySequence_List_func_type,
                 args=pos_args, is_temp=True)
 

--- a/tests/run/builtin_sorted.pyx
+++ b/tests/run/builtin_sorted.pyx
@@ -112,6 +112,44 @@ def sorted_tuple_literal():
 
 
 @cython.test_fail_if_path_exists("//SimpleCallNode")
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    "//PythonCapiCallNode[@function.cname = '__Pyx_PySequence_ListKeepNew']",
+)
+def sorted_or_empty_list(x):
+    # See https://github.com/cython/cython/issues/7957
+    # Non-trivial expressions do not trivially expose their type.
+    """
+    >>> class AttrHolder:
+    ...     methods = None
+
+    >>> holder = AttrHolder()
+    >>> sorted_or_empty_list(holder)
+    []
+
+    >>> holder.methods = [3, 1, 2]
+    >>> sorted_or_empty_list(holder)
+    [1, 2, 3]
+    """
+    return sorted(x.methods or [])
+
+
+@cython.test_fail_if_path_exists("//SimpleCallNode")
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    "//PythonCapiCallNode[@function.cname = '__Pyx_PySequence_ListKeepNew']",
+)
+def sorted_or_empty_list_known_type(x: list):
+    """
+    >>> sorted_or_empty_list_known_type([])
+    []
+    >>> sorted_or_empty_list_known_type([3, 1, 2])
+    [1, 2, 3]
+    """
+    return sorted(x or [])
+
+
+@cython.test_fail_if_path_exists("//SimpleCallNode")
 def sorted_in_loop(L: list, repeat: cython.int, raise_at: cython.int = -1):
     # See https://github.com/cython/cython/issues/6496
     """

--- a/tests/run/builtin_sorted.pyx
+++ b/tests/run/builtin_sorted.pyx
@@ -63,7 +63,10 @@ def sorted_arg_with_key(x):
 
 @cython.test_fail_if_path_exists("//YieldExprNode",
                                  "//NoneCheckNode")
-@cython.test_assert_path_exists("//InlinedGeneratorExpressionNode")
+@cython.test_assert_path_exists(
+    "//InlinedGeneratorExpressionNode",
+    "//SortedListNode",
+)
 def sorted_genexp():
     """
     >>> sorted_genexp()
@@ -74,7 +77,10 @@ def sorted_genexp():
 
 @cython.test_fail_if_path_exists("//YieldExprNode",
                                  "//NoneCheckNode")
-@cython.test_assert_path_exists("//ComprehensionNode")
+@cython.test_assert_path_exists(
+    "//ComprehensionNode",
+    "//SortedListNode",
+)
 def sorted_listcomp():
     """
     >>> sorted_listcomp()
@@ -84,7 +90,10 @@ def sorted_listcomp():
 
 
 @cython.test_fail_if_path_exists("//SimpleCallNode//SimpleCallNode")
-@cython.test_assert_path_exists("//SimpleCallNode/NameNode[@name = 'range']")
+@cython.test_assert_path_exists(
+    "//SimpleCallNode/NameNode[@name = 'range']",
+    "//SortedListNode",
+)
 def sorted_list_of_range():
     """
     >>> sorted_list_of_range()
@@ -94,6 +103,10 @@ def sorted_list_of_range():
 
 
 @cython.test_fail_if_path_exists("//SimpleCallNode")
+@cython.test_assert_path_exists(
+    "//ListNode",
+    "//SortedListNode",
+)
 def sorted_list_literal():
     """
     >>> sorted_list_literal()
@@ -103,6 +116,10 @@ def sorted_list_literal():
 
 
 @cython.test_fail_if_path_exists("//SimpleCallNode")
+@cython.test_assert_path_exists(
+    "//ListNode",
+    "//SortedListNode",
+)
 def sorted_tuple_literal():
     """
     >>> sorted_tuple_literal()
@@ -147,6 +164,24 @@ def sorted_or_empty_list_known_type(x: list):
     [1, 2, 3]
     """
     return sorted(x or [])
+
+
+@cython.test_fail_if_path_exists(
+    "//SimpleCallNode",
+    "//PythonCapiCallNode[@function.cname = '__Pyx_PySequence_ListKeepNew']",
+)
+@cython.test_assert_path_exists(
+    "//PythonCapiCallNode",
+    "//PythonCapiCallNode[@function.cname = 'PySequence_List']",
+)
+def sorted_or_empty_non_list(x: tuple):
+    """
+    >>> sorted_or_empty_non_list(())
+    []
+    >>> sorted_or_empty_non_list((3, 1, 2))
+    [1, 2, 3]
+    """
+    return sorted(x or ())
 
 
 @cython.test_fail_if_path_exists("//SimpleCallNode")


### PR DESCRIPTION
Avoid direct ".type" access which might not be known yet.

Based on https://github.com/cython/cython/pull/7960
Closes https://github.com/cython/cython/issues/7957