### PR TITLE
Remove unused Limited API methoddef from fused function

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -1624,9 +1624,6 @@ typedef struct {
 #endif
     PyObject *__signatures__;
     PyObject *self;
-#if CYTHON_COMPILING_IN_LIMITED_API
-    PyMethodDef *ml;
-#endif
 } __pyx_FusedFunctionObject;
 
 // Definition depends on whether we're using shared utility code or not
@@ -1687,9 +1684,6 @@ __pyx_FusedFunction_New(PyMethodDef *ml, int flags,
         __pyx_FusedFunctionObject *fusedfunc = __Pyx_as_FusedFunctionObject(op);
         fusedfunc->__signatures__ = NULL;
         fusedfunc->self = NULL;
-        #if CYTHON_COMPILING_IN_LIMITED_API
-        fusedfunc->ml = ml;
-        #endif
         PyObject_GC_Track(op);
     }
     return op;
@@ -1757,7 +1751,7 @@ __pyx_FusedFunction_descr_get_locked(PyObject *self, PyObject *obj)
 
     meth = __pyx_FusedFunction_New(
         #if CYTHON_COMPILING_IN_LIMITED_API
-                    func->ml,
+                    cyfunc->func_methoddef,
         #else
                     ((PyCFunctionObject *) func)->m_ml,
         #endif


### PR DESCRIPTION
It was originally there because it wasn't possible to get the methoddef from cyfunction in the Limited API. This is no longer true so it's now just duplicating information and taking up a bit of space.