### PR TITLE
gate pypy workarounds on python version

### DIFF
--- a/Cython/Utility/FunctionArguments.c
+++ b/Cython/Utility/FunctionArguments.c
@@ -180,7 +180,7 @@ static CYTHON_INLINE int __Pyx_CheckKeywordStrings(PyObject *kw); /*proto*/
 
 static int __Pyx_CheckKeywordStrings(PyObject *kw) {
     // PyPy appears to check keyword types at call time, not at unpacking time.
-#if CYTHON_COMPILING_IN_PYPY && !defined(PyArg_ValidateKeywordArguments)
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x030C0000 && !defined(PyArg_ValidateKeywordArguments)
     CYTHON_UNUSED_VAR(kw);
     return 0;
 #else

--- a/Cython/Utility/ModuleSetupCode.c
+++ b/Cython/Utility/ModuleSetupCode.c
@@ -901,7 +901,7 @@ static CYTHON_INLINE int __Pyx__IsSameCFunction(PyObject *func, void (*cfunc)(vo
   #define METH_METHOD 0x200
 #endif
 
-#if CYTHON_COMPILING_IN_PYPY && !defined(PyObject_Malloc)
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x030C0000 && !defined(PyObject_Malloc)
   #define PyObject_Malloc(s)   PyMem_Malloc(s)
   #define PyObject_Free(p)     PyMem_Free(p)
   #define PyObject_Realloc(p)  PyMem_Realloc(p)
@@ -1120,13 +1120,13 @@ static CYTHON_INLINE PyObject * __Pyx_PyDict_GetItemStrWithError(PyObject *dict,
   #if !defined(PyUnicode_DecodeUnicodeEscape)
     #define PyUnicode_DecodeUnicodeEscape(s, size, errors)  PyUnicode_Decode(s, size, "unicode_escape", errors)
   #endif
-  #if !defined(PyUnicode_Contains)
+  #if PY_VERSION_HEX < 0x030C0000 && !defined(PyUnicode_Contains)
     #define PyUnicode_Contains(u, s)  PySequence_Contains(u, s)
   #endif
   #if !defined(PyByteArray_Check)
     #define PyByteArray_Check(obj)  PyObject_TypeCheck(obj, &PyByteArray_Type)
   #endif
-  #if !defined(PyObject_Format)
+  #if PY_VERSION_HEX < 0x030C0000 && !defined(PyObject_Format)
     #define PyObject_Format(obj, fmt)  PyObject_CallMethod(obj, "__format__", "O", fmt)
   #endif
 #endif
@@ -1277,7 +1277,7 @@ static CYTHON_INLINE int __Pyx_PyDict_GetItemRef(PyObject *dict, PyObject *key, 
   #define __Pyx_PyUnicode_GET_LENGTH(o) PyUnicode_GetLength(o)
 #endif
 
-#if CYTHON_COMPILING_IN_PYPY && !defined(PyUnicode_InternFromString)
+#if CYTHON_COMPILING_IN_PYPY && PY_VERSION_HEX < 0x030C0000 && !defined(PyUnicode_InternFromString)
   #define PyUnicode_InternFromString(s) PyUnicode_FromString(s)
 #endif
 


### PR DESCRIPTION
These work-arounds are not needed on PyPy 3.12. In fact PyPy 3.12 will no longer define macros to mangle limited API functions, they will be supported just as on CPython. This is part of an effort to allow PyPy to import cp12-abi3 wheels. As-is, the use of these work-arounds causes some tests to fail.