### PR TITLE
Fix compiler crash when annotation of global variable has unknown type

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2377,7 +2377,9 @@ class NameNode(AtomicExprNode):
                 # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
                 annotation_type = self.annotation.analyse_as_type(env)
                 entry_type = self.entry.type
-                if not (annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)):
+                if annotation_type and not (
+                    annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)
+                ):
                     warning(self.pos,
                         f"Annotation type '{annotation_type}' is not compatible "
                         f"with declaration type '{entry_type}'.", 1)

--- a/tests/run/pure_pxd.srctree
+++ b/tests/run/pure_pxd.srctree
@@ -1,5 +1,6 @@
 PYTHON setup.py build_ext --inplace
 PYTHON -c "import a; a.test(a)"
+PYTHON -c "import c; c.test()"
 
 ######## setup.py ########
 
@@ -65,7 +66,7 @@ def run_sum_generator_expression(a):
     10
     """
     return sum_generator_expression(a)
-    
+
 @cython.cfunc
 def gh4388() -> cython.void:
     pass  # just a compile test
@@ -129,3 +130,19 @@ import cython
 
 def get_a_c_string(length: cython.pointer(cython.Py_ssize_t)) -> cython.void:
     pass
+
+
+############## c.pxd #######
+
+cdef unsigned int LIMIT
+
+############## c.py ########
+
+import cython
+from typing import Final
+
+# Unknown type Final[...] should be ignored and used from .pxd file instead
+LIMIT: Final[int] = 128
+
+def test():
+    assert cython.typeof(LIMIT) == 'unsigned int', cython.typeof(LIMIT)


### PR DESCRIPTION
Fixes issue when global variable is declared in .pxd file but has unknown type in .py file.

Fixes #7942
