### PR TITLE
Shared module: sort exports for reproducible builds

### DIFF
--- a/Cython/Build/SharedModule.py
+++ b/Cython/Build/SharedModule.py
@@ -46,7 +46,7 @@ def _iter_exports(selected_features=None):
     UtilityCode = Code.UtilityCode
     match_special = UtilityCode.get_special_comment_matcher('/')
 
-    for c_utility_file in os.listdir(Code.get_utility_dir()):
+    for c_utility_file in sorted(os.listdir(Code.get_utility_dir())):
         if not c_utility_file.endswith('.c'):
             continue
 


### PR DESCRIPTION
Directory enumeration order changes _cyutility.c and compiled symbol order. Excerpt from `diffoscope` on SciPy wheels built in CI:

```diff
--- compare_output/cyutility-reference/_cyutility.c
+++ compare_output/cyutility-rebuilt/_cyutility.c
@@ -2914,2 +2914,2 @@
-/* CheckUnpickleChecksumError.export */
-static void __Pyx_RaiseUnpickleChecksumError(long checksum, long checksum1, long checksum2, long checksum3, const char *members);
+/* IsLittleEndian.proto */
+static CYTHON_INLINE int __Pyx_Is_Little_Endian(void);
@@ -2933,2 +2933,2 @@
-/* IsLittleEndian.proto */
-static CYTHON_INLINE int __Pyx_Is_Little_Endian(void);
+/* CheckUnpickleChecksumError.export */
+static void __Pyx_RaiseUnpickleChecksumError(long checksum, long checksum1, long checksum2, long checksum3, const char *members);
```