### PR TITLE
Use new GraalPy APIs for array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,8 @@ jobs:
           - pypy-3.9
           - pypy-3.10
           - pypy-3.11
-          - graalpy25
+          - graalpy25.0  # 3.12
+          - graalpy25.3  # 3.13
         os: [ubuntu-24.04]
         backend: [c]
 

--- a/Cython/Includes/cpython/array.pxd
+++ b/Cython/Includes/cpython/array.pxd
@@ -100,7 +100,10 @@ cdef extern from *:  # Hard-coded utility code hack.
 
         cdef:
             Py_ssize_t ob_size
-            arraydescr* ob_descr    # struct arraydescr *ob_descr;
+
+        @property
+        cdef inline arraydescr* ob_descr(self) noexcept nogil:
+            return __Pyx_PyArray_Descr(self)
 
         @property
         cdef inline __data_union data(self) noexcept nogil:
@@ -109,6 +112,7 @@ cdef extern from *:  # Hard-coded utility code hack.
     array newarrayobject(PyTypeObject* type, Py_ssize_t size, arraydescr *descr)
 
     __data_union __Pyx_PyArray_Data(array self) noexcept nogil
+    arraydescr* __Pyx_PyArray_Descr(array self) noexcept nogil
     # fast resize/realloc
     # not suitable for small increments; reallocation 'to the point'
     int resize(array self, Py_ssize_t n) except -1
@@ -120,15 +124,18 @@ cdef inline array clone(array template, Py_ssize_t length, bint zero):
     """ fast creation of a new array, given a template array.
     type will be same as template.
     if zero is true, new array will be initialized with zeroes."""
-    cdef array op = newarrayobject(Py_TYPE(template), length, template.ob_descr)
+    cdef arraydescr* descr = template.ob_descr
+    cdef array op = newarrayobject(Py_TYPE(template), length, descr)
     if zero and op is not None:
-        memset(op.data.as_chars, 0, <size_t> length * op.ob_descr.itemsize)
+        memset(op.data.as_chars, 0, <size_t> length * descr.itemsize)
     return op
 
 cdef inline array copy(array self):
     """ make a copy of an array. """
-    cdef array op = newarrayobject(Py_TYPE(self), Py_SIZE(self), self.ob_descr)
-    memcpy(op.data.as_chars, self.data.as_chars, <size_t> Py_SIZE(op) * op.ob_descr.itemsize)
+    cdef Py_ssize_t length = Py_SIZE(self)
+    cdef arraydescr* descr = self.ob_descr
+    cdef array op = newarrayobject(Py_TYPE(self), length, descr)
+    memcpy(op.data.as_chars, self.data.as_chars, <size_t> length * descr.itemsize)
     return op
 
 cdef inline int extend_buffer(array self, char* stuff, Py_ssize_t n) except -1:

--- a/Cython/Utility/arrayarray.h
+++ b/Cython/Utility/arrayarray.h
@@ -69,10 +69,27 @@ struct arrayobject {
     int ob_exports;  /* Number of exported buffers */
 };
 
+#if CYTHON_COMPILING_IN_GRAAL && defined(GRAALPY_VERSION_NUM) && GRAALPY_VERSION_NUM >= 0x190304a0
+#define __PYX_USE_GRAALPY_ARRAY_API 1
+#else
+#define __PYX_USE_GRAALPY_ARRAY_API 0
+#endif
+
+static CYTHON_INLINE struct arraydescr *__Pyx_PyArray_Descr(arrayobject *self) {
+#if __PYX_USE_GRAALPY_ARRAY_API
+    return (struct arraydescr *)GraalPyArray_GetDescriptor((PyObject*)self);
+#else
+    return self->ob_descr;
+#endif
+}
+
 #ifndef NO_NEWARRAY_INLINE
 //  fast creation of a new array
 static CYTHON_INLINE PyObject * newarrayobject(PyTypeObject *type, Py_ssize_t size,
     struct arraydescr *descr) {
+#if __PYX_USE_GRAALPY_ARRAY_API
+    return GraalPyArray_New((PyObject*)type, size, (GraalPyArray_Descriptor*)descr);
+#else
     arrayobject *op;
     size_t nbytes;
 
@@ -105,6 +122,7 @@ static CYTHON_INLINE PyObject * newarrayobject(PyTypeObject *type, Py_ssize_t si
         }
     }
     return (PyObject *) op;
