### PR TITLE
Restore compact-int fast path in __Pyx_PyIndex_AsSsize_t

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Cython Changelog
 Bugs fixed
 ----------
 
+* ``__Pyx_PyIndex_AsSsize_t()`` lost its fast path for the common case of
+  converting an in-range Python ``int`` to a C integer, making every
+  Python-object index into a C array or pointer measurably slower.
+  (Github issue :issue:`7979`)
+
 * A dangling pointer was fixed when assigning to attributes of extension types.
   (Github issue :issue:`7907`)
 

--- a/Cython/Compiler/Tests/TestTypeConversion.py
+++ b/Cython/Compiler/Tests/TestTypeConversion.py
@@ -1,0 +1,27 @@
+from Cython.Compiler import Code
+from Cython.TestUtils import TimedTest
+
+
+def _function_body(source, signature):
+    start = source.index(signature)
+    end = source.index("\n}", start)
+    return source[start:end]
+
+
+class TestPyIndexAsSsize_t(TimedTest):
+    """
+    GH-7979: __Pyx_PyIndex_AsSsize_t lost its compact-int fast path in 3.3.0.
+    """
+
+    def test_compact_int_fast_path_present(self):
+        proto, impl = Code.TempitaUtilityCode.load_as_string(
+            "TypeConversions", "TypeConversion.c")
+        source = (proto or "") + (impl or "")
+        body = _function_body(source, "__Pyx_PyIndex_AsSsize_t(PyObject* b) {")
+
+        self.assertIn(
+            "__Pyx_PyLong_CompactValue", body,
+            "missing compact-int fast path (GH-7979): %s" % body)
+        self.assertIn(
+            "PyLong_CheckExact", body,
+            "missing exact-type check before PyLong_Check() (GH-7979): %s" % body)

--- a/Cython/Utility/TypeConversion.c
+++ b/Cython/Utility/TypeConversion.c
@@ -429,7 +429,19 @@ static CYTHON_INLINE Py_ssize_t __Pyx_PyLong_AsSsize_t(PyObject* b) {
 }
 
 static CYTHON_INLINE Py_ssize_t __Pyx_PyIndex_AsSsize_t(PyObject* b) {
-    if (likely(PyLong_Check(b))) {
+    // Test the exact type first: it is a single pointer comparison, whereas
+    // PyLong_Check() needs an additional dependent load of tp_flags on the
+    // type object. Exact ints dominate real call sites (loop cursors and
+    // container indices), so pay the cheaper test for them and keep
+    // PyLong_Check() so subclasses (and bool) still avoid PyNumber_Index().
+    if (likely(PyLong_CheckExact(b)) || PyLong_Check(b)) {
+#if CYTHON_USE_PYLONG_INTERNALS
+        // Handle the overwhelmingly common single-digit case with a direct
+        // tagged read, before falling back to the general conversion.
+        if (likely(__Pyx_PyLong_IsCompact(b))) {
+            return __Pyx_PyLong_CompactValue(b);
+        }
+#endif
         return __Pyx_PyLong_AsSsize_t(b);
     } else {
         Py_ssize_t ival;


### PR DESCRIPTION
Fixes #7979.

GH-7471 (3.3.0) split `__Pyx_PyLong_AsSsize_t` out of `__Pyx_PyIndex_AsSsize_t` and, in doing so, dropped the single-digit compact-int fast path and widened the type test from `PyLong_CheckExact` to `PyLong_Check` on the hot path.

This restores both:

- Test the exact type first (one pointer comparison, versus `PyLong_Check`'s extra `tp_flags` load).
- Take the tagged compact-int read before falling back to the general conversion.
- `PyLong_Check` is kept in the slow branch so int subclasses and `bool` still avoid `PyNumber_Index`.

### Measurements

Fresh builds, `-O3`, CPython 3.12.3, five interleaved rounds, ns per inner iteration of a loop doing one/two Python-int-to-`Py_ssize_t` conversions per iteration (see #7979 for the full repro):

| build | one conversion | vs 3.2.9 | two conversions | vs 3.2.9 |
|---|---|---|---|---|
| 3.2.9 | 5.327 | — | 11.069 | — |
| 3.3.0 | 5.784 | 1.086 | 12.502 | 1.129 |
| this PR | 5.293 | 0.994 | 11.210 | 1.013 |

### Correctness

Verified behaviourally identical to 3.2.9 and unpatched 3.3.0 across 20 cases: `bool`, `int` subclasses, the `__index__` protocol (including a subclass return and a raising `__index__`), 1/2/3-digit and oversized ints, `Py_ssize_t` overflow, and non-integer types. Ran the full `slicing`/`bufaccess`/`memslice`/`indexing`/`numpy_` suite against this change (53 modules x 2 backends) with no failures.

### Testing

`Cython/Compiler/Tests/TestTypeConversion.py` loads the `TypeConversions` utility code directly and asserts the compact-int fast path is present, since the fix is behaviour-preserving and a runtime `.pyx` test can't otherwise detect it. Verified it fails against the pre-fix source and passes against this one.
