### PR TITLE
Fix invalid C names in fused-function API headers

### DIFF
--- a/Cython/Compiler/ModuleNode.py
+++ b/Cython/Compiler/ModuleNode.py
@@ -501,9 +501,10 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             h_code.putln("")
             for entry in api_funcs:
                 type = CPtrType(entry.type)
-                cname = env.mangle(Naming.func_prefix_api, entry.name)
+                api_name = entry.legacy_capi_name if entry.is_fused_specialized else entry.name
+                cname = env.mangle(Naming.func_prefix_api, api_name)
                 h_code.putln("static %s = 0;" % type.declaration_code(cname))
-                h_code.putln("#define %s %s" % (entry.name, cname))
+                h_code.putln("#define %s %s" % (api_name, cname))
                 h_code.globalstate.use_entry_utility_code(entry)
         if api_vars:
             h_code.putln("")
@@ -517,6 +518,8 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
             put_utility_code("VoidPtrImport", "ImportExport.c")
         if api_funcs:
             put_utility_code("FunctionImport", "ImportExport.c")
+            if any(entry.is_fused_specialized for entry in api_funcs):
+                put_utility_code("FunctionImportFused", "ImportExport.c")
         if api_extension_types:
             put_utility_code("TypeImport", "ImportExport.c")
         h_code.putln("")
@@ -525,11 +528,16 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
         h_code.putln('module = PyImport_ImportModule(%s);' % env.qualified_name.as_c_string_literal())
         h_code.putln("if (!module) goto bad;")
         for entry in api_funcs:
-            cname = env.mangle(Naming.func_prefix_api, entry.name)
+            api_name = entry.legacy_capi_name if entry.is_fused_specialized else entry.name
+            cname = env.mangle(Naming.func_prefix_api, api_name)
             sig = entry.type.signature_string()
+            if entry.is_fused_specialized:
+                h_code.putln(
+                    'if (__Pyx_ImportFusedFunction_%s(module, %s, (void (**)(void))&%s, "%s") < 0) goto bad;'
+                    % (Naming.cyversion, entry.name.as_c_string_literal(), cname, sig))
             h_code.putln(
                 'if (__Pyx_ImportFunction_%s(module, %s, (void (**)(void))&%s, "%s") < 0) goto bad;'
-                % (Naming.cyversion, entry.name.as_c_string_literal(), cname, sig))
+                % (Naming.cyversion, api_name.as_c_string_literal(), cname, sig))
         for entry in api_vars:
             cname = env.mangle(Naming.varptr_prefix_api, entry.name)
             sig = entry.type.empty_declaration_code()

