### PR TITLE
Shared module: ensure build directory path is stripped from source filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Cython Changelog
 Bugs fixed
 ----------
 
+* Generating a shared utility module no longer embeds its destination directory
+  in the generated C code, making the output reproducible across build directories.
+  This is a follow-up fix to the one in 3.3.0, for ``--generate-shared=/path/to/_{sharedname}.c``.
+  (Github issue :issue:`7723`)
+
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 

--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -139,8 +139,8 @@ def generate_shared_module(options):
     Errors.reset()
 
     dest_c_file = options.shared_c_file_path
-    pyx_file = os.path.splitext(dest_c_file)[0] + '.pyx'
     module_name = os.path.splitext(os.path.basename(dest_c_file))[0]
+    pyx_file = f'{module_name}.pyx'
 
     selected_features = None
     if options.shared_utility_features_enabled or options.shared_utility_features_disabled:
@@ -155,6 +155,7 @@ def generate_shared_module(options):
     source_desc = SharedUtilitySourceDescriptor(pyx_file)
     comp_src = Main.CompilationSource(source_desc, EncodedString(module_name), os.getcwd())
     result = Main.create_default_resultobj(comp_src, options)
+    result.c_file = dest_c_file
 
     pipeline = create_shared_library_pipeline(
         context, scope, options, result,


### PR DESCRIPTION
When used as `--generated-shared=/tmp/builddir/_cyutility.c`, the result was that the build directory ended up in the generated C code, in the `__pyx_f` filename table.

This is a follow-up fix to gh-7723

There is a workaround today, which is to use `cython --working /tmp/builddir --generate-shared=_cyutility.c`. The generated code should be robust to passing the output file as a full path directly though, that's an obvious thing to do.