### PR TITLE
Rename some declarations used in Cython utility code to prevent collisions with user defined/cimported names

### DIFF
--- a/Cython/Utility/CppConvert.pyx
+++ b/Cython/Utility/CppConvert.pyx
@@ -4,25 +4,25 @@
 #################### string.from_py ####################
 
 cdef extern from *:
-    cdef cppclass string "{{type}}":
-        string() except +
-        string(char* c_str, size_t size) except +
+    cdef cppclass __pyx_cpp_string "{{type}}":
+        __pyx_cpp_string() except +
+        __pyx_cpp_string(char* c_str, size_t size) except +
     cdef const char* __Pyx_PyObject_AsStringAndSize(object, Py_ssize_t*) except NULL
 
 @cname("{{cname}}")
-cdef string {{cname}}(object o) except *:
+cdef __pyx_cpp_string {{cname}}(object o) except *:
     cdef Py_ssize_t length = 0
     cdef const char* data = __Pyx_PyObject_AsStringAndSize(o, &length)
-    return string(data, <size_t> length)
+    return __pyx_cpp_string(data, <size_t> length)
 
 
 #################### string.to_py ####################
 
 #cimport cython
-#from libcpp.string cimport string
+#from libcpp.string cimport string as __pyx_cpp_string
 cdef extern from *:
     const Py_ssize_t PY_SSIZE_T_MAX
-    cdef cppclass string "{{type}}":
+    cdef cppclass __pyx_cpp_string "{{type}}":
         char* data()
         size_t size()
 
@@ -31,7 +31,7 @@ cdef extern from *:
     cdef object __Pyx_{{py_type}}_FromStringAndSize(const char*, size_t)
 
 @cname("{{cname.replace("PyObject", py_type, 1)}}")
-cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const string& s):
+cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const __pyx_cpp_string& s):
     if s.size() > <size_t> PY_SSIZE_T_MAX:
         raise MemoryError()
     return __Pyx_{{py_type}}_FromStringAndSize(s.data(), <Py_ssize_t> s.size())
@@ -42,16 +42,16 @@ cdef inline object {{cname.replace("PyObject", py_type, 1)}}(const string& s):
 #@requires: ObjectHandling.c::LengthHint
 
 cdef extern from *:
-    cdef cppclass vector "std::vector" [T]:
+    cdef cppclass __pyx_cpp_vector "std::vector" [T]:
         void push_back(T&) except +
         void reserve(size_t) except +
 
     cdef Py_ssize_t __Pyx_PyObject_LengthHint(object o, Py_ssize_t defaultval) except -1
 
 @cname("{{cname}}")
-cdef vector[X] {{cname}}(object o) except *:
+cdef __pyx_cpp_vector[X] {{cname}}(object o) except *:
 
-    cdef vector[X] v
+    cdef __pyx_cpp_vector[X] v
     cdef Py_ssize_t s = __Pyx_PyObject_LengthHint(o, 0)
 
     if s > 0:
@@ -66,18 +66,18 @@ cdef vector[X] {{cname}}(object o) except *:
 #################### vector.to_py ####################
 
 cdef extern from *:
-    cdef cppclass vector "std::vector" [T]:
+    cdef cppclass __pyx_cpp_vector "std::vector" [T]:
         size_t size()
         T& operator[](size_t)
 
 cdef extern from "Python.h":
     void Py_INCREF(object)
-    list PyList_New(Py_ssize_t size)
-    int __Pyx_PyList_SET_ITEM(object list, Py_ssize_t i, object o) except -1
+    object PyList_New(Py_ssize_t size)
+    int __Pyx_PyList_SET_ITEM(object pylist, Py_ssize_t i, object o) except -1
     const Py_ssize_t PY_SSIZE_T_MAX
 
 @cname("{{cname}}")
-cdef object {{cname}}(const vector[X]& v):
+cdef object {{cname}}(const __pyx_cpp_vector[X]& v):
     if v.size() > <size_t> PY_SSIZE_T_MAX:
         raise MemoryError()
     v_size_signed = <Py_ssize_t> v.size()
@@ -97,12 +97,12 @@ cdef object {{cname}}(const vector[X]& v):
 #################### list.from_py ####################
 
 cdef extern from *:
-    cdef cppclass cpp_list "std::list" [T]:
+    cdef cppclass __pyx_cpp_list "std::list" [T]:
         void push_back(T&) except +
 
 @cname("{{cname}}")
-cdef cpp_list[X] {{cname}}(object o) except *:
-    cdef cpp_list[X] l
+cdef __pyx_cpp_list[X] {{cname}}(object o) except *:
+    cdef __pyx_cpp_list[X] l
     for item in o:
         l.push_back(<X>item)
     return l
@@ -113,7 +113,7 @@ cdef cpp_list[X] {{cname}}(object o) except *:
 cimport cython
 
 cdef extern from *:
-    cdef cppclass cpp_list "std::list" [T]:
+    cdef cppclass __pyx_cpp_list "std::list" [T]:
         cppclass const_iterator:
             T& operator*()
             const_iterator operator++()