+#endif
 }
 #else
 PyObject* newarrayobject(PyTypeObject *type, Py_ssize_t size,

--- a/runtests.py
+++ b/runtests.py
@@ -3172,6 +3172,7 @@ def runtests(options, cmd_args, coverage=None):
             ('pypy_crash_bugs.txt', IS_PYPY),
             ('pypy_implementation_detail_bugs.txt', IS_PYPY),
             ('graal_bugs.txt', IS_GRAAL),
+            ('graal_25_0_bugs.txt', IS_GRAAL and sys.implementation.version[:2] == (25, 0)),
             ('limited_api_bugs.txt', options.limited_api),
             ('limited_api_314_bugs.txt', options.limited_api and sys.version_info[:2] <= (3, 14)),
             ('windows_bugs.txt', sys.platform == 'win32'),

--- a/setup.py
+++ b/setup.py
@@ -494,6 +494,7 @@ def run_build():
             "Programming Language :: Python :: 3.14",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
+            "Programming Language :: Python :: Implementation :: GraalPy",
             "Programming Language :: C",
             "Programming Language :: C++",
             "Programming Language :: Cython",

--- a/tests/graal_25_0_bugs.txt
+++ b/tests/graal_25_0_bugs.txt
@@ -1,0 +1,22 @@
+# Tests that pass on GraalPy 25.3 but fail on GraalPy 25.0.
+ass2global
+[.]coroutines
+test_grammar
+test_named_expressions
+test_release_gil_in_nogil
+slice_ptr
+reraise
+nogil
+class_scope_del_T684
+pyclass_annotations_pep526
+cyfunction_defaults
+posonly
+constant_folding
+large_integer_T5290
+int_literals
+cpython_capi
+pyarray
+pyint
+exectest
+fused_def
+iterdict

--- a/tests/graal_bugs.txt
+++ b/tests/graal_bugs.txt
@@ -1,50 +1,26 @@
 # test fails
 async_iter_pep492
-asyncio_generators
-ass2global
-array_cimport
 buffers[.]buffer
 cdef_multiple_inheritance_errors
-cline_in_traceback
-[.]coroutines  # something small involving cr_frame equality 
 [.]coverage
-cyfunction$
 coverage_api
 embedsignature
-error_pos
-extern_varobject_extensions
 funcexceptchained
 funcexceptcypy
 funcexceptreplace
 funcexc_iter_T228
 function_self
 generators_pep479
-module_init_error
-numpy_import_array_error
 pep442_tp_finalize_cimport
-[.]powop
 pstats_profile_test
-[.]pure_pxd  # docstring
-pxd_syntax  # docstrings
-py35_asyncio_async_def
-pycontextvar
-r_docstrings
 special_method_docstrings
 special_methods_T561$
 test_asyncgen
 test_coroutines_pep492  # although a large chunk works
 test_exceptions  # TypeError: __slots__ items must be strings, not str
-test_grammar
-test_named_expressions
 test_raisefrom
 userbuffer
-unicode_identifiers$
-unicode_identifiers_normalization
-test_fused_memslice_dtype_repeated_2
-constfused_typedef_name_clashes
-listcomp
 test_wraparound_signed
-test_release_gil_in_nogil
 pep442_tp_finalize
 object_float
 py_div_long
@@ -54,14 +30,10 @@ test_weakref
 make_new_args
 test_str_subclass_kwargs
 starargs
-slice_ptr
-reraise
 pep448_extended_unpacking
-nogil
 object_float
 future_division
 ext_auto_richcmp
-enumerate_T316
 embed_modules
 bufaccess
 test_tstring
@@ -80,7 +52,6 @@ py35_pep492_interop
 list_pop
 index
 importfrom
-genexpr_iterable_lookup_T600
 generators_in_refcycles
 generators_GH1731
 generators
@@ -94,9 +65,7 @@ memoryview_pep484_typing
 memoryview_in_subclasses
 memoryview
 cythonarray
-dict_iter_unpack
 asyncio_leaks
-test_benchmark_timer_ns
 
 # probably just GC?
 double_dealloc_T796
@@ -109,9 +78,6 @@ capiimpl
 
 # slightly different exception message
 [.]encoding$
-class_scope_del_T684
-cclass_assign_attr_GH3100  # RuntimeError instead of TypeError
-pyclass_annotations_pep526
 
 # This one's odd because it implies that the correct nodes
 # aren't be generated in the Cython compiler
@@ -119,7 +85,6 @@ pyclass_annotations_pep526
 
 # PyUnicode_CompareWithASCIIString not implemented
 cdef_class_dataclass
-test_dataclasses
 
 # PyUnicode_DecodeUnicodeEscape
 test_unicode
@@ -129,61 +94,23 @@ unicodeliterals
 reimport_from_subinterpreter
 
 # segfault
-cyfunction_defaults
-posonly
 r_extcomplex2
-arg_incref
 builtin_pycomplex
 builtin_type_inheritance_T608
-constant_folding
 memslice
-closure_tests_4_def_to_cdef
 extern_builtins_T258
-large_integer_T5290
-del_temp_slice
-decorators_T593
-int_literals
 py_mix_by_neg1
-cpython_capi
-pyarray
-pyint
-
-# appears to run forever
-common_include_dir
 
 # concurrent.futures.process.BrokenProcessPool
-exectest
 exttype
-datetime_pxd
 parallel
-pep526_variable_annotations_cy
-__pyx_f_22pure_nogil_conditional_f_with_gil
 generator_cclass
-unicode_imports
-
 
 # UnsupportedSpecializationException
-test_carray_forin_constant_char_7_constant
-args_kwargs
-py_enumerate_dict
-test_literal_genexpr_literal_int_266_literal
 fused_types
-fused_def
-fused_cpdef
-iterdict
-pep526_variable_annotations
-iterdict_dictcomp
-ticket_124
-dictcomp
-genexpr_in_dictcomp_dictiter
 unicodemethods
-numpy_test
-r_forloop
-setcomp
-ticket_123
 
 # IllegalMonitorStateException
-test_release_gil_in_nogil
 
 # Functions not implemented in GraalPy:
 # PyThread_acquire_lock_timed
@@ -193,14 +120,4 @@ pymutex
 reload_ext_module
 
 # _PyTime_GetSystemClock
-threading_stress_tests
 time_pxd
-
-# cannot import name '_excepthook' from '_thread' (unknown location)
-
-cython3
-
-# new in 25.1.3
-ext_attr_setter
-# https://github.com/oracle/graalpython/issues/1003 - bug is in pure-Python test. Cython code is fine.
-extra_patma_py


### PR DESCRIPTION
- Use new Cython-specific GraalPy APIs that I added to make the array module work
- Add a few remaning changes that avoid direct struct access to objects that are handles in GraalPy
- Remove many passing tests from the graalpy bug list
- Test spearately 25.0 (LTS, 3.12) and 25.3 (3.13)

CC @timfel