### PR TITLE
Allow redeclarations of annotated variables.

### DIFF
--- a/Cython/Compiler/ExprNodes.py
+++ b/Cython/Compiler/ExprNodes.py
@@ -2369,17 +2369,15 @@ class NameNode(AtomicExprNode):
                 self.annotation and env.is_c_dataclass_scope):
             error(self.pos, "Cannot redeclare inherited fields in Cython dataclasses")
         elif self.entry and self.annotation and env.directives['annotation_typing']:
-            if not self.entry.scope.is_module_scope:
-                error(self.pos, f"'{self.name}' redeclared")
-            else:
-                # Type annotations of global variables (module scope) are ignored by cython.
-                # Hence, we support somewhat contradictory declarations like:
-                # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
-                annotation_type = self.annotation.analyse_as_type(env)
+            # Type annotations of global variables (module scope) are ignored by Cython.
+            # Hence, we support somewhat contradictory declarations like:
+            # _Empty_Tuple: tuple[typing.Any] = cython.declare(tuple, ())
+            # For local variables, we allow at least compatible redeclarations with annotations
+            # (but do not always remember how they were *originally* declared).
+            annotation_type = self.annotation.analyse_as_type(env)
+            if annotation_type:
                 entry_type = self.entry.type
-                if annotation_type and not (
-                    annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)
-                ):
+                if not (annotation_type.assignable_from(entry_type) or entry_type.assignable_from(annotation_type)):
                     warning(self.pos,
                         f"Annotation type '{annotation_type}' is not compatible "
                         f"with declaration type '{entry_type}'.", 1)

--- a/tests/errors/pure_errors.py
+++ b/tests/errors/pure_errors.py
@@ -97,16 +97,17 @@ def return_wrong_type():
 
 def variable_redeclared(x):
     a: int = 5
-    a: int = 6  # not ok
+    a: int = 6  # not currently warned about
 
     if x > 10:
         b: str = 'bar'
-    b: str = 'foo'  # not ok
+    b: str = 'foo'  # not currently warned about
 
     if x < 10:
         c: float = 5.0
     else:
-        c: float = 10.0  # not ok
+        c: float = 10.0  # not currently warned about
+
     with cython.annotation_typing(False):
         a: int = 6
         b: str = 'foo'
@@ -126,9 +127,6 @@ _ERRORS = """
 80:0: cfunc and ccall directives cannot be combined
 86:0: Cannot apply @cfunc to @ufunc, please reverse the decorators.
 93:22: Not a type
-100:4: 'a' redeclared
-104:4: 'b' redeclared
-109:8: 'c' redeclared
 
 # bugs:
 74:0: 'test_contradicting_decorators1' redeclared

--- a/tests/errors/pure_warnings.py
+++ b/tests/errors/pure_warnings.py
@@ -44,6 +44,12 @@ def bar4(a: cython.foo[:]):  # error
 
 cvar: list = cython.declare(dict, {})  # warning
 
+
+def local_redeclared():
+    a: list = []
+    a: dict = {}  # value mismatch with original type should error
+
+
 _WARNINGS = """
 12:10: Unknown type declaration 'Bar' in annotation, ignoring
 15:16: Unknown type declaration 'stdint.bar' in annotation, ignoring
@@ -54,6 +60,7 @@ _WARNINGS = """
 35:14: Unknown type declaration 'Bar' in annotation, ignoring
 39:20: Unknown type declaration 'stdint.bar' in annotation, ignoring
 45:0: Annotation type 'list object' is not compatible with declaration type 'dict object'.
+50:4: Annotation type 'dict object' is not compatible with declaration type 'list object'.
 
 # Spurious warnings from utility code - not part of the core test
 26:4: 'cpdef_method' redeclared
@@ -64,4 +71,5 @@ _ERRORS = """
 17:16: Unknown type declaration 'cython.bar' in annotation
 30:19: Unknown type declaration 'cython.bar' in annotation
 42:18: Unknown type declaration 'cython.foo[:]' in annotation
+50:14: Cannot assign type 'dict object' to 'list object'
 """


### PR DESCRIPTION
Removes the error to avoid false positives. We cannot easily distinguish how they were originally declared, and with assignment (noticed) or not (not noticed), so we rather warn in obvious cases and leave it to that.

Fixes https://github.com/cython/cython/issues/7920
Error was added in https://github.com/cython/cython/pull/7253