@@ -124,12 +124,12 @@ cdef extern from *:
 
 cdef extern from "Python.h":
     void Py_INCREF(object)
-    list PyList_New(Py_ssize_t size)
-    void __Pyx_PyList_SET_ITEM(object list, Py_ssize_t i, object o)
+    object PyList_New(Py_ssize_t size)
+    void __Pyx_PyList_SET_ITEM(object pylist, Py_ssize_t i, object o)
     cdef Py_ssize_t PY_SSIZE_T_MAX
 
 @cname("{{cname}}")
-cdef object {{cname}}(const cpp_list[X]& v):
+cdef object {{cname}}(const __pyx_cpp_list[X]& v):
     if v.size() > <size_t> PY_SSIZE_T_MAX:
         raise MemoryError()
 
@@ -137,7 +137,7 @@ cdef object {{cname}}(const cpp_list[X]& v):
 
     cdef object item
     cdef Py_ssize_t i = 0
-    cdef cpp_list[X].const_iterator iter = v.begin()
+    cdef __pyx_cpp_list[X].const_iterator iter = v.begin()
 
     while iter != v.end():
         item = cython.operator.dereference(iter)
@@ -152,12 +152,12 @@ cdef object {{cname}}(const cpp_list[X]& v):
 #################### set.from_py ####################
 
 cdef extern from *:
-    cdef cppclass set "std::{{maybe_unordered}}set" [T]:
+    cdef cppclass __pyx_cpp_set "std::{{maybe_unordered}}set" [T]:
         void insert(T&) except +
 
 @cname("{{cname}}")
-cdef set[X] {{cname}}(object o) except *:
-    cdef set[X] s
+cdef __pyx_cpp_set[X] {{cname}}(object o) except *:
+    cdef __pyx_cpp_set[X] s
     for item in o:
         s.insert(<X>item)
     return s
@@ -168,7 +168,7 @@ cdef set[X] {{cname}}(object o) except *:
 cimport cython
 
 cdef extern from *:
-    cdef cppclass cpp_set "std::{{maybe_unordered}}set" [T]:
+    cdef cppclass __pyx_cpp_set "std::{{maybe_unordered}}set" [T]:
         cppclass const_iterator:
             T& operator*()
             const_iterator operator++()
@@ -177,50 +177,48 @@ cdef extern from *:
         const_iterator end()
 
 @cname("{{cname}}")
-cdef object {{cname}}(const cpp_set[X]& s):
+cdef object {{cname}}(const __pyx_cpp_set[X]& s):
     return {v for v in s}
 
 #################### pair.from_py ####################
 
 cdef extern from *:
-    cdef cppclass pair "std::pair" [T, U]:
-        pair() except +
-        pair(T&, U&) except +
+    cdef cppclass __pyx_cpp_pair "std::pair" [T, U]:
+        __pyx_cpp_pair() except +
+        __pyx_cpp_pair(T&, U&) except +
 
 @cname("{{cname}}")
-cdef pair[X,Y] {{cname}}(object o) except *:
+cdef __pyx_cpp_pair[X,Y] {{cname}}(object o) except *:
     x, y = o
-    return pair[X,Y](<X>x, <Y>y)
+    return __pyx_cpp_pair[X,Y](<X>x, <Y>y)
 
 
 #################### pair.to_py ####################
 
 cdef extern from *:
-    cdef cppclass pair "std::pair" [T, U]:
+    cdef cppclass __pyx_cpp_pair "std::pair" [T, U]:
         T first
         U second
 
 @cname("{{cname}}")
-cdef object {{cname}}(const pair[X,Y]& p):
+cdef object {{cname}}(const __pyx_cpp_pair[X,Y]& p):
     return p.first, p.second
 
 
 #################### map.from_py ####################
 
 cdef extern from *:
-    cdef cppclass pair "std::pair" [T, U]:
-        pair(T&, U&) except +
-    cdef cppclass map "std::{{maybe_unordered}}map" [T, U]:
-        void insert(pair[T, U]&) except +
-    cdef cppclass vector "std::vector" [T]:
-        pass
+    cdef cppclass __pyx_cpp_pair "std::pair" [T, U]:
+        __pyx_cpp_pair(T&, U&) except +
+    cdef cppclass __pyx_cpp_map "std::{{maybe_unordered}}map" [T, U]:
+        void insert(__pyx_cpp_pair[T, U]&) except +
 
 
 @cname("{{cname}}")
-cdef map[X,Y] {{cname}}(object o) except *:
-    cdef map[X,Y] m
+cdef __pyx_cpp_map[X,Y] {{cname}}(object o) except *:
+    cdef __pyx_cpp_map[X,Y] m
     for key, value in o.items():
-        m.insert(pair[X,Y](<X>key, <Y>value))
+        m.insert(__pyx_cpp_pair[X,Y](<X>key, <Y>value))
     return m
 
 
@@ -231,7 +229,7 @@ cdef map[X,Y] {{cname}}(object o) except *:
 cimport cython
 
 cdef extern from *:
-    cdef cppclass map "std::{{maybe_unordered}}map" [T, U]:
+    cdef cppclass __pyx_cpp_map "std::{{maybe_unordered}}map" [T, U]:
         cppclass value_type:
             T first
             U second