--- a/tests/run/fused_api_header.srctree
+++ b/tests/run/fused_api_header.srctree
@@ -1,0 +1,172 @@
+# tag: cpp
+
+PYTHON setup.py build_ext --inplace
+PYTHON test.py
+PYTHON test_legacy.py
+PYTHON test_new_names.py
+PYTHON test_prefer_new.py
+PYTHON test_import_errors.py missing
+PYTHON test_import_errors.py signature
+PYTHON setup_reordered.py build_ext --build-lib=reordered --build-temp=build/reordered
+PYTHON test_reordered.py
+
+################### setup.py ###################
+
+from setuptools import Extension, setup
+from Cython.Build import cythonize
+
+setup(
+    ext_modules=cythonize([
+        Extension("api_exporter", ["api_exporter.pyx"]),
+        Extension("api_consumer_c", ["api_consumer_c.pyx"]),
+        Extension("api_consumer_cpp", ["api_consumer_cpp.pyx"], language="c++"),
+    ]),
+)
+
+################### api_exporter.pxd ###################
+
+ctypedef fused number:
+    int
+    double
+
+cdef api number identity(number value) noexcept
+cdef api number dereference(const number *value) noexcept
+cdef api int increment(int value) noexcept
+
+################### api_exporter.pyx ###################
+
+cdef number identity(number value) noexcept:
+    return value
+
+cdef number dereference(const number *value) noexcept:
+    return value[0]
+
+cdef int increment(int value) noexcept:
+    return value + 1
+
+################### api_consumer.pxi ###################
+
+cdef extern from "api_exporter_api.h":
+    int import_api_exporter() except -1
+    int __pyx_fuse_0identity(int value)
+    double __pyx_fuse_1identity(double value)
+    int __pyx_fuse_0dereference(const int *value)
+    double __pyx_fuse_1dereference(const double *value)
+    int increment(int value)
+
+def check(int expected_identity=7):
+    import_api_exporter()
+    cdef int int_value = 7
+    cdef double double_value = 2.5
+    assert __pyx_fuse_0identity(int_value) == expected_identity
+    assert __pyx_fuse_1identity(double_value) == double_value
+    assert __pyx_fuse_0dereference(&int_value) == int_value
+    assert __pyx_fuse_1dereference(&double_value) == double_value
+    assert increment(int_value) == 8
+
+################### api_consumer_c.pyx ###################
+
+include "api_consumer.pxi"
+
+################### api_consumer_cpp.pyx ###################
+
+include "api_consumer.pxi"
+
+################### test.py ###################
+
+import api_consumer_c
+import api_consumer_cpp
+
+api_consumer_c.check()
+api_consumer_cpp.check()
+
+################### test_legacy.py ###################
+
+import api_exporter
+
+for name in list(api_exporter.__pyx_capi__):
+    if "[" in name:
+        del api_exporter.__pyx_capi__[name]
+
+import test
+
+################### test_new_names.py ###################
+
+import api_exporter
+
+for name in list(api_exporter.__pyx_capi__):
+    if name.startswith("__pyx_fuse_"):
+        del api_exporter.__pyx_capi__[name]
+
+assert "identity[int]" in api_exporter.__pyx_capi__
+import test
+
+################### test_prefer_new.py ###################
+
+import api_exporter
+import api_consumer_c
+import api_consumer_cpp
+
+api_exporter.__pyx_capi__["identity[int]"] = api_exporter.__pyx_capi__["increment"]
+api_consumer_c.check(8)
+api_consumer_cpp.check(8)
+
+################### test_import_errors.py ###################
+
+import sys
+
+import api_exporter
+import api_consumer_c
+import api_consumer_cpp
+
+if sys.argv[1] == "missing":
+    del api_exporter.__pyx_capi__["identity[int]"]
+    del api_exporter.__pyx_capi__["__pyx_fuse_0identity"]
+    expected_error = ImportError
+    expected_message = "does not export expected C function"
+else:
+    assert sys.argv[1] == "signature"
+    api_exporter.__pyx_capi__["identity[int]"] = api_exporter.__pyx_capi__["identity[double]"]
+    expected_error = TypeError
+    expected_message = "wrong signature"
+
+for consumer in (api_consumer_c, api_consumer_cpp):
+    try:
+        consumer.check()
+    except expected_error as error:
+        assert expected_message in str(error), str(error)
+    else:
+        raise AssertionError("An invalid API import was accepted")
+
+################### setup_reordered.py ###################
+
+from setuptools import Extension, setup
+from Cython.Build import cythonize
+
+setup(ext_modules=cythonize([
+    Extension("api_exporter", ["reordered/api_exporter.pyx"]),
+]))
+
+################### reordered/api_exporter.pxd ###################
+
+ctypedef fused number:
+    double
+    int
+
+cdef api number identity(number value) noexcept
+cdef api number dereference(const number *value) noexcept
+cdef api int increment(int value) noexcept
+
+################### reordered/api_exporter.pyx ###################
+
+include "../api_exporter.pyx"
+
+################### test_reordered.py ###################
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path("reordered").resolve()))
+import api_exporter
+assert Path(api_exporter.__file__).parent.name == "reordered", api_exporter.__file__
+import test


### PR DESCRIPTION
Exporting a fused function with `cdef api` in Cython 3.3.0 produces an invalid C API header. Cython translation succeeds, but C/C++ code that includes the generated header fails to compile.

This regressed in #7656: type-based dictionary keys such as `identity[int]` are also emitted as C identifiers and macro names. Before that change, the header used valid names such as `__pyx_fuse_0identity`.

Keep the existing C identifiers in the header, but look up functions using the new type-based keys first, falling back to the older keys. This matches normal `cimport` behavior and preserves both the lookup improvements from #7656 and compatibility with older modules.

Includes regression tests for C and C++ header consumers, both export-name formats, preference for the new keys, reordered fused types, and missing or incompatible API entries.