### PR TITLE
Fix module string length index if the only bytes literal has length 0.

### DIFF
--- a/Cython/Compiler/Code.py
+++ b/Cython/Compiler/Code.py
@@ -1969,7 +1969,7 @@ class GlobalState:
                 continue
             w.putln(
                 "const struct { "
-                f"const unsigned int length: {max(index).bit_length()}; "
+                f"const unsigned int length: {max(index).bit_length() or 1}; "
                 "} "
                 f"{stype}_length_index[] = {{{','.join(['{%d}' % length for length in index])}}};",
             )

--- a/tests/run/string_compression.srctree
+++ b/tests/run/string_compression.srctree
@@ -98,6 +98,7 @@ else:
 setup(ext_modules=cythonize([
     Extension("*", sources=["module.py"], define_macros=macros),
     Extension("*", sources=["short_text.py"], define_macros=macros),
+    Extension("*", sources=["empty_*.py"], define_macros=macros),
 ]))
 
 
@@ -105,6 +106,21 @@ setup(ext_modules=cythonize([
 
 a = 'a'
 b = b'b'
+
+
+######## empty_bytes.py ########
+# Special because it gives bit length 0 in the bytes length index.
+
+EMPTY = b''
+
+
+######## empty_str_bytes.py ########
+# All (Unicode) names go into the string table, so we can't have
+# a table of only the empty str.  But we should still make sure
+# that short and empty strings compile fine.
+
+S = ''
+B = b''
 
 
 ######## module.py ########


### PR DESCRIPTION
C does not accept bit fields of bit length 0.

Closes https://github.com/cython/cython/issues/7965