@@ -243,10 +241,10 @@ cdef extern from *:
         const_iterator end()
 
 @cname("{{cname}}")
-cdef object {{cname}}(const map[X,Y]& s):
+cdef object {{cname}}(const __pyx_cpp_map[X,Y]& s):
     o = {}
-    cdef const map[X,Y].value_type *key_value
-    cdef map[X,Y].const_iterator iter = s.begin()
+    cdef const __pyx_cpp_map[X,Y].value_type *key_value
+    cdef __pyx_cpp_map[X,Y].const_iterator iter = s.begin()
     while iter != s.end():
         key_value = &cython.operator.dereference(iter)
         o[key_value.first] = key_value.second
@@ -256,27 +254,31 @@ cdef object {{cname}}(const map[X,Y]& s):
 
 #################### complex.from_py ####################
 
+cimport cython
+
 cdef extern from *:
-    cdef cppclass std_complex "std::complex" [T]:
-        std_complex()
-        std_complex(T, T) except +
+    cdef cppclass __pyx_cpp_std_complex "std::complex" [T]:
+        __pyx_cpp_std_complex()
+        __pyx_cpp_std_complex(T, T) except +
 
 @cname("{{cname}}")
-cdef std_complex[X] {{cname}}(object o) except *:
-    cdef double complex z = o
-    return std_complex[X](<X>z.real, <X>z.imag)
+cdef __pyx_cpp_std_complex[X] {{cname}}(object o) except *:
+    cdef cython.doublecomplex z = o
+    return __pyx_cpp_std_complex[X](<X>z.real, <X>z.imag)
 
 
 #################### complex.to_py ####################
 
+cimport cython
+
 cdef extern from *:
-    cdef cppclass std_complex "std::complex" [T]:
+    cdef cppclass __pyx_cpp_std_complex "std::complex" [T]:
         X real()
         X imag()
 
 @cname("{{cname}}")
-cdef object {{cname}}(const std_complex[X]& z):
-    cdef double complex tmp
-    tmp.real = <double>z.real()
-    tmp.imag = <double>z.imag()
+cdef object {{cname}}(const __pyx_cpp_std_complex[X]& z):
+    cdef cython.doublecomplex tmp
+    tmp.real = <cython.double>z.real()
+    tmp.imag = <cython.double>z.imag()
     return tmp

--- a/Cython/Utility/UFuncs.pyx
+++ b/Cython/Utility/UFuncs.pyx
@@ -1,15 +1,15 @@
 ##################### UFuncDefinition ######################
 
 cdef extern from *:
-    ctypedef int npy_intp
+    ctypedef int __pyx_npy_intp "npy_intp"
     struct PyObject
     PyObject* __Pyx_NewRef(object)
 
 # variable names have to come from tempita to avoid duplication
 @cname("{{func_cname}}")
-cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp* steps, void* data) except * {{"nogil" if will_be_called_without_gil else ""}}:
-    cdef npy_intp i
-    cdef npy_intp n = dimensions[0]
+cdef void {{func_cname}}(char **args, const __pyx_npy_intp *dimensions, const __pyx_npy_intp* steps, void* data) except * {{"nogil" if will_be_called_without_gil else ""}}:
+    cdef __pyx_npy_intp i
+    cdef __pyx_npy_intp n = dimensions[0]
     {{for idx, tn_tp in enumerate(in_types)}}
     cdef char* in_{{idx}} = args[{{idx}}]
     cdef {{tn_tp[0]}} cast_in_{{idx}}
@@ -19,7 +19,7 @@ cdef void {{func_cname}}(char **args, const npy_intp *dimensions, const npy_intp
     cdef {{tn_tp[0]}} cast_out_{{idx}}
     {{endfor}}
     {{for idx in range(len(out_types)+len(in_types))}}
-    cdef npy_intp step_{{idx}} = steps[{{idx}}]
+    cdef __pyx_npy_intp step_{{idx}} = steps[{{idx}}]
     {{endfor}}
 
     {{"with gil" if (not nogil and will_be_called_without_gil) else "if True"}}:

--- a/tests/run/cpp_type_annotations.pyx
+++ b/tests/run/cpp_type_annotations.pyx
@@ -1,0 +1,25 @@
+# mode: run
+# tag: cpp, no-cpp-locals
+
+# Shadow Python 'list' with C++ 'std::list'
+from libcpp.list cimport list
+
+
+cdef class LineAccumulator:
+    """
+    >>> la = LineAccumulator()
+    >>> la.get_lines()
+    [5.0]
+
+    >>> import pickle
+    >>> la2 = pickle.loads(pickle.dumps(la))
+    >>> la2.get_lines()
+    [5.0]
+    """
+    cdef list[double] lines
+
+    def __init__(self):
+        self.lines.push_back(5.0)
+
+    def get_lines(self):
+        return self.lines


### PR DESCRIPTION
This workaround is needed because user cimports currently leak into the utility code, which really shouldn't be the case.

Closes https://github.com/cython/cython/issues/7939