### PR TITLE
Avoid leaking function-type references on repeated initialization

### DIFF
--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -14,8 +14,7 @@ Py_CLEAR(clear_module_state->__pyx_CyFunctionType);
 //@substitute: naming
 //@init_block: init_after_shared_utility
 
-if (likely(CGLOBAL(__pyx_CyFunctionType) != NULL ||
-           __pyx_CyFunction_init($module_cname) == 0)); else
+if (likely(__pyx_CyFunction_init($module_cname) == 0)); else
 
 //////////////////// CythonFunctionPerModule.proto //////////////////////////
 // This section always gets included whether we're using CythonFunction through
@@ -224,6 +223,9 @@ static CYTHON_INLINE void __Pyx_CyFunction_SetAnnotationsDict(PyObject *func, Py
 // Cutdown version that's only used when importing from shared utility code
 static int __pyx_CyFunction_init(PyObject *module) {
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
+    if (mstate->__pyx_CyFunctionType != NULL) {
+        return 0;
+    }
 
     PyTypeObject *tp = __Pyx_Get_CyFunction_Type();
     if (!tp) return -1;
@@ -1449,6 +1451,9 @@ static PyType_Spec __pyx_CyFunctionType_spec = {
 
 static int __pyx_CyFunction_init(PyObject *module) {
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
+    if (mstate->__pyx_CyFunctionType != NULL) {
+        return 0;
+    }
     mstate->__pyx_CyFunctionType = __Pyx_FetchCommonTypeFromSpec(
         mstate->__pyx_CommonTypesMetaclassType, module, &__pyx_CyFunctionType_spec, NULL);
     if (unlikely(mstate->__pyx_CyFunctionType == NULL)) {
@@ -1536,8 +1541,7 @@ Py_CLEAR(clear_module_state->__pyx_FusedFunctionType);
 //@substitute: naming
 //@init_block: init_after_shared_utility
 
-if (likely(CGLOBAL(__pyx_FusedFunctionType) != NULL ||
-           __pyx_FusedFunction_init($module_cname) == 0)); else
+if (likely(__pyx_FusedFunction_init($module_cname) == 0)); else
 
 //////////////////// FusedFunctionPerModule.proto ////////////////
 //@requires: CythonFunctionPerModule
@@ -1572,6 +1576,9 @@ static int __pyx_FusedFunction_init(PyObject *module);
 // Cutdown version that's only used when importing from shared utility code
 static int __pyx_FusedFunction_init(PyObject *module) {
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
+    if (mstate->__pyx_FusedFunctionType != NULL) {
+        return 0;
+    }
 
     PyTypeObject *tp = __Pyx_Get_FusedFunction_Type();
     if (!tp) return -1;
@@ -1979,6 +1986,9 @@ static int __pyx_FusedFunction_init(PyObject *module) {
     (void)&__Pyx_Get_FusedFunction_Type;
 
     $modulestatetype_cname *mstate = __Pyx_PyModule_GetState(module);
+    if (mstate->__pyx_FusedFunctionType != NULL) {
+        return 0;
+    }
     PyObject *bases = PyTuple_Pack(1, mstate->__pyx_CyFunctionType);
     if (unlikely(!bases)) {
         return -1;

--- a/Cython/Utility/CythonFunction.c
+++ b/Cython/Utility/CythonFunction.c
@@ -14,7 +14,8 @@ Py_CLEAR(clear_module_state->__pyx_CyFunctionType);
 //@substitute: naming
 //@init_block: init_after_shared_utility
 
-if (likely(__pyx_CyFunction_init($module_cname) == 0)); else
+if (likely(CGLOBAL(__pyx_CyFunctionType) != NULL ||
+           __pyx_CyFunction_init($module_cname) == 0)); else
 
 //////////////////// CythonFunctionPerModule.proto //////////////////////////
 // This section always gets included whether we're using CythonFunction through
@@ -1535,7 +1536,8 @@ Py_CLEAR(clear_module_state->__pyx_FusedFunctionType);
 //@substitute: naming
 //@init_block: init_after_shared_utility
 
-if (likely(__pyx_FusedFunction_init($module_cname) == 0)); else
+if (likely(CGLOBAL(__pyx_FusedFunctionType) != NULL ||
+           __pyx_FusedFunction_init($module_cname) == 0)); else
 
 //////////////////// FusedFunctionPerModule.proto ////////////////
 //@requires: CythonFunctionPerModule

--- a/tests/run/cyfunction_init.pyx
+++ b/tests/run/cyfunction_init.pyx
@@ -9,8 +9,12 @@ import sys
 cdef extern from *:
     """
     static int __Pyx_InitAfterSharedUtility(void);
+    static int __pyx_CyFunction_init(PyObject *module);
+    static int __pyx_FusedFunction_init(PyObject *module);
     """
     int __Pyx_InitAfterSharedUtility() except -1
+    int __pyx_CyFunction_init(object module) except -1
+    int __pyx_FusedFunction_init(object module) except -1
 
 
 def regular(value):
@@ -26,12 +30,17 @@ def fused(numeric value):
     return value
 
 
-def repeat_init(int count):
+def repeat_init(int count, bint direct=False):
+    module = sys.modules[__name__]
     cyfunction_type = type(regular)
     fused_function_type = type(fused)
     before = sys.getrefcount(cyfunction_type), sys.getrefcount(fused_function_type)
     for _ in range(count):
-        __Pyx_InitAfterSharedUtility()
+        if direct:
+            __pyx_CyFunction_init(module)
+            __pyx_FusedFunction_init(module)
+        else:
+            __Pyx_InitAfterSharedUtility()
     return (sys.getrefcount(cyfunction_type) - before[0],
             sys.getrefcount(fused_function_type) - before[1])
 
@@ -41,6 +50,8 @@ def repeat_init(int count):
 if platform.python_implementation() not in ("PyPy", "GraalVM"):
     __doc__ = """
     >>> repeat_init(10)
+    (0, 0)
+    >>> repeat_init(10, direct=True)
     (0, 0)
     >>> regular(123)
     123

--- a/tests/run/cyfunction_init.pyx
+++ b/tests/run/cyfunction_init.pyx
@@ -1,0 +1,51 @@
+# mode: run
+# tag: cyfunction, fused
+# cython: binding=True
+
+import platform
+import sys
+
+
+cdef extern from *:
+    """
+    static int __Pyx_InitAfterSharedUtility(void);
+    """
+    int __Pyx_InitAfterSharedUtility() except -1
+
+
+def regular(value):
+    return value
+
+
+ctypedef fused numeric:
+    int
+    double
+
+
+def fused(numeric value):
+    return value
+
+
+def repeat_init(int count):
+    cyfunction_type = type(regular)
+    fused_function_type = type(fused)
+    before = sys.getrefcount(cyfunction_type), sys.getrefcount(fused_function_type)
+    for _ in range(count):
+        __Pyx_InitAfterSharedUtility()
+    return (sys.getrefcount(cyfunction_type) - before[0],
+            sys.getrefcount(fused_function_type) - before[1])
+
+
+# Downstream code may call the helper before the generated module initializer does.
+# Skip for PyPy and GraalPy, where reference counting is unreliable.
+if platform.python_implementation() not in ("PyPy", "GraalVM"):
+    __doc__ = """
+    >>> repeat_init(10)
+    (0, 0)
+    >>> regular(123)
+    123
+    >>> fused(123)
+    123
+    >>> fused(1.5)
+    1.5
+    """


### PR DESCRIPTION
Repeated calls to `__Pyx_InitAfterSharedUtility()` currently acquire additional owned references to the cached CyFunction and FusedFunction types and overwrite the references already held in module state. This patch makes the two type initializers return early once their respective module-state slots are populated. A standalone regression test reports `(10, 10)` extra references before the fix and `(0, 0)` afterward.

### Trigger and ownership problem

This came up while reviewing the Cython 3.3 compatibility work in sagemath/sage#42742, specifically https://github.com/sagemath/sage/pull/42742#discussion_r3948297972.

#7556 (eee7a607684485e2feb0177da4ea621daf9f1d5c) moved these two initializers from `__Pyx_InitGlobals()` into `__Pyx_InitAfterSharedUtility()`, after shared utility imports and extension type initialization. This ordering also applies to builds without a separate shared utility module.

Sage's custom type-ready hook can execute Cython code that creates functions while extension types are being initialized. Its 3.3 workaround therefore calls the helper before invoking the hook. Those early calls can occur for multiple extension types, followed by the generated module initializer's own call.

Each initializer obtains a new owned reference to a shared type, then assigns it to `mstate->__pyx_CyFunctionType` or `mstate->__pyx_FusedFunctionType` without releasing the previous reference. The ordinary implementation fetches the cached type; the shared-utility implementation obtains and validates it from the shared module. Both have the same ownership issue when called again.

Normal generated module initialization calls this helper once and does not have the repeated-call trigger. The observed effect is extra references retained on cached types, rather than allocation of a new type on every call. The initialization timing change exposed this downstream use; the initializers' assumption of a single call predates 3.3.

### Change

Add an early return inside `__pyx_CyFunction_init()` and `__pyx_FusedFunction_init()` when the corresponding module-state slot is non-NULL. Each function has an ordinary implementation and a shared-utility-backed implementation, so there are four guards in total. The common initialization expressions remain unchanged. The ordinary FusedFunction guard runs before allocating its bases tuple.

The initializer itself now owns the repeated-call check, so both helper calls and direct calls preserve the existing owned reference.

The existing error path remains intact. If CyFunction initialization succeeds but FusedFunction initialization fails, another invocation can retry the missing type without reacquiring CyFunction. Module-state cleanup clears these slots, so no process-global once flag is needed.

This is an internal ownership fix for the two function-type initialization steps. It does not establish the private helper as a public API or promise arbitrary initialization ordering or concurrent/reentrant calls.

### Reproduction and validation

The new `tests/run/cyfunction_init.pyx` requires no Sage installation. It holds a normal function and a fused function, records their type reference counts, and checks two paths: invoking the helper ten times and directly invoking each type initializer ten times. Neither path may change either count. It then calls the normal function and both the integer and floating-point fused specializations. Reference-count assertions follow the existing test suite convention of excluding PyPy and GraalVM.

On unpatched master `82dc8be77701dce30cc85c7d388ccded559879b7`, the helper regression fails in both C and C++ with `(10, 10)` instead of `(0, 0)`. As an additional control, the previous revision with checks only in the initialization expressions passes the helper case but fails the new direct-call case with `(10, 10)` in both ordinary and shared-utility builds, for both C and C++. With the checks inside the initializers, both paths return `(0, 0)`.

Validation of the current patch:

- CPython 3.12.13 and 3.14.4: `cyfunction_init`, `cyfunction`, `cyfunction_defaults`, `fused_def`, and `fused_cpdef` pass in C and C++ (138 runner tests per Python version).
- CPython 3.12.13 with `--shared-utility`: both regression paths pass in C and C++ (4 runner tests). The generated code was checked to use `CythonFunctionFromSharedModule` and `FusedFunctionFromSharedModule`.
- `git diff --check` passes.

Commands, run from the checkout with each Python interpreter:

```sh
CFLAGS=-O0 python runtests.py -vv --no-unit --no-doctest --no-pyregr --no-examples \
  'run\.(cyfunction_init|cyfunction|cyfunction_defaults|fused_def|fused_cpdef)$'
CFLAGS=-O0 python runtests.py -vv --shared-utility cyfunction_init
```

The local validation is targeted; the full Cython test suite has not been run.
