### PR TITLE
Preserve .pxd filenames in module-relative source paths

### DIFF
--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -272,7 +272,14 @@ class Context:
                 try:
                     if debug_find_module:
                         print("Context.find_module: Parsing %s" % pxd_pathname)
-                    rel_path = module_name.replace('.', os.sep) + os.path.splitext(pxd_pathname)[1]
+                    module_path = module_name.replace('.', os.sep)
+                    pxd_filename = os.path.basename(pxd_pathname)
+                    if pxd_filename.startswith('__init__.'):
+                        # Package declarations live below the module path.
+                        rel_path = os.path.join(module_path, pxd_filename)
+                    else:
+                        # Preserve version suffixes such as ".cython-30.pxd".
+                        rel_path = os.path.join(os.path.dirname(module_path), pxd_filename)
                     if not pxd_pathname.endswith(rel_path):
                         rel_path = pxd_pathname  # safety measure to prevent printing incorrect paths
                     source_desc = FileSourceDescriptor(pxd_pathname, rel_path)

--- a/Cython/Compiler/Main.py
+++ b/Cython/Compiler/Main.py
@@ -272,14 +272,13 @@ class Context:
                 try:
                     if debug_find_module:
                         print("Context.find_module: Parsing %s" % pxd_pathname)
-                    module_path = module_name.replace('.', os.sep)
                     pxd_filename = os.path.basename(pxd_pathname)
-                    if pxd_filename.startswith('__init__.'):
-                        # Package declarations live below the module path.
-                        rel_path = os.path.join(module_path, pxd_filename)
-                    else:
-                        # Preserve version suffixes such as ".cython-30.pxd".
-                        rel_path = os.path.join(os.path.dirname(module_path), pxd_filename)
+                    # Package init modules live below the full module path, all else next to it.
+                    packages = module_name.split('.')
+                    if not pxd_filename.startswith('__init__.'):
+                        packages.pop()
+                    # Build full package file path, preserving version suffixes such as ".cython-30.pxd".
+                    rel_path = os.path.join(*packages, pxd_filename)
                     if not pxd_pathname.endswith(rel_path):
                         rel_path = pxd_pathname  # safety measure to prevent printing incorrect paths
                     source_desc = FileSourceDescriptor(pxd_pathname, rel_path)


### PR DESCRIPTION
Constructing a filename from the module name plus .pxd loses `__init__` and version suffixes such as `.cython-30`. The resulting suffix mismatch makes Cython fall back to a build-specific path. Preserve the actual .pxd basename instead.

Diffoscope output comparing strings in a SciPy extension module from two wheel builds:

```diff
-../../../opt/python/cp315-cp315t/lib/python3.15t/site-packages/numpy/__init__.cython-30.pxd
+../../../tmp/scipy-reproducibility-build-venv/lib/python3.15t/site-packages/numpy/__init__.cython-30.pxd
```

After this change, both use `numpy/__init__.cython-30.pxd`, independent of the build directory or path to the detected `numpy` package.

This changes source filenames embedded in generated code, including runtime traceback filenames. It does not change source resolution or Cython's compile-time error locations.

Note that encoding build environment paths as was happening here is not correct for distributed packages, and not even correct on a single machine when building with build isolation (the relative path will be to a tmpdir that immediately gets cleaned up).

As discussed in https://github.com/cython/cython/pull/7982, this fix should be covered by an integration test once the whole set of fixes is in. In case it also needs a unit test, please tell me roughly where/how.