### PR TITLE
Fix memview for nested structs

### DIFF
--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -203,12 +203,6 @@ static void __Pyx_BufFmt_Init(__Pyx_BufFmt_Context* ctx,
   ctx->is_complex = 0;
   ctx->is_valid_array = 0;
   ctx->struct_alignment = 0;
-  while (type->typegroup == 'S') {
-    ++ctx->head;
-    ctx->head->field = type->fields;
-    ctx->head->parent_offset = 0;
-    type = type->fields->type;
-  }
 }
 
 static int __Pyx_BufFmt_ParseNumber(const char** ts) {
@@ -470,7 +464,7 @@ static int __Pyx_BufFmt_ProcessTypeChunk(__Pyx_BufFmt_Context* ctx) {
     }
 
     if (type->size != size || type->typegroup != group) {
-      if (type->typegroup == 'C' && type->fields != NULL) {
+      if ((type->typegroup == 'C' || type->typegroup == 'S') && type->fields != NULL) {
         /* special case -- treat as struct rather than complex number */
         size_t parent_offset = ctx->head->parent_offset + field->offset;
         ++ctx->head;

--- a/Cython/Utility/Buffer.c
+++ b/Cython/Utility/Buffer.c
@@ -203,6 +203,12 @@ static void __Pyx_BufFmt_Init(__Pyx_BufFmt_Context* ctx,
   ctx->is_complex = 0;
   ctx->is_valid_array = 0;
   ctx->struct_alignment = 0;
+  while (type->typegroup == 'S') {
+    ++ctx->head;
+    ctx->head->field = type->fields;
+    ctx->head->parent_offset = 0;
+    type = type->fields->type;
+  }
 }
 
 static int __Pyx_BufFmt_ParseNumber(const char** ts) {

--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -440,6 +440,26 @@ def packed_struct_with_ndarrays(fmt):
     cdef object[PackedStructWithNDArrays] buf = MockBuffer(
         fmt, sizeof(PackedStructWithNDArrays))
 
+ctypedef struct Float2:
+    float a
+    float b
+
+ctypedef struct NestedStructFirst:
+    Float2 a
+    float b
+
+ctypedef struct NestedNestedStructSecond:
+    float a
+    NestedStructFirst b
+
+def nested_structs(fmt):
+    """
+    >>> nested_structs("T{f:a:T{T{f:a:f:b:}:a:f:b:}:b:}")
+    """
+
+    cdef object[NestedNestedStructSecond] buf = MockBuffer(
+        fmt, sizeof(NestedNestedStructSecond))
+
 
 # TODO: empty struct
 # TODO: Incomplete structs

--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -237,12 +237,12 @@ def alignment_string(fmt, exc=None):
     except ValueError, e:
         msg = unicode(e).replace("Big", "X").replace("Little", "X").replace("big", "X").replace("little", "X")
         if msg != exc:
-            print msg
-            print "  is not equal to"
-            print exc
+            print(msg)
+            print("  is not equal to")
+            print(exc)
         return
     if exc:
-        print "fail"
+        print("fail")
 
 
 def int_and_long_are_same():
@@ -440,12 +440,13 @@ def packed_struct_with_ndarrays(fmt):
     cdef object[PackedStructWithNDArrays] buf = MockBuffer(
         fmt, sizeof(PackedStructWithNDArrays))
 
-ctypedef struct Float2:
+ctypedef struct Float3:
     float a
     float b
+    float c
 
 ctypedef struct NestedStructFirst:
-    Float2 a
+    Float3 a
     float b
 
 ctypedef struct NestedNestedStructSecond:
@@ -454,7 +455,7 @@ ctypedef struct NestedNestedStructSecond:
 
 def nested_structs(fmt):
     """
-    >>> nested_structs("T{f:a:T{T{f:a:f:b:}:a:f:b:}:b:}")
+    >>> nested_structs("T{f:a:T{T{f:a:f:b:f:c:}:a:f:b:}:b:}")
     """
 
     cdef object[NestedNestedStructSecond] buf = MockBuffer(

--- a/tests/buffers/buffmt.pyx
+++ b/tests/buffers/buffmt.pyx
@@ -237,12 +237,12 @@ def alignment_string(fmt, exc=None):
     except ValueError, e:
         msg = unicode(e).replace("Big", "X").replace("Little", "X").replace("big", "X").replace("little", "X")
         if msg != exc:
-            print(msg)
-            print("  is not equal to")
-            print(exc)
+            print msg
+            print "  is not equal to"
+            print exc
         return
     if exc:
-        print("fail")
+        print "fail"
 
 
 def int_and_long_are_same():


### PR DESCRIPTION
Currently buffmt checking is broken for some structs which have a field, that is not the first field, which is a struct that contains a struct as it's first element.

This is due a gap where `__Pyx_BufFmt_Init` will advance down nested structs on the first field, and `__Pyx_BufFmt_ProcessTypeChunk` will advance down on nested structs that are not the first field. This leads to structs that have a non-first field that has a struct with a nested struct as its first field falling through and trying to compare the nested struct type to the type of its first field.

To illustrate consider creating memory views of the following structs:
```python
cdef struct Foo:
    float a;
    float b;
    float c;

cdef struct Bar:
    Foo a;
    float b;

cdef struct Baz:
    float a;
    Foo b;

cdef struct A:
    Bar a;
    float b;

cdef struct B:
    float a;
    Bar b;

cdef struct C:
    Baz a;
    float b;

cdef struct D:
    float a;
    Baz b;
```

Memory views can be created for all except for `B` which fails with the following error:
```
ValueError: Buffer dtype mismatch, expected 'Foo' but got 'float' in 'Bar.a'
```
Which is caused by `__Pyx_BufFmt_ProcessTypeChunk` checking the field 'a' of Bar when it should be checking field 'a' of Foo (the nested struct).

To resolve this the special case in `__Pyx_BufFmt_ProcessTypeChunk` that treats complex numbers as a struct and walks into them, was extended to include normal structs as well.

Additionally a test was added to the buffmt tests that checks this specific case.