### PR TITLE
Only optimise unicode comparisons for single character str values.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -14435,7 +14435,7 @@ class CmpNode:
             type1, type2 = operand1.type, self.operand2.type
             if result_is_bool or (type1.is_builtin_type and type2.is_builtin_type):
                 if type1.is_pystr_type or type2.is_pystr_type:
-                    if operand1.is_string_literal and operand1.can_coerce_to_char_literal():
+                    if operand1.is_string_literal and operand1.can_coerce_to_char_literal() and type1.is_pystr_type:
                         # We need to keep the signature (obj1, obj2, eq), so we generate one macro function per character.
                         character = ord(operand1.value[0])
                         is_str = type2.is_pystr_type
@@ -14443,7 +14443,7 @@ class CmpNode:
                             "UnicodeEquals_uchar", "StringTools.c", context={'CHAR': character, 'IS_STR': is_str, 'REVERSE': True})
                         self.special_bool_cmp_function = f"__Pyx_PyObject_Equals_ch{character}_{'str' if is_str else 'obj'}"
                         return True, operand1.coerce_to_pyobject(env)
-                    elif self.operand2.is_string_literal and self.operand2.can_coerce_to_char_literal():
+                    elif self.operand2.is_string_literal and self.operand2.can_coerce_to_char_literal() and type2.is_pystr_type:
                         # We need to keep the signature (obj1, obj2, eq), so we generate one macro function per character.
                         character = ord(self.operand2.value[0])
                         is_str = type1.is_pystr_type

--- a/tests/run/string_comparison.pyx
+++ b/tests/run/string_comparison.pyx
@@ -614,6 +614,47 @@ def literal_compare_bytes_str():
     return b'abc' != 'abc'
 
 
+def str_bytes_char_eq(str s):
+    """
+    >>> 'a' == b'a'
+    False
+    >>> str_bytes_char_eq('a')
+    False
+    >>> 'b' == b'a'
+    False
+    >>> str_bytes_char_eq('b')
+    False
+
+    >>> None == b'a'
+    False
+    >>> str_bytes_char_eq(None)
+    False
+    """
+    # From https://github.com/cython/cython/issues/7924
+    result = s == b'a'
+    return result
+
+
+def str_bytes_char_neq(str s):
+    """
+    >>> 'a' != b'a'
+    True
+    >>> str_bytes_char_neq('a')
+    True
+    >>> 'b' != b'a'
+    True
+    >>> str_bytes_char_neq('b')
+    True
+
+    >>> None != b'a'
+    True
+    >>> str_bytes_char_neq(None)
+    True
+    """
+    result = s != b'a'
+    return result
+
+
 # Py_UCS4 comparison
 
 @cython.test_assert_path_exists(


### PR DESCRIPTION
Exclude bytes literals, for which the comparison always evaluates to false.

Fixes https://github.com/cython/cython/issues/7924